### PR TITLE
Send User-Agent header identifying the Client

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -1,5 +1,6 @@
 import time
 from itertools import chain
+from platform import python_version
 
 from .connection import Urllib3HttpConnection
 from .connection_pool import ConnectionPool, DummyConnectionPool
@@ -338,7 +339,7 @@ class Transport(object):
 
         if headers is None:
             headers = {}
-        headers["user-agent"] = "elasticsearch-py/%s" % __versionstr__
+        headers["user-agent"] = "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())
 
         for attempt in range(self.max_retries + 1):
             connection = self.get_connection()

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -4,6 +4,7 @@ from itertools import chain
 from .connection import Urllib3HttpConnection
 from .connection_pool import ConnectionPool, DummyConnectionPool
 from .serializer import JSONSerializer, Deserializer, DEFAULT_SERIALIZERS
+from . import __versionstr__
 from .exceptions import (
     ConnectionError,
     TransportError,
@@ -334,6 +335,10 @@ class Transport(object):
             ignore = params.pop("ignore", ())
             if isinstance(ignore, int):
                 ignore = (ignore,)
+
+        if headers is None:
+            headers = {}
+        headers["user-agent"] = "elasticsearch-py/%s" % __versionstr__
 
         for attempt in range(self.max_retries + 1):
             connection = self.get_connection()

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -6,6 +6,7 @@ from elasticsearch.transport import Transport, get_host_info
 from elasticsearch.connection import Connection
 from elasticsearch.connection_pool import DummyConnectionPool
 from elasticsearch.exceptions import ConnectionError, ImproperlyConfigured
+from elasticsearch import __versionstr__
 
 from .test_cases import TestCase
 
@@ -77,12 +78,13 @@ class TestTransport(TestCase):
 
     def test_request_timeout_extracted_from_params_and_passed(self):
         t = Transport([{}], connection_class=DummyConnection)
+        user_agent = "elasticsearch-py/%s" % __versionstr__
 
         t.perform_request("GET", "/", params={"request_timeout": 42})
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(("GET", "/", {}, None), t.get_connection().calls[0][0])
         self.assertEquals(
-            {"timeout": 42, "ignore": (), "headers": None},
+            {"timeout": 42, "ignore": (), "headers": {'user-agent': user_agent}},
             t.get_connection().calls[0][1],
         )
 

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import time
+from platform import python_version
 
 from elasticsearch.transport import Transport, get_host_info
 from elasticsearch.connection import Connection
@@ -83,7 +84,9 @@ class TestTransport(TestCase):
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(("GET", "/", {}, None), t.get_connection().calls[0][0])
         self.assertEquals(
-            {"timeout": 42, "ignore": (), "headers": {'user-agent': "elasticsearch-py/%s" % __versionstr__}},
+            {"timeout": 42, "ignore": (), "headers": {
+                'user-agent':"elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())}
+            },
             t.get_connection().calls[0][1],
         )
 

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -78,13 +78,12 @@ class TestTransport(TestCase):
 
     def test_request_timeout_extracted_from_params_and_passed(self):
         t = Transport([{}], connection_class=DummyConnection)
-        user_agent = "elasticsearch-py/%s" % __versionstr__
 
         t.perform_request("GET", "/", params={"request_timeout": 42})
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(("GET", "/", {}, None), t.get_connection().calls[0][0])
         self.assertEquals(
-            {"timeout": 42, "ignore": (), "headers": {'user-agent': user_agent}},
+            {"timeout": 42, "ignore": (), "headers": {'user-agent': "elasticsearch-py/%s" % __versionstr__}},
             t.get_connection().calls[0][1],
         )
 


### PR DESCRIPTION
This PR adds to every request the `user-agent` header with the string `elasticsearch-py/x.y.z`, with `x.y.z` being the Client release version, in order to identify a Client on the Elasticsearch side.