### PR TITLE
[7.x] Refactor cloud_id, api_key, headers, and http_compress

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -296,6 +296,7 @@ documents. This will configure compression.
    from elasticsearch import Elasticsearch
    es = Elasticsearch(hosts, http_compress=True)
 
+Compression is enabled by default when connecting to Elastic Cloud via ``cloud_id``.
 
 Running on AWS with IAM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/elasticsearch/connection/__init__.py
+++ b/elasticsearch/connection/__init__.py
@@ -1,3 +1,10 @@
 from .base import Connection
 from .http_requests import RequestsHttpConnection
 from .http_urllib3 import Urllib3HttpConnection, create_ssl_context
+
+__all__ = [
+    "Connection",
+    "RequestsHttpConnection",
+    "Urllib3HttpConnection",
+    "create_ssl_context",
+]

--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -1,5 +1,5 @@
 import logging
-import base64
+import binascii
 import gzip
 import io
 from platform import python_version
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import json
 
-from ..exceptions import TransportError, HTTP_EXCEPTIONS
+from ..exceptions import TransportError, ImproperlyConfigured, HTTP_EXCEPTIONS
 from .. import __versionstr__
 
 logger = logging.getLogger("elasticsearch")
@@ -29,6 +29,14 @@ class Connection(object):
     (`perform_request`) is thread-safe.
 
     Also responsible for logging.
+
+    :arg host: hostname of the node (default: localhost)
+    :arg port: port to use (integer, default: 9200)
+    :arg use_ssl: use ssl for the connection if `True`
+    :arg url_prefix: optional url prefix for elasticsearch
+    :arg timeout: default timeout in seconds (float, default: 10)
+    :arg http_compress: Use gzip compression
+    :arg cloud_id: The Cloud ID from ElasticCloud. Convenient way to connect to cloud instances.
     """
 
     def __init__(
@@ -38,20 +46,55 @@ class Connection(object):
         use_ssl=False,
         url_prefix="",
         timeout=10,
+        headers=None,
+        http_compress=None,
+        cloud_id=None,
+        api_key=None,
         **kwargs
     ):
-        """
-        :arg host: hostname of the node (default: localhost)
-        :arg port: port to use (integer, default: 9200)
-        :arg url_prefix: optional url prefix for elasticsearch
-        :arg timeout: default timeout in seconds (float, default: 10)
-        """
+
+        if cloud_id:
+            try:
+                _, cloud_id = cloud_id.split(":")
+                parent_dn, es_uuid, _ = (
+                    binascii.a2b_base64(cloud_id.encode("utf-8")).decode("utf-8").split("$")
+                )
+            except ValueError:
+                raise ImproperlyConfigured("'cloud_id' is not properly formatted")
+
+            host = "%s.%s" % (es_uuid, parent_dn)
+            port = 9243
+            use_ssl = True
+            if http_compress is None:
+                http_compress = True
+
+        # Work-around if the implementing class doesn't
+        # define the headers property before calling super().__init__()
+        if not hasattr(self, "headers"):
+            self.headers = {}
+
+        headers = headers or {}
+        for key in headers:
+            self.headers[key.lower()] = headers[key]
+
+        self.headers.setdefault("content-type", "application/json")
+        self.headers.setdefault("user-agent", self._get_default_user_agent())
+
+        if api_key is not None:
+            self.headers["authorization"] = self._get_api_key_header_val(api_key)
+
+        if http_compress:
+            self.headers["accept-encoding"] = "gzip,deflate"
+
         scheme = kwargs.get("scheme", "http")
         if use_ssl or scheme == "https":
             scheme = "https"
             use_ssl = True
         self.use_ssl = use_ssl
+        self.http_compress = http_compress or False
 
+        self.hostname = host
+        self.port = port
         self.host = "%s://%s:%s" % (scheme, host, port)
         if url_prefix:
             url_prefix = "/" + url_prefix.strip("/")
@@ -200,5 +243,5 @@ class Connection(object):
         """
         if isinstance(api_key, (tuple, list)):
             s = "{0}:{1}".format(api_key[0], api_key[1]).encode('utf-8')
-            return "ApiKey " + base64.b64encode(s).decode('utf-8')
+            return "ApiKey " + binascii.b2a_base64(s).rstrip(b"\r\n").decode('utf-8')
         return "ApiKey " + api_key

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -65,6 +65,9 @@ class TestUrllib3Connection(TestCase):
         self.assertEquals(
             con.host, "https://0fd50f62320ed6539f6cb48e1b68.example.cloud.com:9243"
         )
+        self.assertEquals(con.port, 9243)
+        self.assertEquals(con.hostname, "0fd50f62320ed6539f6cb48e1b68.example.cloud.com")
+        self.assertTrue(con.http_compress)
 
     def test_api_key_auth(self):
         # test with tuple
