### PR TITLE
fixing SSL auth issue in 5.x

### DIFF
--- a/elasticsearch5/connection/http_urllib3.py
+++ b/elasticsearch5/connection/http_urllib3.py
@@ -71,23 +71,24 @@ class Urllib3HttpConnection(Connection):
                 'ssl_version': ssl_version,
                 'assert_hostname': ssl_assert_hostname,
                 'assert_fingerprint': ssl_assert_fingerprint,
+                'ca_certs': ca_certs,
+                'cert_file': client_cert,
+                'key_file': client_key,
             })
-
             if verify_certs:
                 if not ca_certs:
                     raise ImproperlyConfigured("Root certificates are missing for certificate "
                         "validation. Either pass them in using the ca_certs parameter or "
                         "install certifi to use it automatically.")
-
                 kw.update({
                     'cert_reqs': 'CERT_REQUIRED',
-                    'ca_certs': ca_certs,
-                    'cert_file': client_cert,
-                    'key_file': client_key,
                 })
             else:
                 warnings.warn(
                     'Connecting to %s using SSL with verify_certs=False is insecure.' % host)
+                kw.update({
+                    'cert_reqs': 'CERT_NONE',
+                })
 
         self.pool = pool_class(host, port=port, timeout=self.timeout, maxsize=maxsize, **kw)
 


### PR DESCRIPTION
If trying to connect to SSL instances with SSL Client Auth, but not verifying the CA cert, the client cert/key will not be added to the request. 

Instead lets add to the KW to be passed into the request, and instead if `verify_certs=False` lets set `cert_reqs=CERT_NONE` and if `verify_certs=True` we can set `cert_reqs=CERT_REQUIRED`