### PR TITLE
Add relative imports so 1.0 and 0.9x can co-exist.

### DIFF
--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -4,12 +4,12 @@ VERSION = (1, 0, 1)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 
-from elasticsearch.client import Elasticsearch
-from elasticsearch.transport import Transport
-from elasticsearch.connection_pool import ConnectionPool, ConnectionSelector, \
+from .client import Elasticsearch
+from .transport import Transport
+from .connection_pool import ConnectionPool, ConnectionSelector, \
     RoundRobinSelector
-from elasticsearch.serializer import JSONSerializer
-from elasticsearch.connection import Connection, RequestsHttpConnection, \
+from .serializer import JSONSerializer
+from .connection import Connection, RequestsHttpConnection, \
     Urllib3HttpConnection, MemcachedConnection, ThriftConnection
-from elasticsearch.exceptions import *
+from .exceptions import *
 

--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -1,8 +1,8 @@
 from itertools import islice
 from operator import methodcaller
 
-from elasticsearch.exceptions import ElasticsearchException
-from elasticsearch.compat import map
+from ..exceptions import ElasticsearchException
+from ..compat import map
 
 class BulkIndexError(ElasticsearchException):
     @property


### PR DESCRIPTION
I understand that to use the ES client with a 0.9x ES install, you need to use a different branch than with the 1.x.   However, when migrating an index from 0.9x to 1.x, it would be really helpful to support having both branches available to you using different folder/module names. 

The two libraries can co-exist in different folder names as long as you change certain imports to relative imports. I've made that change here.
