### PR TITLE
fix python 3.x str.decode exception

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -75,8 +75,11 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        if body:
-            body = body.decode('utf-8', 'ignore')
+        try:
+            if body:
+                body = body.decode('utf-8', 'ignore')
+        except AttributeError:
+            pass
 
         logger.info(
             '%s %s [status:%s request:%.3fs]', method, full_url,
@@ -99,8 +102,11 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        if body:
-            body = body.decode('utf-8', 'ignore')
+        try:
+            if body:
+                body = body.decode('utf-8', 'ignore')
+        except AttributeError:
+            pass
 
         logger.debug('> %s', body)
 

--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -75,11 +75,11 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        try:
-            if body:
+        if body:
+            try:
                 body = body.decode('utf-8', 'ignore')
-        except AttributeError:
-            pass
+            except AttributeError:
+                pass
 
         logger.info(
             '%s %s [status:%s request:%.3fs]', method, full_url,
@@ -102,11 +102,11 @@ class Connection(object):
 
         # body has already been serialized to utf-8, deserialize it for logging
         # TODO: find a better way to avoid (de)encoding the body back and forth
-        try:
-            if body:
+        if body:
+            try:
                 body = body.decode('utf-8', 'ignore')
-        except AttributeError:
-            pass
+            except AttributeError:
+                pass
 
         logger.debug('> %s', body)
 


### PR DESCRIPTION
Python 3.x doesn't support str.decode() causing code to fail with AttributeError exception.  This code change allows the python module to continue to work with older 2.x python while being 3.x friendly as well. Any alternate suggestions?