### PR TITLE
Fixes double creation of urllib3.HTTPSConnectionPool

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -103,7 +103,6 @@ class Urllib3HttpConnection(Connection):
                 'assert_fingerprint': ssl_assert_fingerprint,
                 'ssl_context': ssl_context,
             })
-            self.pool = pool_class(host, port=port, timeout=self.timeout, maxsize=maxsize, **kw)
 
         elif self.use_ssl:
             pool_class = urllib3.HTTPSConnectionPool


### PR DESCRIPTION
Fixes double creation of urllib3.HTTPSConnectionPool when ssl_context and use_ssl are used.