### PR TITLE
Fix error where address is null in _get_host_info

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -219,7 +219,7 @@ class Transport(object):
         host = {}
         address = host_info.get('http', {}).get('publish_address')
 
-        # malformed address
+        # malformed or no address given
         if not address or ':' not in address:
             return None
 

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -220,7 +220,7 @@ class Transport(object):
         address = host_info.get('http', {}).get('publish_address')
 
         # malformed address
-        if ':' not in address:
+        if not address or ':' not in address:
             return None
 
         host['host'], host['port'] = address.rsplit(':', 1)


### PR DESCRIPTION
When the HTTP address is null for a given node (occurs in some configurations on ES5+), filter it instead of throwing an exception (checking for `':' in x` is invalid when `x is None`)