### PR TITLE
Add support for ignore_throttled search request parameter

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -549,7 +549,7 @@ class Elasticsearch(object):
     @query_params('_source', '_source_exclude', '_source_include',
         'allow_no_indices', 'allow_partial_search_results', 'analyze_wildcard',
         'analyzer', 'batched_reduce_size', 'default_operator', 'df',
-        'docvalue_fields', 'expand_wildcards', 'explain', 'from_',
+        'docvalue_fields', 'expand_wildcards', 'explain', 'from_', 'ignore_throttled',
         'ignore_unavailable', 'lenient', 'max_concurrent_shard_requests',
         'pre_filter_shard_size', 'preference', 'q', 'request_cache', 'routing',
         'scroll', 'search_type', 'size', 'sort', 'stats', 'stored_fields',
@@ -661,7 +661,7 @@ class Elasticsearch(object):
 
     @query_params('_source', '_source_exclude', '_source_include',
         'allow_no_indices', 'analyze_wildcard', 'analyzer', 'conflicts',
-        'default_operator', 'df', 'expand_wildcards', 'from_',
+        'default_operator', 'df', 'expand_wildcards', 'from_', 'ignore_throttled',
         'ignore_unavailable', 'lenient', 'pipeline', 'preference', 'q',
         'refresh', 'request_cache', 'requests_per_second', 'routing', 'scroll',
         'scroll_size', 'search_timeout', 'search_type', 'size', 'slices',


### PR DESCRIPTION
Backport to 6.x of change: https://github.com/elastic/elasticsearch-py/pull/928 to allow using frozen indexes.