### PR TITLE
fix `host` arg docs in the Elasticsearch class

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -190,10 +190,10 @@ class Elasticsearch(object):
 
     def __init__(self, hosts=None, transport_class=Transport, **kwargs):
         """
-        :arg hosts: list of nodes we should connect to. Node should be a
-            dictionary ({"host": "localhost", "port": 9200}), the entire dictionary
-            will be passed to the :class:`~elasticsearch.Connection` class as
-            kwargs, or a string in the format of ``host[:port]`` which will be
+        :arg hosts: list of nodes we should connect to or a string of a single node.
+            Node should be a dictionary ({"host": "localhost", "port": 9200}),
+            the entire dictionary will be passed to the :class:`~elasticsearch.Connection`
+            class askwargs, or a string in the format of ``host[:port]`` which will be
             translated to a dictionary automatically.  If no value is given the
             :class:`~elasticsearch.Urllib3HttpConnection` class defaults will be used.
 

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -190,12 +190,12 @@ class Elasticsearch(object):
 
     def __init__(self, hosts=None, transport_class=Transport, **kwargs):
         """
-        :arg hosts: list of nodes we should connect to or a string of a single node.
+        :arg hosts: list of nodes, or a single node, we should connect to.
             Node should be a dictionary ({"host": "localhost", "port": 9200}),
             the entire dictionary will be passed to the :class:`~elasticsearch.Connection`
             class askwargs, or a string in the format of ``host[:port]`` which will be
             translated to a dictionary automatically.  If no value is given the
-            :class:`~elasticsearch.Urllib3HttpConnection` class defaults will be used.
+            :class:`~elasticsearch.Connection` class defaults will be used.
 
         :arg transport_class: :class:`~elasticsearch.Transport` subclass to use.
 

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -193,7 +193,7 @@ class Elasticsearch(object):
         :arg hosts: list of nodes, or a single node, we should connect to.
             Node should be a dictionary ({"host": "localhost", "port": 9200}),
             the entire dictionary will be passed to the :class:`~elasticsearch.Connection`
-            class askwargs, or a string in the format of ``host[:port]`` which will be
+            class as kwargs, or a string in the format of ``host[:port]`` which will be
             translated to a dictionary automatically.  If no value is given the
             :class:`~elasticsearch.Connection` class defaults will be used.
 


### PR DESCRIPTION
Updated the __init__ docs of the Elasticsearch class to reflect the fact that is possible to pass a string representing the URL of the host we want to connect to and not necessarily a list of hosts.

This fixes #1068 