### PR TITLE
Add Python 3.5 and 3.6 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py26,py27,py33,py34
+envlist = pypy,py26,py27,py33,py34,py35,py36
 [testenv]
 whitelist_externals = git
 setenv =


### PR DESCRIPTION
Bring `tox.ini` up to date with `setup.py` and `.travis.yml`.