### PR TITLE
Fix delete by query link

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -686,7 +686,8 @@ class Elasticsearch(object):
         'wait_for_completion')
     def delete_by_query(self, index, body, doc_type=None, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html>`_
+        Note that this API is not available below Elasticsearch 5.x.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-delete-by-query.html>`_
 
         :arg index: A comma-separated list of index names to search; use `_all`
             or empty string to perform the operation on all indices


### PR DESCRIPTION
While I was going through the code, wondering why the delete-by-query plugin is not present in the branch 2.x, I realised that the doc link has been changed in the elasticsearch as this API is currently experimental.