### PR TITLE
Use simplejson if present instead of the stdlib json module.

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -1,5 +1,8 @@
 import logging
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 from ..exceptions import TransportError, HTTP_EXCEPTIONS
 

--- a/elasticsearch/connection/memcached.py
+++ b/elasticsearch/connection/memcached.py
@@ -1,5 +1,8 @@
 import time
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 from ..exceptions import TransportError, ConnectionError, ImproperlyConfigured
 from ..compat import urlencode

--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -1,4 +1,7 @@
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 from datetime import date, datetime
 from decimal import Decimal
 


### PR DESCRIPTION
This pull request updates the client to use the simplejson parser if it is available, and falls back on the standard python JSON parser. (This is fairly idiomatic usage.) The simplejson module is drop-in compatible.

Our use case for this is reindexing, which was CPU bound on python. We see a 3-4x speed improvement with these changes.
