### PR TITLE
BlockingPool must fit thread_count

### DIFF
--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -292,7 +292,9 @@ def parallel_bulk(client, actions, thread_count=4, chunk_size=500,
     class BlockingPool(ThreadPool):
         def _setup_queues(self):
             super(BlockingPool, self)._setup_queues()
-            self._inqueue = Queue(queue_size)
+            # The queue must be at least the size of the number of threads to 
+            # prevent hanging when inserting sentinel values during teardown.
+            self._inqueue = Queue(max(queue_size, thread_count))
             self._quick_put = self._inqueue.put
 
     pool = BlockingPool(thread_count)


### PR DESCRIPTION
queue_size must be greater than or equal to thread_count, or else the main thread can hang trying to acquire a lock to write sentinel values to the queue during teardown.

It is covered by the existing test_chunk_sent_from_different_threads(), which should now work on Python 3.7.2.  If you think a mocked test to test the max() behavior specifically is necessary, let me know.

Closes #816 

