### PR TITLE
[7.x] Restore default metric='_all' to cluster.state()

### DIFF
--- a/elasticsearch/client/cluster.py
+++ b/elasticsearch/client/cluster.py
@@ -102,6 +102,9 @@ class ClusterClient(NamespacedClient):
         :arg wait_for_timeout: The maximum time to wait for
             wait_for_metadata_version before timing out
         """
+        if index and metric in SKIP_IN_PATH:
+            metric = "_all"
+
         return self.transport.perform_request(
             "GET", _make_path("_cluster", "state", metric, index), params=params
         )

--- a/test_elasticsearch/test_client/test_cluster.py
+++ b/test_elasticsearch/test_client/test_cluster.py
@@ -1,0 +1,27 @@
+from test_elasticsearch.test_cases import ElasticsearchTestCase
+
+
+class TestCluster(ElasticsearchTestCase):
+    def test_stats_without_node_id(self):
+        self.client.cluster.stats()
+        self.assert_url_called("GET", "/_cluster/stats")
+
+    def test_stats_with_node_id(self):
+        self.client.cluster.stats("node-1")
+        self.assert_url_called("GET", "/_cluster/stats/nodes/node-1")
+
+        self.client.cluster.stats(node_id="node-2")
+        self.assert_url_called("GET", "/_cluster/stats/nodes/node-2")
+
+    def test_state_with_index_without_metric_defaults_to_all(self):
+        self.client.cluster.state()
+        self.assert_url_called("GET", "/_cluster/state")
+
+        self.client.cluster.state(metric="cluster_name")
+        self.assert_url_called("GET", "/_cluster/state/cluster_name")
+
+        self.client.cluster.state(index="index-1")
+        self.assert_url_called("GET", "/_cluster/state/_all/index-1")
+
+        self.client.cluster.state(index="index-1", metric="cluster_name")
+        self.assert_url_called("GET", "/_cluster/state/cluster_name/index-1")

--- a/test_elasticsearch/test_client/test_indices.py
+++ b/test_elasticsearch/test_client/test_indices.py
@@ -18,3 +18,7 @@ class TestIndices(ElasticsearchTestCase):
         self.assertRaises(ValueError, self.client.indices.exists, index=None)
         self.assertRaises(ValueError, self.client.indices.exists, index=[])
         self.assertRaises(ValueError, self.client.indices.exists, index="")
+
+    def test_put_mapping_without_index(self):
+        self.client.indices.put_mapping(doc_type="doc-type", body={})
+        self.assert_url_called("PUT", "/_all/doc-type/_mapping")

--- a/test_elasticsearch/test_server/__init__.py
+++ b/test_elasticsearch/test_server/__init__.py
@@ -1,3 +1,4 @@
+from unittest import SkipTest
 from elasticsearch.helpers import test
 from elasticsearch.helpers.test import ElasticsearchTestCase as BaseTestCase
 
@@ -6,6 +7,8 @@ client = None
 
 def get_client(**kwargs):
     global client
+    if client is False:
+        raise SkipTest("No client is available")
     if client is not None and not kwargs:
         return client
 
@@ -16,7 +19,11 @@ def get_client(**kwargs):
         new_client = local_get_client(**kwargs)
     except ImportError:
         # fallback to using vanilla client
-        new_client = test.get_test_client(**kwargs)
+        try:
+            new_client = test.get_test_client(**kwargs)
+        except SkipTest:
+            client = False
+            raise
 
     if not kwargs:
         client = new_client

--- a/utils/templates/overrides/cluster/state
+++ b/utils/templates/overrides/cluster/state
@@ -1,0 +1,8 @@
+{% extends "base" %}
+{% block request %}
+        if index and metric in SKIP_IN_PATH:
+            metric = "_all"
+
+        {{ super()|trim }}
+{% endblock %}
+


### PR DESCRIPTION
Backported from ef75a783ede729ac926eae4113c7f23933f89d32