### PR TITLE
Update supported ES API to 7.6

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -429,7 +429,7 @@ class Elasticsearch(object):
             provide one
         :arg pipeline: The pipeline id to preprocess incoming documents
             with
-        :arg refresh: If `true` then refresh the effected shards to make
+        :arg refresh: If `true` then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
             do nothing with refreshes.  Valid choices: true, false, wait_for
@@ -553,7 +553,7 @@ class Elasticsearch(object):
         :arg if_seq_no: only perform the delete operation if the last
             operation that has changed the document has the specified sequence
             number
-        :arg refresh: If `true` then refresh the effected shards to make
+        :arg refresh: If `true` then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
             do nothing with refreshes.  Valid choices: true, false, wait_for
@@ -585,6 +585,7 @@ class Elasticsearch(object):
         "_source_includes",
         "allow_no_indices",
         "analyze_wildcard",
+        "analyzer",
         "conflicts",
         "default_operator",
         "df",
@@ -634,6 +635,7 @@ class Elasticsearch(object):
             string or when no indices have been specified)
         :arg analyze_wildcard: Specify whether wildcard and prefix
             queries should be analyzed (default: false)
+        :arg analyzer: The analyzer to use for the query string
         :arg conflicts: What to do when the delete by query hits version
             conflicts?  Valid choices: abort, proceed  Default: abort
         :arg default_operator: The default operator for query string
@@ -1136,7 +1138,11 @@ class Elasticsearch(object):
         )
 
     @query_params(
-        "max_concurrent_searches", "rest_total_hits_as_int", "search_type", "typed_keys"
+        "ccs_minimize_roundtrips",
+        "max_concurrent_searches",
+        "rest_total_hits_as_int",
+        "search_type",
+        "typed_keys",
     )
     def msearch_template(self, body, index=None, doc_type=None, params=None):
         """
@@ -1149,6 +1155,9 @@ class Elasticsearch(object):
             default
         :arg doc_type: A comma-separated list of document types to use
             as default
+        :arg ccs_minimize_roundtrips: Indicates whether network round-
+            trips should be minimized as part of cross-cluster search requests
+            execution  Default: true
         :arg max_concurrent_searches: Controls the maximum number of
             concurrent searches the multi search api will execute
         :arg rest_total_hits_as_int: Indicates whether hits.total should
@@ -1254,7 +1263,9 @@ class Elasticsearch(object):
             "PUT", _make_path("_scripts", id, context), params=params, body=body
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "search_type"
+    )
     def rank_eval(self, body, index=None, params=None):
         """
         Allows to evaluate the quality of ranked search results over a set of typical
@@ -1273,6 +1284,8 @@ class Elasticsearch(object):
             closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
+        :arg search_type: Search operation type  Valid choices:
+            query_then_fetch, dfs_query_then_fetch
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
@@ -1302,7 +1315,7 @@ class Elasticsearch(object):
             prototype for the index request.
         :arg max_docs: Maximum number of documents to process (default:
             all documents)
-        :arg refresh: Should the effected indexes be refreshed?
+        :arg refresh: Should the affected indexes be refreshed?
         :arg requests_per_second: The throttle to set on this request in
             sub-requests per second. -1 means no throttle.
         :arg scroll: Control how long to keep the search context alive
@@ -1584,6 +1597,7 @@ class Elasticsearch(object):
 
     @query_params(
         "allow_no_indices",
+        "ccs_minimize_roundtrips",
         "expand_wildcards",
         "explain",
         "ignore_throttled",
@@ -1609,6 +1623,9 @@ class Elasticsearch(object):
         :arg allow_no_indices: Whether to ignore if a wildcard indices
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
+        :arg ccs_minimize_roundtrips: Indicates whether network round-
+            trips should be minimized as part of cross-cluster search requests
+            execution  Default: true
         :arg expand_wildcards: Whether to expand wildcard expression to
             concrete indices that are open, closed or both.  Valid choices: open,
             closed, none, all  Default: open
@@ -1737,7 +1754,7 @@ class Elasticsearch(object):
             operation that has changed the document has the specified sequence
             number
         :arg lang: The script language (default: painless)
-        :arg refresh: If `true` then refresh the effected shards to make
+        :arg refresh: If `true` then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
             do nothing with refreshes.  Valid choices: true, false, wait_for
@@ -1843,7 +1860,7 @@ class Elasticsearch(object):
         :arg preference: Specify the node or shard the operation should
             be performed on (default: random)
         :arg q: Query in the Lucene query string syntax
-        :arg refresh: Should the effected indexes be refreshed?
+        :arg refresh: Should the affected indexes be refreshed?
         :arg request_cache: Specify if request cache should be used for
             this request or not, defaults to index level setting
         :arg requests_per_second: The throttle to set on this request in
@@ -1915,3 +1932,19 @@ class Elasticsearch(object):
             _make_path("_update_by_query", task_id, "_rethrottle"),
             params=params,
         )
+
+    @query_params()
+    def get_script_context(self, params=None):
+        """
+        Returns all script contexts.
+
+        """
+        return self.transport.perform_request("GET", "/_script_context", params=params)
+
+    @query_params()
+    def get_script_languages(self, params=None):
+        """
+        Returns available script types, languages and contexts
+
+        """
+        return self.transport.perform_request("GET", "/_script_language", params=params)

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -1174,6 +1174,117 @@ class Elasticsearch(object):
             body=body,
         )
 
