### PR TITLE
refer to README instead of README.rst in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ VERSION = (1, 0, 1)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 
-f = open(join(dirname(__file__), 'README.rst'))
+f = open(join(dirname(__file__), 'README'))
 long_description = f.read().strip()
 f.close()
 


### PR DESCRIPTION
This fixes #64. Not quite sure why exactly to be honest, but referring to the README symlink instead of README.rst fixes easy_install choking when trying to install elasticsearch-py.
