### PR TITLE
Fix scheme for HTTPS URLs

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -42,12 +42,12 @@ def _normalize_hosts(hosts):
             if parsed_url.port:
                 h["port"] = parsed_url.port
 
+            if parsed_url.scheme:
+                h['scheme'] = parsed_url.scheme
+
             if parsed_url.scheme == "https":
                 h['port'] = parsed_url.port or 443
                 h['use_ssl'] = True
-                h['scheme'] = 'http'
-            elif parsed_url.scheme:
-                h['scheme'] = parsed_url.scheme
 
             if parsed_url.username or parsed_url.password:
                 h['http_auth'] = '%s:%s' % (parsed_url.username, parsed_url.password)


### PR DESCRIPTION
For URLs like https://example.org scheme is currently set to 'http'.