### PR TITLE
Add doc for filter_path argument in search

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,6 +63,19 @@ connection class::
 
 .. py:module:: elasticsearch
 
+Response Filtering
+~~~~~~~~~~~~~~~~~~
+
+The `filter_path` parameter is used to reduce the response returned by
+elasticsearch.  For example, to only return `_id` and `_type`, do::
+
+    es.search(index='test-index', filter_path=['hits.hits._id', 'hits.hits._type'])
+
+It also supports the `*` wildcard character to match any field or part of a
+field's name::
+
+    es.search(index='test-index', filter_path=['hits.hits._*'])
+
 Elasticsearch
 -------------
 


### PR DESCRIPTION
I figured out that the `search` function supported this by digging in the source.

Let me know if my way of describing it is not clear...