### PR TITLE
Update scan() helper with proper scroll behavior

### DIFF
--- a/elasticsearch6/helpers/actions.py
+++ b/elasticsearch6/helpers/actions.py
@@ -441,7 +441,7 @@ def scan(
                 first_run = False
             else:
                 resp = client.scroll(
-                    scroll_id,
+                    scroll_id=scroll_id,
                     scroll=scroll,
                     request_timeout=request_timeout,
                     **scroll_kwargs


### PR DESCRIPTION
Previous implementation didn't use kwargs so the `scroll_id` value was landing within `body` instead of `scroll_id`. This implementation changes the call to `scroll()` to be the same as upstream in 7.x so there's no ambiguity about what the body should look like.

Previous implementation was failing both scan unit tests, this implementation passes both now.