### PR TITLE
Fix Issue 39: put_mapping

### DIFF
--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -223,7 +223,7 @@ class IndicesClient(NamespacedClient):
         :arg master_timeout: Specify timeout for connection to master
         :arg timeout: Explicit operation timeout
         """
-        _, data = self.transport.perform_request('PUT', _make_path(index, '_mapping', doc_type),
+        _, data = self.transport.perform_request('PUT', _make_path(index, doc_type, '_mapping'),
             params=params, body=body)
         return data
 


### PR DESCRIPTION
Fix this mistake where the document model type was replaced with the _mapping keyword.  Not sure how this method would have worked before.

Note that this fixes issue #39.
