### PR TITLE
Add ThriftpyConnection module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   # different connection classes to test
   - TEST_ES_CONNECTION=Urllib3HttpConnection
   - TEST_ES_CONNECTION=RequestsHttpConnection
+  - TEST_ES_CONNECTION=ThriftpyConnection
 
 install:
   - mkdir /tmp/elasticsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - pip install .
 
 before_script:
+  - if [[ $TEST_ES_CONNECTION == 'ThriftpyConnection' ]]; then /tmp/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-transport-thrift/2.3.0; fi
   - /tmp/elasticsearch/bin/elasticsearch -d -D es.path.data=/tmp -D es.gateway.type=none -D es.index.store.type=memory -D es.discovery.zen.ping.multicast.enabled=false -Des.node.bench=true
 
 script:

--- a/elasticsearch/connection/__init__.py
+++ b/elasticsearch/connection/__init__.py
@@ -3,3 +3,4 @@ from .http_requests import RequestsHttpConnection
 from .http_urllib3 import Urllib3HttpConnection
 from .memcached import MemcachedConnection
 from .thrift import ThriftConnection, THRIFT_AVAILABLE
+from .thriftpy import ThriftpyConnection, THRIFTPY_AVAILABLE

--- a/elasticsearch/connection/elasticsearch.thrift
+++ b/elasticsearch/connection/elasticsearch.thrift
@@ -1,0 +1,81 @@
+namespace java org.elasticsearch.thrift
+namespace csharp ElasticSearch.Thrift
+namespace cpp  elasticsearch.thrift
+namespace rb ElasticSearch.Thrift
+namespace py elasticsearch
+namespace perl Elasticsearch
+namespace php Elasticsearch
+
+enum Method {
+    GET = 0,
+    PUT = 1,
+    POST = 2,
+    DELETE = 3,
+    HEAD = 4,
+    OPTIONS = 5
+}
+
+struct RestRequest {
+    1: required Method method,
+    2: required string uri
+    3: optional map<string, string> parameters
+    4: optional map<string, string> headers
+    5: optional binary body
+}
+
+enum Status {
+    CONT = 100,
+    SWITCHING_PROTOCOLS = 101,
+    OK = 200,
+    CREATED = 201,
+    ACCEPTED = 202,
+    NON_AUTHORITATIVE_INFORMATION = 203,
+    NO_CONTENT = 204,
+    RESET_CONTENT = 205,
+    PARTIAL_CONTENT = 206,
+    MULTI_STATUS = 207,
+    MULTIPLE_CHOICES = 300,
+    MOVED_PERMANENTLY = 301,
+    FOUND = 302,
+    SEE_OTHER = 303,
+    NOT_MODIFIED = 304,
+    USE_PROXY = 305,
+    TEMPORARY_REDIRECT = 307,
+    BAD_REQUEST = 400,
+    UNAUTHORIZED = 401,
+    PAYMENT_REQUIRED = 402,
+    FORBIDDEN = 403,
+    NOT_FOUND = 404,
+    METHOD_NOT_ALLOWED = 405,
+    NOT_ACCEPTABLE = 406,
+    PROXY_AUTHENTICATION = 407,
+    REQUEST_TIMEOUT = 408,
+    CONFLICT = 409,
+    GONE = 410,
+    LENGTH_REQUIRED = 411,
+    PRECONDITION_FAILED = 412,
+    REQUEST_ENTITY_TOO_LARGE = 413,
+    REQUEST_URI_TOO_LONG = 414,
+    UNSUPPORTED_MEDIA_TYPE = 415,
+    REQUESTED_RANGE_NOT_SATISFIED = 416,
+    EXPECTATION_FAILED = 417,
+    UNPROCESSABLE_ENTITY = 422,
+    LOCKED = 423,
+    FAILED_DEPENDENCY = 424,
+    INTERNAL_SERVER_ERROR = 500,
+    NOT_IMPLEMENTED = 501,
+    BAD_GATEWAY = 502,
+    SERVICE_UNAVAILABLE = 503,
+    GATEWAY_TIMEOUT = 504,
+    INSUFFICIENT_STORAGE = 506
+}
+
+struct RestResponse {
+    1: required Status status,
+    2: optional map<string, string> headers,
+    3: optional binary body
+}
+
+service Rest {
+    RestResponse execute(1:required RestRequest request)
+}

--- a/elasticsearch/connection/thriftpy.py
+++ b/elasticsearch/connection/thriftpy.py
@@ -24,7 +24,7 @@ __all__ = ('THRIFT_FILE', 'THRIFTPY_AVAILABLE', 'ThriftpyConnection')
 
 
 class ThriftpyConnection(PoolingConnection):
