### PR TITLE
Support routing key at bulk action parameter

### DIFF
--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -36,7 +36,7 @@ def expand_action(data):
     data = data.copy()
     op_type = data.pop('_op_type', 'index')
     action = {op_type: {}}
-    for key in ('_index', '_parent', '_percolate', '_routing', '_timestamp',
+    for key in ('_index', '_parent', '_percolate', '_routing', '_timestamp', 'routing',
                 '_type', '_version', '_version_type', '_id',
                 'retry_on_conflict', 'pipeline'):
         if key in data:


### PR DESCRIPTION
when using `_routing` parameter,
`Deprecated field [_routing] used, expected [routing] instead`
warning is appeared at Elasticsearch v6.2.2.

https://discuss.elastic.co/t/deprecated-field-routing-used-expected-routing-instead/115951/3

Elasticsearch-py should be support `routing` field.