### PR TITLE
Fix verify_certs=False behaviour for urllib3>=1.25

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -184,6 +184,7 @@ class Urllib3HttpConnection(Connection):
                     }
                 )
             else:
+                kw.update({"cert_reqs": "CERT_NONE"})
                 if ssl_show_warn:
                     warnings.warn(
                         "Connecting to %s using SSL with verify_certs=False is insecure."


### PR DESCRIPTION
(Addresses #943)

Since [urllib3 1.25](https://github.com/urllib3/urllib3/blob/1.25.3/CHANGES.rst#125-2019-04-22) SSL certificate verification is enabled by default (https://github.com/urllib3/urllib3/pull/1507). This currently makes it impossible to use `verify_certs=False` via elasticsearch (unless one specifies one's own `SSLContext`).

This change explicitly sets `cert_reqs=CERT_NONE` when using `verify_certs=False`.