### PR TITLE
Fix for error while initializing client with xpack

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -255,7 +255,6 @@ class Elasticsearch(object):
         self.slm = SlmClient(self)
         self.transform = TransformClient(self)
         self.xpack = XPackClient(self)
-
         
     def __repr__(self):
         try:

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -236,7 +236,6 @@ class Elasticsearch(object):
         self.snapshot = SnapshotClient(self)
         self.tasks = TasksClient(self)
 
-        self.xpack = XPackClient(self)
         self.ccr = CcrClient(self)
         self.data_frame = Data_FrameClient(self)
         self.deprecation = DeprecationClient(self)
@@ -255,7 +254,9 @@ class Elasticsearch(object):
         self.enrich = EnrichClient(self)
         self.slm = SlmClient(self)
         self.transform = TransformClient(self)
+        self.xpack = XPackClient(self)
 
+        
     def __repr__(self):
         try:
             # get a list of all connections


### PR DESCRIPTION
Fix for the following error



`File "/home/ubuntu/.local/lib/python3.7/site-packages/elasticsearch/client/__init__.py", line 239, in __init__
    self.xpack = XPackClient(self)
  File "/home/ubuntu/.local/lib/python3.7/site-packages/elasticsearch/client/xpack/__init__.py", line 42, in __init__
    setattr(self, namespace, getattr(self.client, namespace))
AttributeError: 'Elasticsearch' object has no attribute 'ccr'
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 63, in apport_excepthook
    from apport.fileutils import likely_packaged, get_recent_crashes
  File "/usr/lib/python3/dist-packages/apport/__init__.py", line 5, in <module>
    from apport.report import Report
  File "/usr/lib/python3/dist-packages/apport/report.py", line 30, in <module>
    import apport.fileutils
  File "/usr/lib/python3/dist-packages/apport/fileutils.py", line 23, in <module>
    from apport.packaging_impl import impl as packaging
  File "/usr/lib/python3/dist-packages/apport/packaging_impl.py", line 24, in <module>
    import apt
  File "/usr/lib/python3/dist-packages/apt/__init__.py", line 23, in <module>
    import apt_pkg
ModuleNotFoundError: No module named 'apt_pkg'
`


Looks like xpack requires ccr and dataframe.
This fix solved my local issue. I am not sure if this change has other implications