### PR TITLE
Allow `bulk_index` to take a `callback` kwarg.

### DIFF
--- a/elasticsearch/helpers.py
+++ b/elasticsearch/helpers.py
@@ -4,7 +4,8 @@ from elasticsearch.exceptions import ElasticsearchException
 
 class BulkIndexError(ElasticsearchException): pass
 
-def bulk_index(client, docs, chunk_size=500, stats_only=False, raise_on_error=False, **kwargs):
+def bulk_index(client, docs, chunk_size=500, stats_only=False,
+               raise_on_error=False, callback=None, **kwargs):
     """
     Helper for the :meth:`~elasticsearch.Elasticsearch.bulk` api that provides
     a more human friendly interface - it consumes an iterator of documents and
@@ -34,6 +35,8 @@ def bulk_index(client, docs, chunk_size=500, stats_only=False, raise_on_error=Fa
         operations instead of just number of successful and a list of error responses
     :arg raise_on_error: raise `BulkIndexError` if some documents failed to
         index (and stop sending chunks to the server)
+    :arg callback: a callable, that is called after each bulk operation
+        the callable must take three arguments: `success`, `failed` and `errors`
 
     Any additional keyword arguments will be passed to the bulk API itself.
     """
@@ -74,6 +77,9 @@ def bulk_index(client, docs, chunk_size=500, stats_only=False, raise_on_error=Fa
 
         if failed and raise_on_error:
             raise BulkIndexError('%i document(s) failed to index.' % failed, errors)
+
+        if callable(callback):
+            callback(success, failed, errors)
 
 def scan(client, query=None, scroll='5m', **kwargs):
     """


### PR DESCRIPTION
I came across a use case for this, but I am not sure how useful it is in general - just I thought I just put it up to discussion.

Allow `elasticsearch.helper.bulk_index` to take a keyword
argument `callback`, which must be a callable, that takes three arguments:
`success`, `failed`, `errors`. The callback is called after each
bulk operation and can be used to collect and display progress information.

Example:

```
...
def progress(success, failed, errors):
    print('%s indexed' % success)

bulk_index(es, docs, chunk_size=2000, callback=progress,
    raise_on_error=True)
...
```
