### PR TITLE
ssl_show_warn option improvements

### DIFF
--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -103,6 +103,10 @@ class RequestsHttpConnection(Connection):
                 )
             self.session.verify = ca_certs
 
+        if not ssl_show_warn:
+            requests.packages.urllib3.disable_warnings()
+
+        self.ssl_show_warn = ssl_show_warn
         if self.use_ssl and not verify_certs and ssl_show_warn:
             warnings.warn(
                 "Connecting to %s using SSL with verify_certs=False is insecure."

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -142,6 +142,7 @@ class Urllib3HttpConnection(Connection):
             or client_cert
             or client_key
             or ssl_version
+            or ssl_show_warn
         ):
             warnings.warn(
                 "When using `ssl_context`, all other SSL related kwargs are ignored"


### PR DESCRIPTION
* No ssl_show_warn accepted when a ssl_context is provided
* Disable InsecureRequestWarning from urllib3's connectionpool with ssl_show_warn option

(Closes #1075)