### PR TITLE
Removes request_timeout params from indices handler.  Closes #1035, #1026

### DIFF
--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -81,7 +81,6 @@ class IndicesClient(NamespacedClient):
     @query_params(
         "master_timeout",
         "timeout",
-        "request_timeout",
         "wait_for_active_shards",
         "include_type_name",
     )
@@ -149,7 +148,6 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "master_timeout",
         "timeout",
-        "request_timeout",
         "wait_for_active_shards",
     )
     def open(self, index, params=None):
@@ -183,7 +181,6 @@ class IndicesClient(NamespacedClient):
         "expand_wildcards",
         "ignore_unavailable",
         "master_timeout",
-        "request_timeout",
         "wait_for_active_shards",
     )
     def close(self, index, params=None):
@@ -218,7 +215,6 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "timeout",
         "master_timeout",
-        "request_timeout",
     )
     def delete(self, index, params=None):
         """
@@ -306,7 +302,6 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "master_timeout",
         "timeout",
-        "request_timeout",
         "include_type_name",
     )
     def put_mapping(self, body, doc_type=None, index=None, params=None):
@@ -412,7 +407,7 @@ class IndicesClient(NamespacedClient):
             params=params,
         )
 
-    @query_params("master_timeout", "request_timeout")
+    @query_params("master_timeout")
     def put_alias(self, index, name, body=None, params=None):
         """
         Create an alias for a specific index/indices.
@@ -479,7 +474,7 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path(index, "_alias", name), params=params
         )
 
-    @query_params("master_timeout", "request_timeout", "timeout")
+    @query_params("master_timeout", "timeout")
     def update_aliases(self, body, params=None):
         """
         Update specified aliases.
@@ -496,7 +491,7 @@ class IndicesClient(NamespacedClient):
             "POST", "/_aliases", params=params, body=body
         )
 
-    @query_params("master_timeout", "request_timeout", "timeout")
+    @query_params("master_timeout", "timeout")
     def delete_alias(self, index, name, params=None):
         """
         Delete specific alias.
@@ -523,7 +518,6 @@ class IndicesClient(NamespacedClient):
         "flat_settings",
         "master_timeout",
         "order",
-        "request_timeout",
         "timeout",
         "include_type_name",
     )
@@ -591,7 +585,7 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path("_template", name), params=params
         )
 
-    @query_params("master_timeout", "request_timeout", "timeout")
+    @query_params("master_timeout", "timeout")
     def delete_template(self, name, params=None):
         """
         Delete an index template by its name.
@@ -1026,7 +1020,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "master_timeout", "timeout", "request_timeout", "wait_for_active_shards"
+        "master_timeout", "timeout", "wait_for_active_shards"
     )
     def shrink(self, index, target, body=None, params=None):
         """
