### PR TITLE
Fix debugging log host

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -73,7 +73,7 @@ class Connection(object):
             path = path.replace('?', '?pretty&', 1) if '?' in path else path + '?pretty'
             if self.url_prefix:
                 path = path.replace(self.url_prefix, '', 1)
-            tracer.info("curl -X%s '%s:9200%s' -d '%s'", method, self.host, path, _pretty_json(body) if body else '')
+            tracer.info("curl -X%s '%s%s' -d '%s'", method, self.host, path, _pretty_json(body) if body else '')
 
         if tracer.isEnabledFor(logging.DEBUG):
             tracer.debug('#[%s] (%.3fs)\n#%s', status_code, duration, _pretty_json(response).replace('\n', '\n#') if response else '')

--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -73,7 +73,7 @@ class Connection(object):
             path = path.replace('?', '?pretty&', 1) if '?' in path else path + '?pretty'
             if self.url_prefix:
                 path = path.replace(self.url_prefix, '', 1)
-            tracer.info("curl -X%s 'http://localhost:9200%s' -d '%s'", method, path, _pretty_json(body) if body else '')
+            tracer.info("curl -X%s '%s:9200%s' -d '%s'", method, self.host, path, _pretty_json(body) if body else '')
 
         if tracer.isEnabledFor(logging.DEBUG):
             tracer.debug('#[%s] (%.3fs)\n#%s', status_code, duration, _pretty_json(response).replace('\n', '\n#') if response else '')
@@ -112,5 +112,3 @@ class Connection(object):
             logger.warning('Undecodable raw error response from server: %s', err)
 
         raise HTTP_EXCEPTIONS.get(status_code, TransportError)(status_code, error_message, additional_info)
-
-


### PR DESCRIPTION
After some WTF moments during debugging, I found that the hostname that is printed in the logs, is actually hardcoded. I'm not sure as to why that is, but it took me a while to figure out that the calls where actually going to my ES cluster as they should, and not to my localhost (which accidentally also had an ES host running).

I hope this PR helps other people from not making the same mistake 😉 