### PR TITLE
Unrecognized parameter: wait_for_merge

### DIFF
--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -817,8 +817,6 @@ class IndicesClient(NamespacedClient):
         :arg only_expunge_deletes: Specify whether the operation should only
             expunge deleted documents
         :arg operation_threading: TODO: ?
-        :arg wait_for_merge: Specify whether the request should block until the
-            merge process is finished (default: true)
         """
         return self.transport.perform_request('POST', _make_path(index,
             '_forcemerge'), params=params)


### PR DESCRIPTION
Tested under ES 5.6.3
```
curl -XPOST 'http://es:9200/index/_forcemerge?flush=true&wait_for_merge=true&ignore_unavailable=true&max_num_segments=1'
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/index/_forcemerge] contains unrecognized parameter: [wait_for_merge]"}],"type":"illegal_argument_exception","reason":"request [/index/_forcemerge] contains unrecognized parameter: [wait_for_merge]"},"status":400}
```