### PR TITLE
`TransportError` not raised in `helpers.streaming_bulk()` with `max_retries`.

### DIFF
--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -210,7 +210,7 @@ def streaming_bulk(client, actions, chunk_size=500, max_chunk_bytes=100 * 1024 *
 
             except TransportError as e:
                 # suppress 429 errors since we will retry them
-                if not max_retries or e.status_code != 429:
+                if attempt == max_retries or e.status_code != 429:
                     raise
             else:
                 if not to_retry:


### PR DESCRIPTION
When `helpers.streaming_bulk()` is called with `max_retries > 0`, the `TransportError(429)` which raise in the last retry is ignored.

Fixed to re-raise `TransportError` if the last retry fails.