### PR TITLE
Fixed a bare except

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -101,9 +101,8 @@ class Connection(object):
             error_message = additional_info.get('error', error_message)
             if isinstance(error_message, dict) and 'type' in error_message:
                 error_message = error_message['type']
-        except:
-            # we don't care what went wrong
-            pass
+        except (ValueError, TypeError) as err:
+            logger.warning('Undecodable raw error response from server: %s', err)
 
         raise HTTP_EXCEPTIONS.get(status_code, TransportError)(status_code, error_message, additional_info)
 


### PR DESCRIPTION
AFAIK the only exception which can occur here is one that the json.loads(..) could raise. So (TypeError or) ValueError.

So except on that. and also log a warning in such case.

bare excepts are 99.99% of the time simply bad/wrong. It's even more the case when the except block is a no-op / pass statement.. It's the case here.