### PR TITLE
Add utils._bulk_body() to API generator

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -314,11 +314,11 @@ class Elasticsearch(object):
         :arg refresh: If `true` then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         :arg routing: Specific routing value
         :arg timeout: Explicit operation timeout
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte
         :arg wait_for_active_shards: Sets the number of shard copies
             that must be active before proceeding with the index operation. Defaults
@@ -366,17 +366,17 @@ class Elasticsearch(object):
             number
         :arg op_type: Explicit operation type. Defaults to `index` for
             requests with an explicit document ID, and to `create`for requests
-            without an explicit document ID Valid choices: index, create
+            without an explicit document ID  Valid choices: index, create
         :arg pipeline: The pipeline id to preprocess incoming documents
             with
         :arg refresh: If `true` then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         :arg routing: Specific routing value
         :arg timeout: Explicit operation timeout
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte
         :arg wait_for_active_shards: Sets the number of shard copies
             that must be active before proceeding with the index operation. Defaults
@@ -432,7 +432,7 @@ class Elasticsearch(object):
         :arg refresh: If `true` then refresh the effected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         :arg routing: Specific routing value
         :arg timeout: Explicit operation timeout
         :arg wait_for_active_shards: Sets the number of shard copies
@@ -504,12 +504,12 @@ class Elasticsearch(object):
             queries should be analyzed (default: false)
         :arg analyzer: The analyzer to use for the query string
         :arg default_operator: The default operator for query string
-            query (AND or OR) Valid choices: AND, OR Default: OR
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
         :arg df: The field to use as default where no field prefix is
             given in the query string
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_throttled: Whether specified concrete, expanded or
             aliased indices should be ignored when throttled
         :arg ignore_unavailable: Whether specified concrete indices
@@ -556,11 +556,11 @@ class Elasticsearch(object):
         :arg refresh: If `true` then refresh the effected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         :arg routing: Specific routing value
         :arg timeout: Explicit operation timeout
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte, force
         :arg wait_for_active_shards: Sets the number of shard copies
             that must be active before proceeding with the delete operation.
@@ -635,14 +635,14 @@ class Elasticsearch(object):
         :arg analyze_wildcard: Specify whether wildcard and prefix
             queries should be analyzed (default: false)
         :arg conflicts: What to do when the delete by query hits version
-            conflicts? Valid choices: abort, proceed Default: abort
+            conflicts?  Valid choices: abort, proceed  Default: abort
         :arg default_operator: The default operator for query string
-            query (AND or OR) Valid choices: AND, OR Default: OR
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
         :arg df: The field to use as default where no field prefix is
             given in the query string
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg from_: Starting offset (default: 0)
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
@@ -665,7 +665,7 @@ class Elasticsearch(object):
             by query
         :arg search_timeout: Explicit timeout for each search request.
             Defaults to no timeout.
-        :arg search_type: Search operation type Valid choices:
+        :arg search_type: Search operation type  Valid choices:
             query_then_fetch, dfs_query_then_fetch
         :arg size: Deprecated, please use `max_docs` instead
         :arg slices: The number of slices this task should be divided
@@ -779,7 +779,7 @@ class Elasticsearch(object):
         :arg stored_fields: A comma-separated list of stored fields to
             return in the response
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte, force
         """
         for param in (index, id):
@@ -827,7 +827,7 @@ class Elasticsearch(object):
             performing the operation
         :arg routing: Specific routing value
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte, force
         """
         for param in (index, id):
@@ -871,7 +871,7 @@ class Elasticsearch(object):
             queries in the query string query should be analyzed (default: false)
         :arg analyzer: The analyzer for the query string query
         :arg default_operator: The default operator for query string