-    transport_schema = 'thriftpy'
+    transport_schema = 'thrift'
 
     def __init__(self, host='localhost', port=9500, **kwargs):
         super(ThriftpyConnection, self).__init__(

--- a/elasticsearch/connection/thriftpy.py
+++ b/elasticsearch/connection/thriftpy.py
@@ -6,7 +6,7 @@ import os
 import time
 from socket import timeout as SocketTimeout
 
-THRIFT_FILE = os.path.join(os.dirname(__file__), 'elasticsearch.thrift')
+THRIFT_FILE = os.path.join(os.path.dirname(__file__), 'elasticsearch.thrift')
 
 try:
     import thriftpy

--- a/elasticsearch/connection/thriftpy.py
+++ b/elasticsearch/connection/thriftpy.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+
+import os
+import time
+from socket import timeout as SocketTimeout
+
+THRIFT_FILE = os.path.join(os.dirname(__file__), 'elasticsearch.thrift')
+
+try:
+    import thriftpy
+    from thriftpy.thrift import TException
+    from thriftpy.rpc import make_client
+    _t = thriftpy.load(THRIFT_FILE, module_name="elasticsearch_thrift")
+    THRIFTPY_AVAILABLE = True
+except ImportError:
+    THRIFTPY_AVAILABLE = False
+
+from ..exceptions import ConnectionError
+from .pooling import PoolingConnection
+
+__all__ = ('THRIFT_FILE', 'THRIFTPY_AVAILABLE', 'ThriftpyConnection')
+
+
+class ThriftpyConnection(PoolingConnection):
+    transport_schema = 'thriftpy'
+
+    def __init__(self, host='localhost', port=9500, **kwargs):
+        super(ThriftpyConnection, self).__init__(
+            host=host, port=port, **kwargs
+        )
+        self._tsocket_host = host
+        self._tsocket_port = port
+
+    def _make_connection(self):
+        client = make_client(
+            _t.Rest, self._tsocket_host, self._tsocket_port,
+            timeout=self.timeout * 1000.0
+        )
+        return client
+
+    def perform_request(self, method, url, params=None, body=None,
+                        timeout=None, ignore=()):
+
+        request = _t.RestRequest(
+            method=_t.Method._NAMES_TO_VALUES[method.upper()],
+            uri=url, parameters=params, body=body
+        )
+
+        start = time.time()
+        tclient = None
+        try:
+            tclient = self._get_connection()
+            response = tclient.execute(request)
+            duration = time.time() - start
+        except (TException, SocketTimeout) as e:
+            self.log_request_fail(
+                method, url, body, time.time() - start, exception=e
+            )
+            raise ConnectionError('N/A', str(e), e)
+        finally:
+            if tclient:
+                self._release_connection(tclient)
+
+        code = response.status
+        if not (200 <= code < 300) and code not in ignore:
+            self.log_request_fail(method, url, body, duration, code)
+            self._raise_error(code, response.body)
+
+        self.log_request_success(
+            method, url, url, body, code, response.body, duration
+        )
+
+        headers = {}
+        if response.headers:
+            headers = dict((k.lower(), v) for k, v in response.headers.items())
+        return code, headers, response.body or ''

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ tests_require = [
     'nosexcover'
 ]
 
+if os.environ.get('TEST_ES_CONNECTION', None) == 'ThriftpyConnection':
+    tests_require.append('thriftpy')
+
 # use external unittest for 2.6
 if sys.version_info[:2] == (2, 6):
     install_requires.append('unittest2')
@@ -35,14 +38,14 @@ if sys.version_info[0] == 2:
     tests_require.append('pylibmc==1.2.3')
 
 setup(
-    name = 'elasticsearch',
-    description = "Python client for Elasticsearch",
+    name='elasticsearch',
+    description="Python client for Elasticsearch",
     license="Apache License, Version 2.0",
-    url = "https://github.com/elasticsearch/elasticsearch-py",
-    long_description = long_description,
-    version = __versionstr__,
-    author = "Honza Král",
-    author_email = "honza.kral@gmail.com",
+    url="https://github.com/elasticsearch/elasticsearch-py",
+    long_description=long_description,
+    version=__versionstr__,
+    author="Honza Král",
+    author_email="honza.kral@gmail.com",
     packages=find_packages(
         where='.',
         exclude=('test_elasticsearch*', )

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -4,9 +4,11 @@ import urllib3
 
 from elasticsearch.exceptions import TransportError, ConflictError, RequestError, NotFoundError
 from elasticsearch.connection import RequestsHttpConnection, \
-    Urllib3HttpConnection, THRIFT_AVAILABLE, ThriftConnection
+    Urllib3HttpConnection, THRIFT_AVAILABLE, ThriftConnection, \
+    THRIFTPY_AVAILABLE, ThriftpyConnection
 
 from .test_cases import TestCase, SkipTest
+
 
 class TestThriftConnection(TestCase):
     def setUp(self):
@@ -27,6 +29,18 @@ class TestThriftConnection(TestCase):
     def test_timeout_set(self):
         con = ThriftConnection(timeout=42)
         self.assertEquals(42, con.timeout)
+
+
+class TestThriftpyConnection(TestCase):
+    def setUp(self):
+        if not THRIFTPY_AVAILABLE:
+            raise SkipTest('Thriftpy is not available.')
+        super(TestThriftpyConnection, self).setUp()
+
+    def test_timeout_set(self):
+        con = ThriftpyConnection(timeout=42)
+        self.assertEquals(42, con.timeout)
+
 
 class TestUrllib3Connection(TestCase):
     def test_timeout_set(self):

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from mock import Mock, patch
 import urllib3
 
@@ -33,6 +34,8 @@ class TestThriftConnection(TestCase):
 
 class TestThriftpyConnection(TestCase):
     def setUp(self):
+        if sys.version_info[:2] == (2, 6):
+            raise SkipTest('Thriftpy is not available.')
         if not THRIFTPY_AVAILABLE:
             raise SkipTest('Thriftpy is not available.')
         super(TestThriftpyConnection, self).setUp()


### PR DESCRIPTION
This module depends on thriftpy, which is a pure python implementation
for Thrift. It supports:

1. Python2.7+, including Python3.3 and Python3.4
2. pypy and pypy3