### PR TITLE
Call to _make_path from indices.put_mapping was passing parameters in the wrong order

### DIFF
--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -229,7 +229,7 @@ class IndicesClient(NamespacedClient):
         :arg master_timeout: Specify timeout for connection to master
         :arg timeout: Explicit operation timeout
         """
-        _, data = self.transport.perform_request('PUT', _make_path(index, '_mapping', doc_type),
+        _, data = self.transport.perform_request('PUT', _make_path(index, doc_type, '_mapping'),
             params=params, body=body)
         return data
 


### PR DESCRIPTION
...hence trying to put a mapping to index/_mapping/doc_type, instead of index/doc_type/_mapping.
