### PR TITLE
It's possible to send content-type to _raise_error

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -109,12 +109,12 @@ class Connection(object):
         if response is not None:
             logger.debug('< %s', response)
 
-    def _raise_error(self, status_code, raw_data):
+    def _raise_error(self, status_code, raw_data, content_type='application/json'):
         """ Locate appropriate exception and raise it. """
         error_message = raw_data
         additional_info = None
         try:
-            if raw_data:
+            if raw_data and content_type == 'application/json':
                 additional_info = json.loads(raw_data)
                 error_message = additional_info.get('error', error_message)
                 if isinstance(error_message, dict) and 'type' in error_message:


### PR DESCRIPTION
Not all error return json content (think about a broken proxy). This requests add an optional content_type argument to _raise_error , that is checked to avoid calling json.loads() on non-json content.
It default to application/json to avoid breaking existing code.