-            query (AND or OR) Valid choices: AND, OR Default: OR
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
         :arg df: The default field for query string query (default:
             _all)
         :arg lenient: Specify whether format-based query failures (such
@@ -913,8 +913,8 @@ class Elasticsearch(object):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg fields: A comma-separated list of field names
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
@@ -962,7 +962,7 @@ class Elasticsearch(object):
         :arg stored_fields: A comma-separated list of stored fields to
             return in the response
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte, force
         """
         for param in (index, id):
@@ -1026,7 +1026,7 @@ class Elasticsearch(object):
             performing the operation
         :arg routing: Specific routing value
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte, force
         """
         for param in (index, id):
@@ -1121,7 +1121,7 @@ class Elasticsearch(object):
             the shard bounds and the query are disjoint.  Default: 128
         :arg rest_total_hits_as_int: Indicates whether hits.total should
             be rendered as an integer or an object in the rest search response
-        :arg search_type: Search operation type Valid choices:
+        :arg search_type: Search operation type  Valid choices:
             query_then_fetch, query_and_fetch, dfs_query_then_fetch,
             dfs_query_and_fetch
         :arg typed_keys: Specify whether aggregation and suggester names
@@ -1153,7 +1153,7 @@ class Elasticsearch(object):
             concurrent searches the multi search api will execute
         :arg rest_total_hits_as_int: Indicates whether hits.total should
             be rendered as an integer or an object in the rest search response
-        :arg search_type: Search operation type Valid choices:
+        :arg search_type: Search operation type  Valid choices:
             query_then_fetch, query_and_fetch, dfs_query_then_fetch,
             dfs_query_and_fetch
         :arg typed_keys: Specify whether aggregation and suggester names
@@ -1223,7 +1223,7 @@ class Elasticsearch(object):
             document frequency should be returned. Applies to all returned documents
             unless otherwise specified in body "params" or "docs".
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte, force
         """
         return self.transport.perform_request(
@@ -1269,8 +1269,8 @@ class Elasticsearch(object):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         """
@@ -1473,14 +1473,14 @@ class Elasticsearch(object):
             trips should be minimized as part of cross-cluster search requests
             execution  Default: true
         :arg default_operator: The default operator for query string
-            query (AND or OR) Valid choices: AND, OR Default: OR
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
         :arg df: The field to use as default where no field prefix is
             given in the query string
         :arg docvalue_fields: A comma-separated list of fields to return
             as the docvalue representation of a field for each hit
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg explain: Specify whether to return detailed information
             about score computation as part of a hit
         :arg from_: Starting offset (default: 0)
@@ -1511,7 +1511,7 @@ class Elasticsearch(object):
         :arg routing: A comma-separated list of specific routing values
         :arg scroll: Specify how long a consistent view of the index
             should be maintained for scrolled search
-        :arg search_type: Search operation type Valid choices:
+        :arg search_type: Search operation type  Valid choices:
             query_then_fetch, dfs_query_then_fetch
         :arg seq_no_primary_term: Specify whether to return sequence
             number and primary term of the last modification of each hit
@@ -1522,8 +1522,8 @@ class Elasticsearch(object):
         :arg stored_fields: A comma-separated list of stored fields to
             return as part of a hit
         :arg suggest_field: Specify which field to use for suggestions
-        :arg suggest_mode: Specify suggest mode Valid choices: missing,
-            popular, always Default: missing
+        :arg suggest_mode: Specify suggest mode  Valid choices: missing,
+            popular, always  Default: missing
         :arg suggest_size: How many suggestions to return in response
         :arg suggest_text: The source text for which the suggestions
             should be returned
@@ -1568,8 +1568,8 @@ class Elasticsearch(object):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
@@ -1610,8 +1610,8 @@ class Elasticsearch(object):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg explain: Specify whether to return detailed information
             about score computation as part of a hit
         :arg ignore_throttled: Whether specified concrete, expanded or
@@ -1626,7 +1626,7 @@ class Elasticsearch(object):
         :arg routing: A comma-separated list of specific routing values
         :arg scroll: Specify how long a consistent view of the index
             should be maintained for scrolled search
-        :arg search_type: Search operation type Valid choices:
+        :arg search_type: Search operation type  Valid choices:
             query_then_fetch, query_and_fetch, dfs_query_then_fetch,
             dfs_query_and_fetch
         :arg typed_keys: Specify whether aggregation and suggester names
@@ -1685,7 +1685,7 @@ class Elasticsearch(object):
         :arg term_statistics: Specifies if total term frequency and
             document frequency should be returned.
         :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type Valid choices:
+        :arg version_type: Specific version type  Valid choices:
             internal, external, external_gte, force
         """
         if index in SKIP_IN_PATH:
@@ -1740,7 +1740,7 @@ class Elasticsearch(object):
         :arg refresh: If `true` then refresh the effected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         :arg retry_on_conflict: Specify how many times should the
             operation be retried when a conflict occurs (default: 0)
         :arg routing: Specific routing value
@@ -1823,14 +1823,14 @@ class Elasticsearch(object):
             queries should be analyzed (default: false)
         :arg analyzer: The analyzer to use for the query string
         :arg conflicts: What to do when the update by query hits version
-            conflicts? Valid choices: abort, proceed Default: abort
+            conflicts?  Valid choices: abort, proceed  Default: abort
         :arg default_operator: The default operator for query string
-            query (AND or OR) Valid choices: AND, OR Default: OR
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
         :arg df: The field to use as default where no field prefix is
             given in the query string
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg from_: Starting offset (default: 0)
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
@@ -1855,7 +1855,7 @@ class Elasticsearch(object):
             by query
         :arg search_timeout: Explicit timeout for each search request.
             Defaults to no timeout.
-        :arg search_type: Search operation type Valid choices:
+        :arg search_type: Search operation type  Valid choices:
             query_then_fetch, dfs_query_then_fetch
         :arg size: Deprecated, please use `max_docs` instead
         :arg slices: The number of slices this task should be divided

--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -33,7 +33,7 @@ class CatClient(NamespacedClient):
 
         :arg node_id: A comma-separated list of node IDs or names to
             limit the returned information
-        :arg bytes: The unit in which to display byte values Valid
+        :arg bytes: The unit in which to display byte values  Valid
             choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg format: a short version of the Accept header, e.g. json,
             yaml
@@ -84,7 +84,7 @@ class CatClient(NamespacedClient):
         :arg help: Return help information
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg ts: Set to false to disable timestamping  Default: True
@@ -126,13 +126,13 @@ class CatClient(NamespacedClient):
 
         :arg index: A comma-separated list of index names to limit the
             returned information
-        :arg bytes: The unit in which to display byte values Valid
+        :arg bytes: The unit in which to display byte values  Valid
             choices: b, k, m, g
         :arg format: a short version of the Accept header, e.g. json,
             yaml
         :arg h: Comma-separated list of column names to display
         :arg health: A health status ("green", "yellow", or "red" to
-            filter only indices matching the specified health status Valid choices:
+            filter only indices matching the specified health status  Valid choices:
             green, yellow, red
         :arg help: Return help information
         :arg include_unloaded_segments: If set to true segment stats
@@ -145,7 +145,7 @@ class CatClient(NamespacedClient):
         :arg pri: Set to true to return stats only for primary shards
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg v: Verbose mode. Display column headers
@@ -191,7 +191,7 @@ class CatClient(NamespacedClient):
         Returns basic statistics about performance of cluster nodes.
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html>`_
 
-        :arg bytes: The unit in which to display byte values Valid
+        :arg bytes: The unit in which to display byte values  Valid
             choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg format: a short version of the Accept header, e.g. json,
             yaml
@@ -205,7 +205,7 @@ class CatClient(NamespacedClient):
             to master node
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg v: Verbose mode. Display column headers
@@ -224,7 +224,7 @@ class CatClient(NamespacedClient):
             names to limit the returned information
         :arg active_only: If `true`, the response only includes ongoing
             shard recoveries
-        :arg bytes: The unit in which to display byte values Valid
+        :arg bytes: The unit in which to display byte values  Valid
             choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg detailed: If `true`, the response includes detailed
             information about shard recoveries
@@ -236,7 +236,7 @@ class CatClient(NamespacedClient):
             names to limit the returned information
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg v: Verbose mode. Display column headers
@@ -255,7 +255,7 @@ class CatClient(NamespacedClient):
 
         :arg index: A comma-separated list of index names to limit the
             returned information
-        :arg bytes: The unit in which to display byte values Valid
+        :arg bytes: The unit in which to display byte values  Valid
             choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg format: a short version of the Accept header, e.g. json,
             yaml
@@ -267,7 +267,7 @@ class CatClient(NamespacedClient):
             to master node
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg v: Verbose mode. Display column headers
@@ -284,7 +284,7 @@ class CatClient(NamespacedClient):
 
         :arg index: A comma-separated list of index names to limit the
             returned information
-        :arg bytes: The unit in which to display byte values Valid
+        :arg bytes: The unit in which to display byte values  Valid
             choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg format: a short version of the Accept header, e.g. json,
             yaml
@@ -314,7 +314,7 @@ class CatClient(NamespacedClient):
             to master node
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg v: Verbose mode. Display column headers
@@ -342,7 +342,7 @@ class CatClient(NamespacedClient):
             to master node
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg size: The multiplier in which to display values Valid
+        :arg size: The multiplier in which to display values  Valid
             choices: , k, m, g, t, p
         :arg v: Verbose mode. Display column headers
         """
@@ -361,7 +361,7 @@ class CatClient(NamespacedClient):
 
         :arg fields: A comma-separated list of fields to return the
             fielddata size
-        :arg bytes: The unit in which to display byte values Valid
+        :arg bytes: The unit in which to display byte values  Valid
             choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg fields: A comma-separated list of fields to return in the
             output
@@ -459,7 +459,7 @@ class CatClient(NamespacedClient):
             to master node
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg v: Verbose mode. Display column headers
@@ -501,7 +501,7 @@ class CatClient(NamespacedClient):
             Set to -1 to return all.
         :arg s: Comma-separated list of column names or column aliases
             to sort by
-        :arg time: The unit in which to display time values Valid
+        :arg time: The unit in which to display time values  Valid
             choices: d (Days), h (Hours), m (Minutes), s (Seconds), ms
             (Milliseconds), micros (Microseconds), nanos (Nanoseconds)
         :arg v: Verbose mode. Display column headers

--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -1,4 +1,4 @@
-from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+from .utils import NamespacedClient, query_params, _make_path
 
 
 class CatClient(NamespacedClient):

--- a/elasticsearch/client/cluster.py
+++ b/elasticsearch/client/cluster.py
@@ -22,10 +22,10 @@ class ClusterClient(NamespacedClient):
 
         :arg index: Limit the information returned to a specific index
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: all
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: all
         :arg level: Specify the level of detail for returned information
-            Valid choices: cluster, indices, shards Default: cluster
+            Valid choices: cluster, indices, shards  Default: cluster
         :arg local: Return local information, do not retrieve the state
             from master node (default: false)
         :arg master_timeout: Explicit operation timeout for connection
@@ -34,7 +34,7 @@ class ClusterClient(NamespacedClient):
         :arg wait_for_active_shards: Wait until the specified number of
             shards is active
         :arg wait_for_events: Wait until all currently queued events
-            with the given priority are processed Valid choices: immediate, urgent,
+            with the given priority are processed  Valid choices: immediate, urgent,
             high, normal, low, languid
         :arg wait_for_no_initializing_shards: Whether to wait until
             there are no initializing shards in the cluster
@@ -80,7 +80,7 @@ class ClusterClient(NamespacedClient):
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html>`_
 
         :arg metric: Limit the information returned to the specified
-            metrics Valid choices: _all, blocks, metadata, nodes, routing_table,
+            metrics  Valid choices: _all, blocks, metadata, nodes, routing_table,
             routing_nodes, master_node, version
         :arg index: A comma-separated list of index names; use `_all` or
             empty string to perform the operation on all indices
@@ -88,8 +88,8 @@ class ClusterClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg flat_settings: Return settings in flat format (default:
             false)
         :arg ignore_unavailable: Whether specified concrete indices
@@ -145,7 +145,7 @@ class ClusterClient(NamespacedClient):
         :arg master_timeout: Explicit operation timeout for connection
             to master node
         :arg metric: Limit the information returned to the specified
-            metrics. Defaults to all but metadata Valid choices: _all, blocks,
+            metrics. Defaults to all but metadata  Valid choices: _all, blocks,
             metadata, nodes, routing_table, master_node, version
         :arg retry_failed: Retries allocation of shards that are blocked
             due to too many subsequent allocation failures

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -30,8 +30,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         """
@@ -57,8 +57,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg force: Whether a flush should be forced even if it is not
             necessarily needed ie. if no changes will be committed to the index.
             This is useful if transaction log IDs should be incremented even if no
@@ -142,8 +142,8 @@ class IndicesClient(NamespacedClient):
         :arg allow_no_indices: Ignore if a wildcard expression resolves
             to no concrete indices (default: false)
         :arg expand_wildcards: Whether wildcard expressions should get
-            expanded to open or closed indices (default: open) Valid choices: open,
-            closed, none, all Default: open
+            expanded to open or closed indices (default: open)  Valid choices: open,
+            closed, none, all  Default: open
         :arg flat_settings: Return settings in flat format (default:
             false)
         :arg ignore_unavailable: Ignore unavailable indexes (default:
@@ -179,8 +179,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: closed
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: closed
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg master_timeout: Specify timeout for connection to master
@@ -213,8 +213,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg master_timeout: Specify timeout for connection to master
@@ -246,8 +246,8 @@ class IndicesClient(NamespacedClient):
         :arg allow_no_indices: Ignore if a wildcard expression resolves
             to no concrete indices (default: false)
         :arg expand_wildcards: Whether wildcard expressions should get
-            expanded to open or closed indices (default: open) Valid choices: open,
-            closed, none, all Default: open
+            expanded to open or closed indices (default: open)  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Ignore unavailable indexes (default:
             false)
         :arg master_timeout: Specify timeout for connection to master
@@ -277,8 +277,8 @@ class IndicesClient(NamespacedClient):
         :arg allow_no_indices: Ignore if a wildcard expression resolves
             to no concrete indices (default: false)
         :arg expand_wildcards: Whether wildcard expressions should get
-            expanded to open or closed indices (default: open) Valid choices: open,
-            closed, none, all Default: open
+            expanded to open or closed indices (default: open)  Valid choices: open,
+            closed, none, all  Default: open
         :arg flat_settings: Return settings in flat format (default:
             false)
         :arg ignore_unavailable: Ignore unavailable indexes (default:
@@ -307,8 +307,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
@@ -344,8 +344,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg include_type_name: Whether a type should be expected in the
@@ -382,8 +382,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg include_type_name: Whether to add the type name to the
@@ -416,8 +416,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg include_defaults: Whether the default mapping values should
@@ -472,8 +472,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: all
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: all
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
@@ -499,8 +499,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: all
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: all
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg local: Return local information, do not retrieve the state
@@ -662,8 +662,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: ['open', 'closed']
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: ['open', 'closed']
         :arg flat_settings: Return settings in flat format (default:
             false)
         :arg ignore_unavailable: Whether specified concrete indices
@@ -699,8 +699,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg flat_settings: Return settings in flat format (default:
             false)
         :arg ignore_unavailable: Whether specified concrete indices
@@ -738,14 +738,14 @@ class IndicesClient(NamespacedClient):
         :arg index: A comma-separated list of index names; use `_all` or
             empty string to perform the operation on all indices
         :arg metric: Limit the information returned the specific
-            metrics. Valid choices: _all, completion, docs, fielddata, query_cache,
+            metrics.  Valid choices: _all, completion, docs, fielddata, query_cache,
             flush, get, indexing, merge, request_cache, refresh, search, segments,
             store, warmer, suggest
         :arg completion_fields: A comma-separated list of fields for
             `fielddata` and `suggest` index metric (supports wildcards)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg fielddata_fields: A comma-separated list of fields for
             `fielddata` index metric (supports wildcards)
         :arg fields: A comma-separated list of fields for `fielddata`
@@ -762,7 +762,7 @@ class IndicesClient(NamespacedClient):
             will include stats for segments that are not currently loaded into
             memory
         :arg level: Return stats aggregated at cluster, index or shard
-            level Valid choices: cluster, indices, shards Default: indices
+            level  Valid choices: cluster, indices, shards  Default: indices
         :arg types: A comma-separated list of document types for the
             `indexing` index metric
         """
@@ -784,8 +784,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg verbose: Includes detailed memory usage by Lucene.
@@ -829,12 +829,12 @@ class IndicesClient(NamespacedClient):
             queries should be analyzed (default: false)
         :arg analyzer: The analyzer to use for the query string
         :arg default_operator: The default operator for query string
-            query (AND or OR) Valid choices: AND, OR Default: OR
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
         :arg df: The field to use as default where no field prefix is
             given in the query string
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg explain: Return detailed information about the error
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
@@ -871,8 +871,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg fielddata: Clear field data
         :arg fields: A comma-separated list of fields to clear when
             using the `fielddata` parameter (default: all)
@@ -922,8 +922,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg only_ancient_segments: If true, only ancient (an older
@@ -947,8 +947,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         """
@@ -968,8 +968,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         """
@@ -991,12 +991,12 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg status: A comma-separated list of statuses used to filter
-            on shards to get store information for Valid choices: green, yellow,
+            on shards to get store information for  Valid choices: green, yellow,
             red, all
         """
         return self.transport.perform_request(
@@ -1022,8 +1022,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg flush: Specify whether the index should be flushed after
             performing the operation (default: true)
         :arg ignore_unavailable: Whether specified concrete indices
@@ -1144,8 +1144,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: closed
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: closed
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg master_timeout: Specify timeout for connection to master
@@ -1177,8 +1177,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: closed
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: closed
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg master_timeout: Specify timeout for connection to master
@@ -1204,8 +1204,8 @@ class IndicesClient(NamespacedClient):
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
         :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both. Valid choices: open,
-            closed, none, all Default: open
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         """

--- a/elasticsearch/client/license.py
+++ b/elasticsearch/client/license.py
@@ -1,4 +1,4 @@
-from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+from .utils import NamespacedClient, query_params
 
 
 class LicenseClient(NamespacedClient):

--- a/elasticsearch/client/migration.py
+++ b/elasticsearch/client/migration.py
@@ -1,4 +1,4 @@
-from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+from .utils import NamespacedClient, query_params, _make_path
 
 
 class MigrationClient(NamespacedClient):

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -203,7 +203,7 @@ class MlClient(NamespacedClient):
         :arg explain: Whether to include a commentary on how the
             structure was derived
         :arg format: Optional parameter to specify the high level file
-            format Valid choices: ndjson, xml, delimited, semi_structured_text
+            format  Valid choices: ndjson, xml, delimited, semi_structured_text
         :arg grok_pattern: Optional parameter to specify the Grok
             pattern that should be used to extract fields from messages in a semi-
             structured text file

--- a/elasticsearch/client/monitoring.py
+++ b/elasticsearch/client/monitoring.py
@@ -19,7 +19,7 @@ class MonitoringClient(NamespacedClient):
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
 
-        body = self._bulk_body(body)
+        body = _bulk_body(self.transport.serializer, body)
         return self.transport.perform_request(
             "POST",
             _make_path("_monitoring", doc_type, "bulk"),

--- a/elasticsearch/client/monitoring.py
+++ b/elasticsearch/client/monitoring.py
@@ -1,4 +1,4 @@
-from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH, _bulk_body
 
 
 class MonitoringClient(NamespacedClient):

--- a/elasticsearch/client/nodes.py
+++ b/elasticsearch/client/nodes.py
@@ -30,7 +30,7 @@ class NodesClient(NamespacedClient):
             the node you're connecting to, leave empty to get information from all
             nodes
         :arg metric: A comma-separated list of metrics you wish
-            returned. Leave empty to return all. Valid choices: settings, os,
+            returned. Leave empty to return all.  Valid choices: settings, os,
             process, jvm, thread_pool, transport, http, plugins, ingest
         :arg flat_settings: Return settings in flat format (default:
             false)
@@ -60,11 +60,11 @@ class NodesClient(NamespacedClient):
             the node you're connecting to, leave empty to get information from all
             nodes
         :arg metric: Limit the information returned to the specified
-            metrics Valid choices: _all, breaker, fs, http, indices, jvm, os,
+            metrics  Valid choices: _all, breaker, fs, http, indices, jvm, os,
             process, thread_pool, transport, discovery
         :arg index_metric: Limit the information returned for `indices`
             metric to the specific index metrics. Isn't used if `indices` (or `all`)
-            metric isn't specified. Valid choices: _all, completion, docs,
+            metric isn't specified.  Valid choices: _all, completion, docs,
             fielddata, query_cache, flush, get, indexing, merge, request_cache,
             refresh, search, segments, store, warmer, suggest
         :arg completion_fields: A comma-separated list of fields for
@@ -79,7 +79,7 @@ class NodesClient(NamespacedClient):
             aggregated disk usage of each one of the Lucene index files (only
             applies if segment stats are requested)
         :arg level: Return indices stats aggregated at index, node or
-            shard level Valid choices: indices, node, shards Default: node
+            shard level  Valid choices: indices, node, shards  Default: node
         :arg timeout: Explicit operation timeout
         :arg types: A comma-separated list of document types for the
             `indexing` index metric
@@ -102,7 +102,7 @@ class NodesClient(NamespacedClient):
             limit the returned information; use `_local` to return information from
             the node you're connecting to, leave empty to get information from all
             nodes
-        :arg doc_type: The type to sample (default: cpu) Valid choices:
+        :arg doc_type: The type to sample (default: cpu)  Valid choices:
             cpu, wait, block
         :arg ignore_idle_threads: Don't show threads that are in known-
             idle places, such as waiting on a socket select or pulling from an empty
@@ -133,7 +133,7 @@ class NodesClient(NamespacedClient):
             the node you're connecting to, leave empty to get information from all
             nodes
         :arg metric: Limit the information returned to the specified
-            metrics Valid choices: _all, rest_actions
+            metrics  Valid choices: _all, rest_actions
         :arg timeout: Explicit operation timeout
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/remote.py
+++ b/elasticsearch/client/remote.py
@@ -1,4 +1,4 @@
-from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+from .utils import NamespacedClient, query_params
 
 
 class RemoteClient(NamespacedClient):

--- a/elasticsearch/client/security.py
+++ b/elasticsearch/client/security.py
@@ -23,7 +23,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
@@ -76,7 +76,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
@@ -95,7 +95,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         for param in (application, name):
             if param in SKIP_IN_PATH:
@@ -116,7 +116,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'name'.")
@@ -134,7 +134,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'name'.")
@@ -152,7 +152,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'username'.")
@@ -170,7 +170,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'username'.")
@@ -188,7 +188,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'username'.")
@@ -341,7 +341,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
@@ -360,7 +360,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         for param in (name, body):
             if param in SKIP_IN_PATH:
@@ -380,7 +380,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         for param in (name, body):
             if param in SKIP_IN_PATH:
@@ -403,7 +403,7 @@ class SecurityClient(NamespacedClient):
         :arg refresh: If `true` (the default) then refresh the affected
             shards to make this operation visible to search, if `wait_for` then wait
             for a refresh to make this operation visible to search, if `false` then
-            do nothing with refreshes. Valid choices: true, false, wait_for
+            do nothing with refreshes.  Valid choices: true, false, wait_for
         """
         for param in (username, body):
             if param in SKIP_IN_PATH:

--- a/elasticsearch/client/sql.py
+++ b/elasticsearch/client/sql.py
@@ -1,4 +1,4 @@
-from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+from .utils import NamespacedClient, query_params, SKIP_IN_PATH
 
 
 class SqlClient(NamespacedClient):

--- a/elasticsearch/client/ssl.py
+++ b/elasticsearch/client/ssl.py
@@ -1,4 +1,4 @@
-from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
+from .utils import NamespacedClient, query_params
 
 
 class SslClient(NamespacedClient):

--- a/elasticsearch/client/tasks.py
+++ b/elasticsearch/client/tasks.py
@@ -20,7 +20,7 @@ class TasksClient(NamespacedClient):
             returned. Leave empty to return all.
         :arg detailed: Return detailed task information (default: false)
         :arg group_by: Group tasks by nodes or parent/child
-            relationships Valid choices: nodes, parents, none Default: nodes
+            relationships  Valid choices: nodes, parents, none  Default: nodes
         :arg nodes: A comma-separated list of node IDs or names to limit
             the returned information; use `_local` to return information from the
             node you're connecting to, leave empty to get information from all nodes

--- a/elasticsearch/client/watcher.py
+++ b/elasticsearch/client/watcher.py
@@ -130,12 +130,12 @@ class WatcherClient(NamespacedClient):
         `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html>`_
 
         :arg metric: Controls what additional stat metrics should be
-            include in the response Valid choices: _all, queued_watches,
+            include in the response  Valid choices: _all, queued_watches,
             current_watches, pending_watches
         :arg emit_stacktraces: Emits stack traces of currently running
             watches
         :arg metric: Controls what additional stat metrics should be
-            include in the response Valid choices: _all, queued_watches,
+            include in the response  Valid choices: _all, queued_watches,
             current_watches, pending_watches
         """
         return self.transport.perform_request(

--- a/utils/templates/base
+++ b/utils/templates/base
@@ -12,7 +12,7 @@
 
         {% for p, info in api.params %}
         {% filter wordwrap(72, wrapstring="\n            ") %}
-        :arg {{ p }}: {{ info.description }} {% if info.options %}Valid choices: {{ info.options|join(", ") }}{% endif %} {% if info.default %}Default: {{ info.default }}{% endif %}
+        :arg {{ p }}: {{ info.description }} {% if info.options %}  Valid choices: {{ info.options|join(", ") }}{% endif %} {% if info.default %}  Default: {{ info.default }}{% endif %}
         {% endfilter %}
 
         {% endfor %}
@@ -21,7 +21,7 @@
         {% include "substitutions" %}
         {% include "required" %}
         {% if api.body.serialize == "bulk" %}
-        body = self._bulk_body(body)
+        body = _bulk_body(self.transport.serializer, body)
         {% endif %}
         {% block request %}
         return self.transport.perform_request("{{ api.method }}", {% include "url" %}, params=params{% if api.body %}, body=body{% endif %})


### PR DESCRIPTION
The commit https://github.com/elastic/elasticsearch-py/commit/415f744b0182f78f20dca15b310cbded1ba291ec changes `_bulk_body()` to be under `clients.utils` instead of attached to the client. Need to reflect this change in the API generator.

I've also changed the documentation section of `base` to put two spaces before `Valid values` and `Default` because it seemed inconsistent across many APIs. Two spaces makes more sense for readability. I've also run `flake8` to find undefined names or extraneous imports and then fix those issues.