### PR TITLE
Use provided request headers in urllib3

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -142,8 +142,7 @@ class Urllib3HttpConnection(Connection):
                 method = method.encode('utf-8')
 
             request_headers = dict(self.headers)
-            if headers:
-                request_headers.update(headers or {})
+            request_headers.update(headers or {})
             response = self.pool.urlopen(method, url, body, retries=False, headers=request_headers, **kw)
             duration = time.time() - start
             raw_data = response.data.decode('utf-8')

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -141,10 +141,10 @@ class Urllib3HttpConnection(Connection):
             if not isinstance(method, str):
                 method = method.encode('utf-8')
 
+            request_headers = dict(self.headers)
             if headers:
-                request_headers = dict(self.headers)
                 request_headers.update(headers or {})
-            response = self.pool.urlopen(method, url, body, retries=False, headers=self.headers, **kw)
+            response = self.pool.urlopen(method, url, body, retries=False, headers=request_headers, **kw)
             duration = time.time() - start
             raw_data = response.data.decode('utf-8')
         except Exception as e:


### PR DESCRIPTION
#618 provided the ability to pass custom http headers.  However, 
`Urllib3HttpConnection` did not use these headers but only its 
default ones.

With this commit, `Urllib3HttpConnection` will either use the default
ones or merge the default headers with the provided ones if there are
any.

Relates #618