### PR TITLE
Remove type hint from TestQueryParams.setUp()

### DIFF
--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -8,7 +8,7 @@ from ..test_cases import TestCase, SkipTest
 
 
 class TestQueryParams(TestCase):
-    def setUp(self) -> None:
+    def setUp(self):
         self.calls = []
 
     @query_params("simple_param")


### PR DESCRIPTION
Mistakenly was added by the IDE. This type hint is a syntax error in Python <3.6