### PR TITLE
Add more alternative examples

### DIFF
--- a/docs/examples/35e8da9410b8432cf4095f2541ad7b1d.asciidoc
+++ b/docs/examples/35e8da9410b8432cf4095f2541ad7b1d.asciidoc
@@ -1,0 +1,18 @@
+// aggregations/bucket/terms-aggregation.asciidoc:264
+
+[source, python]
+----
+client.search(
+    body={
+        "aggs": {
+            "products": {
+                "terms": {
+                    "field": "product",
+                    "size": 5,
+                    "show_term_doc_count_error": True,
+                }
+            }
+        }
+    }
+)
+----

--- a/docs/examples/5d9d7b84e2fec7ecd832145cbb951cf1.asciidoc
+++ b/docs/examples/5d9d7b84e2fec7ecd832145cbb951cf1.asciidoc
@@ -1,0 +1,21 @@
+// aggregations/bucket/terms-aggregation.asciidoc:683
+
+[source, python]
+----
+client.search(
+    body={
+        "size": 0,
+        "aggs": {
+            "expired_sessions": {
+                "terms": {
+                    "field": "account_id",
+                    "include": {"partition": 0, "num_partitions": 20},
+                    "size": 10000,
+                    "order": {"last_access": "asc"},
+                },
+                "aggs": {"last_access": {"max": {"field": "access_date"}}},
+            }
+        },
+    }
+)
+----

--- a/docs/examples/6a4679531e64c492fce16dc12de6dcb0.asciidoc
+++ b/docs/examples/6a4679531e64c492fce16dc12de6dcb0.asciidoc
@@ -1,0 +1,8 @@
+// aggregations/bucket/terms-aggregation.asciidoc:341
+
+[source, python]
+----
+client.search(
+    body={"aggs": {"genres": {"terms": {"field": "genre", "order": {"_count": "asc"}}}}}
+)
+----

--- a/docs/examples/774d715155cd13713e6e327adf6ce328.asciidoc
+++ b/docs/examples/774d715155cd13713e6e327adf6ce328.asciidoc
@@ -1,0 +1,8 @@
+// aggregations/bucket/terms-aggregation.asciidoc:857
+
+[source, python]
+----
+client.search(
+    body={"aggs": {"tags": {"terms": {"field": "tags", "execution_hint": "map"}}}},
+)
+----

--- a/docs/examples/7f28f8ae8fcdbd807dadde0b5b007a6d.asciidoc
+++ b/docs/examples/7f28f8ae8fcdbd807dadde0b5b007a6d.asciidoc
@@ -1,0 +1,15 @@
+// aggregations/bucket/terms-aggregation.asciidoc:775
+
+[source, python]
+----
+client.search(
+    body={
+        "aggs": {
+            "actors": {
+                "terms": {"field": "actors", "size": 10},
+                "aggs": {"costars": {"terms": {"field": "actors", "size": 5}}},
+            }
+        }
+    }
+)
+----

--- a/docs/examples/98b121bf47cebd85671a2cb519688d28.asciidoc
+++ b/docs/examples/98b121bf47cebd85671a2cb519688d28.asciidoc
@@ -1,0 +1,15 @@
+// aggregations/bucket/terms-aggregation.asciidoc:654
+
+[source, python]
+----
+client.search(
+    body={
+        "aggs": {
+            "JapaneseCars": {"terms": {"field": "make", "include": ["mazda", "honda"]}},
+            "ActiveCarManufacturers": {
+                "terms": {"field": "make", "exclude": ["rover", "jensen"]}
+            },
+        }
+    }
+)
+----

--- a/docs/examples/9a8995fd31351045d99c78e40444c8ea.asciidoc
+++ b/docs/examples/9a8995fd31351045d99c78e40444c8ea.asciidoc
@@ -1,0 +1,6 @@
+// aggregations/bucket/terms-aggregation.asciidoc:57
+
+[source, python]
+----
+client.search(body={"aggs": {"genres": {"terms": {"field": "genre"}}}})
+----

--- a/docs/examples/cd5bc5bf7cd58d7b1492c9c298b345f6.asciidoc
+++ b/docs/examples/cd5bc5bf7cd58d7b1492c9c298b345f6.asciidoc
@@ -1,0 +1,19 @@
+// aggregations/bucket/terms-aggregation.asciidoc:806
+
+[source, python]
+----
+client.search(
+    body={
+        "aggs": {
+            "actors": {
+                "terms": {
+                    "field": "actors",
+                    "size": 10,
+                    "collect_mode": "breadth_first",
+                },
+                "aggs": {"costars": {"terms": {"field": "actors", "size": 5}}},
+            }
+        }
+    }
+)
+----

--- a/docs/examples/d50a3835bf5795ac73e58906a3413544.asciidoc
+++ b/docs/examples/d50a3835bf5795ac73e58906a3413544.asciidoc
@@ -1,0 +1,6 @@
+// aggregations/bucket/terms-aggregation.asciidoc:135
+
+[source, python]
+----
+client.search(body={"aggs": {"products": {"terms": {"field": "product", "size": 5}}}})
+----

--- a/docs/examples/f085fb032dae56a3b104ab874eaea2ad.asciidoc
+++ b/docs/examples/f085fb032dae56a3b104ab874eaea2ad.asciidoc
@@ -1,0 +1,6 @@
+// aggregations/bucket/terms-aggregation.asciidoc:882
+
+[source, python]
+----
+client.search(body={"aggs": {"tags": {"terms": {"field": "tags", "missing": "N/A",}}}},)
+----

--- a/docs/examples/feefeb68144002fd1fff57b77b95b85e.asciidoc
+++ b/docs/examples/feefeb68144002fd1fff57b77b95b85e.asciidoc
@@ -1,0 +1,9 @@
+// getting-started.asciidoc:578
+
+[source, python]
+----
+client.search(
+    index="bank",
+    body={"size": 0, "aggs": {"group_by_state": {"terms": {"field": "state.keyword"}}}},
+)
+----


### PR DESCRIPTION
When a generator is created for these examples I'm going to have it match the indentation levels of the `body` argument to match the documentation. Black compresses / changes the indentation in ways that probably aren't desirable.