### PR TITLE
Adding msearch_template to Elasticsearch client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ coverage.xml
 nosetests.xml
 junit-*.xml
 build
+.idea/
+.eggs/

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -798,6 +798,27 @@ class Elasticsearch(object):
             doc_type, '_msearch'), params=params, body=self._bulk_body(body))
         return data
 
+    @query_params('search_type')
+    def msearch_template(self, body, index=None, doc_type=None, params=None):
+        """
+        Execute several search template requests within the same API.
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html>`_
+
+        :arg body: The request definitions (metadata-search request definition
+            pairs), separated by newlines
+        :arg index: A comma-separated list of index names to use as default
+        :arg doc_type: A comma-separated list of document types to use as
+            default
+        :arg search_type: Search operation type, valid choices are:
+            'query_then_fetch', 'query_and_fetch', 'dfs_query_then_fetch',
+            'dfs_query_and_fetch', 'count', 'scan'
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+        _, data = self.transport.perform_request('GET', _make_path(index,
+            doc_type, '_msearch', 'template'), params=params, body=self._bulk_body(body))
+        return data
+
     @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable',
         'preference', 'routing')
     def suggest(self, body, index=None, params=None):

--- a/test_elasticsearch/test_client/__init__.py
+++ b/test_elasticsearch/test_client/__init__.py
@@ -78,3 +78,9 @@ class TestClient(ElasticsearchTestCase):
         self.client.index(index='my-index', doc_type='test-doc', id=0, body={})
 
         self.assert_url_called('PUT', '/my-index/test-doc/0')
+
+    def test_msearch_template(self):
+        body = '{"index":"i"}\n{"inline": "{\"query\": {\"match_{{template}}\": {}}}", "params": {"template": "all"}}\n'
+        self.client.msearch_template(body, index='i', doc_type='t')
+        calls = self.assert_url_called('GET', '/i/t/_msearch/template')
+        self.assertEquals([({}, body)], calls)


### PR DESCRIPTION
I added an end point call to /_msearch/template which is available since elasticsearch version 2.1.0 (see elastic/elasticsearch#12414).
Also added .idea and .eggs directories to .gitignore.
