### PR TITLE
doc_type = type to sample

### DIFF
--- a/elasticsearch/client/nodes.py
+++ b/elasticsearch/client/nodes.py
@@ -57,7 +57,7 @@ class NodesClient(NamespacedClient):
         return self.transport.perform_request('GET', _make_path('_nodes',
             node_id, 'stats', metric, index_metric), params=params)
 
-    @query_params('doc_type', 'ignore_idle_threads', 'interval', 'snapshots',
+    @query_params('type', 'ignore_idle_threads', 'interval', 'snapshots',
         'threads', 'timeout')
     def hot_threads(self, node_id=None, params=None):
         """
@@ -68,7 +68,7 @@ class NodesClient(NamespacedClient):
             returned information; use `_local` to return information from the
             node you're connecting to, leave empty to get information from all
             nodes
-        :arg doc_type: The type to sample (default: cpu), valid choices are:
+        :arg type: The type to sample (default: cpu), valid choices are:
             'cpu', 'wait', 'block'
         :arg ignore_idle_threads: Don't show threads that are in known-idle
             places, such as waiting on a socket select or pulling from an empty


### PR DESCRIPTION

> elasticsearch.exceptions.RequestError: TransportError(400, 'illegal_argument_exception', 'request [/_cluster/nodes/hotthreads] contains unrecognized parameter: [doc_type]')


https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-hot-threads.html