### PR TITLE
Drop support for EOL Python 2.6, 3.2 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,8 +56,8 @@ Example Usage
     es = Elasticsearch()
 
     doc = {
-        'author': 'kimchy', 
-        'text': 'Elasticsearch: cool. bonsai cool.', 
+        'author': 'kimchy',
+        'text': 'Elasticsearch: cool. bonsai cool.',
         'timestamp': datetime.now(),
     }
     res = es.index(index="test-index", doc_type='tweet', id=1, body=doc)
@@ -236,7 +236,7 @@ an issue) it also just uses ``localhost:9200`` as the address instead of the
 actual address of the host. If the trace logger has not been configured
 already it is set to `propagate=False` so it needs to be activated separately.
 
-.. _logging library: http://docs.python.org/3.3/library/logging.html
+.. _logging library: http://docs.python.org/3.6/library/logging.html
 
 Environment considerations
 --------------------------

--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -6,7 +6,7 @@ __versionstr__ = '.'.join(map(str, VERSION))
 
 import sys
 
-if sys.version_info == (2, 7):
+if sys.version_info[:2] == (2, 7):
     # On Python 2.7, install no-op handler to silence
     # `No handlers could be found for logger "elasticsearch"` message per
     # <https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library>

--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -6,8 +6,8 @@ __versionstr__ = '.'.join(map(str, VERSION))
 
 import sys
 
-if (2, 7) <= sys.version_info < (3, 2):
-    # On Python 2.7 and Python3 < 3.2, install no-op handler to silence
+if sys.version_info == (2, 7):
+    # On Python 2.7, install no-op handler to silence
     # `No handlers could be found for logger "elasticsearch"` message per
     # <https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library>
     import logging

--- a/elasticsearch/helpers/test.py
+++ b/elasticsearch/helpers/test.py
@@ -1,10 +1,6 @@
 import time
 import os
-try:
-    # python 2.6
-    from unittest2 import TestCase, SkipTest
-except ImportError:
-    from unittest import TestCase, SkipTest
+from unittest import TestCase, SkipTest
 
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ConnectionError

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,6 @@ tests_require = [
     'nosexcover'
 ]
 
-# use external unittest for 2.6
-if sys.version_info[:2] == (2, 6):
-    install_requires.append('unittest2')
-
 setup(
     name = 'elasticsearch',
     description = "Python client for Elasticsearch",
@@ -47,7 +43,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",

--- a/test_elasticsearch/test_cases.py
+++ b/test_elasticsearch/test_cases.py
@@ -1,9 +1,5 @@
 from collections import defaultdict
-try:
-    # python 2.6
-    from unittest2 import TestCase, SkipTest
-except ImportError:
-    from unittest import TestCase, SkipTest
+from unittest import TestCase, SkipTest
 
 from elasticsearch import Elasticsearch
 

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -48,7 +48,7 @@ class TestUrllib3Connection(TestCase):
         if (
             sys.version_info >= (3,0) and sys.version_info <= (3,4)
             ) or (
-            sys.version_info >= (2,6) and sys.version_info <= (2,7)
+            sys.version_info == (2,7)
         ):
             raise SkipTest("SSL Context not supported in this version of python")
         with warnings.catch_warnings(record=True) as w:

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -46,9 +46,9 @@ class TestUrllib3Connection(TestCase):
 
     def test_uses_https_if_verify_certs_is_off(self):
         if (
-            sys.version_info >= (3,0) and sys.version_info <= (3,4)
+            sys.version_info == (3, 4)
             ) or (
-            sys.version_info == (2,7)
+            sys.version_info == (2, 7)
         ):
             raise SkipTest("SSL Context not supported in this version of python")
         with warnings.catch_warnings(record=True) as w:

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -46,9 +46,9 @@ class TestUrllib3Connection(TestCase):
 
     def test_uses_https_if_verify_certs_is_off(self):
         if (
-            sys.version_info == (3, 4)
+            sys.version_info[:2] == (3, 4)
             ) or (
-            sys.version_info == (2, 7)
+            sys.version_info[:2] == (2, 7)
         ):
             raise SkipTest("SSL Context not supported in this version of python")
         with warnings.catch_warnings(record=True) as w:

--- a/test_elasticsearch/test_serializer.py
+++ b/test_elasticsearch/test_serializer.py
@@ -15,8 +15,6 @@ class TestJSONSerializer(TestCase):
         self.assertEquals('{"d": "2010-10-01T02:30:00"}', JSONSerializer().dumps({'d': datetime(2010, 10, 1, 2, 30)}))
 
     def test_decimal_serialization(self):
-        if sys.version_info[:2] == (2, 6):
-            raise SkipTest("Float rounding is broken in 2.6.")
         self.assertEquals('{"d": 3.8}', JSONSerializer().dumps({'d': Decimal('3.8')}))
 
     def test_uuid_serialization(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py27,py33,py34,py35,py36
+envlist = pypy,py27,py34,py35,py36
 [testenv]
 whitelist_externals = git
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py26,py27,py33,py34,py35,py36
+envlist = pypy,py27,py33,py34,py35,py36
 [testenv]
 whitelist_externals = git
 setenv =


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-py/pull/548#issuecomment-291575889:

> `2.6` and `3.3` should be dropped. They're obsolete now and nobody on those versions is going to be upgrading to new versions of this library.

Here's the pip installs for elasticsearch from PyPI for the last month, showing low usage of the old ones:
```
$ pypinfo --percent --pip elasticsearch pyversion
python_version percent download_count
-------------- ------- --------------
2.7              73.0%        550,247
3.6              12.0%         90,671
3.5               8.6%         65,031
3.4               4.9%         36,811
2.6               1.4%         10,329
3.3               0.0%            299
3.7               0.0%             64
3.2               0.0%             11
None              0.0%              5

```