### PR TITLE
Adding gzip compression support to requests connection

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,6 +4,7 @@ Changelog
 =========
 7.1.0 (dev)
 -----------
+  * Added request compression handling to RequestsHttpConnection
 
 7.0.5 (2019-10-01)
 -----------

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -211,6 +211,11 @@ class TestRequestsConnection(TestCase):
         )
         self.assertEquals(con.session.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTI=")
 
+    def test_http_compression(self):
+        con = RequestsHttpConnection(http_compress=True)
+        self.assertTrue(con.http_compress)
+        self.assertEquals(con.session.headers["content-encoding"], "gzip")
+
     def test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
             con = self._get_mock_connection(


### PR DESCRIPTION
Currently gzip compression and `http_compress` parameter handling is only implemented for `Urllib3HttpConnection`, so when using alternative `RequestsHttpConnection` the parameter is ignored and the requests are not compressed, which might be unexpected for the users.
The PR adds gzip compression support to `RequestsHttpConnection` class. Compression is enabled by setting `http_compress` constructor parameter to `True` exactly as in the `Urllib3HttpConnection`.