### PR TITLE
Fixes issue introduced in 482f166 where the tracer spams when

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -12,7 +12,8 @@ logger = logging.getLogger('elasticsearch')
 # logger hasn't already been configured
 _tracer_already_configured = 'elasticsearch.trace' in logging.Logger.manager.loggerDict
 tracer = logging.getLogger('elasticsearch.trace')
-tracer.propagate = not _tracer_already_configured
+if not _tracer_already_configured:
+    tracer.propagate = False
 
 
 class Connection(object):


### PR DESCRIPTION
unconfigured.

In the aforementioned commit, the existing behavior was changed,
I believe in advertantly, to set propagate to False if the
trace logger already has been configured. This seems to be the
opposite of the internet, and this change restores what appears
to have been the intent, and silences the tracer unless
it has been configured, in which case it will propagate.