### PR TITLE
Allow the maxsize parameter to be passed to the urllib3 connection pool

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -15,8 +15,10 @@ class Urllib3HttpConnection(Connection):
     :arg http_auth: optional http auth information as either ':' separated
         string or a tuple
     :arg use_ssl: use ssl for the connection if `True`
+    :arg maxsize: the maximum number of connections which will be kept open to
+        this host.  Useful to set this higher than 1 for multithreaded situations.
     """
-    def __init__(self, host='localhost', port=9200, http_auth=None, use_ssl=False, **kwargs):
+    def __init__(self, host='localhost', port=9200, http_auth=None, use_ssl=False, maxsize=1, **kwargs):
         super(Urllib3HttpConnection, self).__init__(host=host, port=port, **kwargs)
         headers = {}
         if http_auth is not None:
@@ -28,7 +30,7 @@ class Urllib3HttpConnection(Connection):
         if use_ssl:
             pool_class = urllib3.HTTPSConnectionPool
 
-        self.pool = pool_class(host, port=port, timeout=kwargs.get('timeout', None), headers=headers)
+        self.pool = pool_class(host, port=port, timeout=kwargs.get('timeout', None), headers=headers, maxsize=maxsize)
 
     def perform_request(self, method, url, params=None, body=None, timeout=None, ignore=()):
         url = self.url_prefix + url


### PR DESCRIPTION
When an Elasticsearch client object is being shared by multiple threads, it is possible for the urllib3 connection pools managing each host connection to be asked for more than 1 concurrent connection.  Currently, elasticsearch-py doesn't permit the UrllibConnectionPool constructor's maxsize parameter to be changed from the default value of 1.  This results in connections frequently being opened and closed under concurrent load.

This PR simply exposes the maxsize parameter, so that it can be passed to the Elasticsearch client constructor, such that users can set the per-host pool size.
