### PR TITLE
Pass `Retry` object to urllib3 instead of `False`

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -2,6 +2,7 @@ import time
 import ssl
 import urllib3
 from urllib3.exceptions import ReadTimeoutError, SSLError as UrllibSSLError
+from urllib3.util.retry import Retry
 import warnings
 import gzip
 
@@ -168,7 +169,7 @@ class Urllib3HttpConnection(Connection):
                     # again
                     body = gzip.zlib.compress(body)
 
-            response = self.pool.urlopen(method, url, body, retries=False, headers=request_headers, **kw)
+            response = self.pool.urlopen(method, url, body, retries=Retry(False), headers=request_headers, **kw)
             duration = time.time() - start
             raw_data = response.data.decode('utf-8')
         except Exception as e:


### PR DESCRIPTION
Closes #826 

By passing a `Retry` object to `urlopen` instead of just `False`, it
prevents `urllib3` from having to create a Retry object with `from_int`.

`from_int` emits an undesirable log message when called with
`retries=False`, and this can be avoided by the method described above.

I'm specifically interested in having this change available for version 5.4 - is this PR correct for doing this, or would it go into the v6 release? Thanks!