### PR TITLE
Fix wrong ssl warning

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -142,7 +142,7 @@ class Urllib3HttpConnection(Connection):
             or client_cert
             or client_key
             or ssl_version
-            or ssl_show_warn
+            and ssl_show_warn
         ):
             warnings.warn(
                 "When using `ssl_context`, all other SSL related kwargs are ignored"


### PR DESCRIPTION
Resolves: https://github.com/elastic/elasticsearch-py/issues/1115

The ssl_show_warn defaults to True, making this warning to be printed even in situations where no extra ssl parameter has been set.

The fix is to check for the extra parameter **and** that ssl_show_warn is True