### PR TITLE
Add NullHandler to logger for all Python versions

### DIFF
--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -1,18 +1,22 @@
+#flake8: noqa
 from __future__ import absolute_import
 
 VERSION = (6, 3, 1)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 
+import logging
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
 import sys
 
-if (2, 7) <= sys.version_info < (3, 2):
-    # On Python 2.7 and Python3 < 3.2, install no-op handler to silence
-    # `No handlers could be found for logger "elasticsearch"` message per
-    # <https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library>
-    import logging
-    logger = logging.getLogger('elasticsearch')
-    logger.addHandler(logging.NullHandler())
+logger = logging.getLogger('elasticsearch')
+logger.addHandler(logging.NullHandler())
 
 from .client import Elasticsearch
 from .transport import Transport


### PR DESCRIPTION
It would be prudent to add `logging.NullHandler` for _all_ versions of Python, not just 2.7 thru 3.2.

Currently in `__init__.py`:

```python
if (2, 7) <= sys.version_info < (3, 2):
    # On Python 2.7 and Python3 < 3.2, install no-op handler to silence
    # `No handlers could be found for logger "elasticsearch"` message per
    # <https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library>
    import logging
    logger = logging.getLogger('elasticsearch')
    logger.addHandler(logging.NullHandler())
```

The comment above is partially missing the purpose of `NullHandler`.  A logger that is declared in a library (such as it is here) with no further configuration will log to `sys.stderr`, even if that's not what the end user wants.  This is a library, not an application--best practice is to set a bare-minimum logger that doesn't log to stdout unless the end-user opts-in.

This is done by [`urllib3`](https://github.com/urllib3/urllib3/blob/master/src/urllib3/__init__.py#L48), [`requests`](https://github.com/requests/requests/blob/master/requests/__init__.py), and many other mature libraries.

Here is a confirmation of that directly from the [`logging` docs](https://docs.python.org/3.7/howto/logging.html#configuring-logging-for-a-library):

> An instance of this handler could be added to the top-level logger of the logging namespace used by the library (if you want to prevent your library’s logged events being output to sys.stderr in the absence of logging configuration).