### PR TITLE
make Elasticsearch.scroll POST the scroll ID

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -441,8 +441,8 @@ class Elasticsearch(object):
         :arg scroll: Specify how long a consistent view of the index should be
             maintained for scrolled search
         """
-        _, data = self.transport.perform_request('GET', _make_path('_search', 'scroll', scroll_id),
-            params=params)
+        _, data = self.transport.perform_request('POST', _make_path('_search', 'scroll'),
+            params=params, body=scroll_id)
         return data
 
     @query_params()


### PR DESCRIPTION
Without this, if you have a large number of indices the `scroll_id` will be very long, and ElasticSearch will return an invalid response. (A urllib3 `ConnectionError` to be precise.) This changes the behavior to POST to the scroll endpoint, which gets around the URL length restriction.

This is an implementation of the solution to the same problem [in the elasticsearch-users](http://elasticsearch-users.115913.n3.nabble.com/Ridiculously-long-Scroll-id-td4038567.html) mailing list.

I'm just opening this to see if it's a welcome change, if need be I can change whatever tests need to be fiddled with as well.
