### PR TITLE
Write log with customized port number

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -61,7 +61,7 @@ class Connection(object):
         path = path.replace('?', '?pretty&', 1) if '?' in path else path + '?pretty'
         if self.url_prefix:
             path = path.replace(self.url_prefix, '', 1)
-        tracer.info("curl -X%s 'http://localhost:9200%s' -d '%s'", method, path, self._pretty_json(body) if body else '')
+        tracer.info("curl -X%s '%s%s' -d '%s'", method, self.host, path, self._pretty_json(body) if body else '')
 
         if tracer.isEnabledFor(logging.DEBUG):
             tracer.debug('#[%s] (%.3fs)\n#%s', status_code, duration, self._pretty_json(response).replace('\n', '\n#') if response else '')


### PR DESCRIPTION
When I am monitoring the debug log from elasticsearch-py, it cannot show the correct port number which I am using. I found that this debug message is hardcoded with 'http://localhost:9200', so I changed it into using the customized info from self.host.