### PR TITLE
fix error due to missing comma in between timeout and request_timeout…

### DIFF
--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -80,7 +80,8 @@ class IndicesClient(NamespacedClient):
 
     @query_params(
         "master_timeout",
-        "timeout", "request_timeout",
+        "timeout",
+        "request_timeout",
         "wait_for_active_shards",
         "include_type_name",
     )

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -80,7 +80,7 @@ class IndicesClient(NamespacedClient):
 
     @query_params(
         "master_timeout",
-        "timeout" "request_timeout",
+        "timeout", "request_timeout",
         "wait_for_active_shards",
         "include_type_name",
     )


### PR DESCRIPTION
client.indices.create has broken "timeout" and "request_timeout" params. The query_params was missing comma(,) between timeout and request_timeout in index create method in the client module.
Closes #989 