### PR TITLE
fixes https://github.com/elasticsearch/elasticsearch-py/issues/62

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -363,7 +363,8 @@ class Elasticsearch(object):
 
     @query_params('_source', '_source_exclude', '_source_include',
         'analyze_wildcard', 'analyzer', 'default_operator', 'df',
-        'explain', 'fields', 'ignore_indices', 'indices_boost', 'lenient',
+        'explain', 'fields', 'indices_boost', 'lenient',
+        'allow_no_indices', 'expand_wildcards', 'ignore_unavailable',
         'lowercase_expanded_terms', 'from_', 'preference', 'q', 'routing',
         'scroll', 'search_type', 'size', 'sort', 'source', 'stats',
         'suggest_field', 'suggest_mode', 'suggest_size', 'suggest_text', 'timeout',
@@ -394,11 +395,16 @@ class Elasticsearch(object):
         :arg explain: Specify whether to return detailed information about
             score computation as part of a hit
         :arg fields: A comma-separated list of fields to return as part of a hit
-        :arg ignore_indices: When performed on multiple indices, allows to
-            ignore `missing` ones (default: none)
         :arg indices_boost: Comma-separated list of index boosts
         :arg lenient: Specify whether format-based query failures (such as
             providing text to a numeric field) should be ignored
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to concrete
+            indices that are open, closed or both., default 'open'
+        :arg ignore_unavailable: Whether specified concrete indices should be
+            ignored when unavailable (missing or closed)
         :arg lowercase_expanded_terms: Specify whether query terms should be lowercased
         :arg from_: Starting offset (default: 0)
         :arg preference: Specify the node or shard the operation should be
@@ -523,7 +529,7 @@ class Elasticsearch(object):
         _, data = self.transport.perform_request('DELETE', _make_path(index, doc_type, id), params=params)
         return data
 
-    @query_params('ignore_indices', 'min_score', 'preference', 'q', 'routing', 'source')
+    @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable', 'min_score', 'preference', 'q', 'routing', 'source')
     def count(self, index=None, doc_type=None, body=None, params=None):
         """
         Execute a query and get the number of matches for that query.
@@ -532,8 +538,13 @@ class Elasticsearch(object):
         :arg index: A comma-separated list of indices to restrict the results
         :arg doc_type: A comma-separated list of types to restrict the results
         :arg body: A query to restrict the results (optional)
-        :arg ignore_indices: When performed on multiple indices, allows to
-            ignore `missing` ones (default: none)
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to concrete
+            indices that are open, closed or both., default 'open'
+        :arg ignore_unavailable: Whether specified concrete indices should be
+            ignored when unavailable (missing or closed)
         :arg min_score: Include only documents with a specific `_score` value in the result
         :arg preference: Specify the node or shard the operation should be
             performed on (default: random)
@@ -586,7 +597,7 @@ class Elasticsearch(object):
             params=params, body=self._bulk_body(body))
         return data
 
-    @query_params('consistency', 'ignore_indices', 'replication', 'routing', 'source', 'timeout', 'q')
+    @query_params('consistency', 'allow_no_indices', 'expand_wildcards', 'ignore_unavailable', 'replication', 'routing', 'source', 'timeout', 'q')
     def delete_by_query(self, index, doc_type=None, body=None, params=None):
         """
         Delete documents from one or more indices and one or more types based on a query.
@@ -596,8 +607,13 @@ class Elasticsearch(object):
         :arg doc_type: A comma-separated list of types to restrict the operation
         :arg body: A query to restrict the operation
         :arg consistency: Specific write consistency setting for the operation
-        :arg ignore_indices: When performed on multiple indices, allows to
-            ignore `missing` ones (default: none)
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to concrete
+            indices that are open, closed or both., default 'open'
+        :arg ignore_unavailable: Whether specified concrete indices should be
+            ignored when unavailable (missing or closed)
         :arg replication: Specific replication type (default: sync)
         :arg routing: Specific routing value
         :arg source: The URL-encoded query definition (instead of using the request body)
@@ -608,7 +624,7 @@ class Elasticsearch(object):
             params=params, body=body)
         return data
 
-    @query_params('ignore_indices', 'preference', 'routing', 'source')
+    @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable', 'preference', 'routing', 'source')
     def suggest(self, body, index=None, params=None):
         """
         The suggest feature suggests similar looking terms based on a provided
@@ -618,8 +634,13 @@ class Elasticsearch(object):
         :arg index: A comma-separated list of index names to restrict the operation;
             use `_all` or empty string to perform the operation on all indices
         :arg body: The request definition
-        :arg ignore_indices: When performed on multiple indices, allows to
-            ignore `missing` ones (default: none)
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to concrete
+            indices that are open, closed or both., default 'open'
+        :arg ignore_unavailable: Whether specified concrete indices should be
+            ignored when unavailable (missing or closed)
         :arg preference: Specify the node or shard the operation should be
             performed on (default: random)
         :arg routing: Specific routing value


### PR DESCRIPTION
the parameter `ignore_indices` was replaced with `ignore_unavailable`, `expand_wildcards` and `allow_no_indices`.
see https://github.com/elasticsearch/elasticsearch/commit/f4bf0d5112b5c6f29b651586d72c3972db5a2834

elasticsearch-py still uses the not supported `ignore_indices`-parameter.
