### PR TITLE
Fix ImportError elasticsearch #951

### DIFF
--- a/elasticsearch6/client/xpack/__init__.py
+++ b/elasticsearch6/client/xpack/__init__.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import NamespacedClient, query_params
+from ..utils import NamespacedClient, query_params
 
 from .graph import GraphClient
 from .license import LicenseClient

--- a/elasticsearch6/client/xpack/deprecation.py
+++ b/elasticsearch6/client/xpack/deprecation.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import NamespacedClient, query_params, _make_path
+from ..utils import NamespacedClient, query_params, _make_path
 
 
 class DeprecationClient(NamespacedClient):

--- a/elasticsearch6/client/xpack/graph.py
+++ b/elasticsearch6/client/xpack/graph.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import NamespacedClient, query_params, _make_path
+from ..utils import NamespacedClient, query_params, _make_path
 
 
 class GraphClient(NamespacedClient):

--- a/elasticsearch6/client/xpack/license.py
+++ b/elasticsearch6/client/xpack/license.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import (
+from ..utils import (
     NamespacedClient,
     query_params,
     _make_path,

--- a/elasticsearch6/client/xpack/migration.py
+++ b/elasticsearch6/client/xpack/migration.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import (
+from ..utils import (
     NamespacedClient,
     query_params,
     _make_path,

--- a/elasticsearch6/client/xpack/ml.py
+++ b/elasticsearch6/client/xpack/ml.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import (
+from ..utils import (
     NamespacedClient,
     query_params,
     _make_path,

--- a/elasticsearch6/client/xpack/monitoring.py
+++ b/elasticsearch6/client/xpack/monitoring.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import (
+from ..utils import (
     NamespacedClient,
     query_params,
     _make_path,

--- a/elasticsearch6/client/xpack/security.py
+++ b/elasticsearch6/client/xpack/security.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import (
+from ..utils import (
     NamespacedClient,
     query_params,
     _make_path,

--- a/elasticsearch6/client/xpack/watcher.py
+++ b/elasticsearch6/client/xpack/watcher.py
@@ -1,4 +1,4 @@
-from elasticsearch.client.utils import (
+from ..utils import (
     NamespacedClient,
     query_params,
     _make_path,

--- a/test_elasticsearch/test_exceptions.py
+++ b/test_elasticsearch/test_exceptions.py
@@ -1,4 +1,4 @@
-from elasticsearch.exceptions import TransportError
+from elasticsearch6.exceptions import TransportError
 
 from .test_cases import TestCase
 


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/issues/951

I changed some imports so that they're relative, to avoid hard-coding the top-level elasticsearch6 package name.

Please let me know if these changes aren't satisfactory, and I'll try reworking them.

Thanks!