### PR TITLE
Updated requirement specifier.

### DIFF
--- a/README
+++ b/README
@@ -47,7 +47,7 @@ The recommended way to set your requirements in your `setup.py` or
     elasticsearch>=7.0.0,<8.0.0
 
     # Elasticsearch 6.x
-    elasticsearch6>=6.0.0,<7.0.0
+    elasticsearch>=6.0.0,<7.0.0
 
     # Elasticsearch 5.x
     elasticsearch>=5.0.0,<6.0.0


### PR DESCRIPTION
Updated as per pypi's [requirement-specifiers](https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers) doc, also defined at - [PEP 508](https://www.python.org/dev/peps/pep-0508/)
Keeping it simple will avoid causes for confusion like - https://www.zdnet.com/article/two-malicious-python-libraries-removed-from-pypi/