### PR TITLE
[Fix] fix sniff host when extract node address from es api response.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage.xml
 nosetests.xml
 junit-*.xml
 build
+.eggs

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -29,10 +29,10 @@ CLUSTER_NODES = '''{
     "nodes" : {
         "wE_6OGBNSjGksbONNncIbg" : {
             "name" : "Nightwind",
-            "transport_address" : "127.0.0.1:9300",
+            "transport_address" : "inet[/127.0.0.1:9300]",
             "hostname" : "wind",
             "version" : "0.20.4",
-            "http_address" : "1.1.1.1:123",
+            "http_address" : "inet[/127.0.0.1:9200]",
             "thrift_address" : "1.1.1.1:9500"
         }
     }
@@ -44,12 +44,12 @@ CLUSTER_NODE_PUBLISH_HOST = '''{
     "nodes" : {
         "wE_6OGBNSjGksbONNncIbg" : {
             "name": "Thunderbird",
-            "transport_address": "obsidian/192.168.1.60:9300",
+            "transport_address": "inet[/192.168.1.60:9300]",
             "host": "192.168.1.60",
             "ip": "192.168.1.60",
             "version": "2.1.0",
             "build": "72cd1f1",
-            "http_address": "obsidian/192.168.1.60:9200",
+            "http_address": "inet[/192.168.1.60:9200]",
             "attributes": {
                 "testattr": "test"
             }
@@ -173,27 +173,19 @@ class TestTransport(TestCase):
 
         t.sniff_hosts()
         self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals('http://1.1.1.1:123', t.get_connection().host)
+        self.assertEquals('http://127.0.0.1:9200', t.get_connection().host)
 
     def test_sniff_will_pick_up_published_host(self):
         t = Transport([{'data': CLUSTER_NODE_PUBLISH_HOST}], connection_class=DummyConnection)
         t.sniff_hosts()
 
         self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals('http://obsidian:9200', t.get_connection().host)
-
-
-    def test_sniff_on_start_fetches_and_uses_nodes_list_for_its_schema(self):
-        class DummyThriftConnection(DummyConnection):
-            transport_schema = 'thrift'
-        t = Transport([{'data': CLUSTER_NODES}], connection_class=DummyThriftConnection, sniff_on_start=True)
-        self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals('thrift://1.1.1.1:9500', t.get_connection().host)
+        self.assertEquals('http://192.168.1.60:9200', t.get_connection().host)
 
     def test_sniff_on_start_fetches_and_uses_nodes_list(self):
         t = Transport([{'data': CLUSTER_NODES}], connection_class=DummyConnection, sniff_on_start=True)
         self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals('http://1.1.1.1:123', t.get_connection().host)
+        self.assertEquals('http://127.0.0.1:9200', t.get_connection().host)
 
     def test_sniff_on_start_ignores_sniff_timeout(self):
         t = Transport([{'data': CLUSTER_NODES}], connection_class=DummyConnection, sniff_on_start=True, sniff_timeout=12)
@@ -206,7 +198,7 @@ class TestTransport(TestCase):
 
 
     def test_sniff_reuses_connection_instances_if_possible(self):
-        t = Transport([{'data': CLUSTER_NODES}, {"host": "1.1.1.1", "port": 123}], connection_class=DummyConnection, randomize_hosts=False)
+        t = Transport([{'data': CLUSTER_NODES}, {"host": "127.0.0.1", "port": 9200}], connection_class=DummyConnection, randomize_hosts=False)
         connection = t.connection_pool.connections[1]
 
         t.sniff_hosts()
@@ -219,11 +211,11 @@ class TestTransport(TestCase):
 
         self.assertRaises(ConnectionError, t.perform_request, 'GET', '/')
         self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals('http://1.1.1.1:123', t.get_connection().host)
+        self.assertEquals('http://127.0.0.1:9200', t.get_connection().host)
 
     def test_sniff_after_n_seconds(self):
         t = Transport([{"data": CLUSTER_NODES}],
-            connection_class=DummyConnection, sniffer_timeout=5)
+                      connection_class=DummyConnection, sniffer_timeout=5)
 
         for _ in range(4):
             t.perform_request('GET', '/')
@@ -233,6 +225,6 @@ class TestTransport(TestCase):
 
         t.perform_request('GET', '/')
         self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals('http://1.1.1.1:123', t.get_connection().host)
+        self.assertEquals('http://127.0.0.1:9200', t.get_connection().host)
         self.assertTrue(time.time() - 1 < t.last_sniff < time.time() + 0.01 )
 


### PR DESCRIPTION
Current response from api `/_nodes/_all/clear` is below:

```
{
    "cluster_name": "test",
    "nodes": {
         "47UWFACERJuqujyi60jQMA": {
                 "name":"test-1",
                 "transport_address":"inet[/10.10.0.1:9300]",
                 "host": "test1",
                 "ip": "10.10.0.1",
                 "version":"1.7.2",
                "build":"e43676b",
                "http_address":"inet[/10.10.0.1:9200]",
                "attributes":{
                     "max_local_storage_nodes":"1",
                     "rack":"rack0","master":"true"
                }
         }
}
```

The format of  `transport_address` and `http_address` has changed. Do as the old way, it will lead `ValueError` when call `int(port)`.