### PR TITLE
Add bytes param to cat.shards and cat.segments

### DIFF
--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -175,7 +175,7 @@ class CatClient(NamespacedClient):
             'recovery', index), params=params)
         return data
 
-    @query_params('h', 'help', 'local', 'master_timeout', 'v')
+    @query_params('bytes', 'h', 'help', 'local', 'master_timeout', 'v')
     def shards(self, index=None, params=None):
         """
         The shards command is the detailed view of what nodes contain which shards.
@@ -183,6 +183,8 @@ class CatClient(NamespacedClient):
 
         :arg index: A comma-separated list of index names to limit the returned
             information
+        :arg bytes: The unit in which to display byte values, valid choices are:
+            'b', 'k', 'm', 'g'
         :arg h: Comma-separated list of column names to display
         :arg help: Return help information, default False
         :arg local: Return local information, do not retrieve the state from
@@ -195,7 +197,7 @@ class CatClient(NamespacedClient):
             'shards', index), params=params)
         return data
 
-    @query_params('h', 'help', 'v')
+    @query_params('bytes', 'h', 'help', 'v')
     def segments(self, index=None, params=None):
         """
         The segments command is the detailed view of Lucene segments per index.
@@ -203,6 +205,8 @@ class CatClient(NamespacedClient):
 
         :arg index: A comma-separated list of index names to limit the returned
             information
+        :arg bytes: The unit in which to display byte values, valid choices are:
+            'b', 'k', 'm', 'g'
         :arg h: Comma-separated list of column names to display
         :arg help: Return help information, default False
         :arg v: Verbose mode. Display column headers, default False


### PR DESCRIPTION
'bytes' appears to be a valid parameter for the shards and segments endpoints in the CAT API.
Would like to be able to specify this in the python functions.