### PR TITLE
Add .ci/jobs to master for Jenkins

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,76 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: clients-ci
+
+##### JOB DEFAULTS
+
+- job:
+    project-type: matrix
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 100
+    properties:
+    - github:
+        url: https://github.com/elastic/elasticsearch-py/
+    - inject:
+        properties-content: HOME=$JENKINS_HOME
+    concurrent: true
+    node: flyweight
+    scm:
+    - git:
+        name: origin
+        credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        reference-repo: /var/lib/jenkins/.git-references/elasticsearch-py.git
+        branches:
+        - ${branch_specifier}
+        url: git@github.com:elastic/elasticsearch-py.git
+        wipe-workspace: 'True'
+    triggers:
+    - github
+    - timed: '@daily'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        type: yaml
+        filename: .ci/test-matrix.yml
+        name: ELASTICSEARCH_VERSION
+    - axis:
+        type: yaml
+        filename: .ci/test-matrix.yml
+        name: PYTHON_VERSION
+    - axis:
+        type: yaml
+        filename: .ci/test-matrix.yml
+        name: PYTHON_CONNECTION_CLASS
+    - axis:
+        type: yaml
+        filename: .ci/test-matrix.yml
+        name: TEST_SUITE
+    yaml-strategy:
+      exclude-key: exclude
+      filename: .ci/test-matrix.yml
+    wrappers:
+    - ansicolor
+    - timeout:
+        type: absolute
+        timeout: 120
+        fail: true
+    - timestamps
+    - workspace-cleanup
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        .ci/run-tests
+    publishers:
+    - email:
+        recipients: infra-root+build@elastic.co
+    - junit:
+        results: "*-junit.xml"
+        allow-empty-results: true

--- a/.ci/jobs/elastic+elasticsearch-py+7.x.yml
+++ b/.ci/jobs/elastic+elasticsearch-py+7.x.yml
@@ -1,0 +1,12 @@
+---
+- job:
+    name: elastic+elasticsearch-py+7.x
+    display-name: 'elastic / elasticsearch-py # 7.x'
+    description: Testing the elasticsearch-py 7.x branch.
+    junit_results: "*-junit.xml"
+    parameters:
+    - string:
+        name: branch_specifier
+        default: refs/heads/7.x
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)

--- a/.ci/jobs/elastic+elasticsearch-py+pull-request.yml
+++ b/.ci/jobs/elastic+elasticsearch-py+pull-request.yml
@@ -1,0 +1,19 @@
+---
+- job:
+    name: elastic+elasticsearch-py+pull-request
+    display-name: 'elastic / elasticsearch-py # pull-request'
+    description: Testing of elasticsearch-py pull requests.
+    junit_results: "*-junit.xml"
+    scm:
+    - git:
+        branches:
+        - ${ghprbActualCommit}
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    triggers:
+    - github-pull-request:
+        org-list:
+        - elastic
+        allow-whitelist-orgs-as-admins: true
+        github-hooks: true
+        status-context: clients-ci
+        cancel-builds-on-update: true


### PR DESCRIPTION
Jenkins needs these files to be on master to show our jobs on the dashboard. This doesn't enable CI for master, only for 7.x branch for now.