### PR TITLE
generate id automatically use POST method

### DIFF
--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 VERSION = (5, 4, 0)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
-test
+
 import sys
 
 if (2, 7) <= sys.version_info < (3, 2):

--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 VERSION = (5, 4, 0)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
-
+test
 import sys
 
 if (2, 7) <= sys.version_info < (3, 2):

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -223,7 +223,7 @@ class Elasticsearch(object):
 
     @query_params('parent', 'pipeline', 'refresh', 'routing', 'timeout',
         'timestamp', 'ttl', 'version', 'version_type', 'wait_for_active_shards')
-    def create(self, index, doc_type, id, body, params=None):
+    def create(self, index, doc_type, body, id=None, params=None):
         """
         Adds a typed JSON document in a specific index, making it searchable.
         Behind the scenes this method calls index(..., op_type='create')
@@ -231,7 +231,7 @@ class Elasticsearch(object):
 
         :arg index: The name of the index
         :arg doc_type: The type of the document
-        :arg id: Document ID
+        :arg id: Document ID,if id is None,an id will be generated automatically.
         :arg body: The document
         :arg parent: ID of the parent document
         :arg pipeline: The pipeline id to preprocess incoming documents with
@@ -256,8 +256,12 @@ class Elasticsearch(object):
         for param in (index, doc_type, id, body):
             if param in SKIP_IN_PATH:
                 raise ValueError("Empty value passed for a required argument.")
-        return self.transport.perform_request('PUT', _make_path(index, doc_type,
-            id, '_create'), params=params, body=body)
+        if id:
+            return self.transport.perform_request('PUT', _make_path(index, doc_type,
+                id, '_create'), params=params, body=body)
+        else:
+            return self.transport.perform_request('POST', _make_path(index, doc_type)
+                                                  , params=params, body=body)
 
     @query_params('op_type', 'parent', 'pipeline', 'refresh', 'routing',
         'timeout', 'timestamp', 'ttl', 'version', 'version_type',


### PR DESCRIPTION
Hi,
   I modified Elasticsearch().create() to allow it to automatically generate document id using the "POST" method.We can find this fearture in doc:https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html