### PR TITLE
Renaming manpage to elasticsearch-py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,7 +228,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'elasticsearch', u'Elasticsearch Documentation',
+    ('index', 'elasticsearch-py', u'Elasticsearch Documentation',
      [u'Honza Král'], 1)
 ]
 


### PR DESCRIPTION
Currently elasticsearch-py installs the manpage as "elasticsearch" - that manpage should belong to elasticsearch itself.

before:
$ man elasticsearch

after:
$ man elasticsearch-py