### PR TITLE
Backport Fix #833: "TypeError: string indices must be integers in TransportError"

### DIFF
--- a/elasticsearch5/exceptions.py
+++ b/elasticsearch5/exceptions.py
@@ -51,8 +51,11 @@ class TransportError(ElasticsearchException):
     def __str__(self):
         cause = ''
         try:
-            if self.info:
-                cause = ', %r' % self.info['error']['root_cause'][0]['reason']
+            if self.info and 'error' in self.info:
+                if isinstance(self.info['error'], dict):
+                    cause = ', %r' % self.info['error']['root_cause'][0]['reason']
+                else:
+                    cause = ', %r' % self.info['error']
         except LookupError:
             pass
         return 'TransportError(%s, %r%s)' % (self.status_code, self.error, cause)

--- a/test_elasticsearch/test_exceptions.py
+++ b/test_elasticsearch/test_exceptions.py
@@ -1,0 +1,23 @@
+from elasticsearch.exceptions import TransportError
+
+from .test_cases import TestCase
+
+
+class TestTransformError(TestCase):
+    def test_transform_error_parse_with_error_reason(self):
+        e = TransportError(500, 'InternalServerError', {
+            'error': {
+                'root_cause': [
+                    {"type": "error", "reason": "error reason"}
+                ]
+            }
+        })
+
+        self.assertEqual(str(e), "TransportError(500, 'InternalServerError', 'error reason')")
+
+    def test_transform_error_parse_with_error_string(self):
+        e = TransportError(500, 'InternalServerError', {
+            'error': 'something error message'
+        })
+
+        self.assertEqual(str(e), "TransportError(500, 'InternalServerError', 'something error message')")


### PR DESCRIPTION
Backports the fix from https://github.com/elastic/elasticsearch-py/pull/833 to the 5.x branch.

I hope this is fine! Let me know if anything should be done differently to have this done.