### PR TITLE
Also add headers to all APIs not generated

### DIFF
--- a/elasticsearch/client/data_frame.py
+++ b/elasticsearch/client/data_frame.py
@@ -3,7 +3,7 @@ from .utils import NamespacedClient, query_params, _make_path, SKIP_IN_PATH
 
 class Data_FrameClient(NamespacedClient):
     @query_params()
-    def delete_data_frame_transform(self, transform_id, params=None):
+    def delete_data_frame_transform(self, transform_id, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-data-frame-transform.html>`_
 
@@ -17,10 +17,11 @@ class Data_FrameClient(NamespacedClient):
             "DELETE",
             _make_path("_data_frame", "transforms", transform_id),
             params=params,
+            headers=headers,
         )
 
     @query_params("from_", "size")
-    def get_data_frame_transform(self, transform_id=None, params=None):
+    def get_data_frame_transform(self, transform_id=None, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform.html>`_
 
@@ -30,11 +31,16 @@ class Data_FrameClient(NamespacedClient):
         :arg size: specifies a max number of transforms to get, defaults to 100
         """
         return self.transport.perform_request(
-            "GET", _make_path("_data_frame", "transforms", transform_id), params=params
+            "GET",
+            _make_path("_data_frame", "transforms", transform_id),
+            params=params,
+            headers=headers,
         )
 
     @query_params()
-    def get_data_frame_transform_stats(self, transform_id=None, params=None):
+    def get_data_frame_transform_stats(
+        self, transform_id=None, params=None, headers=None
+    ):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform-stats.html>`_
 
@@ -45,10 +51,11 @@ class Data_FrameClient(NamespacedClient):
             "GET",
             _make_path("_data_frame", "transforms", transform_id, "_stats"),
             params=params,
+            headers=headers,
         )
 
     @query_params()
-    def preview_data_frame_transform(self, body, params=None):
+    def preview_data_frame_transform(self, body, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-data-frame-transform.html>`_
 
@@ -57,11 +64,15 @@ class Data_FrameClient(NamespacedClient):
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
         return self.transport.perform_request(
-            "POST", "/_data_frame/transforms/_preview", params=params, body=body
+            "POST",
+            "/_data_frame/transforms/_preview",
+            params=params,
+            headers=headers,
+            body=body,
         )
 
     @query_params()
-    def put_data_frame_transform(self, transform_id, body, params=None):
+    def put_data_frame_transform(self, transform_id, body, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/put-data-frame-transform.html>`_
 
@@ -75,11 +86,12 @@ class Data_FrameClient(NamespacedClient):
             "PUT",
             _make_path("_data_frame", "transforms", transform_id),
             params=params,
+            headers=headers,
             body=body,
         )
 
     @query_params("timeout")
-    def start_data_frame_transform(self, transform_id, params=None):
+    def start_data_frame_transform(self, transform_id, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/start-data-frame-transform.html>`_
 
@@ -94,10 +106,11 @@ class Data_FrameClient(NamespacedClient):
             "POST",
             _make_path("_data_frame", "transforms", transform_id, "_start"),
             params=params,
+            headers=headers,
         )
 
     @query_params("timeout", "wait_for_completion")
-    def stop_data_frame_transform(self, transform_id, params=None):
+    def stop_data_frame_transform(self, transform_id, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-data-frame-transform.html>`_
 
@@ -115,4 +128,5 @@ class Data_FrameClient(NamespacedClient):
             "POST",
             _make_path("_data_frame", "transforms", transform_id, "_stop"),
             params=params,
+            headers=headers,
         )

--- a/elasticsearch/client/deprecation.py
+++ b/elasticsearch/client/deprecation.py
@@ -3,7 +3,7 @@ from .utils import NamespacedClient, query_params, _make_path
 
 class DeprecationClient(NamespacedClient):
     @query_params()
-    def info(self, index=None, params=None):
+    def info(self, index=None, params=None, headers=None):
         """
         `<http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html>`_
 
@@ -13,4 +13,5 @@ class DeprecationClient(NamespacedClient):
             "GET",
             _make_path(index, "_xpack", "migration", "deprecations"),
             params=params,
+            headers=headers,
         )

--- a/elasticsearch/client/remote.py
+++ b/elasticsearch/client/remote.py
@@ -3,8 +3,10 @@ from .utils import NamespacedClient, query_params
 
 class RemoteClient(NamespacedClient):
     @query_params()
-    def info(self, params=None):
+    def info(self, params=None, headers=None):
         """
         `<http://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-remote-info.html>`_
         """
-        return self.transport.perform_request("GET", "/_remote/info", params=params)
+        return self.transport.perform_request(
+            "GET", "/_remote/info", params=params, headers=headers
+        )


### PR DESCRIPTION
A few files aren't hit by the auto-generator so didn't receive the `headers` parameter from #1135. Adding them here. These are all present in the 7.x backport PR.