### PR TITLE
Adding documentation for passing custom serializer to es client instance

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -292,6 +292,29 @@ the `requests-aws4auth`_ package::
 
 .. _requests-aws4auth: https://pypi.python.org/pypi/requests-aws4auth
 
+Customization
+-------------
+
+Custom serializers
+~~~~~~~~~~~~~~~~~~
+
+By default, `JSONSerializer`_ is used to encode all outgoing requests.
+However, you can implement your own custom serializer::
+
+   from elasticsearch.serializer import JSONSerializer
+
+   class SetEncoder(JSONSerializer):
+       def default(self, obj):
+           if isinstance(obj, set):
+               return list(obj)
+           if isinstance(obj, Something):
+               return 'CustomSomethingRepresentation'
+           return JSONSerializer.default(self, obj)
+
+   es = Elasticsearch(serializer=SetEncoder())
+
+.. _JSONSerializer: https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/serializer.py#L24
+
 Contents
 --------
 

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -150,6 +150,23 @@ class Elasticsearch(object):
             ],
             verify_certs=True
         )
+    
+    By default, `JSONSerializer
+    <https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/serializer.py#L24>`_ 
+    is used to encode all outgoing requests.
+    However, you can implement your own custom serializer::
+    
+        from elasticsearch.serializer import JSONSerializer
+
+        class SetEncoder(JSONSerializer):
+            def default(self, obj):
+                if isinstance(obj, set):
+                    return list(obj)
+                if isinstance(obj, Something):
+                    return 'CustomSomethingRepresentation'
+                return JSONSerializer.default(self, obj)
+        
+        es = Elasticsearch(serializer=SetEncoder())
 
     """
     def __init__(self, hosts=None, transport_class=Transport, **kwargs):


### PR DESCRIPTION
While using and query where passing an array is required, a set cannot be used. This is because sets are not json serializable.
Discussion has been captured here https://github.com/elastic/elasticsearch-py/issues/744