### PR TITLE
Refine documentation of Exceptions

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -21,3 +21,5 @@ Exceptions
 .. autoclass:: NotFoundError(TransportError)
 .. autoclass:: ConflictError(TransportError)
 .. autoclass:: RequestError(TransportError)
+.. autoclass:: AuthenticationException(TransportError)
+.. autoclass:: AuthorizationException(TransportError)

--- a/elasticsearch/exceptions.py
+++ b/elasticsearch/exceptions.py
@@ -91,7 +91,7 @@ class ConnectionError(TransportError):
     """
     Error raised when there was an exception while talking to ES. Original
     exception from the underlying :class:`~elasticsearch.Connection`
-    implementation is available as ``.info.``
+    implementation is available as ``.info``.
     """
 
     def __str__(self):


### PR DESCRIPTION
- `AuthenticationException ` and `AuthorizationException` are missing in `docs/exceptions.rst`. This resulted in that these two exceptions are not listed in https://elasticsearch-py.readthedocs.io/en/master/exceptions.html
- Correcting a typo in docstring of `ConnectionError`.