### PR TITLE
Raise ElasticsearchException when bulk_index returns an error

### DIFF
--- a/elasticsearch/helpers.py
+++ b/elasticsearch/helpers.py
@@ -1,5 +1,7 @@
 from itertools import islice
 
+from .exceptions import ElasticsearchException
+
 def bulk_index(client, docs, chunk_size=500, stats_only=False, **kwargs):
     """
     Helper for the :meth:`~elasticsearch.Elasticsearch.bulk` api that provides
@@ -57,6 +59,8 @@ def bulk_index(client, docs, chunk_size=500, stats_only=False, **kwargs):
         for req, item in zip(bulk_actions[::2], resp['items']):
             # TODO: better reporting
             act = 'index' if '_id' in req['index'] else 'create'
+            if 'error' in item[act]:
+                raise ElasticsearchException(item[act]['error'])
             if stats_only:
                 if item[act]['ok']:
                     success += 1


### PR DESCRIPTION
Hi,

I found myself with a `KeyError: 'ok'` after something like 3 millions document indexed, and I was a little bit disappointed. So it seems to me that a better error message and the ability to catch it worth the extra "if" statement.

What do you think?

Thanks!

Yohan

For the record, here is the JSON I get:

```
{'index': {'_type': 'place', '_id': 'IGNADRNIVX_0000000269162415', 'error': 'UnavailableShardsException[[osm][4] [2] shardIt, [0] active : Timeout waiting for [1m], request: org.elasticsearch.action.bulk.BulkShardRequest@504430b5]', '_index': 'osm'}}

```
