### PR TITLE
datetime.time support for JSONSerializer

### DIFF
--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -2,7 +2,7 @@ try:
     import simplejson as json
 except ImportError:
     import json
-from datetime import date, datetime
+from datetime import date, time
 from decimal import Decimal
 
 from .exceptions import SerializationError, ImproperlyConfigured
@@ -24,7 +24,7 @@ class JSONSerializer(object):
     mimetype = 'application/json'
 
     def default(self, data):
-        if isinstance(data, (date, datetime)):
+        if isinstance(data, (date, time)):
             return data.isoformat()
         elif isinstance(data, Decimal):
             return float(data)

--- a/test_elasticsearch/test_serializer.py
+++ b/test_elasticsearch/test_serializer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from datetime import datetime
+from datetime import datetime, time
 from decimal import Decimal
 
 from elasticsearch.serializer import JSONSerializer, Deserializer, DEFAULT_SERIALIZERS, TextSerializer
@@ -9,7 +9,11 @@ from elasticsearch.exceptions import SerializationError, ImproperlyConfigured
 
 from .test_cases import TestCase, SkipTest
 
+
 class TestJSONSerializer(TestCase):
+    def test_time_serialization(self):
+        self.assertEqual('{"t": "02:03:45"}', JSONSerializer().dumps({'t': time(2, 3, 45)}))
+
     def test_datetime_serialization(self):
         self.assertEquals('{"d": "2010-10-01T02:30:00"}', JSONSerializer().dumps({'d': datetime(2010, 10, 1, 2, 30)}))
 


### PR DESCRIPTION
datetime.datetime is subclass of datetime.date class.
This PR is adding support for serializing datetime.time objects.  

datetime.time.isoformat() is returning time in same ISO 8601 as datetime.datetime.isoformat() method does.