### PR TITLE
Support for Basic Authentication and HTTPS

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -17,13 +17,17 @@ class Connection(object):
     """
     transport_schema = 'http'
 
-    def __init__(self, host='localhost', port=9200, url_prefix='', timeout=10, **kwargs):
+    def __init__(self, host='localhost', port=9200, url_prefix='', timeout=10, transport_schema='http', auth=None, **kwargs):
         """
         :arg host: hostname of the node (default: localhost)
         :arg port: port to use (default: 9200)
         :arg url_prefix: optional url prefix for elasticsearch
         :arg timeout: default timeout in seconds (default: 10)
         """
+        self.transport_schema = transport_schema
+
+        self.auth = auth
+
         self.host = '%s://%s:%s' % (self.transport_schema, host, port)
         if url_prefix:
             url_prefix = '/' + url_prefix.strip('/')


### PR DESCRIPTION
Many people use Elasticsearch over unsecured networks that requires encryption and authentication. 

Added support for connecting to HTTPS servers and authenticating via basic auth.

```
from elasticsearch import Elasticsearch

dc = Elasticsearch(["secure-server.com:443"], transport_schema='https', auth='user:password')
dc.search()

from elasticsearch.connection.http import RequestsHttpConnection

rc = Elasticsearch(["secure-server.com:443"], transport_schema='https', auth='user:password', connection_class=RequestsHttpConnection)
rc.search()
```

Theres a few failing tests on `test_elasticsearch.test_connection.TestRequestsConnection`, which is caused by the mock object used in the tests not being set up to handle actually being merged with the session config.

If this is an acceptable API, the tests can of course be fixed, but awaiting feedback before spending time on it.
