### PR TITLE
Adding X-Pack clients to -py repo

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -12,6 +12,7 @@ from .nodes import NodesClient
 from .remote import RemoteClient
 from .snapshot import SnapshotClient
 from .tasks import TasksClient
+from .xpack import XPackClient
 from .utils import query_params, _make_path, SKIP_IN_PATH
 
 logger = logging.getLogger('elasticsearch')
@@ -178,6 +179,7 @@ class Elasticsearch(object):
         self.remote = RemoteClient(self)
         self.snapshot = SnapshotClient(self)
         self.tasks = TasksClient(self)
+        self.xpack = XPackClient(self)
 
     def __repr__(self):
         try:

--- a/elasticsearch/client/xpack/__init__.py
+++ b/elasticsearch/client/xpack/__init__.py
@@ -1,0 +1,47 @@
+from elasticsearch.client.utils import NamespacedClient, query_params
+
+from .graph import GraphClient
+from .license import LicenseClient
+from .monitoring import MonitoringClient
+from .security import SecurityClient
+from .watcher import WatcherClient
+from .ml import MlClient
+from .migration import MigrationClient
+from .deprecation import DeprecationClient
+
+class XPackClient(NamespacedClient):
+    namespace = 'xpack'
+
+    def __init__(self, *args, **kwargs):
+        super(XPackClient, self).__init__(*args, **kwargs)
+        self.graph = GraphClient(self.client)
+        self.license = LicenseClient(self.client)
+        self.monitoring = MonitoringClient(self.client)
+        self.security = SecurityClient(self.client)
+        self.watcher = WatcherClient(self.client)
+        self.ml = MlClient(self.client)
+        self.migration = MigrationClient(self.client)
+        self.deprecation = DeprecationClient(self.client)
+
+    @query_params('categories', 'human')
+    def info(self, params=None):
+        """
+        Retrieve information about xpack, including build number/timestamp and license status
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html>`_
+
+        :arg categories: Comma-separated list of info categories. Can be any of:
+            build, license, features
+        :arg human: Presents additional info for humans (feature descriptions
+            and X-Pack tagline)
+        """
+        return self.transport.perform_request('GET', '/_xpack', params=params)
+
+    @query_params('master_timeout')
+    def usage(self, params=None):
+        """
+        Retrieve information about xpack features usage
+
+        :arg master_timeout: Specify timeout for watch write operation
+        """
+        return self.transport.perform_request('GET', '/_xpack/usage',
+            params=params)

--- a/elasticsearch/client/xpack/deprecation.py
+++ b/elasticsearch/client/xpack/deprecation.py
@@ -1,0 +1,13 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path
+
+class DeprecationClient(NamespacedClient):
+    @query_params()
+    def info(self, index=None, params=None):
+        """
+        `<http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html>`_
+
+        :arg index: Index pattern
+        """
+        return self.transport.perform_request('GET', _make_path(index, '_xpack',
+            'migration', 'deprecations'), params=params)
+

