### PR TITLE
Fix #6607 Scroll throws 403 Forbidden on read-only ES

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -552,7 +552,7 @@ class Elasticsearch(object):
         :arg scroll: Specify how long a consistent view of the index should be
             maintained for scrolled search
         """
-        _, data = self.transport.perform_request('POST', _make_path('_search', 'scroll'),
+        _, data = self.transport.perform_request('GET', _make_path('_search', 'scroll'),
             params=params, body=scroll_id)
         return data
 


### PR DESCRIPTION
Modified POST to GET according ES documentation.
See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-scroll.html
