### PR TITLE
fix Elasticsearch.index with id=0

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -252,7 +252,8 @@ class Elasticsearch(object):
         for param in (index, doc_type, body):
             if param in SKIP_IN_PATH:
                 raise ValueError("Empty value passed for a required argument.")
-        _, data = self.transport.perform_request('PUT' if id else 'POST',
+        method = 'POST' if id is None else 'PUT'
+        _, data = self.transport.perform_request(method,
             _make_path(index, doc_type, id), params=params, body=body)
         return data
 


### PR DESCRIPTION
Previously, `id=0` triggered a POST rather than a PUT to id 0 because 0 is false in Python.
