### PR TITLE
Elastic now supports oss Docker Images

### DIFF
--- a/test_elasticsearch/start_elasticsearch.sh
+++ b/test_elasticsearch/start_elasticsearch.sh
@@ -6,7 +6,6 @@ ES_VERSION=${ES_VERSION:-"latest"}
 ES_TEST_SERVER=${ES_TEST_SERVER:-"http://localhost:9200"}
 
 exec docker run -d \
-    -e script.inline=true \
     -e path.repo=/tmp \
     -e "repositories.url.allowed_urls=http://*" \
     -e node.attr.testattr=test \
@@ -14,5 +13,4 @@ exec docker run -d \
     -v `pwd`/../elasticsearch:/code/elasticsearch \
     -v /tmp:/tmp \
     -p "9200:9200" \
-fxdgear/elasticsearch:$ES_VERSION
-
+docker.elastic.co/elasticsearch/elasticsearch-oss:$ES_VERSION


### PR DESCRIPTION
No need to use my personal docker iamges, now that Elastic creates oss docker images

Also removing `script.inline` as it's not a valid flag for ES6 +