### PR TITLE
Regex to allow hostnames as well as IP addresses

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -8,8 +8,11 @@ from .serializer import JSONSerializer, Deserializer, DEFAULT_SERIALIZERS
 from .exceptions import ConnectionError, TransportError, SerializationError, \
                         ConnectionTimeout, ImproperlyConfigured
 
-# get host/ip and port from "inet[wind/127.0.0.1:9200]" or "inet[127.0.0.1:9200"
-ADDRESS_RE = re.compile(r'(?P<host>[-a-zA-Z0-9\.]+(?=/[\.:0-9a-f]*:)|(?<=/)[\.:0-9a-f]*)[^:]*:(?P<port>[0-9]+)\]?$')
+# get host/ip and port from one of the following format:
+#   "inet[wind/127.0.0.1:9200]"
+#   "inet[/127.0.0.1:9200]"
+#   "127.0.0.1:9200"
+ADDRESS_RE = re.compile(r'(?P<host>[-a-zA-Z0-9\.]+(?=/[\.:0-9a-f]*:)|(?<=/)[\.:0-9a-f]+|^[\.:0-9a-f]+)[^:]*:(?P<port>[0-9]+)\]?$')
 
 
 def get_host_info(node_info, host):

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -8,11 +8,21 @@ from .serializer import JSONSerializer, Deserializer, DEFAULT_SERIALIZERS
 from .exceptions import ConnectionError, TransportError, SerializationError, \
                         ConnectionTimeout, ImproperlyConfigured
 
-# get host/ip and port from one of the following format:
-#   "inet[wind/127.0.0.1:9200]"
-#   "inet[/127.0.0.1:9200]"
+# strip out square brackets if exist, e.g.:
+#   "inet[wind/127.0.0.1:9200]"  ->  "wind/127.0.0.1:9200"
+#   "inet[/127.0.0.1:9200]"      ->  "/127.0.0.1:9200"
+#   "127.0.0.1:9200"             ->  "127.0.0.1:9200"  (untouched)
+ADDRESS_RE_GET_FULLADDR = re.compile(r'(?<=\[).+(?=\])|^[^\[\]]+$')
+
+# find hostname in format: 'wind/127.0.0.1:9200'
+ADDRESS_RE_GET_HOSTNAME = re.compile(r'^(?<!/)[-a-zA-Z0-9\.]+')
+
+# find host IP address and port number in on of the following format:
+#   "wind/127.0.0.1:9200"
+#   "/127.0.0.1:9200"
 #   "127.0.0.1:9200"
-ADDRESS_RE = re.compile(r'(?P<host>[-a-zA-Z0-9\.]+(?=/[\.:0-9a-f]*:)|(?<=/)[\.:0-9a-f]+|^[\.:0-9a-f]+)[^:]*:(?P<port>[0-9]+)\]?$')
+ADDRESS_RE_GET_HOSTIP = re.compile(r'[\.:0-9a-f]+(?=:)')
+ADDRESS_RE_GET_PORT = re.compile(r'(?<=:)[0-9]+$')
 
 
 def get_host_info(node_info, host):
@@ -223,13 +233,27 @@ class Transport(object):
         hosts = []
         address = self.connection_class.transport_schema + '_address'
         for n in node_info['nodes'].values():
-            match = ADDRESS_RE.search(n.get(address, ''))
+            match = ADDRESS_RE_GET_FULLADDR.search(n.get(address, ''))
             if not match:
                 continue
 
-            host = match.groupdict()
-            if 'port' in host:
-                host['port'] = int(host['port'])
+            address = match.group()
+            match_hostname = ADDRESS_RE_GET_HOSTNAME.search(address)
+            match_hostip = ADDRESS_RE_GET_HOSTIP.search(address)
+            match_port = ADDRESS_RE_GET_PORT.search(address)
+
+            host = {}
+            if match_port:
+                host['port'] = int(match_port.group())
+
+            # prefer to use host name, use IP if hostname not found
+            if match_hostname:
+                host['host'] = match_hostname.group()
+            elif match_hostip:
+                host['host'] = match_hostip.group()
+            else:
+                continue
+
             host = self.host_info_callback(n, host)
             if host is not None:
                 hosts.append(host)

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -8,8 +8,8 @@ from .serializer import JSONSerializer, Deserializer, DEFAULT_SERIALIZERS
 from .exceptions import ConnectionError, TransportError, SerializationError, \
                         ConnectionTimeout, ImproperlyConfigured
 
-# get ip/port from "127.0.0.1:9200"
-ADDRESS_RE = re.compile(r'^(?P<host>[\.:0-9a-f]*):(?P<port>[0-9]+)?$')
+# get host/ip and port from "inet[wind/127.0.0.1:9200]" or "inet[127.0.0.1:9200"
+ADDRESS_RE = re.compile(r'(?P<host>[-a-zA-Z0-9\.]+(?=/[\.:0-9a-f]*:)|(?<=/)[\.:0-9a-f]*)[^:]*:(?P<port>[0-9]+)\]?$')
 
 
 def get_host_info(node_info, host):


### PR DESCRIPTION
I have modified the regex to support obtaining "host.name.com" from '/_nodes/_all/clear' when using elasticsearch's sniff functionality.

e.g.
"http_address":"inet[host.name.com/1.2.3.4:443]"

I needed this because I am using a wildcard SSL certificate behind an nginx proxy and the current implementation produces:

SSLError: ConnectionError(hostname u'1.2.3.4' doesn't match either of '*.name.com', 'name.com') caused by: SSLError(hostname u'1.2.3.4' doesn't match either of '*.name.com', 'name.com')

Using this regex so the client uses the hostname to connect instead of the IP address solved my problem.