### PR TITLE
Support for Custom Authentication Handler in RequestsHttpConnection

### DIFF
--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -9,7 +9,6 @@ except ImportError:
 from .base import Connection
 from ..exceptions import ConnectionError, ImproperlyConfigured, ConnectionTimeout, SSLError
 from ..compat import urlencode, string_types
-from requests_kerberos import HTTPKerberosAuth
 
 class RequestsHttpConnection(Connection):
     """


### PR DESCRIPTION
This allows for the use of the requests_kerberos custom authentication handler (amongst others).

Example use:

```
from requests_kerberos import HTTPKerberosAuth

es = Elasticsearch(
    hosts=["https://sample.com:443/"],
    auth=HTTPKerberosAuth(),
    connection_class=RequestsHttpConnection,
    use_ssl=True,
    verify_certs=True
)
```
