### PR TITLE
Remove put_template and get_template endpoints

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -1309,34 +1309,6 @@ class Elasticsearch(object):
             params=params)
 
     @query_params()
-    def put_template(self, id, body, params=None):
-        """
-        Create a search template.
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html>`_
-
-        :arg id: Template ID
-        :arg body: The document
-        """
-        for param in (id, body):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
-        return self.transport.perform_request('PUT', _make_path('_search',
-            'template', id), params=params, body=body)
-
-    @query_params()
-    def get_template(self, id, params=None):
-        """
-        Retrieve a search template.
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html>`_
-
-        :arg id: Template ID
-        """
-        if id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'id'.")
-        return self.transport.perform_request('GET', _make_path('_search',
-            'template', id), params=params)
-
-    @query_params()
     def delete_script(self, id, params=None):
         """
         Remove a stored script from elasticsearch.


### PR DESCRIPTION
In ES 6.0 the search template system has changed over to stored scripts.
https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html#pre-registered-templates

Closes #802 
