### PR TITLE
When _just_ using an SSL context we don't want breaking behavior

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -80,8 +80,8 @@ class Urllib3HttpConnection(Connection):
         kw = {}
 
         # if providing an SSL context, raise error if any other SSL related flag is used
-        if ssl_context and (verify_certs or ca_certs or ssl_version):
-            raise ImproperlyConfigured("When using `ssl_context`, `use_ssl`, `verify_certs`, `ca_certs` and `ssl_version` are not permitted")
+        if ssl_context and (ca_certs or ssl_version or use_ssl):
+            raise ImproperlyConfigured("When using `ssl_context`, `use_ssl`, `ca_certs` and `ssl_version` are not permitted")
 
         # if ssl_context provided use SSL by default
         if use_ssl or ssl_context:

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -68,7 +68,6 @@ class TestUrllib3Connection(TestCase):
         except AttributeError:
             raise SkipTest("SSL Context not supported in this version of python")
         self.assertRaises(ImproperlyConfigured, Urllib3HttpConnection, ssl_context=ctx, use_ssl=True)
-        self.assertRaises(ImproperlyConfigured, Urllib3HttpConnection, ssl_context=ctx, verify_certs=True)
         self.assertRaises(ImproperlyConfigured, Urllib3HttpConnection, ssl_context=ctx, ca_certs="/some/path/to/cert.crt")
         self.assertRaises(ImproperlyConfigured, Urllib3HttpConnection, ssl_context=ctx, ssl_version=ssl.PROTOCOL_SSLv23)
 


### PR DESCRIPTION
Also don't want to break backwards compat. So when checking for deprecated values ignore
the check on `verify_certs`. Since it's True by default. The verify certs will be default True
in the ssl_context. And can be turned off in the SSL context when using it.