### PR TITLE
use now() instead of fixed time

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,7 +46,7 @@ Example Usage
     doc = {
         'author': 'kimchy', 
         'text': 'Elasticsearch: cool. bonsai cool.', 
-        'timestamp': datetime(2010, 10, 10, 10, 10, 10)
+        'timestamp': datetime.now(),
     }
     res = es.index(index="test-index", doc_type='tweet', id=1, body=doc)
     print(res['created'])


### PR DESCRIPTION
took me a few minutes to figure out why the doc i just added didn't show up in kibana. a more recent timestamp may be friendlier for beginners

unless it's fixed in the past for a reason?
