### PR TITLE
TypeError: string indices must be integers in TransportError

### DIFF
--- a/elasticsearch/exceptions.py
+++ b/elasticsearch/exceptions.py
@@ -54,8 +54,11 @@ class TransportError(ElasticsearchException):
     def __str__(self):
         cause = ''
         try:
-            if self.info:
-                cause = ', %r' % self.info['error']['root_cause'][0]['reason']
+            if self.info and 'error' in self.info:
+                if isinstance(self.info['error'], dict):
+                    cause = ', %r' % self.info['error']['root_cause'][0]['reason']
+                else:
+                    cause = ', %r' % self.info['error']
         except LookupError:
             pass
         return '%s(%s, %r%s)' % (self.__class__.__name__, self.status_code, self.error, cause)

--- a/test_elasticsearch/test_exceptions.py
+++ b/test_elasticsearch/test_exceptions.py
@@ -1,0 +1,23 @@
+from elasticsearch.exceptions import TransportError
+
+from .test_cases import TestCase
+
+
+class TestTransformError(TestCase):
+    def test_transform_error_parse_with_error_reason(self):
+        e = TransportError(500, 'InternalServerError', {
+            'error': {
+                'root_cause': [
+                    {"type": "error", "reason": "error reason"}
+                ]
+            }
+        })
+
+        self.assertEqual(str(e), "TransportError(500, 'InternalServerError', 'error reason')")
+
+    def test_transform_error_parse_with_error_string(self):
+        e = TransportError(500, 'InternalServerError', {
+            'error': 'something error message'
+        })
+
+        self.assertEqual(str(e), "TransportError(500, 'InternalServerError', 'something error message')")


### PR DESCRIPTION

When the error message returned from the server has the structure as below, TransportError can not handle the error content correctly.

example error response:

```json
{"error":"Content-Type header [application/octet-stream] is not supported","status":406}
```

error logs:

```
Traceback (most recent call last):
  File "/google-cloud-sdk/platform/google_appengine/google/appengine/api/app_logging.py", line 80, in emit
    message = self._AppLogsMessage(record)
  File "/google-cloud-sdk/platform/google_appengine/google/appengine/api/app_logging.py", line 96, in _AppLogsMessage
    message = self.format(record).replace("\r\n", NEWLINE_REPLACEMENT)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 325, in getMessage
    msg = str(self.msg)
  File "/usr/src/app/app/lib/elasticsearch/exceptions.py", line 58, in __str__
    cause = ', %r' % self.info['error']['root_cause'][0]['reason']
TypeError: string indices must be integers
```

