### PR TITLE
Drop support for EOL Python 2.6, 3.2 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -237,7 +237,7 @@ an issue) it also just uses ``localhost:9200`` as the address instead of the
 actual address of the host. If the trace logger has not been configured
 already it is set to `propagate=False` so it needs to be activated separately.
 
-.. _logging library: http://docs.python.org/3.3/library/logging.html
+.. _logging library: http://docs.python.org/3.6/library/logging.html
 
 Environment considerations
 --------------------------

--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -6,7 +6,7 @@ __versionstr__ = '.'.join(map(str, VERSION))
 
 import sys
 
-if sys.version_info == (2, 7):
+if sys.version_info[:2] == (2, 7):
     # On Python 2.7, install no-op handler to silence
     # `No handlers could be found for logger "elasticsearch"` message per
     # <https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library>

--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -6,8 +6,8 @@ __versionstr__ = '.'.join(map(str, VERSION))
 
 import sys
 
-if (2, 7) <= sys.version_info < (3, 2):
-    # On Python 2.7 and Python3 < 3.2, install no-op handler to silence
+if sys.version_info == (2, 7):
+    # On Python 2.7, install no-op handler to silence
     # `No handlers could be found for logger "elasticsearch"` message per
     # <https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library>
     import logging

--- a/elasticsearch/helpers/test.py
+++ b/elasticsearch/helpers/test.py
@@ -1,10 +1,6 @@
 import time
 import os
-try:
-    # python 2.6
-    from unittest2 import TestCase, SkipTest
-except ImportError:
-    from unittest import TestCase, SkipTest
+from unittest import TestCase, SkipTest
 
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ConnectionError

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         where='.',
         exclude=('test_elasticsearch*', )
     ),
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,6 @@ tests_require = [
     'nosexcover'
 ]
 
-# use external unittest for 2.6
-if sys.version_info[:2] == (2, 6):
-    install_requires.append('unittest2')
-
 setup(
     name = 'elasticsearch',
     description = "Python client for Elasticsearch",
@@ -47,7 +43,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",

--- a/test_elasticsearch/test_cases.py
+++ b/test_elasticsearch/test_cases.py
@@ -1,9 +1,5 @@
 from collections import defaultdict
-try:
-    # python 2.6
-    from unittest2 import TestCase, SkipTest
-except ImportError:
-    from unittest import TestCase, SkipTest
+from unittest import TestCase, SkipTest
 
 from elasticsearch import Elasticsearch
 

--- a/test_elasticsearch/test_serializer.py
+++ b/test_elasticsearch/test_serializer.py
@@ -15,8 +15,6 @@ class TestJSONSerializer(TestCase):
         self.assertEquals('{"d":"2010-10-01T02:30:00"}', JSONSerializer().dumps({'d': datetime(2010, 10, 1, 2, 30)}))
 
     def test_decimal_serialization(self):
-        if sys.version_info[:2] == (2, 6):
-            raise SkipTest("Float rounding is broken in 2.6.")
         self.assertEquals('{"d":3.8}', JSONSerializer().dumps({'d': Decimal('3.8')}))
 
     def test_uuid_serialization(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py27,py33,py34,py35,py36
+envlist = pypy,py27,py34,py35,py36
 [testenv]
 whitelist_externals = git
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py26,py27,py33,py34,py35,py36
+envlist = pypy,py27,py33,py34,py35,py36
 [testenv]
 whitelist_externals = git
 setenv =


### PR DESCRIPTION
Fixes #788.

Here's the pip installs for elasticsearch from PyPI for April 2018, showing low numbers for 2.6 and even lower for 3.2 and 3.3:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  57.69% |        350,098 |
| 3.6            |  23.78% |        144,329 |
| 3.4            |   9.88% |         59,932 |
| 3.5            |   8.11% |         49,221 |
| 2.6            |   0.48% |          2,916 |
| 3.3            |   0.03% |            180 |
| 3.7            |   0.02% |            131 |
| 3.2            |   0.01% |             32 |
| 3.8            |   0.00% |              1 |
| Total          |         |        606,840 |

Source: `pypinfo --start-date 2018-04-01 --end-date 2018-04-30 --percent --pip --markdown elasticsearch pyversion`
