### PR TITLE
Fix/round robin zero division

### DIFF
--- a/elasticsearch/connection_pool.py
+++ b/elasticsearch/connection_pool.py
@@ -60,8 +60,11 @@ class RoundRobinSelector(ConnectionSelector):
 
     def select(self, connections):
         self.rr += 1
-        self.rr %= len(connections)
-        return connections[self.rr]
+        try:
+            self.rr %= len(connections)
+            return connections[self.rr]
+        except ZeroDivisionError:
+            return
 
 
 class ConnectionPool(object):

--- a/test_elasticsearch/test_connection_pool.py
+++ b/test_elasticsearch/test_connection_pool.py
@@ -16,9 +16,10 @@ class TestConnectionPool(TestCase):
     def test_zero_division_round_robin_selector(self):
         try:
             pool = ConnectionPool([])
-            pool.selector.select(pool.connections)
+            connection = pool.get_connection()
         except ZeroDivisionError:
             self.fail("The ConnectionPool throwed a ZeroDivisionError.")
+        self.assertEqual(connection, None)
 
     def test_disable_shuffling(self):
         pool = ConnectionPool([(x, {}) for x in range(100)], randomize_hosts=False)


### PR DESCRIPTION
Hi,
I stumbled upon a `ZeroDivisionError` raised by the `connection_pool.RoundRobinSelector`.
I am not sure exactly how it happened but i was testing my apps fall-backs so elasticsearch was not running at the time.
This pull request only fix the `ZeroDivisionError`, but obviously whatever class that use the connection doesn't like a None value and throws an AttributeError, but I am not familiar enough with the code to know if the `ConnectionError` should be raised in get_connection or directly in `RoundRobinSelector`, or what message to use.
