### PR TITLE
docs: fix versioning typo

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Compatibility
 The library is compatible with all Elasticsearch versions since ``0.90.x`` but you
 **have to use a matching major version**:
 
-For **Elasticsearch 2.0** and later, use the major version 1 (``1.x.y``) of the
+For **Elasticsearch 2.0** and later, use the major version 2 (``2.x.y``) of the
 library.
 
 For **Elasticsearch 1.0** and later, use the major version 1 (``1.x.y``) of the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Compatibility
 The library is compatible with all Elasticsearch versions since ``0.90.x`` but you
 **have to use a matching major version**:
 
-For **Elasticsearch 2.0** and later, use the major version 1 (``1.x.y``) of the
+For **Elasticsearch 2.0** and later, use the major version 2 (``2.x.y``) of the
 library.
 
 For **Elasticsearch 1.0** and later, use the major version 1 (``1.x.y``) of the


### PR DESCRIPTION
For Elasticsearch 2.0, the major version should be 2, not 1.

Closes #284.