### PR TITLE
Don't swallow reason for error on non-200 reply from older ES

### DIFF
--- a/elasticsearch/exceptions.py
+++ b/elasticsearch/exceptions.py
@@ -55,6 +55,8 @@ class TransportError(ElasticsearchException):
                 cause = ', %r' % self.info['error']['root_cause'][0]['reason']
         except LookupError:
             pass
+        except TypeError:
+            pass
         return 'TransportError(%s, %r%s)' % (self.status_code, self.error, cause)
 
 


### PR DESCRIPTION
ES replies with message as follows:
{u'status': 400, u'error': u'RemoteTransportException[[Brother
Nature][inet[/x.x.x.x:y]][cluster:admin/snapshot/create]]; nested:
InvalidSnapshotNameException[[s3:foo] Invalid snapshot
name [foo], snapshot with such name already exists]; '}

We attempt to get info out of said message with:
info['error']['root_cause'][0]['reason']

But info['error'] is a unicode string. So we get TypeError,
while expect only LookupError.

As a result exception used to look like this:
elasticsearch.exceptions.RequestError

But now looks like this:
elasticsearch.exceptions.RequestError: TransportError(400,
u'RemoteTransportException[[Brother
Nature][inet[/x.x.x.x:y]][cluster:admin/snapshot/create]]; nested:
InvalidSnapshotNameException[[s3:foo] Invalid snapshot
name [foo], snapshot with such name already exists]; ')

I suspect this behavior is limited to older versions of ES, only have
access 1.5.2 (AWS).