### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Example Usage
 
 .. testcode::
 
+    from datetime import datetime
     from elasticsearch import Elasticsearch
     es = Elasticsearch()
 


### PR DESCRIPTION
The missing import is already in the `.. testsetup::` however that block is not shown at http://elasticsearch-py.readthedocs.org/en/master/#python-elasticsearch-client. Not sure what's wrong, nevertheless one does not simply yank the example and go. 
