### PR TITLE
Fix for 7.4 space encoding change

### DIFF
--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import weakref
 from datetime import date, datetime
 from functools import wraps
-from ..compat import string_types, quote_plus, PY2
+from ..compat import string_types, quote, PY2
 
 # parts of URL to be omitted
 SKIP_IN_PATH = (None, "", b"", [], ())
@@ -49,7 +49,7 @@ def _make_path(*parts):
     # TODO: maybe only allow some parts to be lists/tuples ?
     return "/" + "/".join(
         # preserve ',' and '*' in url for nicer URLs in logs
-        quote_plus(_escape(p), b",*")
+        quote(_escape(p), b",*")
         for p in parts
         if p not in SKIP_IN_PATH
     )

--- a/elasticsearch/compat.py
+++ b/elasticsearch/compat.py
@@ -10,7 +10,7 @@ if PY2:
     from Queue import Queue
 else:
     string_types = str, bytes
-    from urllib.parse import quote_plus, urlencode, urlparse, unquote
+    from urllib.parse import quote, quote_plus, urlencode, urlparse, unquote
 
     map = map
     from queue import Queue

--- a/elasticsearch/compat.py
+++ b/elasticsearch/compat.py
@@ -4,7 +4,7 @@ PY2 = sys.version_info[0] == 2
 
 if PY2:
     string_types = (basestring,)
-    from urllib import quote_plus, urlencode, unquote
+    from urllib import quote_plus, quote, urlencode, unquote
     from urlparse import urlparse
     from itertools import imap as map
     from Queue import Queue


### PR DESCRIPTION
Ref: #1037 

Elastic-py currently encodes spaces in the url as `+` (as opposed to `%20`).   Elasticsearch in 7.4 no longer decode `+` as a space, so this breaks parameters (id's in my test) that have spaces.   

(Note the bulk API works correctly with ID's with spaces, so indexing is currently also divergent between the bulk and single api)

This PR uses the python quote method instead of quote_plus which is the same except for encoding spaces as `%20` instead of `+`.