--- a/elasticsearch/client/xpack/graph.py
+++ b/elasticsearch/client/xpack/graph.py
@@ -1,0 +1,18 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path
+
+class GraphClient(NamespacedClient):
+    @query_params('routing', 'timeout')
+    def explore(self, index=None, doc_type=None, body=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html>`_
+
+        :arg index: A comma-separated list of index names to search; use `_all`
+            or empty string to perform the operation on all indices
+        :arg doc_type: A comma-separated list of document types to search; leave
+            empty to perform the operation on all types
+        :arg body: Graph Query DSL
+        :arg routing: Specific routing value
+        :arg timeout: Explicit operation timeout
+        """
+        return self.transport.perform_request('GET', _make_path(index, doc_type,
+            '_xpack', 'graph', '_explore'), params=params, body=body)

--- a/elasticsearch/client/xpack/license.py
+++ b/elasticsearch/client/xpack/license.py
@@ -1,0 +1,37 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+
+class LicenseClient(NamespacedClient):
+    @query_params()
+    def delete(self, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/x-pack/current/license-management.html>`_
+        """
+        return self.transport.perform_request('DELETE', '/_xpack/license',
+            params=params)
+
+    @query_params('local')
+    def get(self, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/x-pack/current/license-management.html>`_
+
+        :arg local: Return local information, do not retrieve the state from
+            master node (default: false)
+        """
+        return self.transport.perform_request('GET', '/_xpack/license',
+            params=params)
+
+    @query_params('acknowledge')
+    def post(self, body=None, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/x-pack/current/license-management.html>`_
+
+        :arg body: licenses to be installed
+        :arg acknowledge: whether the user has acknowledged acknowledge messages
+            (default: false)
+        """
+        return self.transport.perform_request('PUT', '/_xpack/license',
+            params=params, body=body)
+

--- a/elasticsearch/client/xpack/migration.py
+++ b/elasticsearch/client/xpack/migration.py
@@ -1,0 +1,36 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+
+class MigrationClient(NamespacedClient):
+    @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable')
+    def get_assistance(self, index=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html>`_
+
+        :arg index: A comma-separated list of index names; use `_all` or empty
+            string to perform the operation on all indices
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to concrete
+            indices that are open, closed or both., default 'open', valid
+            choices are: 'open', 'closed', 'none', 'all'
+        :arg ignore_unavailable: Whether specified concrete indices should be
+            ignored when unavailable (missing or closed)
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack',
+            'migration', 'assistance', index), params=params)
+
+    @query_params('wait_for_completion')
+    def upgrade(self, index, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html>`_
+
+        :arg index: The name of the index
+        :arg wait_for_completion: Should the request block until the upgrade
+            operation is completed, default True
+        """
+        if index in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'index'.")
+        return self.transport.perform_request('POST', _make_path('_xpack',
+            'migration', 'upgrade', index), params=params)

--- a/elasticsearch/client/xpack/ml.py
+++ b/elasticsearch/client/xpack/ml.py
@@ -1,0 +1,489 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+
+class MlClient(NamespacedClient):
+    @query_params('from_', 'size')
+    def get_filters(self, filter_id=None, params=None):
+        """
+
+        :arg filter_id: The ID of the filter to fetch
+        :arg from_: skips a number of filters
+        :arg size: specifies a max number of filters to get
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'filters', filter_id), params=params)
+
+    @query_params()
+    def get_datafeeds(self, datafeed_id=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html>`_
+
+        :arg datafeed_id: The ID of the datafeeds to fetch
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'datafeeds', datafeed_id), params=params)
+
+    @query_params()
+    def get_datafeed_stats(self, datafeed_id=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html>`_
+
+        :arg datafeed_id: The ID of the datafeeds stats to fetch
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'datafeeds', datafeed_id, '_stats'), params=params)
+
+    @query_params('anomaly_score', 'desc', 'end', 'exclude_interim', 'expand',
+        'from_', 'size', 'sort', 'start')
+    def get_buckets(self, job_id, timestamp=None, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html>`_
+
+        :arg job_id: ID of the job to get bucket results from
+        :arg timestamp: The timestamp of the desired single bucket result
+        :arg body: Bucket selection details if not provided in URI
+        :arg anomaly_score: Filter for the most anomalous buckets
+        :arg desc: Set the sort direction
+        :arg end: End time filter for buckets
+        :arg exclude_interim: Exclude interim results
+        :arg expand: Include anomaly records
+        :arg from_: skips a number of buckets
+        :arg size: specifies a max number of buckets to get
+        :arg sort: Sort buckets by a particular field
+        :arg start: Start time filter for buckets
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, 'results', 'buckets', timestamp),
+            params=params, body=body)
+
+    @query_params('reset_end', 'reset_start')
+    def post_data(self, job_id, body, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html>`_
+
+        :arg job_id: The name of the job receiving the data
+        :arg body: The data to process
+        :arg reset_end: Optional parameter to specify the end of the bucket
+            resetting range
+        :arg reset_start: Optional parameter to specify the start of the bucket
+            resetting range
+        """
+        for param in (job_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, '_data'), params=params,
+            body=self._bulk_body(body))
+
+    @query_params('force', 'timeout')
+    def stop_datafeed(self, datafeed_id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html>`_
+
+        :arg datafeed_id: The ID of the datafeed to stop
+        :arg force: True if the datafeed should be forcefully stopped.
+        :arg timeout: Controls the time to wait until a datafeed has stopped.
+            Default to 20 seconds
+        """
+        if datafeed_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'datafeed_id'.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'datafeeds', datafeed_id, '_stop'), params=params)
+
+    @query_params()
+    def get_jobs(self, job_id=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html>`_
+
+        :arg job_id: The ID of the jobs to fetch
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id), params=params)
+
+    @query_params()
+    def delete_expired_data(self, params=None):
+        """
+        """
+        return self.transport.perform_request('DELETE',
+            '/_xpack/ml/_delete_expired_data', params=params)
+
+    @query_params()
+    def put_job(self, job_id, body, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html>`_
+
+        :arg job_id: The ID of the job to create
+        :arg body: The job
+        """
+        for param in (job_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('PUT', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id), params=params, body=body)
+
+    @query_params()
+    def validate_detector(self, body, params=None):
+        """
+
+        :arg body: The detector
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+        return self.transport.perform_request('POST',
+            '/_xpack/ml/anomaly_detectors/_validate/detector', params=params,
+            body=body)
+
+    @query_params('end', 'start', 'timeout')
+    def start_datafeed(self, datafeed_id, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`_
+
+        :arg datafeed_id: The ID of the datafeed to start
+        :arg body: The start datafeed parameters
+        :arg end: The end time when the datafeed should stop. When not set, the
+            datafeed continues in real time
+        :arg start: The start time from where the datafeed should begin
+        :arg timeout: Controls the time to wait until a datafeed has started.
+            Default to 20 seconds
+        """
+        if datafeed_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'datafeed_id'.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'datafeeds', datafeed_id, '_start'), params=params, body=body)
+
+    @query_params('desc', 'end', 'exclude_interim', 'from_', 'record_score',
+        'size', 'sort', 'start')
+    def get_records(self, job_id, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html>`_
+
+        :arg job_id: None
+        :arg body: Record selection criteria
+        :arg desc: Set the sort direction
+        :arg end: End time filter for records
+        :arg exclude_interim: Exclude interim results
+        :arg from_: skips a number of records
+        :arg record_score:
+        :arg size: specifies a max number of records to get
+        :arg sort: Sort records by a particular field
+        :arg start: Start time filter for records
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, 'results', 'records'), params=params,
+            body=body)
+
+    @query_params()
+    def update_job(self, job_id, body, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html>`_
+
+        :arg job_id: The ID of the job to create
+        :arg body: The job update settings
+        """
+        for param in (job_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, '_update'), params=params, body=body)
+
+    @query_params()
+    def put_filter(self, filter_id, body, params=None):
+        """
+
+        :arg filter_id: The ID of the filter to create
+        :arg body: The filter details
+        """
+        for param in (filter_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('PUT', _make_path('_xpack', 'ml',
+            'filters', filter_id), params=params, body=body)
+
+    @query_params()
+    def update_datafeed(self, datafeed_id, body, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html>`_
+
+        :arg datafeed_id: The ID of the datafeed to update
+        :arg body: The datafeed update settings
+        """
+        for param in (datafeed_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'datafeeds', datafeed_id, '_update'), params=params, body=body)
+
+    @query_params()
+    def preview_datafeed(self, datafeed_id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html>`_
+
+        :arg datafeed_id: The ID of the datafeed to preview
+        """
+        if datafeed_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'datafeed_id'.")
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'datafeeds', datafeed_id, '_preview'), params=params)
+
+    @query_params('advance_time', 'calc_interim', 'end', 'skip_time', 'start')
+    def flush_job(self, job_id, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html>`_
+
+        :arg job_id: The name of the job to flush
+        :arg body: Flush parameters
+        :arg advance_time: Advances time to the given value generating results
+            and updating the model for the advanced interval
+        :arg calc_interim: Calculates interim results for the most recent bucket
+            or all buckets within the latency period
+        :arg end: When used in conjunction with calc_interim, specifies the
+            range of buckets on which to calculate interim results
+        :arg skip_time: Skips time to the given value without generating results
+            or updating the model for the skipped interval
+        :arg start: When used in conjunction with calc_interim, specifies the
+            range of buckets on which to calculate interim results
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, '_flush'), params=params, body=body)
+
+    @query_params('force', 'timeout')
+    def close_job(self, job_id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html>`_
+
+        :arg job_id: The name of the job to close
+        :arg force: True if the job should be forcefully closed
+        :arg timeout: Controls the time to wait until a job has closed. Default
+            to 30 minutes
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, '_close'), params=params)
+
+    @query_params()
+    def open_job(self, job_id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html>`_
+
+        :arg job_id: The ID of the job to open
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, '_open'), params=params)
+
+    @query_params('force')
+    def delete_job(self, job_id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html>`_
+
+        :arg job_id: The ID of the job to delete
+        :arg force: True if the job should be forcefully deleted
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'ml', 'anomaly_detectors', job_id), params=params)
+
+    @query_params()
+    def update_model_snapshot(self, job_id, snapshot_id, body, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to update
+        :arg body: The model snapshot properties to update
+        """
+        for param in (job_id, snapshot_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, 'model_snapshots', snapshot_id,
+            '_update'), params=params, body=body)
+
+    @query_params()
+    def delete_filter(self, filter_id, params=None):
+        """
+
+        :arg filter_id: The ID of the filter to delete
+        """
+        if filter_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'filter_id'.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'ml', 'filters', filter_id), params=params)
+
+    @query_params()
+    def validate(self, body, params=None):
+        """
+
+        :arg body: The job config
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+        return self.transport.perform_request('POST',
+            '/_xpack/ml/anomaly_detectors/_validate', params=params, body=body)
+
+    @query_params('from_', 'size')
+    def get_categories(self, job_id, category_id=None, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
+
+        :arg job_id: The name of the job
+        :arg category_id: The identifier of the category definition of interest
+        :arg body: Category selection details if not provided in URI
+        :arg from_: skips a number of categories
+        :arg size: specifies a max number of categories to get
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, 'results', 'categories', category_id),
+            params=params, body=body)
+
+    @query_params('desc', 'end', 'exclude_interim', 'from_', 'influencer_score',
+        'size', 'sort', 'start')
+    def get_influencers(self, job_id, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html>`_
+
+        :arg job_id: None
+        :arg body: Influencer selection criteria
+        :arg desc: whether the results should be sorted in decending order
+        :arg end: end timestamp for the requested influencers
+        :arg exclude_interim: Exclude interim results
+        :arg from_: skips a number of influencers
+        :arg influencer_score: influencer score threshold for the requested
+            influencers
+        :arg size: specifies a max number of influencers to get
+        :arg sort: sort field for the requested influencers
+        :arg start: start timestamp for the requested influencers
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, 'results', 'influencers'),
+            params=params, body=body)
+
+    @query_params()
+    def put_datafeed(self, datafeed_id, body, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html>`_
+
+        :arg datafeed_id: The ID of the datafeed to create
+        :arg body: The datafeed config
+        """
+        for param in (datafeed_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('PUT', _make_path('_xpack', 'ml',
+            'datafeeds', datafeed_id), params=params, body=body)
+
+    @query_params('force')
+    def delete_datafeed(self, datafeed_id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html>`_
+
+        :arg datafeed_id: The ID of the datafeed to delete
+        :arg force: True if the datafeed should be forcefully deleted
+        """
+        if datafeed_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'datafeed_id'.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'ml', 'datafeeds', datafeed_id), params=params)
+
+    @query_params()
+    def get_job_stats(self, job_id=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html>`_
+
+        :arg job_id: The ID of the jobs stats to fetch
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, '_stats'), params=params)
+
+    @query_params('delete_intervening_results')
+    def revert_model_snapshot(self, job_id, snapshot_id, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to revert to
+        :arg body: Reversion options
+        :arg delete_intervening_results: Should we reset the results back to the
+            time of the snapshot?
+        """
+        for param in (job_id, snapshot_id):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('POST', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, 'model_snapshots', snapshot_id,
+            '_revert'), params=params, body=body)
+
+    @query_params('desc', 'end', 'from_', 'size', 'sort', 'start')
+    def get_model_snapshots(self, job_id, snapshot_id=None, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to fetch
+        :arg body: Model snapshot selection criteria
+        :arg desc: True if the results should be sorted in descending order
+        :arg end: The filter 'end' query parameter
+        :arg from_: Skips a number of documents
+        :arg size: The default number of documents returned in queries as a
+            string.
+        :arg sort: Name of the field to sort on
+        :arg start: The filter 'start' query parameter
+        """
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+        return self.transport.perform_request('GET', _make_path('_xpack', 'ml',
+            'anomaly_detectors', job_id, 'model_snapshots', snapshot_id),
+            params=params, body=body)
+
+    @query_params()
+    def delete_model_snapshot(self, job_id, snapshot_id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to delete
+        """
+        for param in (job_id, snapshot_id):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'ml', 'anomaly_detectors', job_id, 'model_snapshots', snapshot_id),
+            params=params)
+

