### PR TITLE
set propagate=False on elasticsearch.trace only if logger not already co...

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,8 +136,8 @@ two loggers: ``elasticsearch`` and ``elasticsearch.trace``. ``elasticsearch``
 is used by the client to log standard activity, depending on the log level.
 ``elasticsearch.trace`` can be used to log requests to the server in the form
 of ``curl`` commands using pretty-printed json that can then be executed from
-command line. The trace logger doesn't inherit from the base one - it needs to
-be activated separately.
+command line. If the trace logger has not been configured already it is set to
+`propagate=False` so it needs to be activated separately.
 
 .. _logging library: http://docs.python.org/3.3/library/logging.html
 

--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -7,8 +7,16 @@ except ImportError:
 from ..exceptions import TransportError, HTTP_EXCEPTIONS
 
 logger = logging.getLogger('elasticsearch')
+
+# create the elasticsearch.trace logger, but only set propagate to False if the
+# logger hasn't already been configured
+_tracer_already_configured = False
+if 'elasticsearch.trace' in logging.Logger.manager.loggerDict:
+    _tracer_already_configured = True
 tracer = logging.getLogger('elasticsearch.trace')
-tracer.propagate = False
+if not _tracer_already_configured:
+    tracer.propagate = False
+
 
 class Connection(object):
     """


### PR DESCRIPTION
...nfigured

Currently elasticsearch is setting `propagate = False` on `elasticsearch.trace` when I've already specifically configured it to be `True`, after this change `propagate = False` will only be set when there's no prior configuration.
