### PR TITLE
Use side effect call count instead of mock call count

### DIFF
--- a/test_elasticsearch/test_helpers.py
+++ b/test_elasticsearch/test_helpers.py
@@ -35,7 +35,7 @@ class TestParallelBulk(TestCase):
         actions = ({"x": i} for i in range(100))
         list(helpers.parallel_bulk(Elasticsearch(), actions, chunk_size=2))
 
-        self.assertEquals(50, _process_bulk_chunk.call_count)
+        self.assertEquals(50, mock_process_bulk_chunk.call_count)
 
     @SkipTest
     @mock.patch(


### PR DESCRIPTION
Improves upon https://github.com/elastic/elasticsearch-py/pull/875

The flaky test failures prior to this PR can be reliably reproduced with Python 2.7.17 by modifying `test_all_chunks_sent` to create 100000 documents instead of 100 and using 1000 threads in `parallel_bulk` instead of the default of 4.  Local tests under these conditions typically had `_process_bulk_chunk.call_count` ~= 49990 instead of the correct value of 50000.  

The flaky test failures were not reproducible using Python 3.7.5.

This PR fixes the issue in Python 2 by using the mock_process_bulk_chunk.call_count instead, which is updated with a lock and therefore thread safe.  