### PR TITLE
Fix attempting to decode non-str when logging error

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -75,7 +75,7 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        if body:
+        if body and isinstance(body, str):
             body = body.decode('utf-8', 'ignore')
 
         logger.info(
@@ -99,7 +99,7 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        if body:
+        if body and isinstance(body, str):
             body = body.decode('utf-8', 'ignore')
 
         logger.debug('> %s', body)


### PR DESCRIPTION
fix error when node 599, and there is no "body" to decode.
` File "***/venv3/lib/python3.5/site-packages/elasticsearch/connection/base.py", line 103, in log_request_fail
body = body.decode('utf-8', 'ignore')
AttributeError: 'float' object has no attribute 'decode'`