### PR TITLE
Use proper retry_on_conflict for helpers.expand_action

### DIFF
--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -38,7 +38,7 @@ def expand_action(data):
     action = {op_type: {}}
     for key in ('_index', '_parent', '_percolate', '_routing', '_timestamp',
                 '_type', '_version', '_version_type', '_id',
-                '_retry_on_conflict', 'pipeline'):
+                'retry_on_conflict', 'pipeline'):
         if key in data:
             action[op_type][key] = data.pop(key)
 


### PR DESCRIPTION
As per
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-update,
retry_on_conflict should not be preceded by an underscore.