### PR TITLE
Adds dynamic class-based `__repr__`

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -183,10 +183,10 @@ class Elasticsearch(object):
         try:
             # get a list of all connections
             cons = self.transport.hosts
-            # truncate to 10 if there are too many
+            # truncate to 5 if there are too many
             if len(cons) > 5:
                 cons = cons[:5] + ['...']
-            return '<Elasticsearch(%r)>' % cons
+            return '<{cls}({cons})>'.format(cls=self.__class__.__name__, cons=cons)
         except:
             # probably operating on custom transport and connection_pool, ignore
             return super(Elasticsearch, self).__repr__()

--- a/test_elasticsearch/test_client/__init__.py
+++ b/test_elasticsearch/test_client/__init__.py
@@ -75,12 +75,18 @@ class TestClient(ElasticsearchTestCase):
     def test_repr_contains_hosts(self):
         self.assertEquals('<Elasticsearch([{}])>', repr(self.client))
 
+    def test_repr_subclass(self):
+        class OtherElasticsearch(Elasticsearch): pass
+        self.assertEqual('<OtherElasticsearch([{}])>', repr(OtherElasticsearch()))
+
     def test_repr_contains_hosts_passed_in(self):
         self.assertIn("es.org", repr(Elasticsearch(['es.org:123'])))
 
-    def test_repr_truncates_host_to_10(self):
-        hosts = [{"host": "es" + str(i)} for i in range(20)]
-        self.assertNotIn("es5", repr(Elasticsearch(hosts)))
+    def test_repr_truncates_host_to_5(self):
+        hosts = [{"host": "es" + str(i)} for i in range(10)]
+        es = Elasticsearch(hosts)
+        self.assertNotIn("es5", repr(es))
+        self.assertIn('...', repr(es))
 
     def test_index_uses_post_if_id_is_empty(self):
         self.client.index(index='my-index', doc_type='test-doc', id='', body={})


### PR DESCRIPTION
 * minor typo/stale fix
 * makes `__repr__` dynamic, based on class name. Gives ability to inherit `Elasticsearch` without reloading `__repr__` and still having proper representation

Faced inconvenience based on this while working with `elasticsearch-py-async`. Not sure that this is proper place for this code, but copy-pasting logic to dependent libs doesn't seem to be good way.