### PR TITLE
allow to set a specific CA directory through ca_cert_dir option

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -123,6 +123,19 @@ class Elasticsearch(object):
             ca_certs='/path/to/CA_certs'
         )
 
+    If using SSL with a certain CA directory, it can be specified in the following way::
+
+        es = Elasticsearch(
+            ['localhost:443', 'other_host:443'],
+            # turn on SSL
+            use_ssl=True,
+            # make sure we verify SSL certificates (off by default)
+            verify_certs=True,
+            # provide a path to CA directory on disk
+            ca_cert_dir='/path/to/CA_certs_directory'
+        )
+    Note: Only ca_certs or ca_cert_dir option can be given
+ 
     SSL client authentication is supported
     (see :class:`~elasticsearch.Urllib3HttpConnection` for
     detailed description of the options)::

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -59,7 +59,7 @@ class Urllib3HttpConnection(Connection):
             self.headers.update(urllib3.make_headers(basic_auth=http_auth))
 
         if ca_certs and ca_cert_dir:
-            raise ImproperlyConfigured("Please use ca_certs or ca_cert_dir for specifying root certificates"
+            raise ImproperlyConfigured("Please use ca_certs or ca_cert_dir for specifying root certificates")
    
         ca_certs = CA_CERTS if ca_certs is None else ca_certs
         pool_class = urllib3.HTTPConnectionPool


### PR DESCRIPTION
I am having a problem setting up the authentication using host certificate, because I can not specify a directory path to the CA certificates. What I wanted to have:

``` pyhton
cl = Elasticsearch('https:', verify_certs=True,ca_cert_dir='/opt/xxx/yyyy/security/certificates/')
```

I know I can create a file which contains all CAs in /opt/xxx/yyyy/security/certificates/ directory, but this means I have to maintain this file always. 
I exposed the ca_cert_dir option and it works well. Could you please include to the next release?
Thanks,
Zoltan
