### PR TITLE
Include simplejson in extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,6 @@ setup(
     extras_require={
         "develop": tests_require + ["sphinx<1.7", "sphinx_rtd_theme"],
         "requests": ["requests>=2.4.0, <3.0.0"],
+        "simplejson": ["simplejson"],
     },
 )


### PR DESCRIPTION
elasticsearch-py has support [here](https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/serializer.py#L2) for [simplejson](https://github.com/simplejson/simplejson) if it's installed but does not currently include this dependency as an optional extra in the setup file.