### PR TITLE
Custom headers in http requests with requests library 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
   - "3.4"
   - "3.5"
 
+jdk:
+  - "oraclejdk8"
+
 env:
   # different connection classes to test
   - TEST_ES_CONNECTION=Urllib3HttpConnection

--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -24,7 +24,7 @@ class RequestsHttpConnection(Connection):
         certificate, or cert only if using client_key
     :arg client_key: path to the file containing the private key if using
         separate cert and key files (client_cert will contain only the cert)
-    :arg headers: a dictionary with custom headers to use in http requests
+    :arg headers: a dictionary with custom headers to use in http requests.
     """
     def __init__(self, host='localhost', port=9200, http_auth=None,
         use_ssl=False, verify_certs=False, ca_certs=None, client_cert=None,


### PR DESCRIPTION
I needed custom http headers in one of my projects. I have added a few lines of code to the requests library to support this. It is an additional parameter to init and adds these as headers.