--- a/elasticsearch/client/xpack/monitoring.py
+++ b/elasticsearch/client/xpack/monitoring.py
@@ -1,0 +1,21 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+
+class MonitoringClient(NamespacedClient):
+    @query_params('interval', 'system_api_version', 'system_id')
+    def bulk(self, body, doc_type=None, params=None):
+        """
+        `<http://www.elastic.co/guide/en/monitoring/current/appendix-api-bulk.html>`_
+
+        :arg body: The operation definition and data (action-data pairs),
+            separated by newlines
+        :arg doc_type: Default document type for items which don't provide one
+        :arg interval: Collection interval (e.g., '10s' or '10000ms') of the
+            payload
+        :arg system_api_version: API Version of the monitored system
+        :arg system_id: Identifier of the monitored system
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+        return self.transport.perform_request('POST', _make_path('_xpack',
+            'monitoring', doc_type, '_bulk'), params=params,
+            body=self.client._bulk_body(body))

--- a/elasticsearch/client/xpack/security.py
+++ b/elasticsearch/client/xpack/security.py
@@ -1,0 +1,258 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+
+class SecurityClient(NamespacedClient):
+    @query_params('refresh')
+    def delete_user(self, username, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-users.html#security-api-delete-user>`_
+
+        :arg username: username
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        if username in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'username'.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'security', 'user', username), params=params)
+
+    @query_params()
+    def get_user(self, username=None, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-users.html#security-api-get-user>`_
+
+        :arg username: A comma-separated list of usernames
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack',
+            'security', 'user', username), params=params)
+
+    @query_params('refresh')
+    def put_role(self, name, body, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-roles.html#security-api-put-role>`_
+
+        :arg name: Role name
+        :arg body: The role to add
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        for param in (name, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'security', 'role', name), params=params, body=body)
+
+    @query_params()
+    def authenticate(self, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html>`_
+        """
+        return self.transport.perform_request('GET',
+            '/_xpack/security/_authenticate', params=params)
+
+    @query_params('refresh')
+    def put_user(self, username, body, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-users.html#security-api-put-user>`_
+
+        :arg username: The username of the User
+        :arg body: The user to add
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        for param in (username, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'security', 'user', username), params=params, body=body)
+
+    @query_params('usernames')
+    def clear_cached_realms(self, realms, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html>`_
+
+        :arg realms: Comma-separated list of realms to clear
+        :arg usernames: Comma-separated list of usernames to clear from the
+            cache
+        """
+        if realms in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'realms'.")
+        return self.transport.perform_request('POST', _make_path('_xpack',
+            'security', 'realm', realms, '_clear_cache'), params=params)
+
+    @query_params('refresh')
+    def change_password(self, body, username=None, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html>`_
+
+        :arg body: the new password for the user
+        :arg username: The username of the user to change the password for
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'security', 'user', username, '_password'), params=params,
+            body=body)
+
+    @query_params()
+    def get_role(self, name=None, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-roles.html#security-api-get-role>`_
+
+        :arg name: Role name
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack',
+            'security', 'role', name), params=params)
+
+    @query_params()
+    def clear_cached_roles(self, name, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-roles.html#security-api-clear-role-cache>`_
+
+        :arg name: Role name
+        """
+        if name in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'name'.")
+        return self.transport.perform_request('POST', _make_path('_xpack',
+            'security', 'role', name, '_clear_cache'), params=params)
+
+    @query_params('refresh')
+    def delete_role(self, name, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-roles.html#security-api-delete-role>`_
+
+        :arg name: Role name
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        if name in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'name'.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'security', 'role', name), params=params)
+
+    @query_params('refresh')
+    def delete_role_mapping(self, name, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-role-mapping.html#security-api-delete-role-mapping>`_
+
+        :arg name: Role-mapping name
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        if name in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'name'.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'security', 'role_mapping', name), params=params)
+
+    @query_params('refresh')
+    def disable_user(self, username=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-users.html#security-api-disable-user>`_
+
+        :arg username: The username of the user to disable
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'security', 'user', username, '_disable'), params=params)
+
+    @query_params('refresh')
+    def enable_user(self, username=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-users.html#security-api-enable-user>`_
+
+        :arg username: The username of the user to enable
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'security', 'user', username, '_enable'), params=params)
+
+    @query_params()
+    def get_role_mapping(self, name=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-role-mapping.html#security-api-get-role-mapping>`_
+
+        :arg name: Role-Mapping name
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack',
+            'security', 'role_mapping', name), params=params)
+
+    @query_params()
+    def get_token(self, body, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-tokens.html#security-api-get-token>`_
+
+        :arg body: The token request to get
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+        return self.transport.perform_request('POST',
+            '/_xpack/security/oauth2/token', params=params, body=body)
+
+    @query_params()
+    def invalidate_token(self, body, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-tokens.html#security-api-invalidate-token>`_
+
+        :arg body: The token to invalidate
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+        return self.transport.perform_request('DELETE',
+            '/_xpack/security/oauth2/token', params=params, body=body)
+
+    @query_params('refresh')
+    def put_role_mapping(self, name, body, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-role-mapping.html#security-api-put-role-mapping>`_
+
+        :arg name: Role-mapping name
+        :arg body: The role to add
+        :arg refresh: If `true` (the default) then refresh the affected shards
+            to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false`
+            then do nothing with refreshes., valid choices are: 'true', 'false',
+            'wait_for'
+        """
+        for param in (name, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'security', 'role_mapping', name), params=params, body=body)
+

