### PR TITLE
add how to install using pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,14 @@ Official low-level client for Elasticsearch. It's goal is to provide common
 ground for all Elasticsearch-related code in Python; because of this it tries
 to be opinion-free and very extendable.
 
+Installation
+------------
+
+Install the `elasticsearch` package with `pip
+<https://pypi.python.org/pypi/elasticsearch/0.4.3>`_::
+
+    pip install elasticsearch
+
 
 Example use
 -----------


### PR DESCRIPTION
i couldn't find how to install elasticsearch package, and didn't know that you already deployed it to pip repository. now i know, and i think it's worth adding this piece of info to README.rst.
