### PR TITLE
Forward kwargs from scan helper to scroll method as well.

### DIFF
--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -232,7 +232,9 @@ def parallel_bulk(client, actions, thread_count=4, chunk_size=500,
     pool.close()
     pool.join()
 
-def scan(client, query=None, scroll='5m', raise_on_error=True, preserve_order=False, **kwargs):
+def scan(client, query=None, scroll='5m', raise_on_error=True,
+        preserve_order=False, global_kwargs={}, search_kwargs=None,
+        scroll_kwargs=None, **kwargs):
     """
     Simple abstraction on top of the
     :meth:`~elasticsearch.Elasticsearch.scroll` api - a simple iterator that
@@ -254,6 +256,13 @@ def scan(client, query=None, scroll='5m', raise_on_error=True, preserve_order=Fa
         cause the scroll to paginate with preserving the order. Note that this
         can be an extremely expensive operation and can easily lead to
         unpredictable results, use with caution.
+    :arg global_kwargs: additional kwargs to be passed to both
+        :meth:`~elasticsearch.Elasticsearch.search` and to
+        :meth:`~elasticsearch.Elasticsearch.scroll`
+    :arg search_kwargs: additional kwargs to be passed to
+        :meth:`~elasticsearch.Elasticsearch.search`
+    :arg scroll_kwargs: additional kwargs to be passed to
+        :meth:`~elasticsearch.Elasticsearch.scroll`
 
     Any additional keyword arguments will be passed to the initial
     :meth:`~elasticsearch.Elasticsearch.search` call::
@@ -268,7 +277,10 @@ def scan(client, query=None, scroll='5m', raise_on_error=True, preserve_order=Fa
     if not preserve_order:
         kwargs['search_type'] = 'scan'
     # initial search
-    resp = client.search(body=query, scroll=scroll, **kwargs)
+    search_kwargs = search_kwargs or {}
+    search_kwargs.update(global_kwargs)
+    search_kwargs.update(kwargs)
+    resp = client.search(body=query, scroll=scroll, **search_kwargs)
 
     scroll_id = resp.get('_scroll_id')
     if scroll_id is None:
@@ -280,7 +292,9 @@ def scan(client, query=None, scroll='5m', raise_on_error=True, preserve_order=Fa
         if preserve_order and first_run:
             first_run = False
         else:
-            resp = client.scroll(scroll_id, scroll=scroll, **kwargs)
+            scroll_kwargs = scroll_kwargs or {}
+            scroll_kwargs.update(global_kwargs)
+            resp = client.scroll(scroll_id, scroll=scroll, **scroll_kwargs)
 
         for hit in resp['hits']['hits']:
             yield hit

--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -280,7 +280,7 @@ def scan(client, query=None, scroll='5m', raise_on_error=True, preserve_order=Fa
         if preserve_order and first_run:
             first_run = False
         else:
-            resp = client.scroll(scroll_id, scroll=scroll)
+            resp = client.scroll(scroll_id, scroll=scroll, **kwargs)
 
         for hit in resp['hits']['hits']:
             yield hit


### PR DESCRIPTION
### Description

I've called `elasticsearch.helpers.reindex` with a custom `request_timeout` present in both `scan_kwargs` and `bulk_kwargs`. But that's not sent down to `client.scroll` which would send it to `self.transport.perform_request` which would then use it.

The first call from `scan` helper does forward the `**kwargs`: `client.search(body=query, scroll=scroll, **kwargs)`, so I'd say `client.scroll` should as well. Because this wasn't happening, I eventually got a timeout near the end of a huge reindexing with the below output, even though I supplied a `request_timeout=600`.

``` bash
....
  File "/Users/andrei/.virtualenvs/genesis/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 342, in _change_doc_index
    for h in hits:
  File "/Users/andrei/.virtualenvs/genesis/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 283, in scan
    resp = client.scroll(scroll_id, scroll=scroll)
  File "/Users/andrei/.virtualenvs/genesis/lib/python2.7/site-packages/elasticsearch/client/utils.py", line 69, in _wrapped
    return func(*args, params=params, **kwargs)
  File "/Users/andrei/.virtualenvs/genesis/lib/python2.7/site-packages/elasticsearch/client/__init__.py", line 662, in scroll
    params=params, body=body)
  File "/Users/andrei/.virtualenvs/genesis/lib/python2.7/site-packages/elasticsearch/transport.py", line 307, in perform_request
    status, headers, data = connection.perform_request(method, url, params, body, ignore=ignore, timeout=timeout)
  File "/Users/andrei/.virtualenvs/genesis/lib/python2.7/site-packages/elasticsearch/connection/http_urllib3.py", line 86, in perform_request
    raise ConnectionTimeout('TIMEOUT', str(e), e)
elasticsearch.exceptions.ConnectionTimeout: ConnectionTimeout caused by - ReadTimeoutError(HTTPSConnectionPool(host='139f46bdca40404618dec7e5a8ecad29.us-east-1.aws.found.io', port=9243): Read timed out. (read timeout=10))
```
### Later edit

I saw the failing tests, `**kwargs` wasn't thought as being forwarded on `scroll`. And adding an inline case for forwarding only `request_timeout` there is a hack. But I was trying to make use of the fact that it's gonna be added to params in [here](https://github.com/elastic/elasticsearch-py/blob/799918712fc1136b82eacf24fc2a5860da2dadaa/elasticsearch/client/utils.py#L66). If there's an easy fix here I'd appreciate a suggestion though.
