### PR TITLE
Add segment cat api

### DIFF
--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -192,6 +192,25 @@ class CatClient(NamespacedClient):
         _, data = self.transport.perform_request('GET', _make_path('_cat',
             'shards', index), params=params)
         return data
+
+    @query_params('h', 'help', 'local', 'master_timeout', 'v')
+    def segments(self, index=None, params=None):
+        """
+        The segments command is the detailed view of Lucene segments per index.
+
+        :arg index: A comma-separated list of index names to limit the returned
+            information
+        :arg h: Comma-separated list of column names to display
+        :arg help: Return help information, default False
+        :arg local: Return local information, do not retrieve the state from
+            master node (default: false)
+        :arg master_timeout: Explicit operation timeout for connection to master
+            node
+        :arg v: Verbose mode. Display column headers, default False    
+        """
+        _, data = self.transport.perform_request('GET', _make_path('_cat',
+            'segments', index), params=params)
+        return data
     
     @query_params('h', 'help', 'local', 'master_timeout', 'v')
     def pending_tasks(self, params=None):


### PR DESCRIPTION
Hi, the segments() wrapper for the cat API is implemented here.
I didn't find the explicit documentation on www.elasticsearch.org on the _cat/segments endpoint but it is straightforward if you look at :

curl 'localhost:9200/_cat/segments?help'
curl 'localhost:9200/_cat/segments?v'

Cheers,

-- Mathieu
