### PR TITLE
Update python doc: added timeout to params in delete() call

### DIFF
--- a/elasticsearch/client/snapshot.py
+++ b/elasticsearch/client/snapshot.py
@@ -21,7 +21,7 @@ class SnapshotClient(NamespacedClient):
         return self.transport.perform_request('PUT', _make_path('_snapshot',
             repository, snapshot), params=params, body=body)
 
-    @query_params('master_timeout')
+    @query_params('master_timeout', 'timeout')
     def delete(self, repository, snapshot, params=None):
         """
         Deletes a snapshot from a repository.

--- a/elasticsearch/client/snapshot.py
+++ b/elasticsearch/client/snapshot.py
@@ -31,6 +31,7 @@ class SnapshotClient(NamespacedClient):
         :arg snapshot: A snapshot name
         :arg master_timeout: Explicit operation timeout for connection to master
             node
+        :arg timeout: Explicit operation timeout
         """
         for param in (repository, snapshot):
             if param in SKIP_IN_PATH:


### PR DESCRIPTION
When I try to delete snapshot with huge indices (~5-10gb), delete call raises an HttpConnectionError exception: ReadTimeout
