### PR TITLE
Ensure a custom User-Agent header is not overwritten

### DIFF
--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -1,11 +1,14 @@
 import logging
 
+from platform import python_version
+
 try:
     import simplejson as json
 except ImportError:
     import json
 
 from ..exceptions import TransportError, HTTP_EXCEPTIONS
+from .. import __versionstr__
 
 logger = logging.getLogger("elasticsearch")
 
@@ -177,3 +180,6 @@ class Connection(object):
         raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
             status_code, error_message, additional_info
         )
+
+    def _get_default_user_agent(self):
+        return "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())

--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -73,6 +73,7 @@ class RequestsHttpConnection(Connection):
         self.session = requests.Session()
         self.session.headers = headers or {}
         self.session.headers.setdefault("content-type", "application/json")
+        self.session.headers.setdefault("user-agent", self._get_default_user_agent())
         if http_auth is not None:
             if isinstance(http_auth, (tuple, list)):
                 http_auth = tuple(http_auth)

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -127,6 +127,7 @@ class Urllib3HttpConnection(Connection):
             self.headers.update({"content-encoding": "gzip"})
 
         self.headers.setdefault("content-type", "application/json")
+        self.headers.setdefault("user-agent", self._get_default_user_agent())
         pool_class = urllib3.HTTPConnectionPool
         kw = {}
 

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -336,12 +336,6 @@ class Transport(object):
             ignore = params.pop("ignore", ())
             if isinstance(ignore, int):
                 ignore = (ignore,)
-
-        if headers is None:
-            headers = {}
-        if "user-agent" not in headers:
-            headers["user-agent"] = "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())
-
         for attempt in range(self.max_retries + 1):
             connection = self.get_connection()
 

--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -339,7 +339,8 @@ class Transport(object):
 
         if headers is None:
             headers = {}
-        headers["user-agent"] = "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())
+        if "user-agent" not in headers:
+            headers["user-agent"] = "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())
 
         for attempt in range(self.max_retries + 1):
             connection = self.get_connection()

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -85,7 +85,18 @@ class TestTransport(TestCase):
         self.assertEquals(("GET", "/", {}, None), t.get_connection().calls[0][0])
         self.assertEquals(
             {"timeout": 42, "ignore": (), "headers": {
-                'user-agent':"elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())}
+                "user-agent": "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())}
+            },
+            t.get_connection().calls[0][1],
+        )
+
+    def test_request_with_custom_user_agent_header(self):
+        t = Transport([{}], connection_class=DummyConnection)
+
+        t.perform_request("GET", "/", headers={"user-agent": "my-custom-value/1.2.3"})
+        self.assertEquals(1, len(t.get_connection().calls))
+        self.assertEquals(
+            {"timeout": None, "ignore": (), "headers": {"user-agent": "my-custom-value/1.2.3"}
             },
             t.get_connection().calls[0][1],
         )

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import time
-from platform import python_version
 
 from elasticsearch.transport import Transport, get_host_info
 from elasticsearch.connection import Connection
 from elasticsearch.connection_pool import DummyConnectionPool
 from elasticsearch.exceptions import ConnectionError, ImproperlyConfigured
-from elasticsearch import __versionstr__
 
 from .test_cases import TestCase
 
@@ -84,8 +82,10 @@ class TestTransport(TestCase):
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(("GET", "/", {}, None), t.get_connection().calls[0][0])
         self.assertEquals(
-            {"timeout": 42, "ignore": (), "headers": {
-                "user-agent": "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())}
+            {
+                "timeout": 42,
+                "ignore": (),
+                "headers": None,
             },
             t.get_connection().calls[0][1],
         )


### PR DESCRIPTION
The PR is an enhancement to the [comment](https://github.com/elastic/elasticsearch-py/pull/991/files/4a355cdbc526e586672fe1d506e52ff92bb32dfe#r312094064) of PR#991 and ensures that a custom `user-agent` header is not overwritten with the default value.