### PR TITLE
Add support for providing additional keyword arguments to the Elasticsearch clients used in tests.

### DIFF
--- a/test_elasticsearch/test_server/__init__.py
+++ b/test_elasticsearch/test_server/__init__.py
@@ -1,4 +1,5 @@
 import time
+import json
 import subprocess
 import tempfile
 import os
@@ -34,6 +35,8 @@ def get_client(**kwargs):
     if 'TEST_ES_CONNECTION' in os.environ:
         from elasticsearch import connection
         kw['connection_class'] = getattr(connection, os.environ['TEST_ES_CONNECTION'])
+    if 'TEST_ES_KWARGS' in os.environ:
+        kw.update(json.loads(os.environ['TEST_ES_KWARGS']))
     kw.update(kwargs)
     return Elasticsearch([os.environ['TEST_ES_SERVER']], **kw)
 


### PR DESCRIPTION
The new environment variable TEST_ES_KWARGS should contain a json-encoded dict with extra keyword
arguments.

Example:

```
TEST_ES_KWARGS='{"use_ssl": true, "http_auth": "foo:bar"}' python setup.py test
```

The above would enable the SSL support in the http connection classes and provide some basic
credentials.
