### PR TITLE
ml client has no method _bulk_body

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,6 +5,7 @@ Changelog
 7.1.0 (dev)
 -----------
   * Add connection parameter for Elastic Cloud cloud_id.
+  * ML client uses client object for _bulk_body requests
 
 7.0.1 (2019-05019)
 -----------

--- a/elasticsearch/client/xpack/ml.py
+++ b/elasticsearch/client/xpack/ml.py
@@ -224,7 +224,7 @@ class MlClient(NamespacedClient):
             "POST",
             "/_ml/find_file_structure",
             params=params,
-            body=self._bulk_body(body),
+            body=self.client._bulk_body(body),
         )
 
     @query_params("advance_time", "calc_interim", "end", "skip_time", "start")
@@ -634,7 +634,7 @@ class MlClient(NamespacedClient):
             "POST",
             _make_path("_ml", "anomaly_detectors", job_id, "_data"),
             params=params,
-            body=self._bulk_body(body),
+            body=self.client._bulk_body(body),
         )
 
     @query_params()


### PR DESCRIPTION
Need to access the _bulk_body method from the client object

closes: #959