### PR TITLE
Allow the hosts variable to be callable.

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -23,6 +23,10 @@ def _normalize_hosts(hosts):
     if hosts is None:
         return [{}]
 
+    # If we were given a callable, lets call it.
+    if callable(hosts):
+        hosts = hosts()
+
     # passed in just one string
     if isinstance(hosts, string_types):
         hosts = [hosts]


### PR DESCRIPTION
A minor feature request: When choosing which hosts to make a connection with, allow the variable to be callable so that it can calculated dynamically.

For better or worse, I use haystack on top of the elasticsearch client. Their system forces me to specify the connection URL in `settings.py` file. However, I would like to dynamically decide where to setup the elasticsearch connection, and I don't have sufficient information to do that in settings.py. Making the hosts variable callable will allow me to perform the necessary calculations when I'm setting up the connection, rather than statically in the `settings.py` file.