### PR TITLE
Use string.partition rather than string.split for mimetype

### DIFF
--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -72,7 +72,7 @@ class Deserializer(object):
             deserializer = self.default
         else:
             # split out charset
-            mimetype = mimetype.split(';', 1)[0]
+            mimetype, _, _ = mimetype.partition(';')
             try:
                 deserializer = self.serializers[mimetype]
             except KeyError:


### PR DESCRIPTION
I noticed that it was spending a bit more time than expected in `loads` in serializer.py just analysing the mimetype. This PR replaces the use of `.split` with `.partition` on the mimetype.

Falcon uses `.partition` instead of `.split` throughout the code because it's a bit faster (eg https://github.com/falconry/falcon/blob/b2a601495ccb0ab2d47968e4a60818b68b07d776/falcon/request.py#L824-L825).

Example:

```python
# test.py
import timeit

def time_strip(s, mimetype):
    print(timeit.timeit(s, setup="mimetype = '{}'".format(mimetype), number=10000000))

print("Split:")
time_strip("mimetype = mimetype.split(';', 1)[0]", mimetype="application/json")
print("Partition:")
time_strip("mimetype, _, _ = mimetype.partition(';')", mimetype="application/json")
print()
print("Split with utf8:")
time_strip("mimetype = mimetype.split(';', 1)[0]", mimetype="application/json;utf8")
print("Partition with utf8:")
time_strip("mimetype, _, _ = mimetype.partition(';')", mimetype="application/json;utf8")
```
Output (python 3.5):
```
$ python test.py
Split:
1.925636083993595
Partition:
0.9025002819835208

Split with utf8:
1.9355367120006122
Partition with utf8:
0.9203260110225528
```
python 2.7:
```
 $ python test.py
Split:
1.77026295662
Partition:
0.866982936859

Split with utf8:
1.82030391693
Partition with utf8:
0.83936715126
```
pypy3:
```
$ python test.py 
Split:
0.25560496596153826
Partition:
0.00911501602968201

Split with utf8:
0.24626824300503358
Partition with utf8:
0.008667621004860848
```

A more in depth example using the Deserializer class (note that I'm not actually dumping the json to stop that affecting the timing - monkey patching this with ujon/rapidjson is a lot quicker than json/simplejson like in the master branch anyway):

```python
# test2.py
import timeit

from elasticsearch.serializer import Deserializer, DEFAULT_SERIALIZERS, SerializationError
DEFAULT_SERIALIZERS["application/json"].loads = lambda x: None
d1 = Deserializer(DEFAULT_SERIALIZERS)


class Deserializer2(Deserializer):

    def loads(self, s, mimetype=None):
        if not mimetype:
            deserializer = self.default
        else:
            # split out charset
            mimetype, _, _ = mimetype.partition(';')
            try:
                deserializer = self.serializers[mimetype]
            except KeyError:
                raise SerializationError('Unknown mimetype, unable to deserialize: %s' % mimetype)

        return deserializer.loads(s)


d2 = Deserializer2(DEFAULT_SERIALIZERS)


def time_strip(s):
    print(timeit.timeit(s, number=10000000, globals=globals()))


print("Split:")
time_strip("""d1.loads('{"a": "b"}', "application/json")""")
print("Partition:")
time_strip("""d2.loads('{"a": "b"}', "application/json")""")
print()
print("Split with utf8:")
time_strip("""d1.loads('{"a": "b"}', "application/json;utf8")""")
print("Partition with utf8:")
time_strip("""d2.loads('{"a": "b"}', "application/json;utf8")""")
```
output (python 3.5)
```
$ python test2.py
Split:
4.975090911961161
Partition:
3.7508687949739397

Split with utf8:
5.690062493958976
Partition with utf8:
4.3920825000386685
```
pypy3:
```
 $ python test2.py
Split:
0.4341110459645279
Partition:
0.2171118290279992

Split with utf8:
1.5033086360199377
Partition with utf8:
0.2041827340144664
```
(no results for python 2 because `timeit()` doesn't have the `globals` argument)