+    @query_params(
+        "ccs_minimize_roundtrips",
+        "max_concurrent_searches",
+        "rest_total_hits_as_int",
+        "search_type",
+        "typed_keys",
+    )
+    def msearch_template(
+        self, body, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Allows to execute several search template operations in one request.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html>`_
+
+        :arg body: The request definitions (metadata-search request
+            definition pairs), separated by newlines
+        :arg index: A comma-separated list of index names to use as
+            default
+        :arg doc_type: A comma-separated list of document types to use
+            as default
+        :arg ccs_minimize_roundtrips: Indicates whether network round-
+            trips should be minimized as part of cross-cluster search requests
+            execution  Default: true
+        :arg max_concurrent_searches: Controls the maximum number of
+            concurrent searches the multi search api will execute
+        :arg rest_total_hits_as_int: Indicates whether hits.total should
+            be rendered as an integer or an object in the rest search response
+        :arg search_type: Search operation type  Valid choices:
+            query_then_fetch, query_and_fetch, dfs_query_then_fetch,
+            dfs_query_and_fetch
+        :arg typed_keys: Specify whether aggregation and suggester names
+            should be prefixed by their respective types in the response
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        body = _bulk_body(self.transport.serializer, body)
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, doc_type, "_msearch", "template"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params(
+        "field_statistics",
+        "fields",
+        "ids",
+        "offsets",
+        "payloads",
+        "positions",
+        "preference",
+        "realtime",
+        "routing",
+        "term_statistics",
+        "version",
+        "version_type",
+    )
+    def mtermvectors(
+        self, body=None, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Returns multiple termvectors in one request.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
+
+        :arg body: Define ids, documents, parameters or a list of
+            parameters per document here. You must at least provide a list of
+            document ids. See documentation.
+        :arg index: The index in which the document resides.
+        :arg doc_type: The type of the document.
+        :arg field_statistics: Specifies if document count, sum of
+            document frequencies and sum of total term frequencies should be
+            returned. Applies to all returned documents unless otherwise specified
+            in body "params" or "docs".  Default: True
+        :arg fields: A comma-separated list of fields to return. Applies
+            to all returned documents unless otherwise specified in body "params" or
+            "docs".
+        :arg ids: A comma-separated list of documents ids. You must
+            define ids as parameter or set "ids" or "docs" in the request body
+        :arg offsets: Specifies if term offsets should be returned.
+            Applies to all returned documents unless otherwise specified in body
+            "params" or "docs".  Default: True
+        :arg payloads: Specifies if term payloads should be returned.
+            Applies to all returned documents unless otherwise specified in body
+            "params" or "docs".  Default: True
+        :arg positions: Specifies if term positions should be returned.
+            Applies to all returned documents unless otherwise specified in body
+            "params" or "docs".  Default: True
+        :arg preference: Specify the node or shard the operation should
+            be performed on (default: random) .Applies to all returned documents
+            unless otherwise specified in body "params" or "docs".
+        :arg realtime: Specifies if requests are real-time as opposed to
+            near-real-time (default: true).
+        :arg routing: Specific routing value. Applies to all returned
+            documents unless otherwise specified in body "params" or "docs".
+        :arg term_statistics: Specifies if total term frequency and
+            document frequency should be returned. Applies to all returned documents
+            unless otherwise specified in body "params" or "docs".
+        :arg version: Explicit version number for concurrency control
+        :arg version_type: Specific version type  Valid choices:
+            internal, external, external_gte, force
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, doc_type, "_mtermvectors"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
     @query_params("master_timeout", "timeout")
     def put_script(self, id, body, context=None, params=None, headers=None):
         """
@@ -1551,223 +1662,6 @@ class Elasticsearch(object):
         )
 
     @query_params(
-        "_source",
-        "_source_excludes",
-        "_source_includes",
-        "if_primary_term",
-        "if_seq_no",
-        "lang",
-        "refresh",
-        "retry_on_conflict",
-        "routing",
-        "timeout",
-        "wait_for_active_shards",
-    )
-    def update(self, index, id, body, doc_type=None, params=None, headers=None):
-        """
-        Updates a document with a script or partial document.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
-
-        :arg index: The name of the index
-        :arg id: Document ID
-        :arg body: The request definition requires either `script` or
-            partial `doc`
-        :arg doc_type: The type of the document
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return
-        :arg _source_excludes: A list of fields to exclude from the
-            returned _source field
-        :arg _source_includes: A list of fields to extract and return
-            from the _source field
-        :arg if_primary_term: only perform the update operation if the
-            last operation that has changed the document has the specified primary
-            term
-        :arg if_seq_no: only perform the update operation if the last
-            operation that has changed the document has the specified sequence
-            number
-        :arg lang: The script language (default: painless)
-        :arg refresh: If `true` then refresh the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh
-            to make this operation visible to search, if `false` (the default) then
-            do nothing with refreshes.  Valid choices: true, false, wait_for
-        :arg retry_on_conflict: Specify how many times should the
-            operation be retried when a conflict occurs (default: 0)
-        :arg routing: Specific routing value
-        :arg timeout: Explicit operation timeout
-        :arg wait_for_active_shards: Sets the number of shard copies
-            that must be active before proceeding with the update operation.
-            Defaults to 1, meaning the primary shard only. Set to `all` for all
-            shard copies, otherwise set to any non-negative value less than or equal
-            to the total number of copies for the shard (number of replicas + 1)
-        """
-        for param in (index, id, body):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
-
-        if doc_type in SKIP_IN_PATH:
-            doc_type = "_doc"
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(index, doc_type, id, "_update"),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params("requests_per_second")
-    def update_by_query_rethrottle(self, task_id, params=None, headers=None):
-        """
-        Changes the number of requests per second for a particular Update By Query
-        operation.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html>`_
-
-        :arg task_id: The task id to rethrottle
-        :arg requests_per_second: The throttle to set on this request in
-            floating sub-requests per second. -1 means set no throttle.
-        """
-        if task_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'task_id'.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path("_update_by_query", task_id, "_rethrottle"),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params()
-    def get_script_context(self, params=None, headers=None):
-        """
-        Returns all script contexts.
-
-        """
-        return self.transport.perform_request(
-            "GET", "/_script_context", params=params, headers=headers
-        )
-
-    @query_params()
-    def get_script_languages(self, params=None, headers=None):
-        """
-        Returns available script types, languages and contexts
-
-        """
-        return self.transport.perform_request(
-            "GET", "/_script_language", params=params, headers=headers
-        )
-
-    @query_params(
-        "ccs_minimize_roundtrips",
-        "max_concurrent_searches",
-        "rest_total_hits_as_int",
-        "search_type",
-        "typed_keys",
-    )
-    def msearch_template(
-        self, body, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Allows to execute several search template operations in one request.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html>`_
-
-        :arg body: The request definitions (metadata-search request
-            definition pairs), separated by newlines
-        :arg index: A comma-separated list of index names to use as
-            default
-        :arg doc_type: A comma-separated list of document types to use
-            as default
-        :arg ccs_minimize_roundtrips: Indicates whether network round-
-            trips should be minimized as part of cross-cluster search requests
-            execution  Default: true
-        :arg max_concurrent_searches: Controls the maximum number of
-            concurrent searches the multi search api will execute
-        :arg rest_total_hits_as_int: Indicates whether hits.total should
-            be rendered as an integer or an object in the rest search response
-        :arg search_type: Search operation type  Valid choices:
-            query_then_fetch, query_and_fetch, dfs_query_then_fetch,
-            dfs_query_and_fetch
-        :arg typed_keys: Specify whether aggregation and suggester names
-            should be prefixed by their respective types in the response
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        body = _bulk_body(self.transport.serializer, body)
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, doc_type, "_msearch", "template"),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params(
-        "field_statistics",
-        "fields",
-        "ids",
-        "offsets",
-        "payloads",
-        "positions",
-        "preference",
-        "realtime",
-        "routing",
-        "term_statistics",
-        "version",
-        "version_type",
-    )
-    def mtermvectors(
-        self, body=None, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Returns multiple termvectors in one request.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
-
-        :arg body: Define ids, documents, parameters or a list of
-            parameters per document here. You must at least provide a list of
-            document ids. See documentation.
-        :arg index: The index in which the document resides.
-        :arg doc_type: The type of the document.
-        :arg field_statistics: Specifies if document count, sum of
-            document frequencies and sum of total term frequencies should be
-            returned. Applies to all returned documents unless otherwise specified
-            in body "params" or "docs".  Default: True
-        :arg fields: A comma-separated list of fields to return. Applies
-            to all returned documents unless otherwise specified in body "params" or
-            "docs".
-        :arg ids: A comma-separated list of documents ids. You must
-            define ids as parameter or set "ids" or "docs" in the request body
-        :arg offsets: Specifies if term offsets should be returned.
-            Applies to all returned documents unless otherwise specified in body
-            "params" or "docs".  Default: True
-        :arg payloads: Specifies if term payloads should be returned.
-            Applies to all returned documents unless otherwise specified in body
-            "params" or "docs".  Default: True
-        :arg positions: Specifies if term positions should be returned.
-            Applies to all returned documents unless otherwise specified in body
-            "params" or "docs".  Default: True
-        :arg preference: Specify the node or shard the operation should
-            be performed on (default: random) .Applies to all returned documents
-            unless otherwise specified in body "params" or "docs".
-        :arg realtime: Specifies if requests are real-time as opposed to
-            near-real-time (default: true).
-        :arg routing: Specific routing value. Applies to all returned
-            documents unless otherwise specified in body "params" or "docs".
-        :arg term_statistics: Specifies if total term frequency and
-            document frequency should be returned. Applies to all returned documents
-            unless otherwise specified in body "params" or "docs".
-        :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type  Valid choices:
-            internal, external, external_gte, force
-        """
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, doc_type, "_mtermvectors"),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params(
         "allow_no_indices",
         "ccs_minimize_roundtrips",
         "expand_wildcards",
@@ -1891,6 +1785,71 @@ class Elasticsearch(object):
         return self.transport.perform_request(
             "GET",
             _make_path(index, doc_type, id, "_termvectors"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params(
+        "_source",
+        "_source_excludes",
+        "_source_includes",
+        "if_primary_term",
+        "if_seq_no",
+        "lang",
+        "refresh",
+        "retry_on_conflict",
+        "routing",
+        "timeout",
+        "wait_for_active_shards",
+    )
+    def update(self, index, id, body, doc_type=None, params=None, headers=None):
+        """
+        Updates a document with a script or partial document.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
+
+        :arg index: The name of the index
+        :arg id: Document ID
+        :arg body: The request definition requires either `script` or
+            partial `doc`
+        :arg doc_type: The type of the document
+        :arg _source: True or false to return the _source field or not,
+            or a list of fields to return
+        :arg _source_excludes: A list of fields to exclude from the
+            returned _source field
+        :arg _source_includes: A list of fields to extract and return
+            from the _source field
+        :arg if_primary_term: only perform the update operation if the
+            last operation that has changed the document has the specified primary
+            term
+        :arg if_seq_no: only perform the update operation if the last
+            operation that has changed the document has the specified sequence
+            number
+        :arg lang: The script language (default: painless)
+        :arg refresh: If `true` then refresh the affected shards to make
+            this operation visible to search, if `wait_for` then wait for a refresh
+            to make this operation visible to search, if `false` (the default) then
+            do nothing with refreshes.  Valid choices: true, false, wait_for
+        :arg retry_on_conflict: Specify how many times should the
+            operation be retried when a conflict occurs (default: 0)
+        :arg routing: Specific routing value
+        :arg timeout: Explicit operation timeout
+        :arg wait_for_active_shards: Sets the number of shard copies
+            that must be active before proceeding with the update operation.
+            Defaults to 1, meaning the primary shard only. Set to `all` for all
+            shard copies, otherwise set to any non-negative value less than or equal
+            to the total number of copies for the shard (number of replicas + 1)
+        """
+        for param in (index, id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        if doc_type in SKIP_IN_PATH:
+            doc_type = "_doc"
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(index, doc_type, id, "_update"),
             params=params,
             headers=headers,
             body=body,
@@ -2031,4 +1990,45 @@ class Elasticsearch(object):
             params=params,
             headers=headers,
             body=body,
+        )
+
+    @query_params("requests_per_second")
+    def update_by_query_rethrottle(self, task_id, params=None, headers=None):
+        """
+        Changes the number of requests per second for a particular Update By Query
+        operation.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html>`_
+
+        :arg task_id: The task id to rethrottle
+        :arg requests_per_second: The throttle to set on this request in
+            floating sub-requests per second. -1 means set no throttle.
+        """
+        if task_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'task_id'.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path("_update_by_query", task_id, "_rethrottle"),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params()
+    def get_script_context(self, params=None, headers=None):
+        """
+        Returns all script contexts.
+
+        """
+        return self.transport.perform_request(
+            "GET", "/_script_context", params=params, headers=headers
+        )
+
+    @query_params()
+    def get_script_languages(self, params=None, headers=None):
+        """
+        Returns available script types, languages and contexts
+
+        """
+        return self.transport.perform_request(
+            "GET", "/_script_language", params=params, headers=headers
         )

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -915,7 +915,7 @@ class Elasticsearch(object):
             doc_type = "_doc"
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, id, "_explain"),
             params=params,
             headers=headers,
@@ -1111,7 +1111,7 @@ class Elasticsearch(object):
             raise ValueError("Empty value passed for a required argument 'body'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_mget"),
             params=params,
             headers=headers,
@@ -1167,7 +1167,7 @@ class Elasticsearch(object):
 
         body = _bulk_body(self.transport.serializer, body)
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_msearch"),
             params=params,
             headers=headers,
@@ -1212,7 +1212,7 @@ class Elasticsearch(object):
 
         body = _bulk_body(self.transport.serializer, body)
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_msearch", "template"),
             params=params,
             headers=headers,
@@ -1278,7 +1278,7 @@ class Elasticsearch(object):
             internal, external, external_gte, force
         """
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_mtermvectors"),
             params=params,
             headers=headers,
@@ -1338,7 +1338,7 @@ class Elasticsearch(object):
             raise ValueError("Empty value passed for a required argument 'body'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, "_rank_eval"),
             params=params,
             headers=headers,
@@ -1421,7 +1421,7 @@ class Elasticsearch(object):
         :arg id: The id of the stored search template
         """
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path("_render", "template", id),
             params=params,
             headers=headers,
@@ -1437,7 +1437,7 @@ class Elasticsearch(object):
         :arg body: The script to execute
         """
         return self.transport.perform_request(
-            "GET",
+            "POST",
             "/_scripts/painless/_execute",
             params=params,
             headers=headers,
@@ -1467,7 +1467,7 @@ class Elasticsearch(object):
             params["scroll_id"] = scroll_id
 
         return self.transport.perform_request(
-            "GET", "/_search/scroll", params=params, headers=headers, body=body
+            "POST", "/_search/scroll", params=params, headers=headers, body=body
         )
 
     @query_params(
@@ -1620,7 +1620,7 @@ class Elasticsearch(object):
             params["from"] = params.pop("from_")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_search"),
             params=params,
             headers=headers,
@@ -1721,7 +1721,7 @@ class Elasticsearch(object):
             raise ValueError("Empty value passed for a required argument 'body'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_search", "template"),
             params=params,
             headers=headers,
@@ -1783,7 +1783,7 @@ class Elasticsearch(object):
             doc_type = "_doc"
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, id, "_termvectors"),
             params=params,
             headers=headers,

--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -127,7 +127,7 @@ class CatClient(NamespacedClient):
         :arg index: A comma-separated list of index names to limit the
             returned information
         :arg bytes: The unit in which to display byte values  Valid
-            choices: b, k, m, g
+            choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg format: a short version of the Accept header, e.g. json,
             yaml
         :arg h: Comma-separated list of column names to display
@@ -199,8 +199,8 @@ class CatClient(NamespacedClient):
             version (default: false)
         :arg h: Comma-separated list of column names to display
         :arg help: Return help information
-        :arg local: Return local information, do not retrieve the state
-            from master node (default: false)
+        :arg local: Calculate the selected nodes using the local cluster
+            state rather than the state from master node (default: false)
         :arg master_timeout: Explicit operation timeout for connection
             to master node
         :arg s: Comma-separated list of column names or column aliases

--- a/elasticsearch/client/ccr.py
+++ b/elasticsearch/client/ccr.py
@@ -71,7 +71,7 @@ class CcrClient(NamespacedClient):
     @query_params()
     def forget_follower(self, index, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current>`_
 
         :arg index: the name of the leader index for which specified
             follower retention leases should be removed
@@ -160,7 +160,7 @@ class CcrClient(NamespacedClient):
     @query_params()
     def unfollow(self, index, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current>`_
 
         :arg index: The name of the follower index that should be turned
             into a regular index.

--- a/elasticsearch/client/cluster.py
+++ b/elasticsearch/client/cluster.py
@@ -229,7 +229,7 @@ class ClusterClient(NamespacedClient):
             explanation (default: false)
         """
         return self.transport.perform_request(
-            "GET",
+            "POST",
             "/_cluster/allocation/explain",
             params=params,
             headers=headers,

--- a/elasticsearch/client/enrich.py
+++ b/elasticsearch/client/enrich.py
@@ -37,7 +37,7 @@ class EnrichClient(NamespacedClient):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-get-policy.html>`_
 
-        :arg name: The name of the enrich policy
+        :arg name: A comma-separated list of enrich policy names
         """
         return self.transport.perform_request(
             "GET", _make_path("_enrich", "policy", name), params=params

--- a/elasticsearch/client/graph.py
+++ b/elasticsearch/client/graph.py
@@ -19,7 +19,7 @@ class GraphClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'index'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_graph", "explore"),
             params=params,
             headers=headers,

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -15,7 +15,7 @@ class IndicesClient(NamespacedClient):
         :arg index: The name of the index to scope the operation
         """
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, "_analyze"),
             params=params,
             headers=headers,
@@ -884,7 +884,7 @@ class IndicesClient(NamespacedClient):
             actual Lucene query that will be executed.
         """
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_validate", "query"),
             params=params,
             headers=headers,

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -959,7 +959,8 @@ class IndicesClient(NamespacedClient):
     @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
     def flush_synced(self, index=None, params=None):
         """
-        Performs a synced flush operation on one or more indices.
+        Performs a synced flush operation on one or more indices. Synced flush is
+        deprecated and will be removed in 8.0. Use flush instead
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -418,6 +418,49 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "include_defaults",
+        "include_type_name",
+        "local",
+    )
+    def get_field_mapping(
+        self, fields, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Returns mapping for one or more fields.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
+
+        :arg fields: A comma-separated list of fields
+        :arg index: A comma-separated list of index names
+        :arg doc_type: A comma-separated list of document types
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
+        :arg ignore_unavailable: Whether specified concrete indices
+            should be ignored when unavailable (missing or closed)
+        :arg include_defaults: Whether the default mapping values should
+            be returned as well
+        :arg include_type_name: Whether a type should be returned in the
+            body of the mappings.
+        :arg local: Return local information, do not retrieve the state
+            from master node (default: false)
+        """
+        if fields in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'fields'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, "_mapping", doc_type, "field", fields),
+            params=params,
+            headers=headers,
+        )
+
     @query_params("master_timeout", "timeout")
     def put_alias(self, index, name, body=None, params=None, headers=None):
         """
@@ -786,6 +829,66 @@ class IndicesClient(NamespacedClient):
         """
         return self.transport.perform_request(
             "GET", _make_path(index, "_segments"), params=params, headers=headers
+        )
+
+    @query_params(
+        "all_shards",
+        "allow_no_indices",
+        "analyze_wildcard",
+        "analyzer",
+        "default_operator",
+        "df",
+        "expand_wildcards",
+        "explain",
+        "ignore_unavailable",
+        "lenient",
+        "q",
+        "rewrite",
+    )
+    def validate_query(
+        self, body=None, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Allows a user to validate a potentially expensive query without executing it.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
+
+        :arg body: The query definition specified with the Query DSL
+        :arg index: A comma-separated list of index names to restrict
+            the operation; use `_all` or empty string to perform the operation on
+            all indices
+        :arg doc_type: A comma-separated list of document types to
+            restrict the operation; leave empty to perform the operation on all
+            types
+        :arg all_shards: Execute validation on all shards instead of one
+            random shard per index
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg analyze_wildcard: Specify whether wildcard and prefix
+            queries should be analyzed (default: false)
+        :arg analyzer: The analyzer to use for the query string
+        :arg default_operator: The default operator for query string
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
+        :arg df: The field to use as default where no field prefix is
+            given in the query string
+        :arg expand_wildcards: Whether to expand wildcard expression to
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
+        :arg explain: Return detailed information about the error
+        :arg ignore_unavailable: Whether specified concrete indices
+            should be ignored when unavailable (missing or closed)
+        :arg lenient: Specify whether format-based query failures (such
+            as providing text to a numeric field) should be ignored
+        :arg q: Query in the Lucene query string syntax
+        :arg rewrite: Provide a more detailed explanation showing the
+            actual Lucene query that will be executed.
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, doc_type, "_validate", "query"),
+            params=params,
+            headers=headers,
+            body=body,
         )
 
     @query_params(
@@ -1170,107 +1273,4 @@ class IndicesClient(NamespacedClient):
             _make_path(index, "_reload_search_analyzers"),
             params=params,
             headers=headers,
-        )
-
-    @query_params(
-        "allow_no_indices",
-        "expand_wildcards",
-        "ignore_unavailable",
-        "include_defaults",
-        "include_type_name",
-        "local",
-    )
-    def get_field_mapping(
-        self, fields, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Returns mapping for one or more fields.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
-
-        :arg fields: A comma-separated list of fields
-        :arg index: A comma-separated list of index names
-        :arg doc_type: A comma-separated list of document types
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
-        :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both.  Valid choices: open,
-            closed, none, all  Default: open
-        :arg ignore_unavailable: Whether specified concrete indices
-            should be ignored when unavailable (missing or closed)
-        :arg include_defaults: Whether the default mapping values should
-            be returned as well
-        :arg include_type_name: Whether a type should be returned in the
-            body of the mappings.
-        :arg local: Return local information, do not retrieve the state
-            from master node (default: false)
-        """
-        if fields in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'fields'.")
-
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, "_mapping", doc_type, "field", fields),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params(
-        "all_shards",
-        "allow_no_indices",
-        "analyze_wildcard",
-        "analyzer",
-        "default_operator",
-        "df",
-        "expand_wildcards",
-        "explain",
-        "ignore_unavailable",
-        "lenient",
-        "q",
-        "rewrite",
-    )
-    def validate_query(
-        self, body=None, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Allows a user to validate a potentially expensive query without executing it.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
-
-        :arg body: The query definition specified with the Query DSL
-        :arg index: A comma-separated list of index names to restrict
-            the operation; use `_all` or empty string to perform the operation on
-            all indices
-        :arg doc_type: A comma-separated list of document types to
-            restrict the operation; leave empty to perform the operation on all
-            types
-        :arg all_shards: Execute validation on all shards instead of one
-            random shard per index
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
-        :arg analyze_wildcard: Specify whether wildcard and prefix
-            queries should be analyzed (default: false)
-        :arg analyzer: The analyzer to use for the query string
-        :arg default_operator: The default operator for query string
-            query (AND or OR)  Valid choices: AND, OR  Default: OR
-        :arg df: The field to use as default where no field prefix is
-            given in the query string
-        :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both.  Valid choices: open,
-            closed, none, all  Default: open
-        :arg explain: Return detailed information about the error
-        :arg ignore_unavailable: Whether specified concrete indices
-            should be ignored when unavailable (missing or closed)
-        :arg lenient: Specify whether format-based query failures (such
-            as providing text to a numeric field) should be ignored
-        :arg q: Query in the Lucene query string syntax
-        :arg rewrite: Provide a more detailed explanation showing the
-            actual Lucene query that will be executed.
-        """
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, doc_type, "_validate", "query"),
-            params=params,
-            headers=headers,
-            body=body,
         )

--- a/elasticsearch/client/ingest.py
+++ b/elasticsearch/client/ingest.py
@@ -77,7 +77,7 @@ class IngestClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'body'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path("_ingest", "pipeline", id, "_simulate"),
             params=params,
             headers=headers,

--- a/elasticsearch/client/license.py
+++ b/elasticsearch/client/license.py
@@ -10,11 +10,13 @@ class LicenseClient(NamespacedClient):
         """
         return self.transport.perform_request("DELETE", "/_license", params=params)
 
-    @query_params("local")
+    @query_params("accept_enterprise", "local")
     def get(self, params=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
 
+        :arg accept_enterprise: If the active license is an enterprise
+            license, return type as 'enterprise' (default: false)
         :arg local: Return local information, do not retrieve the state
             from master node (default: false)
         """

--- a/elasticsearch/client/migration.py
+++ b/elasticsearch/client/migration.py
@@ -5,7 +5,7 @@ class MigrationClient(NamespacedClient):
     @query_params()
     def deprecations(self, index=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html>`_
 
         :arg index: Index pattern
         """

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -1144,6 +1144,73 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
+    @query_params("from_", "size")
+    def get_categories(
+        self, job_id, body=None, category_id=None, params=None, headers=None
+    ):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
+
+        :arg job_id: The name of the job
+        :arg body: Category selection details if not provided in URI
+        :arg category_id: The identifier of the category definition of
+            interest
+        :arg from_: skips a number of categories
+        :arg size: specifies a max number of categories to get
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path(
+                "_ml", "anomaly_detectors", job_id, "results", "categories", category_id
+            ),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("desc", "end", "from_", "size", "sort", "start")
+    def get_model_snapshots(
+        self, job_id, body=None, snapshot_id=None, params=None, headers=None
+    ):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg body: Model snapshot selection criteria
+        :arg snapshot_id: The ID of the snapshot to fetch
+        :arg desc: True if the results should be sorted in descending
+            order
+        :arg end: The filter 'end' query parameter
+        :arg from_: Skips a number of documents
+        :arg size: The default number of documents returned in queries
+            as a string.
+        :arg sort: Name of the field to sort on
+        :arg start: The filter 'start' query parameter
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path(
+                "_ml", "anomaly_detectors", job_id, "model_snapshots", snapshot_id
+            ),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
     @query_params(
         "allow_no_match",
         "decompress_definition",
@@ -1218,73 +1285,6 @@ class MlClient(NamespacedClient):
         return self.transport.perform_request(
             "PUT",
             _make_path("_ml", "inference", model_id),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params("from_", "size")
-    def get_categories(
-        self, job_id, body=None, category_id=None, params=None, headers=None
-    ):
-        """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
-
-        :arg job_id: The name of the job
-        :arg body: Category selection details if not provided in URI
-        :arg category_id: The identifier of the category definition of
-            interest
-        :arg from_: skips a number of categories
-        :arg size: specifies a max number of categories to get
-        """
-        # from is a reserved word so it cannot be used, use from_ instead
-        if "from_" in params:
-            params["from"] = params.pop("from_")
-
-        if job_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'job_id'.")
-
-        return self.transport.perform_request(
-            "GET",
-            _make_path(
-                "_ml", "anomaly_detectors", job_id, "results", "categories", category_id
-            ),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params("desc", "end", "from_", "size", "sort", "start")
-    def get_model_snapshots(
-        self, job_id, body=None, snapshot_id=None, params=None, headers=None
-    ):
-        """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
-
-        :arg job_id: The ID of the job to fetch
-        :arg body: Model snapshot selection criteria
-        :arg snapshot_id: The ID of the snapshot to fetch
-        :arg desc: True if the results should be sorted in descending
-            order
-        :arg end: The filter 'end' query parameter
-        :arg from_: Skips a number of documents
-        :arg size: The default number of documents returned in queries
-            as a string.
-        :arg sort: Name of the field to sort on
-        :arg start: The filter 'start' query parameter
-        """
-        # from is a reserved word so it cannot be used, use from_ instead
-        if "from_" in params:
-            params["from"] = params.pop("from_")
-
-        if job_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'job_id'.")
-
-        return self.transport.perform_request(
-            "GET",
-            _make_path(
-                "_ml", "anomaly_detectors", job_id, "model_snapshots", snapshot_id
-            ),
             params=params,
             headers=headers,
             body=body,

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -399,6 +399,37 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
+    @query_params("from_", "size")
+    def get_categories(
+        self, job_id, body=None, category_id=None, params=None, headers=None
+    ):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
+
+        :arg job_id: The name of the job
+        :arg body: Category selection details if not provided in URI
+        :arg category_id: The identifier of the category definition of
+            interest
+        :arg from_: skips a number of categories
+        :arg size: specifies a max number of categories to get
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_ml", "anomaly_detectors", job_id, "results", "categories", category_id
+            ),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
     @query_params("allow_no_datafeeds")
     def get_datafeed_stats(self, datafeed_id=None, params=None, headers=None):
         """
@@ -526,6 +557,42 @@ class MlClient(NamespacedClient):
             _make_path("_ml", "anomaly_detectors", job_id),
             params=params,
             headers=headers,
+        )
+
+    @query_params("desc", "end", "from_", "size", "sort", "start")
+    def get_model_snapshots(
+        self, job_id, body=None, snapshot_id=None, params=None, headers=None
+    ):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg body: Model snapshot selection criteria
+        :arg snapshot_id: The ID of the snapshot to fetch
+        :arg desc: True if the results should be sorted in descending
+            order
+        :arg end: The filter 'end' query parameter
+        :arg from_: Skips a number of documents
+        :arg size: The default number of documents returned in queries
+            as a string.
+        :arg sort: Name of the field to sort on
+        :arg start: The filter 'start' query parameter
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_ml", "anomaly_detectors", job_id, "model_snapshots", snapshot_id
+            ),
+            params=params,
+            headers=headers,
+            body=body,
         )
 
     @query_params(
@@ -800,6 +867,38 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
+    @query_params("delete_intervening_results")
+    def revert_model_snapshot(
+        self, job_id, snapshot_id, body=None, params=None, headers=None
+    ):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to revert to
+        :arg body: Reversion options
+        :arg delete_intervening_results: Should we reset the results
+            back to the time of the snapshot?
+        """
+        for param in (job_id, snapshot_id):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_ml",
+                "anomaly_detectors",
+                job_id,
+                "model_snapshots",
+                snapshot_id,
+                "_revert",
+            ),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
     @query_params("enabled", "timeout")
     def set_upgrade_mode(self, params=None, headers=None):
         """
@@ -919,6 +1018,36 @@ class MlClient(NamespacedClient):
         return self.transport.perform_request(
             "POST",
             _make_path("_ml", "anomaly_detectors", job_id, "_update"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params()
+    def update_model_snapshot(
+        self, job_id, snapshot_id, body, params=None, headers=None
+    ):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to update
+        :arg body: The model snapshot properties to update
+        """
+        for param in (job_id, snapshot_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_ml",
+                "anomaly_detectors",
+                job_id,
+                "model_snapshots",
+                snapshot_id,
+                "_update",
+            ),
             params=params,
             headers=headers,
             body=body,
@@ -1144,73 +1273,6 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("from_", "size")
-    def get_categories(
-        self, job_id, body=None, category_id=None, params=None, headers=None
-    ):
-        """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
-
-        :arg job_id: The name of the job
-        :arg body: Category selection details if not provided in URI
-        :arg category_id: The identifier of the category definition of
-            interest
-        :arg from_: skips a number of categories
-        :arg size: specifies a max number of categories to get
-        """
-        # from is a reserved word so it cannot be used, use from_ instead
-        if "from_" in params:
-            params["from"] = params.pop("from_")
-
-        if job_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'job_id'.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(
-                "_ml", "anomaly_detectors", job_id, "results", "categories", category_id
-            ),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params("desc", "end", "from_", "size", "sort", "start")
-    def get_model_snapshots(
-        self, job_id, body=None, snapshot_id=None, params=None, headers=None
-    ):
-        """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
-
-        :arg job_id: The ID of the job to fetch
-        :arg body: Model snapshot selection criteria
-        :arg snapshot_id: The ID of the snapshot to fetch
-        :arg desc: True if the results should be sorted in descending
-            order
-        :arg end: The filter 'end' query parameter
-        :arg from_: Skips a number of documents
-        :arg size: The default number of documents returned in queries
-            as a string.
-        :arg sort: Name of the field to sort on
-        :arg start: The filter 'start' query parameter
-        """
-        # from is a reserved word so it cannot be used, use from_ instead
-        if "from_" in params:
-            params["from"] = params.pop("from_")
-
-        if job_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'job_id'.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(
-                "_ml", "anomaly_detectors", job_id, "model_snapshots", snapshot_id
-            ),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
     @query_params(
         "allow_no_match",
         "decompress_definition",
@@ -1285,68 +1347,6 @@ class MlClient(NamespacedClient):
         return self.transport.perform_request(
             "PUT",
             _make_path("_ml", "inference", model_id),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params("delete_intervening_results")
-    def revert_model_snapshot(
-        self, job_id, snapshot_id, body=None, params=None, headers=None
-    ):
-        """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html>`_
-
-        :arg job_id: The ID of the job to fetch
-        :arg snapshot_id: The ID of the snapshot to revert to
-        :arg body: Reversion options
-        :arg delete_intervening_results: Should we reset the results
-            back to the time of the snapshot?
-        """
-        for param in (job_id, snapshot_id):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(
-                "_ml",
-                "anomaly_detectors",
-                job_id,
-                "model_snapshots",
-                snapshot_id,
-                "_revert",
-            ),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params()
-    def update_model_snapshot(
-        self, job_id, snapshot_id, body, params=None, headers=None
-    ):
-        """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html>`_
-
-        :arg job_id: The ID of the job to fetch
-        :arg snapshot_id: The ID of the snapshot to update
-        :arg body: The model snapshot properties to update
-        """
-        for param in (job_id, snapshot_id, body):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(
-                "_ml",
-                "anomaly_detectors",
-                job_id,
-                "model_snapshots",
-                snapshot_id,
-                "_update",
-            ),
             params=params,
             headers=headers,
             body=body,

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -340,7 +340,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'job_id'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(
                 "_ml", "anomaly_detectors", job_id, "results", "buckets", timestamp
             ),
@@ -392,7 +392,7 @@ class MlClient(NamespacedClient):
             params["from"] = params.pop("from_")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path("_ml", "calendars", calendar_id),
             params=params,
             headers=headers,
@@ -487,7 +487,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'job_id'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path("_ml", "anomaly_detectors", job_id, "results", "influencers"),
             params=params,
             headers=headers,
@@ -565,7 +565,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'job_id'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(
                 "_ml", "anomaly_detectors", job_id, "results", "overall_buckets"
             ),
@@ -607,7 +607,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'job_id'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path("_ml", "anomaly_detectors", job_id, "results", "records"),
             params=params,
             headers=headers,
@@ -1137,7 +1137,7 @@ class MlClient(NamespacedClient):
         :arg id: The ID of the data frame analytics to explain
         """
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path("_ml", "data_frame", "analytics", id, "_explain"),
             params=params,
             headers=headers,
@@ -1166,7 +1166,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'job_id'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(
                 "_ml", "anomaly_detectors", job_id, "results", "categories", category_id
             ),
@@ -1202,7 +1202,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'job_id'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(
                 "_ml", "anomaly_detectors", job_id, "model_snapshots", snapshot_id
             ),

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -5,7 +5,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_jobs", "force", "timeout")
     def close_job(self, job_id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html>`_
 
         :arg job_id: The name of the job to close
         :arg body: The URL params optionally sent in the body
@@ -78,7 +78,7 @@ class MlClient(NamespacedClient):
     @query_params("force")
     def delete_datafeed(self, datafeed_id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to delete
         :arg force: True if the datafeed should be forcefully deleted
@@ -117,7 +117,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_forecasts", "timeout")
     def delete_forecast(self, job_id, forecast_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html>`_
 
         :arg job_id: The ID of the job from which to delete forecasts
         :arg forecast_id: The ID of the forecast to delete, can be comma
@@ -139,7 +139,7 @@ class MlClient(NamespacedClient):
     @query_params("force", "wait_for_completion")
     def delete_job(self, job_id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html>`_
 
         :arg job_id: The ID of the job to delete
         :arg force: True if the job should be forcefully deleted
@@ -156,7 +156,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def delete_model_snapshot(self, job_id, snapshot_id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
         :arg snapshot_id: The ID of the snapshot to delete
@@ -191,7 +191,7 @@ class MlClient(NamespacedClient):
     )
     def find_file_structure(self, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html>`_
 
         :arg body: The contents of the file to be analyzed
         :arg charset: Optional parameter to specify the character set of
@@ -237,7 +237,7 @@ class MlClient(NamespacedClient):
     @query_params("advance_time", "calc_interim", "end", "skip_time", "start")
     def flush_job(self, job_id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html>`_
 
         :arg job_id: The name of the job to flush
         :arg body: Flush parameters
@@ -293,7 +293,7 @@ class MlClient(NamespacedClient):
     )
     def get_buckets(self, job_id, body=None, timestamp=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html>`_
 
         :arg job_id: ID of the job to get bucket results from
         :arg body: Bucket selection details if not provided in URI
@@ -371,7 +371,7 @@ class MlClient(NamespacedClient):
     @query_params("from_", "size")
     def get_categories(self, job_id, body=None, category_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
 
         :arg job_id: The name of the job
         :arg body: Category selection details if not provided in URI
@@ -399,7 +399,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_datafeeds")
     def get_datafeed_stats(self, datafeed_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html>`_
 
         :arg datafeed_id: The ID of the datafeeds stats to fetch
         :arg allow_no_datafeeds: Whether to ignore if a wildcard
@@ -413,7 +413,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_datafeeds")
     def get_datafeeds(self, datafeed_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeeds to fetch
         :arg allow_no_datafeeds: Whether to ignore if a wildcard
@@ -452,7 +452,7 @@ class MlClient(NamespacedClient):
     )
     def get_influencers(self, job_id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html>`_
 
         :arg job_id:
         :arg body: Influencer selection criteria
@@ -484,7 +484,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_jobs")
     def get_job_stats(self, job_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html>`_
 
         :arg job_id: The ID of the jobs stats to fetch
         :arg allow_no_jobs: Whether to ignore if a wildcard expression
@@ -500,7 +500,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_jobs")
     def get_jobs(self, job_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html>`_
 
         :arg job_id: The ID of the jobs to fetch
         :arg allow_no_jobs: Whether to ignore if a wildcard expression
@@ -514,7 +514,7 @@ class MlClient(NamespacedClient):
     @query_params("desc", "end", "from_", "size", "sort", "start")
     def get_model_snapshots(self, job_id, body=None, snapshot_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
         :arg body: Model snapshot selection criteria
@@ -555,7 +555,7 @@ class MlClient(NamespacedClient):
     )
     def get_overall_buckets(self, job_id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html>`_
 
         :arg job_id: The job IDs for which to calculate overall bucket
             results
@@ -601,7 +601,7 @@ class MlClient(NamespacedClient):
     )
     def get_records(self, job_id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html>`_
 
         :arg job_id:
         :arg body: Record selection criteria
@@ -638,7 +638,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def open_job(self, job_id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html>`_
 
         :arg job_id: The ID of the job to open
         """
@@ -672,7 +672,7 @@ class MlClient(NamespacedClient):
     @query_params("reset_end", "reset_start")
     def post_data(self, job_id, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html>`_
 
         :arg job_id: The name of the job receiving the data
         :arg body: The data to process
@@ -696,7 +696,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def preview_datafeed(self, datafeed_id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to preview
         """
@@ -747,7 +747,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def put_datafeed(self, datafeed_id, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to create
         :arg body: The datafeed config
@@ -778,7 +778,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def put_job(self, job_id, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html>`_
 
         :arg job_id: The ID of the job to create
         :arg body: The job
@@ -797,7 +797,7 @@ class MlClient(NamespacedClient):
     @query_params("delete_intervening_results")
     def revert_model_snapshot(self, job_id, snapshot_id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
         :arg snapshot_id: The ID of the snapshot to revert to
@@ -826,7 +826,7 @@ class MlClient(NamespacedClient):
     @query_params("enabled", "timeout")
     def set_upgrade_mode(self, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html>`_
 
         :arg enabled: Whether to enable upgrade_mode ML setting or not.
             Defaults to false.
@@ -840,7 +840,7 @@ class MlClient(NamespacedClient):
     @query_params("end", "start", "timeout")
     def start_datafeed(self, datafeed_id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to start
         :arg body: The start datafeed parameters
@@ -865,7 +865,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_datafeeds", "force", "timeout")
     def stop_datafeed(self, datafeed_id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to stop
         :arg allow_no_datafeeds: Whether to ignore if a wildcard
@@ -887,7 +887,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def update_datafeed(self, datafeed_id, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to update
         :arg body: The datafeed update settings
@@ -924,7 +924,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def update_job(self, job_id, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html>`_
 
         :arg job_id: The ID of the job to create
         :arg body: The job update settings
@@ -943,7 +943,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def update_model_snapshot(self, job_id, snapshot_id, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
         :arg snapshot_id: The ID of the snapshot to update
@@ -996,12 +996,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params("force")
     def delete_data_frame_analytics(self, id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to delete
+        :arg force: True if the job should be forcefully deleted
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'id'.")
@@ -1011,26 +1012,9 @@ class MlClient(NamespacedClient):
         )
 
     @query_params()
-    def estimate_memory_usage(self, body, params=None):
-        """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/estimate-memory-usage-dfanalytics.html>`_
-
-        :arg body: Memory usage estimation definition
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return self.transport.perform_request(
-            "POST",
-            "/_ml/data_frame/analytics/_estimate_memory_usage",
-            params=params,
-            body=body,
-        )
-
-    @query_params()
     def evaluate_data_frame(self, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html>`_
 
         :arg body: The evaluation definition
         """
@@ -1044,7 +1028,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_match", "from_", "size")
     def get_data_frame_analytics(self, id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
@@ -1065,7 +1049,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_match", "from_", "size")
     def get_data_frame_analytics_stats(self, id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html>`_
 
         :arg id: The ID of the data frame analytics stats to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
@@ -1088,7 +1072,7 @@ class MlClient(NamespacedClient):
     @query_params()
     def put_data_frame_analytics(self, id, body, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to create
         :arg body: The data frame analytics configuration
@@ -1107,7 +1091,7 @@ class MlClient(NamespacedClient):
     @query_params("timeout")
     def start_data_frame_analytics(self, id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to start
         :arg body: The start data frame analytics parameters
@@ -1127,7 +1111,7 @@ class MlClient(NamespacedClient):
     @query_params("allow_no_match", "force", "timeout")
     def stop_data_frame_analytics(self, id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to stop
         :arg body: The stop data frame analytics parameters
@@ -1147,4 +1131,102 @@ class MlClient(NamespacedClient):
             _make_path("_ml", "data_frame", "analytics", id, "_stop"),
             params=params,
             body=body,
+        )
+
+    @query_params()
+    def delete_trained_model(self, model_id, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-inference.html>`_
+
+        :arg model_id: The ID of the trained model to delete
+        """
+        if model_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'model_id'.")
+
+        return self.transport.perform_request(
+            "DELETE", _make_path("_ml", "inference", model_id), params=params
+        )
+
+    @query_params()
+    def explain_data_frame_analytics(self, body=None, id=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html>`_
+
+        :arg body: The data frame analytics config to explain
+        :arg id: The ID of the data frame analytics to explain
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_ml", "data_frame", "analytics", id, "_explain"),
+            params=params,
+            body=body,
+        )
+
+    @query_params(
+        "allow_no_match",
+        "decompress_definition",
+        "from_",
+        "include_model_definition",
+        "size",
+    )
+    def get_trained_models(self, model_id=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference.html>`_
+
+        :arg model_id: The ID of the trained models to fetch
+        :arg allow_no_match: Whether to ignore if a wildcard expression
+            matches no trained models. (This includes `_all` string or when no
+            trained models have been specified)  Default: True
+        :arg decompress_definition: Should the model definition be
+            decompressed into valid JSON or returned in a custom compressed format.
+            Defaults to true.  Default: True
+        :arg from_: skips a number of trained models
+        :arg include_model_definition: Should the full model definition
+            be included in the results. These definitions can be large. So be
+            cautious when including them. Defaults to false.
+        :arg size: specifies a max number of trained models to get
+            Default: 100
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        return self.transport.perform_request(
+            "GET", _make_path("_ml", "inference", model_id), params=params
+        )
+
+    @query_params("allow_no_match", "from_", "size")
+    def get_trained_models_stats(self, model_id=None, params=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference-stats.html>`_
+
+        :arg model_id: The ID of the trained models stats to fetch
+        :arg allow_no_match: Whether to ignore if a wildcard expression
+            matches no trained models. (This includes `_all` string or when no
+            trained models have been specified)  Default: True
+        :arg from_: skips a number of trained models
+        :arg size: specifies a max number of trained models to get
+            Default: 100
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        return self.transport.perform_request(
+            "GET", _make_path("_ml", "inference", model_id, "_stats"), params=params
+        )
+
+    @query_params()
+    def put_trained_model(self, model_id, body, params=None):
+        """
+
+        :arg model_id: The ID of the trained models to store
+        :arg body: The trained model configuration
+        """
+        for param in (model_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "PUT", _make_path("_ml", "inference", model_id), params=params, body=body
         )

--- a/elasticsearch/client/monitoring.py
+++ b/elasticsearch/client/monitoring.py
@@ -5,7 +5,7 @@ class MonitoringClient(NamespacedClient):
     @query_params("interval", "system_api_version", "system_id")
     def bulk(self, body, doc_type=None, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
 
         :arg body: The operation definition and data (action-data
             pairs), separated by newlines

--- a/elasticsearch/client/nodes.py
+++ b/elasticsearch/client/nodes.py
@@ -42,6 +42,59 @@ class NodesClient(NamespacedClient):
         )
 
     @query_params(
+        "completion_fields",
+        "fielddata_fields",
+        "fields",
+        "groups",
+        "include_segment_file_sizes",
+        "level",
+        "timeout",
+        "types",
+    )
+    def stats(
+        self, node_id=None, metric=None, index_metric=None, params=None, headers=None
+    ):
+        """
+        Returns statistical information about nodes in the cluster.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
+
+        :arg node_id: A comma-separated list of node IDs or names to
+            limit the returned information; use `_local` to return information from
+            the node you're connecting to, leave empty to get information from all
+            nodes
+        :arg metric: Limit the information returned to the specified
+            metrics  Valid choices: _all, breaker, fs, http, indices, jvm, os,
+            process, thread_pool, transport, discovery
+        :arg index_metric: Limit the information returned for `indices`
+            metric to the specific index metrics. Isn't used if `indices` (or `all`)
+            metric isn't specified.  Valid choices: _all, completion, docs,
+            fielddata, query_cache, flush, get, indexing, merge, request_cache,
+            refresh, search, segments, store, warmer, suggest
+        :arg completion_fields: A comma-separated list of fields for
+            `fielddata` and `suggest` index metric (supports wildcards)
+        :arg fielddata_fields: A comma-separated list of fields for
+            `fielddata` index metric (supports wildcards)
+        :arg fields: A comma-separated list of fields for `fielddata`
+            and `completion` index metric (supports wildcards)
+        :arg groups: A comma-separated list of search groups for
+            `search` index metric
+        :arg include_segment_file_sizes: Whether to report the
+            aggregated disk usage of each one of the Lucene index files (only
+            applies if segment stats are requested)
+        :arg level: Return indices stats aggregated at index, node or
+            shard level  Valid choices: indices, node, shards  Default: node
+        :arg timeout: Explicit operation timeout
+        :arg types: A comma-separated list of document types for the
+            `indexing` index metric
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_nodes", node_id, "stats", metric, index_metric),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
         "doc_type", "ignore_idle_threads", "interval", "snapshots", "threads", "timeout"
     )
     def hot_threads(self, node_id=None, params=None, headers=None):
@@ -93,59 +146,6 @@ class NodesClient(NamespacedClient):
         return self.transport.perform_request(
             "GET",
             _make_path("_nodes", node_id, "usage", metric),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params(
-        "completion_fields",
-        "fielddata_fields",
-        "fields",
-        "groups",
-        "include_segment_file_sizes",
-        "level",
-        "timeout",
-        "types",
-    )
-    def stats(
-        self, node_id=None, metric=None, index_metric=None, params=None, headers=None
-    ):
-        """
-        Returns statistical information about nodes in the cluster.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
-
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
-        :arg metric: Limit the information returned to the specified
-            metrics  Valid choices: _all, breaker, fs, http, indices, jvm, os,
-            process, thread_pool, transport, discovery
-        :arg index_metric: Limit the information returned for `indices`
-            metric to the specific index metrics. Isn't used if `indices` (or `all`)
-            metric isn't specified.  Valid choices: _all, completion, docs,
-            fielddata, query_cache, flush, get, indexing, merge, request_cache,
-            refresh, search, segments, store, warmer, suggest
-        :arg completion_fields: A comma-separated list of fields for
-            `fielddata` and `suggest` index metric (supports wildcards)
-        :arg fielddata_fields: A comma-separated list of fields for
-            `fielddata` index metric (supports wildcards)
-        :arg fields: A comma-separated list of fields for `fielddata`
-            and `completion` index metric (supports wildcards)
-        :arg groups: A comma-separated list of search groups for
-            `search` index metric
-        :arg include_segment_file_sizes: Whether to report the
-            aggregated disk usage of each one of the Lucene index files (only
-            applies if segment stats are requested)
-        :arg level: Return indices stats aggregated at index, node or
-            shard level  Valid choices: indices, node, shards  Default: node
-        :arg timeout: Explicit operation timeout
-        :arg types: A comma-separated list of document types for the
-            `indexing` index metric
-        """
-        return self.transport.perform_request(
-            "GET",
-            _make_path("_nodes", node_id, "stats", metric, index_metric),
             params=params,
             headers=headers,
         )

--- a/elasticsearch/client/rollup.py
+++ b/elasticsearch/client/rollup.py
@@ -88,7 +88,7 @@ class RollupClient(NamespacedClient):
                 raise ValueError("Empty value passed for a required argument.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path(index, doc_type, "_rollup_search"),
             params=params,
             headers=headers,

--- a/elasticsearch/client/security.py
+++ b/elasticsearch/client/security.py
@@ -88,7 +88,6 @@ class SecurityClient(NamespacedClient):
     @query_params("refresh")
     def delete_privileges(self, application, name, params=None):
         """
-        `<TODO>`_
 
         :arg application: Application name
         :arg name: Privilege name
@@ -335,7 +334,6 @@ class SecurityClient(NamespacedClient):
     @query_params("refresh")
     def put_privileges(self, body, params=None):
         """
-        `<TODO>`_
 
         :arg body: The privilege(s) to add
         :arg refresh: If `true` (the default) then refresh the affected

--- a/elasticsearch/client/security.py
+++ b/elasticsearch/client/security.py
@@ -325,7 +325,7 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for a required argument 'body'.")
 
         return self.transport.perform_request(
-            "GET",
+            "POST",
             _make_path("_security", "user", user, "_has_privileges"),
             params=params,
             headers=headers,

--- a/elasticsearch/client/slm.py
+++ b/elasticsearch/client/slm.py
@@ -5,7 +5,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def delete_lifecycle(self, policy_id, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to
             remove
@@ -20,7 +20,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def execute_lifecycle(self, policy_id, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-lifecycle.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to be
             executed
@@ -45,7 +45,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def get_lifecycle(self, policy_id=None, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-policy.html>`_
 
         :arg policy_id: Comma-separated list of snapshot lifecycle
             policies to retrieve
@@ -57,7 +57,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def get_stats(self, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
 
         """
         return self.transport.perform_request("GET", "/_slm/stats", params=params)
@@ -65,7 +65,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def put_lifecycle(self, policy_id, body=None, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy
         :arg body: The snapshot lifecycle policy definition to register
@@ -80,7 +80,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def get_status(self, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-status.html>`_
 
         """
         return self.transport.perform_request("GET", "/_slm/status", params=params)
@@ -88,7 +88,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def start(self, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-start.html>`_
 
         """
         return self.transport.perform_request("POST", "/_slm/start", params=params)
@@ -96,7 +96,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def stop(self, params=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-stop.html>`_
 
         """
         return self.transport.perform_request("POST", "/_slm/stop", params=params)

--- a/elasticsearch/client/sql.py
+++ b/elasticsearch/client/sql.py
@@ -5,7 +5,6 @@ class SqlClient(NamespacedClient):
     @query_params()
     def clear_cursor(self, body, params=None):
         """
-        `<Clear SQL cursor>`_
 
         :arg body: Specify the cursor value in the `cursor` element to
             clean the cursor.
@@ -20,7 +19,6 @@ class SqlClient(NamespacedClient):
     @query_params("format")
     def query(self, body, params=None):
         """
-        `<Execute SQL>`_
 
         :arg body: Use the `query` element to start a query. Use the
             `cursor` element to continue a query.
@@ -35,7 +33,6 @@ class SqlClient(NamespacedClient):
     @query_params()
     def translate(self, body, params=None):
         """
-        `<Translate SQL into Elasticsearch queries>`_
 
         :arg body: Specify the query in the `query` element.
         """

--- a/elasticsearch/client/transform.py
+++ b/elasticsearch/client/transform.py
@@ -121,7 +121,13 @@ class TransformClient(NamespacedClient):
             "POST", _make_path("_transform", transform_id, "_start"), params=params
         )
 
-    @query_params("allow_no_match", "timeout", "wait_for_completion")
+    @query_params(
+        "allow_no_match",
+        "force",
+        "timeout",
+        "wait_for_checkpoint",
+        "wait_for_completion",
+    )
     def stop_transform(self, transform_id, params=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html>`_
@@ -130,8 +136,12 @@ class TransformClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no transforms. (This includes `_all` string or when no
             transforms have been specified)
+        :arg force: Whether to force stop a failed transform or not.
+            Default to false
         :arg timeout: Controls the time to wait until the transform has
             stopped. Default to 30 seconds
+        :arg wait_for_checkpoint: Whether to wait for the transform to
+            reach a checkpoint before stopping. Default to false
         :arg wait_for_completion: Whether to wait for the transform to
             fully stop before returning or not. Default to false
         """

--- a/elasticsearch/client/watcher.py
+++ b/elasticsearch/client/watcher.py
@@ -5,7 +5,7 @@ class WatcherClient(NamespacedClient):
     @query_params()
     def ack_watch(self, watch_id, action_id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html>`_
 
         :arg watch_id: Watch ID
         :arg action_id: A comma-separated list of the action ids to be
@@ -53,7 +53,7 @@ class WatcherClient(NamespacedClient):
     @query_params()
     def delete_watch(self, id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html>`_
 
         :arg id: Watch ID
         """
@@ -67,7 +67,7 @@ class WatcherClient(NamespacedClient):
     @query_params("debug")
     def execute_watch(self, body=None, id=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html>`_
 
         :arg body: Execution control
         :arg id: Watch ID
@@ -84,7 +84,7 @@ class WatcherClient(NamespacedClient):
     @query_params()
     def get_watch(self, id, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html>`_
 
         :arg id: Watch ID
         """
@@ -98,7 +98,7 @@ class WatcherClient(NamespacedClient):
     @query_params("active", "if_primary_term", "if_seq_no", "version")
     def put_watch(self, id, body=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html>`_
 
         :arg id: Watch ID
         :arg body: The watch
@@ -119,7 +119,7 @@ class WatcherClient(NamespacedClient):
     @query_params()
     def start(self, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html>`_
 
         """
         return self.transport.perform_request("POST", "/_watcher/_start", params=params)
@@ -127,7 +127,7 @@ class WatcherClient(NamespacedClient):
     @query_params("emit_stacktraces")
     def stats(self, metric=None, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html>`_
 
         :arg metric: Controls what additional stat metrics should be
             include in the response  Valid choices: _all, queued_watches,
@@ -145,7 +145,7 @@ class WatcherClient(NamespacedClient):
     @query_params()
     def stop(self, params=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html>`_
 
         """
         return self.transport.perform_request("POST", "/_watcher/_stop", params=params)

--- a/elasticsearch/client/xpack.py
+++ b/elasticsearch/client/xpack.py
@@ -19,7 +19,7 @@ class XPackClient(NamespacedClient):
     @query_params("master_timeout")
     def usage(self, params=None):
         """
-        `<Retrieve information about xpack features usage>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/usage-api.html>`_
 
         :arg master_timeout: Specify timeout for watch write operation
         """

--- a/test_elasticsearch/test_client/__init__.py
+++ b/test_elasticsearch/test_client/__init__.py
@@ -80,7 +80,7 @@ class TestClient(ElasticsearchTestCase):
 
     def test_from_in_search(self):
         self.client.search(index="i", from_=10)
-        calls = self.assert_url_called("GET", "/i/_search")
+        calls = self.assert_url_called("POST", "/i/_search")
         self.assertEquals([({"from": "10"}, {}, None)], calls)
 
     def test_repr_contains_hosts(self):

--- a/test_elasticsearch/test_server/test_common.py
+++ b/test_elasticsearch/test_server/test_common.py
@@ -37,9 +37,6 @@ SKIP_TESTS = {
     "*": {
         # Can't figure out the get_alias(expand_wildcards=open) failure.
         "TestIndicesGetAlias10Basic",
-        # Scripts are 7.6+
-        "TestScripts20GetScriptContext",
-        "TestScripts25GetScriptLanguages",
         # Disallowing expensive queries is 7.7+
         "TestSearch320DisallowQueries",
     }

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -128,6 +128,14 @@ class API:
             self.description = definition["documentation"].get("description", "")
             self.doc_url = definition["documentation"].get("url", "")
 
+        # Filter out bad URL refs like 'TODO'
+        # and serve all docs over HTTPS.
+        if self.doc_url:
+            if not self.doc_url.startswith("http"):
+                self.doc_url = ""
+            if self.doc_url.startswith("http://"):
+                self.doc_url = self.doc_url.replace("http://", "https://")
+
     @property
     def all_parts(self):
         parts = {}
@@ -245,6 +253,10 @@ def read_modules():
             namespace = "__init__"
             if "." in name:
                 namespace, name = name.rsplit(".", 1)
+
+            # The data_frame API has been changed to transform.
+            if namespace == "data_frame_transform_deprecated":
+                continue
 
             if namespace not in modules:
                 modules[namespace] = Module(namespace)

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -82,12 +82,11 @@ class Module:
                         if line.startswith("class"):
                             break
                 self.header = "\n".join(header_lines)
-                defined_apis = re.findall(
-                    r'\n    def ([a-z_]+)\([^\n]*\n *"""\n *([\w\W]*?)(?:`<|""")',
+                self.orders = re.findall(
+                    r'\n    def ([a-z_]+)\(',
                     content,
-                    re.MULTILINE,
+                    re.MULTILINE
                 )
-                self.orders = list(map(lambda x: x[0], defined_apis))
 
     def _position(self, api):
         try:

--- a/utils/generate_api.py
+++ b/utils/generate_api.py
@@ -195,7 +195,12 @@ class API:
 
     @property
     def method(self):
-        return self.path["methods"][0]
+        # To adhere to the HTTP RFC we shouldn't send
+        # bodies in GET requests.
+        default_method = self.path["methods"][0]
+        if self.body and default_method == "GET" and "POST" in self.path["methods"]:
+            return "POST"
+        return default_method
 
     @property
     def url_parts(self):


### PR DESCRIPTION
Generated from ES v7.6.1 API specs.
Updated the API generator script to not use documentation links that are obviously not hyperlinks and to skip the renamed/deprecated data_frame module.