### PR TITLE
Bulk Update Usage Clarification

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -65,7 +65,7 @@ action (``_op_type`` defaults to ``index``):
         '_index': 'index-name',
         '_type': 'document',
         '_id': 42,
-        'doc': {'question': 'The life, universe and everything.'}
+        '_source': {'doc': {'question': 'The life, universe and everything.'} }
     }
 
 


### PR DESCRIPTION
Bulk update appears to require 'doc' to be wrapped inside of a '_source'. The documentation update reflects that requirement.