### PR TITLE
Tweaks to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
-from os.path import join, dirname
-from setuptools import setup, find_packages
 import sys
+from io import open
+from os.path import join, dirname, normpath
+
+from setuptools import setup, find_packages
 
 VERSION = (5, 1, 0, 'dev')
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 
-f = open(join(dirname(__file__), 'README'))
-long_description = f.read().strip()
-f.close()
+with open(normpath(join(dirname(__file__), 'README')), encoding='utf-8') as f:
+    long_description = f.read().strip()
 
 install_requires = [
     'urllib3>=1.8, <2.0',
@@ -25,36 +26,36 @@ tests_require = [
 
 # use external unittest for 2.6
 if sys.version_info[:2] == (2, 6):
-    install_requires.append('unittest2')
+    tests_require.append('unittest2')
 
 setup(
-    name = 'elasticsearch',
-    description = "Python client for Elasticsearch",
-    license="Apache License, Version 2.0",
-    url = "https://github.com/elastic/elasticsearch-py",
-    long_description = long_description,
-    version = __versionstr__,
-    author = "Honza Král",
-    author_email = "honza.kral@gmail.com",
+    name='elasticsearch',
+    description='Python client for Elasticsearch',
+    license='Apache License, Version 2.0',
+    url='https://github.com/elastic/elasticsearch-py',
+    long_description=long_description,
+    version=__versionstr__,
+    author='Honza Král',
+    author_email='honza.kral@gmail.com',
     packages=find_packages(
         where='.',
-        exclude=('test_elasticsearch*', )
+        exclude=('test_elasticsearch*',)
     ),
-    classifiers = [
-        "Development Status :: 5 - Production/Stable",
-        "License :: OSI Approved :: Apache Software License",
-        "Intended Audience :: Developers",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: Apache Software License',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=install_requires,
 


### PR DESCRIPTION
- Use context manager for opening README
- Specify encoding of README file
- Normalize path of README file
- The unittest2 should be in tests_require and not in install_requires
- Use single quotes strings consistently everywhere
- pep8 reformat