### PR TITLE
Convert timeout to a float instead of a string

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -39,7 +39,7 @@ class Urllib3HttpConnection(Connection):
         try:
             kw = {}
             if timeout:
-                kw['timeout'] = timeout
+                kw['timeout'] = float(timeout)
             headers = self.headers.copy()
             if body:
                 headers['content-length'] = str(len(body))


### PR DESCRIPTION
The "request_timeout" argument gets converted to a string here in the utils._escape function :  https://github.com/elasticsearch/elasticsearch-py/blob/c112399631a9bfb8517f1483051c5ba5510951e6/elasticsearch/client/utils.py#L62

Later, "request_timeout" gets popped and passed into def perform_request() as the "timeout" argument, still as a string, leading to a type error. -- The "timeout" kwarg expects a float.

casting to a float() seems to fix it.
