### PR TITLE
Update packaging metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ include README.rst
 include README
 include tox.ini
 include setup.py
-include elasticsearch/connection/esthrift/Rest-remote
 recursive-include docs *
 
 prune docs/_build

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ source-dir = docs/
 build-dir = docs/_build
 all_files = 1
 
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [bdist_rpm]

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,8 @@ VERSION = (7, 5, 1)
 __version__ = VERSION
 __versionstr__ = ".".join(map(str, VERSION))
 
-f = open(join(dirname(__file__), "README"))
-long_description = f.read().strip()
-f.close()
+with open(join(dirname(__file__), "README")) as f:
+    long_description = f.read().strip()
 
 install_requires = ["urllib3>=1.21.1"]
 tests_require = [
@@ -17,26 +16,25 @@ tests_require = [
     "nose",
     "coverage",
     "mock",
-    "pyaml",
+    "pyyaml",
     "nosexcover",
 ]
 
 docs_require = ["sphinx<1.7", "sphinx_rtd_theme"]
 generate_require = ["black", "jinja2"]
 
-# use external unittest for 2.6
-if sys.version_info[:2] == (2, 6):
-    install_requires.append("unittest2")
-
 setup(
     name="elasticsearch",
     description="Python client for Elasticsearch",
-    license="Apache License, Version 2.0",
+    license="Apache-2.0",
     url="https://github.com/elastic/elasticsearch-py",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     version=__versionstr__,
     author="Honza Král, Nick Lang",
     author_email="honza.kral@gmail.com, nick@nicklang.com",
+    maintainer="Seth Michael Larson",
+    maintainer_email="seth.larson@elastic.co",
     packages=find_packages(where=".", exclude=("test_elasticsearch*",)),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -55,6 +53,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
     install_requires=install_requires,
     test_suite="test_elasticsearch.run_tests.run_all",
     tests_require=tests_require,


### PR DESCRIPTION
PR updates the package metadata in multiple places to bring it up to modern packaging requirements. Still need to remove the deprecated `setup.py test` but that's more integrated throughout the repository.

Found some of these issues with `twine check dist/*` and others via looking around.