### PR TITLE
Add support for script actions to bulk helpers.

### DIFF
--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -36,6 +36,14 @@ def expand_action(data):
     data = data.copy()
     op_type = data.pop('_op_type', 'index')
     action = {op_type: {}}
+
+    if op_type == 'script':
+        for key in ('scripted_upsert', 'upsert'):
+            if key in data:
+                action[key] = data.pop(key)
+        action[op_type] = data.pop('_script', {})
+        return action, None
+
     for key in ('_index', '_parent', '_percolate', '_routing', '_timestamp',
                 '_type', '_version', '_version_type', '_id',
                 '_retry_on_conflict', 'pipeline'):

--- a/test_elasticsearch/test_helpers.py
+++ b/test_elasticsearch/test_helpers.py
@@ -40,3 +40,26 @@ class TestChunkActions(TestCase):
 class TestExpandActions(TestCase):
     def test_string_actions_are_marked_as_simple_inserts(self):
         self.assertEquals(('{"index":{}}', "whatever"), helpers.expand_action('whatever'))
+
+    def test_script_actions(self):
+        action = {
+            '_op_type': 'script',
+            '_script': {
+                "id": "test",
+                "source": "ctx._source.counter += params.param1",
+                "lang": "painless",
+                "params": {
+                    "param1": 1
+                }
+            },
+            "scripted_upsert": True,
+            "upsert": {
+                "counter": 1
+            }
+        }
+        expected = {
+            'script': action['_script'],
+            'upsert': action['upsert'],
+            'scripted_upsert': action['scripted_upsert'],
+        }
+        self.assertEquals(helpers.expand_action(action), (expected, None))


### PR DESCRIPTION
Docs specify that script actions are possible with the BULK endpoint but `expand_action` doesn't support them https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html.

This PR adds support to `expand_action` for actions that look like:

```python
{
    '_op_type': 'script',
    '_script': {
        "id": "test",
        "source": "ctx._source.counter += params.param1",
        "lang": "painless",
        "params": {
                "param1": 1
        }
    },
    "scripted_upsert": True,
    "upsert": {
        "counter": 1
    }
}
```

Open to ideas on tweaking that format, but it seemed sane and in the spirit of what happens with doc updates.

I've already signed a CLA.