### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README
+++ b/README
@@ -18,9 +18,9 @@ It also provides an optional `persistence layer`_ for working with documents as
 Python objects in an ORM-like fashion: defining mappings, retrieving and saving
 documents, wrapping the document data in user-defined classes.
 
-.. _elasticsearch-dsl: http://elasticsearch-dsl.rtfd.org/
-.. _queries: http://elasticsearch-dsl.readthedocs.org/en/latest/search_dsl.html
-.. _persistence layer: http://elasticsearch-dsl.readthedocs.org/en/latest/persistence.html#doctype
+.. _elasticsearch-dsl: https://elasticsearch-dsl.readthedocs.io/
+.. _queries: https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html
+.. _persistence layer: https://elasticsearch-dsl.readthedocs.io/en/latest/persistence.html#doctype
 
 Compatibility
 -------------
@@ -91,7 +91,7 @@ Simple use-case::
 
 `Full documentation`_.
 
-.. _Full documentation: http://elasticsearch-py.rtfd.org/
+.. _Full documentation: https://elasticsearch-py.readthedocs.io/
 
 
 Features

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ For a more high level client library with more limited scope, have a look at
 `elasticsearch-dsl`_ - it is a more pythonic library sitting on top of
 ``elasticsearch-py``.
 
-.. _elasticsearch-dsl: http://elasticsearch-dsl.rtfd.org/
+.. _elasticsearch-dsl: https://elasticsearch-dsl.readthedocs.io/
 
 Compatibility
 -------------
@@ -78,7 +78,7 @@ Python. We have created some :ref:`helpers` to help with this issue as well as
 a more high level library (`elasticsearch-dsl`_) on top of this one to provide
 a more convenient way of working with Elasticsearch.
 
-.. _elasticsearch-dsl: http://elasticsearch-dsl.rtfd.org/
+.. _elasticsearch-dsl: https://elasticsearch-dsl.readthedocs.io/
 
 Persistent Connections
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -20,7 +20,7 @@ class Urllib3HttpConnection(Connection):
     :arg use_ssl: use ssl for the connection if `True`
     :arg verify_certs: whether to verify SSL certificates
     :arg ca_certs: optional path to CA bundle. See
-        http://urllib3.readthedocs.org/en/latest/security.html#using-certifi-with-urllib3
+        https://urllib3.readthedocs.io/en/latest/security.html#using-certifi-with-urllib3
         for instructions how to get default set
     :arg client_cert: path to the file containing the private key and the
         certificate, or cert only if using client_key


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.