### PR TITLE
Log response body for failed requests

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -75,7 +75,7 @@ class Connection(object):
         if tracer.isEnabledFor(logging.DEBUG):
             tracer.debug('#[%s] (%.3fs)\n#%s', status_code, duration, _pretty_json(response).replace('\n', '\n#') if response else '')
 
-    def log_request_fail(self, method, full_url, body, duration, status_code=None, exception=None):
+    def log_request_fail(self, method, full_url, body, duration, status_code=None, response=None, exception=None):
         """ Log an unsuccessful API call.  """
         logger.warning(
             '%s %s [status:%s request:%.3fs]', method, full_url,
@@ -88,6 +88,9 @@ class Connection(object):
             body = body.decode('utf-8')
 
         logger.debug('> %s', body)
+
+        if response:
+            logger.debug('< %s', response)
 
     def _raise_error(self, status_code, raw_data):
         """ Locate appropriate exception and raise it. """

--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -74,7 +74,7 @@ class RequestsHttpConnection(Connection):
 
         # raise errors based on http status codes, let the client handle those if needed
         if not (200 <= response.status_code < 300) and response.status_code not in ignore:
-            self.log_request_fail(method, url, body, duration, response.status_code)
+            self.log_request_fail(method, url, body, duration, response.status_code, raw_data)
             self._raise_error(response.status_code, raw_data)
 
         self.log_request_success(method, url, response.request.path_url, body, response.status_code, raw_data, duration)

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -102,7 +102,7 @@ class Urllib3HttpConnection(Connection):
             raise ConnectionError('N/A', str(e), e)
 
         if not (200 <= response.status < 300) and response.status not in ignore:
-            self.log_request_fail(method, url, body, duration, response.status)
+            self.log_request_fail(method, url, body, duration, response.status, raw_data)
             self._raise_error(response.status, raw_data)
 
         self.log_request_success(method, full_url, url, body, response.status,


### PR DESCRIPTION
Addresses #346. Response bodies from failed requests are logged along with the request body. The behaviour is the same for successful requests.