### PR TITLE
Issue #46: Encode unicode strings to UTF-8 bytes

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -43,6 +43,8 @@ class Urllib3HttpConnection(Connection):
             kw = {}
             if timeout:
                 kw['timeout'] = timeout
+            if isinstance(body, (type(u''))):
+                body = body.encode('utf-8')
             response = self.pool.urlopen(method, url, body, **kw)
             duration = time.time() - start
             raw_data = response.data.decode('utf-8')


### PR DESCRIPTION
The solution proposed in the patch works well for me. When a Unicode string is detected (which is left alone by the serializer before we end up here) it is encoded to UTF-8 to prevent encoding errors later on. Of course: this assumes the JSON is in UTF-8 format (which I think is a reasonable assumption when passing Unicode strings).

An alternative to this would be to try encoding to iso-latin-1 first and then to utf-8 failing that, but I see no advantage in doing that.
