### PR TITLE
Updated example scripts for ES v5

### DIFF
--- a/example/load.py
+++ b/example/load.py
@@ -159,7 +159,7 @@ REPO_ACTIONS = [
     {'_type': 'repos', '_id': 'elasticsearch', '_source': {
         'owner': {'name': 'Shay Bannon', 'email': 'kimchy@gmail.com'},
         'created_at': datetime(2010, 2, 8, 15, 22, 27),
-        'tags': ['search', 'distributed', 'lucene', 'java'],
+        'tags': ['search', 'distributed', 'lucene'],
         'description': 'You know, for search.'}
     },
 
@@ -190,6 +190,21 @@ if __name__ == '__main__':
     # now we can retrieve the documents
     es_repo = es.get(index='git', doc_type='repos', id='elasticsearch')
     print('%s: %s' % (es_repo['_id'], es_repo['_source']['description']))
+
+    # update - add java to es tags
+    es.update(
+        index='git',
+        doc_type='repos',
+        id='elasticsearch',
+        body={
+        "script": {
+          "inline" : "ctx._source.tags.add(params.tag)",
+            "params" : {
+              "tag" : "java"
+            }
+          }
+        }
+    )
 
     # refresh to make the documents available for search
     es.indices.refresh(index='git')

--- a/example/load.py
+++ b/example/load.py
@@ -164,7 +164,7 @@ REPO_ACTIONS = [
     },
 
     {'_type': 'repos', '_id': 'elasticsearch-py', '_op_type': 'update', 'doc': {
-        'owner': {'name': 'Honza Král', 'email': 'honza.kral@gmail.com'},
+        'owner': {'name': u'Honza Král', 'email': 'honza.kral@gmail.com'},
         'created_at': datetime(2013, 5, 1, 16, 37, 32),
         'tags': ['elasticsearch', 'search', 'python', 'client'],
         'description': 'For searching snakes.'}

--- a/example/load.py
+++ b/example/load.py
@@ -197,8 +197,8 @@ if __name__ == '__main__':
         doc_type='repos',
         id='elasticsearch',
         body={
-        "script": {
-          "inline" : "ctx._source.tags.add(params.tag)",
+          "script": {
+            "inline" : "ctx._source.tags.add(params.tag)",
             "params" : {
               "tag" : "java"
             }

--- a/example/load.py
+++ b/example/load.py
@@ -159,7 +159,7 @@ REPO_ACTIONS = [
     {'_type': 'repos', '_id': 'elasticsearch', '_source': {
         'owner': {'name': 'Shay Bannon', 'email': 'kimchy@gmail.com'},
         'created_at': datetime(2010, 2, 8, 15, 22, 27),
-        'tags': ['search', 'distributed', 'lucene'],
+        'tags': ['search', 'distributed', 'lucene', 'java'],
         'description': 'You know, for search.'}
     },
 
@@ -190,19 +190,6 @@ if __name__ == '__main__':
     # now we can retrieve the documents
     es_repo = es.get(index='git', doc_type='repos', id='elasticsearch')
     print('%s: %s' % (es_repo['_id'], es_repo['_source']['description']))
-
-    # update - add java to es tags
-    es.update(
-        index='git',
-        doc_type='repos',
-        id='elasticsearch',
-        body={
-          "script" : "ctx._source.tags += tag",
-          "params" : {
-            "tag" : "java"
-          }
-        }
-    )
 
     # refresh to make the documents available for search
     es.indices.refresh(index='git')

--- a/example/queries.py
+++ b/example/queries.py
@@ -60,13 +60,8 @@ result = es.search(
     doc_type='commits',
     body={
       'query': {
-        'bool': {
-          'must': {
-            'term': {
-              # parent ref is stored as type#id
-              '_parent': 'repos#elasticsearch-py'
-            }
-          }
+        'parent_id': {
+            'type': 'commits', 'id': 'elasticsearch-py'
         }
       },
       'sort': [

--- a/example/queries.py
+++ b/example/queries.py
@@ -41,14 +41,12 @@ result = es.search(
     doc_type='commits',
     body={
       'query': {
-        'filtered': {
-          'query': {
+        'bool': {
+          'must': {
             'match': {'description': 'fix'}
           },
-          'filter': {
-            'not': {
-              'term': {'files': 'test_elasticsearch'}
-            }
+          'must_not': {
+            'term': {'files': 'test_elasticsearch'}
           }
         }
       }
@@ -62,8 +60,8 @@ result = es.search(
     doc_type='commits',
     body={
       'query': {
-        'filtered': {
-          'filter': {
+        'bool': {
+          'must': {
             'term': {
               # parent ref is stored as type#id
               '_parent': 'repos#elasticsearch-py'
@@ -86,19 +84,11 @@ result = es.search(
     body={
       'size': 0,
       'query': {
-        'filtered': {
-          'filter': {
-            'has_parent': {
-              'type': 'repos',
-              'query': {
-                'filtered': {
-                  'filter': {
-                    'term': {
-                      'tags': 'python'
-                    }
-                  }
-                }
-              }
+        'has_parent': {
+          'parent_type': 'repos',
+          'query': {
+            'term': {
+              'tags': 'python'
             }
           }
         }


### PR DESCRIPTION
`example/load.py` was failing to create an index because the `multi_field` type has been removed from ES 5. Index creation was failing silently because of the use of `ignore=400`, so now TransportErrors are caught and only ignored if the error is `index_already_exists_exception`. Scripted updates are disabled by default in ES 5, so removing the `update` example seemed like the cleanest fix. `example/queries.py` has also been updated to fix breaking changes in query syntax in ES 5.