@@ -1082,7 +1076,6 @@ class IndicesClient(NamespacedClient):
     @query_params(
         "dry_run",
         "master_timeout",
-        "request_timeout",
         "timeout",
         "wait_for_active_shards",
         "include_type_name",

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -93,7 +93,6 @@ class IndicesClient(NamespacedClient):
         :arg body: The configuration for the index (`settings` and `mappings`)
         :arg master_timeout: Specify timeout for connection to master
         :arg timeout: Explicit operation timeout
-        :arg request_timeout: Explicit operation timeout
         :arg wait_for_active_shards: Set the number of active shards to wait for
             before the operation returns.
         :arg include_type_name: Specify whether requests and responses should include a
@@ -166,7 +165,6 @@ class IndicesClient(NamespacedClient):
             ignored when unavailable (missing or closed)
         :arg master_timeout: Specify timeout for connection to master
         :arg timeout: Explicit operation timeout
-        :arg request_timeout: Explicit operation timeout
         :arg wait_for_active_shards: Sets the number of active shards to wait
             for before the operation returns.
         """
@@ -199,7 +197,6 @@ class IndicesClient(NamespacedClient):
         :arg ignore_unavailable: Whether specified concrete indices should be
             ignored when unavailable (missing or closed)
         :arg master_timeout: Specify timeout for connection to master
-        :arg request_timeout: Explicit operation timeout
         :arg wait_for_active_shards: Sets the number of active shards to wait
             for before the operation returns.
         """
@@ -231,7 +228,6 @@ class IndicesClient(NamespacedClient):
         :arg ignore_unavailable: Ignore unavailable indexes (default: false)
         :arg master_timeout: Specify timeout for connection to master
         :arg timeout: Explicit operation timeout
-        :arg request_timeout: Explicit operation timeout
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'index'.")
@@ -324,7 +320,6 @@ class IndicesClient(NamespacedClient):
             ignored when unavailable (missing or closed)
         :arg master_timeout: Specify timeout for connection to master
         :arg timeout: Explicit operation timeout
-        :arg request_timeout: Explicit operation timeout (For pre 7.x ES Clusters)
         :arg include_type_name: Specify whether requests and responses should include a
             type name (default: depends on Elasticsearch version).
         """
@@ -419,7 +414,6 @@ class IndicesClient(NamespacedClient):
         :arg name: The name of the alias to be created or updated
         :arg body: The settings for the alias, such as `routing` or `filter`
         :arg master_timeout: Specify timeout for connection to master
-        :arg request_timeout: Explicit timeout for the operation
         """
         for param in (index, name):
             if param in SKIP_IN_PATH:
@@ -482,7 +476,6 @@ class IndicesClient(NamespacedClient):
 
         :arg body: The definition of `actions` to perform
         :arg master_timeout: Specify timeout for connection to master
-        :arg request_timeout: Request timeout (For pre 7.x ES Clusters)
         :arg timeout: Request timeout
         """
         if body in SKIP_IN_PATH:
@@ -503,7 +496,6 @@ class IndicesClient(NamespacedClient):
             wildcards); use `_all` to delete all aliases for the specified
             indices.
         :arg master_timeout: Specify timeout for connection to master
-        :arg request_timeout: Explicit timeout for the operation (for pre 7.x ES clusters)
         :arg timeout: Explicit timeout for the operation
         """
         for param in (index, name):
@@ -535,7 +527,6 @@ class IndicesClient(NamespacedClient):
         :arg master_timeout: Specify timeout for connection to master
         :arg order: The order for this template when merging multiple matching
             ones (higher numbers are merged later, overriding the lower numbers)
-        :arg request_timeout: Explicit operation timeout (For pre ES 6 clusters)
         :arg timeout: Explicit operation timeout
         :arg include_type_name: Specify whether requests and responses should include a
             type name (default: depends on Elasticsearch version).
@@ -593,7 +584,6 @@ class IndicesClient(NamespacedClient):
 
         :arg name: The name of the template
         :arg master_timeout: Specify timeout for connection to master
-        :arg request_timeout: Explicit operation timeout (for pre 7.x clusters)
         :arg timeout: Explicit operation timeout
         """
         if name in SKIP_IN_PATH:
@@ -1040,7 +1030,6 @@ class IndicesClient(NamespacedClient):
         :arg body: The configuration for the target index (`settings` and
             `aliases`)
         :arg master_timeout: Specify timeout for connection to master
-        :arg request_timeout: Explicit operation timeout (For pre 7.x ES clusters)
         :arg timeout: Explicit operation timeout
         :arg wait_for_active_shards: Set the number of active shards to wait for
             on the shrunken index before the operation returns.
@@ -1098,7 +1087,6 @@ class IndicesClient(NamespacedClient):
             but not actually performed even if a condition matches. The default
             is false
         :arg master_timeout: Specify timeout for connection to master
-        :arg request_timeout: Explicit operation timeout (for pre 7.x ES clusters)
         :arg timeout: Explicit operation timeout
         :arg wait_for_active_shards: Set the number of active shards to wait for
             on the newly created rollover index before the operation returns.


### PR DESCRIPTION
Follow up from the closed discussion here: https://github.com/elastic/elasticsearch-py/pull/1049