### PR TITLE
Preserve input actions when yielding in bulk helpers

### DIFF
--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -1,4 +1,5 @@
 from .errors import BulkIndexError, ScanError
 from .actions import expand_action, streaming_bulk, bulk, parallel_bulk
+from .actions import streaming_chunks, parallel_chunks
 from .actions import scan, reindex
 from .actions import _chunk_actions, _process_bulk_chunk

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -1,3 +1,4 @@
+from functools import partial
 from operator import methodcaller
 import time
 
@@ -53,14 +54,21 @@ def expand_action(data):
     return action, data.get("_source", data)
 
 
-def _chunk_actions(actions, chunk_size, max_chunk_bytes, serializer):
+def _chunk_actions(
+    actions,
+    chunk_size,
+    max_chunk_bytes,
+    serializer,
+    expand_action_callback=expand_action
+):
     """
     Split actions into chunks by number or size, serialize them into strings in
     the process.
     """
     bulk_actions, bulk_data = [], []
     size, action_count = 0, 0
-    for action, data in actions:
+    for input_action in actions:
+        action, data = expand_action_callback(input_action)
         raw_data, raw_action = data, action
         action = serializer.dumps(action)
         # +1 to account for the trailing new line character
@@ -81,9 +89,9 @@ def _chunk_actions(actions, chunk_size, max_chunk_bytes, serializer):
         bulk_actions.append(action)
         if data is not None:
             bulk_actions.append(data)
-            bulk_data.append((raw_action, raw_data))
+            bulk_data.append((input_action, raw_action, raw_data))
         else:
-            bulk_data.append((raw_action,))
+            bulk_data.append((input_action, raw_action,))
 
         size += cur_size
         action_count += 1
