### PR TITLE
fix: AttributeError: 'bytes' object has no attribute 'encode'(PY3)

### DIFF
--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import weakref
 from datetime import date, datetime
 from functools import wraps
-from ..compat import string_types, quote_plus
+from ..compat import string_types, quote_plus, PY2
 
 # parts of URL to be omitted
 SKIP_IN_PATH = (None, '', b'', [], ())
@@ -32,7 +32,10 @@ def _escape(value):
 
     # encode strings to utf-8
     if isinstance(value, string_types):
-        return value.encode('utf-8')
+        if PY2 and isinstance(value, unicode):
+            return value.encode('utf-8')
+        if not PY2 and isinstance(value, str):
+            return value.encode('utf-8')
 
     return str(value)
 


### PR DESCRIPTION
Hi, I had this error in python3.6.2 while using elasticsearch as backend of celery. So I tracked down the error message and come to a simple fix for this. It's working now in my local python3.6.2 virtualenv, and I guess this should work for all. I'd like to hear your comments :)