### PR TITLE
fixes issue on decoding str type body when logging on python3

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -55,7 +55,7 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        if body:
+        if body and isinstance(body, bytes):
             body = body.decode('utf-8')
 
         logger.info(
@@ -84,7 +84,7 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        if body:
+        if body and isinstance(body, bytes):
             body = body.decode('utf-8')
 
         logger.debug('> %s', body)


### PR DESCRIPTION
When using python3.5 an error is occured below
```
  File "<string>", line 3, in raise_exc_info
  File "/Users/leehyeon/.py3virtualenv/andong_api/lib/python3.5/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/Users/leehyeon/.py3virtualenv/andong_api/lib/python3.5/site-packages/tornado_elasticsearch.py", line 175, in perform_request
    ignore=ignore)
  File "/Users/leehyeon/.py3virtualenv/andong_api/lib/python3.5/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/Users/leehyeon/.py3virtualenv/andong_api/lib/python3.5/site-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
  File "/Users/leehyeon/.py3virtualenv/andong_api/lib/python3.5/site-packages/tornado/stack_context.py", line 314, in wrapped
    ret = fn(*args, **kwargs)
  File "/Users/leehyeon/.py3virtualenv/andong_api/lib/python3.5/site-packages/tornado_elasticsearch.py", line 91, in on_response
    response.code, response.body, duration)
  File "/Users/leehyeon/.py3virtualenv/andong_api/lib/python3.5/site-packages/elasticsearch/connection/base.py", line 59, in log_request_success
    body = body.decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```