### PR TITLE
fix invalid type of request_timeout (#969)

### DIFF
--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -71,16 +71,16 @@ def query_params(*es_query_params):
             params = {}
             if "params" in kwargs:
                 params = kwargs.pop("params").copy()
-            for p in es_query_params + GLOBAL_PARAMS:
-                if p in kwargs:
-                    v = kwargs.pop(p)
-                    if v is not None:
-                        params[p] = _escape(v)
 
             # don't treat ignore and request_timeout as other params to avoid escaping
             for p in ("ignore", "request_timeout"):
                 if p in kwargs:
                     params[p] = kwargs.pop(p)
+            for p in es_query_params + GLOBAL_PARAMS:
+                if p in kwargs:
+                    v = kwargs.pop(p)
+                    if v is not None:
+                        params[p] = _escape(v)
             return func(*args, params=params, **kwargs)
 
         return _wrapped

--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from elasticsearch.client.utils import _make_path, _escape
+from elasticsearch.client.utils import _make_path, _escape, query_params
 from elasticsearch.compat import PY2
 
 from ..test_cases import TestCase, SkipTest
@@ -35,3 +35,21 @@ class TestEscape(TestCase):
     def test_handles_bytestring(self):
         string = b"celery-task-meta-c4f1201f-eb7b-41d5-9318-a75a8cfbdaa0"
         self.assertEquals(string, _escape(string))
+
+class TestQueryParams(TestCase):
+    @query_params("request_timeout", "ignore", "some_param")
+    def decorated_func(index, body=None, params=None):
+        return params
+
+    def test_handle_escape_unicode(self):
+        string = "中文"
+        ret=TestQueryParams.decorated_func(index='foo',
+                                           body=None,
+                                           some_param=string)
+        self.assertEquals(b"\xe4\xb8\xad\xe6\x96\x87", ret['some_param'])
+
+    def test_handle_type_of_request_timeout(self):
+        ret=TestQueryParams.decorated_func(index='foo',
+                                           body=None,
+                                           request_timeout=60)
+        self.assertEquals(int, type(ret['request_timeout']))

--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -38,18 +38,14 @@ class TestEscape(TestCase):
 
 class TestQueryParams(TestCase):
     @query_params("request_timeout", "ignore", "some_param")
-    def decorated_func(index, body=None, params=None):
+    def decorated_func(self, index, body=None, params=None):
         return params
 
     def test_handle_escape_unicode(self):
         string = "中文"
-        ret=TestQueryParams.decorated_func(index='foo',
-                                           body=None,
-                                           some_param=string)
+        ret=self.decorated_func(index='foo', body=None, some_param=string)
         self.assertEquals(b"\xe4\xb8\xad\xe6\x96\x87", ret['some_param'])
 
     def test_handle_type_of_request_timeout(self):
-        ret=TestQueryParams.decorated_func(index='foo',
-                                           body=None,
-                                           request_timeout=60)
+        ret=self.decorated_func(index='foo', body=None, request_timeout=60)
         self.assertEquals(int, type(ret['request_timeout']))


### PR DESCRIPTION
Some elasticsearch indices object methods(such as delete_template and update_aliases) could not handle request_timeout argument correctly (It was expected pass as int, but it was actually as str).

Fixed the processing order in decorator query_params because it  could not process correctly special arguments.

It seems likely the original section of "don't treat ignore and request_timeout as other params to avoid escaping" does nothing.

And there are no test about decorator query_params, so added few test cases for this issue.