### PR TITLE
Updates to SSL Context changes

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -80,13 +80,14 @@ class Urllib3HttpConnection(Connection):
         kw = {}
 
         # if providing an SSL context, raise error if any other SSL related flag is used
-        if ssl_context and (ca_certs or ssl_version or use_ssl):
-            raise ImproperlyConfigured("When using `ssl_context`, `use_ssl`, `ca_certs` and `ssl_version` are not permitted")
+        if ssl_context and (ca_certs or ssl_version):
+            raise ImproperlyConfigured("When using `ssl_context`, `use_ssl`, `verify_certs`, `ca_certs` and `ssl_version` are not permitted")
 
         # if ssl_context provided use SSL by default
         if use_ssl or ssl_context:
-            cafile = CA_CERTS if ca_certs is None else ca_certs
-            if not cafile and not ssl_context and verify_certs:
+            ca_certs = CA_CERTS if ca_certs is None else ca_certs
+
+            if not ca_certs and not ssl_context and verify_certs:
                 # If no ca_certs and no sslcontext passed and asking to verify certs
                 # raise error
                 raise ImproperlyConfigured("Root certificates are missing for certificate "
@@ -100,7 +101,7 @@ class Urllib3HttpConnection(Connection):
                 # if SSLContext hasn't been passed in, create one.
                 # need to skip if sslContext isn't avail
                 try:
-                    ssl_context = create_ssl_context(cafile=cafile)
+                    ssl_context = create_ssl_context(cafile=ca_certs)
                 except AttributeError:
                     ssl_context = None
 
@@ -116,7 +117,7 @@ class Urllib3HttpConnection(Connection):
                 'assert_fingerprint': ssl_assert_fingerprint,
                 'ssl_context': ssl_context,
                 'cert_file': client_cert,
-                'ca_certs': cafile,
+                'ca_certs': ca_certs,
                 'key_file': client_key,
             })
         self.pool = pool_class(host, port=port, timeout=self.timeout, maxsize=maxsize, **kw)

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -67,7 +67,6 @@ class TestUrllib3Connection(TestCase):
             ctx = create_ssl_context()
         except AttributeError:
             raise SkipTest("SSL Context not supported in this version of python")
-        self.assertRaises(ImproperlyConfigured, Urllib3HttpConnection, ssl_context=ctx, use_ssl=True)
         self.assertRaises(ImproperlyConfigured, Urllib3HttpConnection, ssl_context=ctx, ca_certs="/some/path/to/cert.crt")
         self.assertRaises(ImproperlyConfigured, Urllib3HttpConnection, ssl_context=ctx, ssl_version=ssl.PROTOCOL_SSLv23)
 


### PR DESCRIPTION
Bug with OSX made breaking changes to the way certifi was being imported
and used.

Unable to reproduce with Linux.

Found improper logic. Fixed now.
Also changing removing the flag for checking `verify_certs` as
it is `True` by default. Don't want to make users flag that as
`False` just to make things work.

A connection to an SSL instance should be:

    es = Elasticsearch("https://host:port", http_auth=(user,pass))

* If using Elastic Cloud or some other publicly recognized certificate
  that certifi can recognize.