### PR TITLE
Fix HTTPS URL support

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -42,12 +42,12 @@ def _normalize_hosts(hosts):
             if parsed_url.port:
                 h["port"] = parsed_url.port
 
+            if parsed_url.scheme:
+                h['scheme'] = parsed_url.scheme
+
             if parsed_url.scheme == "https":
                 h['port'] = parsed_url.port or 443
                 h['use_ssl'] = True
-                h['scheme'] = 'http'
-            elif parsed_url.scheme:
-                h['scheme'] = parsed_url.scheme
 
             if parsed_url.username or parsed_url.password:
                 h['http_auth'] = '%s:%s' % (parsed_url.username, parsed_url.password)

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -42,12 +42,12 @@ def _normalize_hosts(hosts):
             if parsed_url.port:
                 h["port"] = parsed_url.port
 
-            if parsed_url.scheme:
-                h['scheme'] = parsed_url.scheme
-
             if parsed_url.scheme == "https":
                 h['port'] = parsed_url.port or 443
                 h['use_ssl'] = True
+                h['scheme'] = 'http'
+            elif parsed_url.scheme:
+                h['scheme'] = parsed_url.scheme
 
             if parsed_url.username or parsed_url.password:
                 h['http_auth'] = '%s:%s' % (parsed_url.username, parsed_url.password)

--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -26,14 +26,15 @@ class Connection(object):
     """
     transport_schema = 'http'
 
-    def __init__(self, host='localhost', port=9200, url_prefix='', timeout=10, **kwargs):
+    def __init__(self, host='localhost', port=9200, use_ssl=False, url_prefix='', timeout=10, **kwargs):
         """
         :arg host: hostname of the node (default: localhost)
         :arg port: port to use (integer, default: 9200)
         :arg url_prefix: optional url prefix for elasticsearch
         :arg timeout: default timeout in seconds (float, default: 10)
         """
-        self.host = '%s://%s:%s' % (self.transport_schema, host, port)
+        scheme = 'https' if use_ssl else 'http'
+        self.host = '%s://%s:%s' % (scheme, host, port)
         if url_prefix:
             url_prefix = '/' + url_prefix.strip('/')
         self.url_prefix = url_prefix

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -39,7 +39,7 @@ class Urllib3HttpConnection(Connection):
             client_key=None, ssl_version=None, ssl_assert_hostname=None,
             ssl_assert_fingerprint=None, maxsize=10, **kwargs):
 
-        super(Urllib3HttpConnection, self).__init__(host=host, port=port, **kwargs)
+        super(Urllib3HttpConnection, self).__init__(host=host, port=port, use_ssl=use_ssl, **kwargs)
         self.headers = urllib3.make_headers(keep_alive=True)
         if http_auth is not None:
             if isinstance(http_auth, (tuple, list)):


### PR DESCRIPTION
Current behavior:

```
>>> from elasticsearch import Elasticsearch
>>> x = Elasticsearch(['https://localhost'])
>>> x.transport.get_connection()
<Urllib3HttpConnection: http://localhost:443>
```

-- note that `Urllib3HttpConnection` contains `http://` URL -- should be `https://`.

With this fix applied:

```
>>> from elasticsearch import Elasticsearch
>>> x = Elasticsearch(['https://localhost'])
>>> x.transport.get_connection()
<Urllib3HttpConnection: https://localhost:443>
```

-- URL protocol in `Urllib3HttpConnection` is correct.