### PR TITLE
optimize TransportError when show error msg is incomplete

### DIFF
--- a/elasticsearch/exceptions.py
+++ b/elasticsearch/exceptions.py
@@ -55,9 +55,12 @@ class TransportError(ElasticsearchException):
         cause = ''
         try:
             if self.info:
-                cause = ', %r' % self.info['error']['root_cause'][0]['reason']
+                if self.info['error']['root_cause'][0]['type'] ==  self.info['error']['type']:
+                    cause = ', %r' % self.info['error']['root_cause'][0]['reason']
+                else:
+                    cause = ', error root_cause reason: %r, error reason: %r' % (self.info['error']['root_cause'][0]['reason'], self.info['error']['reason'])
         except LookupError:
-            pass
+            cause = str(self.info)
         return 'TransportError(%s, %r%s)' % (self.status_code, self.error, cause)
 
 


### PR DESCRIPTION
when update es, mapping fileds more than "index.mapping.total_fields.limit", I only got error message is "TransportError(400, illegal_argument_exception, [10.xx.xx.15][]dices:data/write/update[s]]". that is not really error msg, so that can't tell me what' wrong.
Eg curl repsonse msg:
{"error":{"root_cause":[{"type":"remote_transport_exception","reason":"[10.xx.xx.241][10.xx.xx.241:19413][indices:data/write/update[s]]"}],"type":"illegal_argument_exception","reason":"Limit of total fields [1000] in index [my_index] has been exceeded"},"status":400}