### PR TITLE
Add ignore_throttled to query_params for search

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -678,6 +678,7 @@ class Elasticsearch(object):
         "expand_wildcards",
         "explain",
         "from_",
+        "ignore_throttled",
         "ignore_unavailable",
         "lenient",
         "max_concurrent_shard_requests",


### PR DESCRIPTION
When trying to query a frozen index in ES6 with the elasticsearch library I got the following exception:

```
....
  File ".../lib/python2.7/site-packages/elasticsearch/client/utils.py", line 73, in _wrapped
    return func(*args, params=params, **kwargs)
TypeError: search() got an unexpected keyword argument 'ignore_throttle
```

It looks like we need to add: ignore_throttled to the allowed query parameters for search (https://www.elastic.co/guide/en/elasticsearch/reference/current/searching_a_frozen_index.html)

This change should be applied for 6.x and 7.x versions of the lib.
