### PR TITLE
Use yajl library if present. boost performance when serialize or deserialize objects

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -1,8 +1,11 @@
 import logging
 try:
-    import simplejson as json
+    import yajl as json
 except ImportError:
-    import json
+    try:
+        import simplejson as json
+    except ImportError:
+        import json
 
 from ..exceptions import TransportError, HTTP_EXCEPTIONS
 

--- a/elasticsearch/connection/memcached.py
+++ b/elasticsearch/connection/memcached.py
@@ -1,8 +1,11 @@
 import time
 try:
-    import simplejson as json
+    import yajl as json
 except ImportError:
-    import json
+    try:
+        import simplejson as json
+    except ImportError:
+        import json
 
 from ..exceptions import TransportError, ConnectionError, ImproperlyConfigured
 from ..compat import urlencode

--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -1,7 +1,10 @@
 try:
-    import simplejson as json
+    import yajl as json
 except ImportError:
-    import json
+    try:
+        import simplejson as json
+    except ImportError:
+        import json
 from datetime import date, datetime
 from decimal import Decimal
 


### PR DESCRIPTION
This library increse more than 100% performance when serialize or deserialize objects from elasticsearch resquest.