--- a/elasticsearch/client/xpack/watcher.py
+++ b/elasticsearch/client/xpack/watcher.py
@@ -1,0 +1,148 @@
+from elasticsearch.client.utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+
+class WatcherClient(NamespacedClient):
+    @query_params()
+    def stop(self, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html>`_
+        """
+        return self.transport.perform_request('POST', '/_xpack/watcher/_stop',
+            params=params)
+
+    @query_params('master_timeout')
+    def ack_watch(self, watch_id, action_id=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html>`_
+
+        :arg watch_id: Watch ID
+        :arg action_id: A comma-separated list of the action ids to be acked
+        :arg master_timeout: Explicit operation timeout for connection to master
+            node
+        """
+        if watch_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'watch_id'.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'watcher', 'watch', watch_id, '_ack', action_id), params=params)
+
+    @query_params('debug')
+    def execute_watch(self, id=None, body=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html>`_
+
+        :arg id: Watch ID
+        :arg body: Execution control
+        :arg debug: indicates whether the watch should execute in debug mode
+        """
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'watcher', 'watch', id, '_execute'), params=params, body=body)
+
+    @query_params()
+    def start(self, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html>`_
+        """
+        return self.transport.perform_request('POST', '/_xpack/watcher/_start',
+            params=params)
+
+    @query_params('master_timeout')
+    def activate_watch(self, watch_id, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html>`_
+
+        :arg watch_id: Watch ID
+        :arg master_timeout: Explicit operation timeout for connection to master
+            node
+        """
+        if watch_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'watch_id'.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'watcher', 'watch', watch_id, '_activate'), params=params)
+
+    @query_params('master_timeout')
+    def deactivate_watch(self, watch_id, params=None):
+        """
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html>`_
+
+        :arg watch_id: Watch ID
+        :arg master_timeout: Explicit operation timeout for connection to master
+            node
+        """
+        if watch_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'watch_id'.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'watcher', 'watch', watch_id, '_deactivate'), params=params)
+
+    @query_params('active', 'master_timeout')
+    def put_watch(self, id, body, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html>`_
+
+        :arg id: Watch ID
+        :arg body: The watch
+        :arg active: Specify whether the watch is in/active by default
+        :arg master_timeout: Explicit operation timeout for connection to master
+            node
+        """
+        for param in (id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+        return self.transport.perform_request('PUT', _make_path('_xpack',
+            'watcher', 'watch', id), params=params, body=body)
+
+    @query_params('master_timeout')
+    def delete_watch(self, id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html>`_
+
+        :arg id: Watch ID
+        :arg master_timeout: Explicit operation timeout for connection to master
+            node
+        """
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'id'.")
+        return self.transport.perform_request('DELETE', _make_path('_xpack',
+            'watcher', 'watch', id), params=params)
+
+    @query_params()
+    def get_watch(self, id, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html>`_
+
+        :arg id: Watch ID
+        """
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'id'.")
+        return self.transport.perform_request('GET', _make_path('_xpack',
+            'watcher', 'watch', id), params=params)
+
+    @query_params('emit_stacktraces')
+    def stats(self, metric=None, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html>`_
+
+        :arg metric: Controls what additional stat metrics should be include in
+            the response
+        :arg emit_stacktraces: Emits stack traces of currently running watches
+        """
+        return self.transport.perform_request('GET', _make_path('_xpack',
+            'watcher', 'stats', metric), params=params)
+
+    @query_params()
+    def restart(self, params=None):
+        """
+
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-restart.html>`_
+        """
+        return self.transport.perform_request('POST',
+            '/_xpack/watcher/_restart', params=params)
+


### PR DESCRIPTION
With the opening and inclusion of x-pack in Elasticsearch it makes more sense for the x-pack clients to be bundled with `elasticsearch-py`. 