@@ -73,6 +76,7 @@ class TestUrllib3Connection(TestCase):
             api_key=("elastic", "changeme1"),
         )
         self.assertEquals(con.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTE=")
+        self.assertEquals(con.host, "https://0fd50f62320ed6539f6cb48e1b68.example.cloud.com:9243")
 
         # test with base64 encoded string
         con = Urllib3HttpConnection(
@@ -80,6 +84,7 @@ class TestUrllib3Connection(TestCase):
             api_key="ZWxhc3RpYzpjaGFuZ2VtZTI=",
         )
         self.assertEquals(con.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTI=")
+        self.assertEquals(con.host, "https://0fd50f62320ed6539f6cb48e1b68.example.cloud.com:9243")
 
     def test_no_http_compression(self):
         con = self._get_mock_connection()
@@ -118,6 +123,26 @@ class TestUrllib3Connection(TestCase):
         self.assertFalse(req_body)
         self.assertEqual(kwargs["headers"]["accept-encoding"], "gzip,deflate")
         self.assertNotIn("content-encoding", kwargs["headers"])
+
+    def test_cloud_id_http_compress_override(self):
+        # 'http_compress' will be 'True' by default for connections with
+        # 'cloud_id' set but should prioritize user-defined values.
+        con = Urllib3HttpConnection(
+            cloud_id="foobar:ZXhhbXBsZS5jbG91ZC5jb20kMGZkNTBmNjIzMjBlZDY1MzlmNmNiNDhlMWI2OCRhYzUzOTVhODgz\nNDU2NmM5ZjE1Y2Q4ZTQ5MGE=\n",
+        )
+        self.assertEquals(con.http_compress, True)
+
+        con = Urllib3HttpConnection(
+            cloud_id="foobar:ZXhhbXBsZS5jbG91ZC5jb20kMGZkNTBmNjIzMjBlZDY1MzlmNmNiNDhlMWI2OCRhYzUzOTVhODgz\nNDU2NmM5ZjE1Y2Q4ZTQ5MGE=\n",
+            http_compress=False
+        )
+        self.assertEquals(con.http_compress, False)
+
+        con = Urllib3HttpConnection(
+            cloud_id="foobar:ZXhhbXBsZS5jbG91ZC5jb20kMGZkNTBmNjIzMjBlZDY1MzlmNmNiNDhlMWI2OCRhYzUzOTVhODgz\nNDU2NmM5ZjE1Y2Q4ZTQ5MGE=\n",
+            http_compress=True
+        )
+        self.assertEquals(con.http_compress, True)
 
     def test_default_user_agent(self):
         con = Urllib3HttpConnection()
@@ -289,6 +314,9 @@ class TestRequestsConnection(TestCase):
         self.assertEquals(
             con.host, "https://0fd50f62320ed6539f6cb48e1b68.example.cloud.com:9243"
         )
+        self.assertEquals(con.port, 9243)
+        self.assertEquals(con.hostname, "0fd50f62320ed6539f6cb48e1b68.example.cloud.com")
+        self.assertTrue(con.http_compress)
 
     def test_api_key_auth(self):
         # test with tuple
@@ -297,6 +325,7 @@ class TestRequestsConnection(TestCase):
             api_key=("elastic", "changeme1"),
         )
         self.assertEquals(con.session.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTE=")
+        self.assertEquals(con.host, "https://0fd50f62320ed6539f6cb48e1b68.example.cloud.com:9243")
 
         # test with base64 encoded string
         con = RequestsHttpConnection(
@@ -304,6 +333,7 @@ class TestRequestsConnection(TestCase):
             api_key="ZWxhc3RpYzpjaGFuZ2VtZTI=",
         )
         self.assertEquals(con.session.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTI=")
+        self.assertEquals(con.host, "https://0fd50f62320ed6539f6cb48e1b68.example.cloud.com:9243")
 
     def test_no_http_compression(self):
         con = self._get_mock_connection()
@@ -339,6 +369,26 @@ class TestRequestsConnection(TestCase):
         req = con.session.send.call_args[0][0]
         self.assertNotIn("content-encoding", req.headers)
         self.assertEqual(req.headers["accept-encoding"], "gzip,deflate")
+
+    def test_cloud_id_http_compress_override(self):
+        # 'http_compress' will be 'True' by default for connections with
+        # 'cloud_id' set but should prioritize user-defined values.
+        con = RequestsHttpConnection(
+            cloud_id="foobar:ZXhhbXBsZS5jbG91ZC5jb20kMGZkNTBmNjIzMjBlZDY1MzlmNmNiNDhlMWI2OCRhYzUzOTVhODgz\nNDU2NmM5ZjE1Y2Q4ZTQ5MGE=\n",
+        )
+        self.assertEquals(con.http_compress, True)
+
+        con = RequestsHttpConnection(
+            cloud_id="foobar:ZXhhbXBsZS5jbG91ZC5jb20kMGZkNTBmNjIzMjBlZDY1MzlmNmNiNDhlMWI2OCRhYzUzOTVhODgz\nNDU2NmM5ZjE1Y2Q4ZTQ5MGE=\n",
+            http_compress=False
+        )
+        self.assertEquals(con.http_compress, False)
+
+        con = RequestsHttpConnection(
+            cloud_id="foobar:ZXhhbXBsZS5jbG91ZC5jb20kMGZkNTBmNjIzMjBlZDY1MzlmNmNiNDhlMWI2OCRhYzUzOTVhODgz\nNDU2NmM5ZjE1Y2Q4ZTQ5MGE=\n",
+            http_compress=True
+        )
+        self.assertEquals(con.http_compress, True)
 
     def test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Backported from 742aadd57b1953afc35524220d93e296954b45d0