### PR TITLE
Set requests proxies via kwargs in RequestsHttpConnection.session

### DIFF
--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -31,6 +31,8 @@ class RequestsHttpConnection(Connection):
                 http_auth = http_auth.split(':', 1)
             http_auth = tuple(http_auth)
             self.session.auth = http_auth
+        if kwargs.get("proxies", {}):
+            self.session.proxies = kwargs["proxies"]
         self.base_url = 'http%s://%s:%d%s' % (
             's' if use_ssl else '',
             host, port, self.url_prefix


### PR DESCRIPTION
Hi,
would you please consider pulling this change - it enables the usage of proxies in RequestsHttpConnection.
Thank you,
J. Balas