@@ -121,10 +129,12 @@ def _process_bulk_chunk(
 
         for data in bulk_data:
             # collect all the information about failed actions
-            op_type, action = data[0].copy().popitem()
+            op_type, action = data[1].copy().popitem()
             info = {"error": err_message, "status": e.status_code, "exception": e}
+            # include original input action
+            info["action"] = data[0]
             if op_type != "delete":
-                info["data"] = data[1]
+                info["data"] = data[2]
             info.update(action)
             exc_errors.append({op_type: info})
 
@@ -142,11 +152,13 @@ def _process_bulk_chunk(
     for data, (op_type, item) in zip(
         bulk_data, map(methodcaller("popitem"), resp["items"])
     ):
+        # include original input action
+        item["action"] = data[0]
         ok = 200 <= item.get("status", 500) < 300
         if not ok and raise_on_error:
             # include original document source
-            if len(data) > 1:
-                item["data"] = data[1]
+            if len(data) > 2:
+                item["data"] = data[2]
             errors.append({op_type: item})
 
         if ok or not errors:
@@ -173,7 +185,6 @@ def streaming_bulk(
     *args,
     **kwargs
 ):
-
     """
     Streaming bulk consumes actions from the iterable passed in and yields
     results per action. For non-streaming usecases use
@@ -206,10 +217,70 @@ def streaming_bulk(
     :arg max_backoff: maximum number of seconds a retry will wait
     :arg yield_ok: if set to False will skip successful documents in the output
     """
-    actions = map(expand_action_callback, actions)
+    chunker = partial(
+        _chunk_actions, chunk_size=chunk_size, max_chunk_bytes=max_chunk_bytes
+    )
 
-    for bulk_data, bulk_actions in _chunk_actions(
-        actions, chunk_size, max_chunk_bytes, client.transport.serializer
+    for item in streaming_chunks(
+        client,
+        actions,
+        chunker,
+        raise_on_error=raise_on_error,
+        expand_action_callback=expand_action_callback,
+        raise_on_exception=raise_on_exception,
+        max_retries=max_retries,
+        initial_backoff=initial_backoff,
+        max_backoff=max_backoff,
+        yield_ok=yield_ok,
+        *args,
+        **kwargs
+    ):
+        yield item
+
+
+def streaming_chunks(
+    client,
+    actions,
+    chunker,
+    # chunk_size=500,
+    # max_chunk_bytes=100 * 1024 * 1024,
+    raise_on_error=True,
+    expand_action_callback=expand_action,
+    raise_on_exception=True,
+    max_retries=0,
+    initial_backoff=2,
+    max_backoff=600,
+    yield_ok=True,
+    *args,
+    **kwargs
+):
+    """
+    Implementation of the ``streaming_bulk`` helper, chunking actions using
+    given chunker function.
+
+    :arg client: instance of :class:`~elasticsearch.Elasticsearch` to use
+    :arg actions: iterable containing the actions to be executed
+    :arg chunker: function to chunk actions into separate ``bulk`` calls,
+        should yield tuples of raw data and serialized actions.
+    :arg raise_on_error: raise ``BulkIndexError`` containing errors (as `.errors`)
+        from the execution of the last chunk when some occur. By default we raise.
+    :arg raise_on_exception: if ``False`` then don't propagate exceptions from
+        call to ``bulk`` and just report the items that failed as failed.
+    :arg expand_action_callback: callback executed on each action passed in,
+        should return a tuple containing the action line and the data line
+        (`None` if data line should be omitted).
+    :arg max_retries: maximum number of times a document will be retried when
+        ``429`` is received, set to 0 (default) for no retries on ``429``
+    :arg initial_backoff: number of seconds we should wait before the first
+        retry. Any subsequent retries will be powers of ``initial_backoff *
+        2**retry_number``
+    :arg max_backoff: maximum number of seconds a retry will wait
+    :arg yield_ok: if set to False will skip successful documents in the output
+    """
+    for bulk_data, bulk_actions in chunker(
+        actions,
+        serializer=client.transport.serializer,
+        expand_action_callback=expand_action_callback
     ):
 
         for attempt in range(max_retries + 1):
@@ -241,9 +312,9 @@ def streaming_bulk(
                             and (attempt + 1) <= max_retries
                         ):
                             # _process_bulk_chunk expects strings so we need to
-                            # re-serialize the data
+                            # re-serialize the expanded action and data
                             to_retry.extend(
-                                map(client.transport.serializer.dumps, data)
+                                map(client.transport.serializer.dumps, data[1:])
                             )
                             to_retry_data.append(data)
                         else:
@@ -338,11 +409,55 @@ def parallel_bulk(
     :arg queue_size: size of the task queue between the main thread (producing
         chunks to send) and the processing threads.
     """
+    chunker = partial(
+        _chunk_actions, chunk_size=chunk_size, max_chunk_bytes=max_chunk_bytes
+    )
+
+    for item in parallel_chunks(
+        client,
+        actions,
+        chunker,
+        thread_count=thread_count,
+        queue_size=queue_size,
+        expand_action_callback=expand_action_callback,
+        *args,
+        **kwargs
+    ):
+        yield item
+
+
+def parallel_chunks(
+    client,
+    actions,
+    chunker,
+    thread_count=4,
+    queue_size=4,
+    expand_action_callback=expand_action,
+    *args,
+    **kwargs
+):
+    """
+    Implementation of the ``parallel_bulk`` helper, chunking actions using
+    given chunker function.
+
+    :arg client: instance of :class:`~elasticsearch.Elasticsearch` to use
+    :arg actions: iterator containing the actions
+    :arg chunker: function to chunk actions into separate ``bulk`` calls,
+        should yield tuples of raw data and serialized actions.
+    :arg thread_count: size of the threadpool to use for the bulk requests
+    :arg raise_on_error: raise ``BulkIndexError`` containing errors (as `.errors`)
+        from the execution of the last chunk when some occur. By default we raise.
+    :arg raise_on_exception: if ``False`` then don't propagate exceptions from
+        call to ``bulk`` and just report the items that failed as failed.
+    :arg expand_action_callback: callback executed on each action passed in,
+        should return a tuple containing the action line and the data line
+        (`None` if data line should be omitted).
+    :arg queue_size: size of the task queue between the main thread (producing
+        chunks to send) and the processing threads.
+    """
     # Avoid importing multiprocessing unless parallel_bulk is used
     # to avoid exceptions on restricted environments like App Engine
     from multiprocessing.pool import ThreadPool
-
-    actions = map(expand_action_callback, actions)
 
     class BlockingPool(ThreadPool):
         def _setup_queues(self):
@@ -361,9 +476,11 @@ def parallel_bulk(
                     client, bulk_chunk[1], bulk_chunk[0], *args, **kwargs
                 )
             ),
-            _chunk_actions(
-                actions, chunk_size, max_chunk_bytes, client.transport.serializer
-            ),
+            chunker(
+                actions,
+                serializer=client.transport.serializer,
+                expand_action_callback=expand_action_callback
+            )
         ):
             for item in result:
                 yield item

--- a/test_elasticsearch/test_helpers.py
+++ b/test_elasticsearch/test_helpers.py
@@ -58,7 +58,7 @@ class TestParallelBulk(TestCase):
 class TestChunkActions(TestCase):
     def setUp(self):
         super(TestChunkActions, self).setUp()
-        self.actions = [({"index": {}}, {"some": u"datá", "i": i}) for i in range(100)]
+        self.actions = [{"_op_type": "index", "some": u"datá", "i": i} for i in range(100)]
 
     def test_chunks_are_chopped_by_byte_size(self):
         self.assertEquals(


### PR DESCRIPTION
This PR solves the issue of the `streaming_bulk` and `parallel_bulk` helpers discarding original input actions while exhausting the generator. Somewhat related to #940 and probably solves that issue as well. 

**Use case**
Let's say you have a lot of *items*, too many for memory, that you want to index and report on. For example; a XML stream-parsing generator, or an unresolved django queryset.  
To index those items with the current api, you pass that generator as `actions` argument along with an `expand_action_callback` function to construct the actual documents.

Problem is that if you want to take further actions, like reporting, to the items in the generator after being index (or failed), the original input item *(xml element or django model in this example)* is not yielded back by the `bulk` helpers, resulting in an exhausted generator with items lost in translation, unable to report on.

The `bulk` helpers therefore needs to yield each input item along with the current ES action result.

**Example**
``` py
def parse(filename):
    # open file, iter parse xml and yield elements

def make_document(element):
    return {
        "_index": "articles",
        "_type": "article",
        "_id": element["id"],
        "_source": {
            "title": element["title"],
            # ...
        },
    }

def index(elements):
    for ok, result in parallel_bulk(client, elements, expand_action_callback=make_document):        
        yield ok, result["index"]["action"]  # Yielding original input element for further actions

def report(elements):
    for ok, element in elements:
        # report on parsed and indexed element
        yield element

elements = parse("data.xml")
elements = index(elements)
elements = report(elements)
# elements = something_more ...

collections.deque(elements)
```

**Additionally**, this PR adds two new low level bulk helpers, `streaming_chunks` and `parallel_chunks`, allowing the chunking function to be customised.

**Note:** Current versions of `streaming_bulk` and `parallel_bulk` uses `map()` to extend actions, which in python 2 exhausts the generator at once and loads all items in the generator in memory. This PR also fixes this issue as an implementation bonus.