### PR TITLE
Fixes non UTF-8 surrogateescapes

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -295,7 +295,10 @@ class Transport(object):
                 body = body.encode('utf-8')
             except UnicodeEncodeError as e:
                 if e.reason == 'surrogates not allowed':
-                  body = body.encode('utf-8', "backslashreplace").decode('utf-8')
+                  body = body.encode('utf-8', "backslashreplace")
+                  pass
+                
+                raise e
             except (UnicodeDecodeError, AttributeError):
                 # bytes/str - no need to re-encode
                 pass

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -293,6 +293,9 @@ class Transport(object):
         if body is not None:
             try:
                 body = body.encode('utf-8')
+            except UnicodeEncodeError as e:
+                if e.reason == 'surrogates not allowed':
+                  body = body.encode('utf-8', "backslashreplace").decode('utf-8')
             except (UnicodeDecodeError, AttributeError):
                 # bytes/str - no need to re-encode
                 pass

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -292,12 +292,7 @@ class Transport(object):
 
         if body is not None:
             try:
-                body = body.encode('utf-8')
-            except UnicodeEncodeError as e:
-                if e.reason == 'surrogates not allowed':
-                  body = body.encode('utf-8', "surrogatepass")
-                else:                
-                  raise e
+                body = body.encode('utf-8', 'surrogatepass')            
             except (UnicodeDecodeError, AttributeError):
                 # bytes/str - no need to re-encode
                 pass

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -296,9 +296,8 @@ class Transport(object):
             except UnicodeEncodeError as e:
                 if e.reason == 'surrogates not allowed':
                   body = body.encode('utf-8', "backslashreplace")
-                  pass
-                
-                raise e
+                else:                
+                  raise e
             except (UnicodeDecodeError, AttributeError):
                 # bytes/str - no need to re-encode
                 pass

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -295,7 +295,7 @@ class Transport(object):
                 body = body.encode('utf-8')
             except UnicodeEncodeError as e:
                 if e.reason == 'surrogates not allowed':
-                  body = body.encode('utf-8', "backslashreplace")
+                  body = body.encode('utf-8', "surrogatepass")
                 else:                
                   raise e
             except (UnicodeDecodeError, AttributeError):

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -110,7 +110,7 @@ class TestTransport(TestCase):
 
         t.perform_request('GET', '/', body='你好\udd9e')
         self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\\udd9e'), t.get_connection().calls[0][0])        
+        self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\xed\xb6\x9e'), t.get_connection().calls[0][0])        
                 
     def test_kwargs_passed_on_to_connections(self):
         t = Transport([{'host': 'google.com'}], port=123)

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -108,9 +108,9 @@ class TestTransport(TestCase):
     def test_body_surrogates_replaced_encoded_into_bytes(self):
         t = Transport([{}], connection_class=DummyConnection)
 
-        t.perform_request('GET', '/', body='你好\udd9e')
+        t.perform_request('GET', '/', body='你好\uda6a')
         self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\xed\xb6\x9e'), t.get_connection().calls[0][0])        
+        self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\\uda6a'), t.get_connection().calls[0][0])        
                 
     def test_kwargs_passed_on_to_connections(self):
         t = Transport([{'host': 'google.com'}], port=123)

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -110,7 +110,7 @@ class TestTransport(TestCase):
 
         t.perform_request('GET', '/', body='你好\uda6a')
         self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\\uda6a'), t.get_connection().calls[0][0])        
+        self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\xed\xa9\xaa'), t.get_connection().calls[0][0])        
                 
     def test_kwargs_passed_on_to_connections(self):
         t = Transport([{'host': 'google.com'}], port=123)

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -96,7 +96,7 @@ class TestTransport(TestCase):
         t.perform_request('GET', '/', body='你好')
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd'), t.get_connection().calls[0][0])
-
+                
     def test_body_bytes_get_passed_untouched(self):
         t = Transport([{}], connection_class=DummyConnection)
 
@@ -105,6 +105,13 @@ class TestTransport(TestCase):
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(('GET', '/', None, body), t.get_connection().calls[0][0])
 
+    def test_body_surrogates_replaced_encoded_into_bytes(self):
+        t = Transport([{}], connection_class=DummyConnection)
+
+        t.perform_request('GET', '/', body='你好\udd9e')
+        self.assertEquals(1, len(t.get_connection().calls))
+        self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\\udd9e'), t.get_connection().calls[0][0])        
+                
     def test_kwargs_passed_on_to_connections(self):
         t = Transport([{'host': 'google.com'}], port=123)
         self.assertEquals(1, len(t.connection_pool.connections))

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -96,7 +96,7 @@ class TestTransport(TestCase):
         t.perform_request('GET', '/', body='你好')
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd'), t.get_connection().calls[0][0])
-                
+
     def test_body_bytes_get_passed_untouched(self):
         t = Transport([{}], connection_class=DummyConnection)
 


### PR DESCRIPTION
Surrogate escapes in Unicode (non UTF-8 encoding) will be properly escaped with backslashes when encountered, versus breaking the transport layer.

This addresses my issue here: https://github.com/elastic/elasticsearch-py/issues/611