### PR TITLE
Be more informative when unable to JSON serialize

### DIFF
--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -24,7 +24,7 @@ class JSONSerializer(object):
             return data.isoformat()
         elif isinstance(data, Decimal):
             return float(data)
-        raise TypeError
+        raise TypeError("Unable to serialize %r (type: %s)" % (data, type(data)))
 
     def loads(self, s):
         try:


### PR DESCRIPTION
Instead of raising a bare TypeError, let the user know where it went wrong.
