### PR TITLE
bumping requests to 2.0.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'urllib3>=1.8, <2.0',
 ]
 tests_require = [
-    'requests>=1.0.0, <3.0.0',
+    'requests>=2.0.0, <3.0.0',
     'nose',
     'coverage',
     'mock',


### PR DESCRIPTION
requests < 2.0.0 causes the following attribute error:
    `AttributeError: type object 'Session' has no attribute 'prepare_request'`