### PR TITLE
Fix params=None in client.search()

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -801,6 +801,8 @@ class Elasticsearch(object):
         :arg version: Specify whether to return document version as part of a
             hit
         """
+        if params is None:
+            params = {}
         # from is a reserved word so it cannot be used, use from_ instead
         if "from_" in params:
             params["from"] = params.pop("from_")


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/issues/1082

* Default arg is None yet params is iterated over immedately in body
* Add check for None and redefine as {}