### PR TITLE
use GET method for count instead of POST

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -741,7 +741,7 @@ class Elasticsearch(object):
         if doc_type and not index:
             index = '_all'
 
-        _, data = self.transport.perform_request('POST', _make_path(index,
+        _, data = self.transport.perform_request('GET', _make_path(index,
             doc_type, '_count'), params=params, body=body)
         return data
 


### PR DESCRIPTION
As documented in the elasticsearch API, count should be requested as GET.

My motivation is a simple rule to protect my data: public requests deny any POST/PUT/DELETE requests. Count is a read-only operation but requests it's data via POST.