### PR TITLE
[DRAFT] Add support for type-checkers via stubs

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -438,7 +438,7 @@ class Elasticsearch(object):
             provide one
         :arg pipeline: The pipeline id to preprocess incoming documents
             with
-        :arg refresh: If `true` then refresh the effected shards to make
+        :arg refresh: If `true` then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
             do nothing with refreshes.  Valid choices: true, false, wait_for
@@ -570,7 +570,7 @@ class Elasticsearch(object):
         :arg if_seq_no: only perform the delete operation if the last
             operation that has changed the document has the specified sequence
             number
-        :arg refresh: If `true` then refresh the effected shards to make
+        :arg refresh: If `true` then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh
             to make this operation visible to search, if `false` (the default) then
             do nothing with refreshes.  Valid choices: true, false, wait_for
@@ -602,6 +602,7 @@ class Elasticsearch(object):
         "_source_includes",
         "allow_no_indices",
         "analyze_wildcard",
+        "analyzer",
         "conflicts",
         "default_operator",
         "df",
@@ -651,6 +652,7 @@ class Elasticsearch(object):
             string or when no indices have been specified)
         :arg analyze_wildcard: Specify whether wildcard and prefix
             queries should be analyzed (default: false)
+        :arg analyzer: The analyzer to use for the query string
         :arg conflicts: What to do when the delete by query hits version
             conflicts?  Valid choices: abort, proceed  Default: abort
         :arg default_operator: The default operator for query string
@@ -1172,110 +1174,6 @@ class Elasticsearch(object):
             body=body,
         )
 
-    @query_params(
-        "max_concurrent_searches", "rest_total_hits_as_int", "search_type", "typed_keys"
-    )
-    def msearch_template(
-        self, body, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Allows to execute several search template operations in one request.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html>`_
-
-        :arg body: The request definitions (metadata-search request
-            definition pairs), separated by newlines
-        :arg index: A comma-separated list of index names to use as
-            default
-        :arg doc_type: A comma-separated list of document types to use
-            as default
-        :arg max_concurrent_searches: Controls the maximum number of
-            concurrent searches the multi search api will execute
-        :arg rest_total_hits_as_int: Indicates whether hits.total should
-            be rendered as an integer or an object in the rest search response
-        :arg search_type: Search operation type  Valid choices:
-            query_then_fetch, query_and_fetch, dfs_query_then_fetch,
-            dfs_query_and_fetch
-        :arg typed_keys: Specify whether aggregation and suggester names
-            should be prefixed by their respective types in the response
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        body = _bulk_body(self.transport.serializer, body)
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, doc_type, "_msearch", "template"),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params(
-        "field_statistics",
-        "fields",
-        "ids",
-        "offsets",
-        "payloads",
-        "positions",
-        "preference",
-        "realtime",
-        "routing",
-        "term_statistics",
-        "version",
-        "version_type",
-    )
-    def mtermvectors(
-        self, body=None, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Returns multiple termvectors in one request.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
-
-        :arg body: Define ids, documents, parameters or a list of
-            parameters per document here. You must at least provide a list of
-            document ids. See documentation.
-        :arg index: The index in which the document resides.
-        :arg doc_type: The type of the document.
-        :arg field_statistics: Specifies if document count, sum of
-            document frequencies and sum of total term frequencies should be
-            returned. Applies to all returned documents unless otherwise specified
-            in body "params" or "docs".  Default: True
-        :arg fields: A comma-separated list of fields to return. Applies
-            to all returned documents unless otherwise specified in body "params" or
-            "docs".
-        :arg ids: A comma-separated list of documents ids. You must
-            define ids as parameter or set "ids" or "docs" in the request body
-        :arg offsets: Specifies if term offsets should be returned.
-            Applies to all returned documents unless otherwise specified in body
-            "params" or "docs".  Default: True
-        :arg payloads: Specifies if term payloads should be returned.
-            Applies to all returned documents unless otherwise specified in body
-            "params" or "docs".  Default: True
-        :arg positions: Specifies if term positions should be returned.
-            Applies to all returned documents unless otherwise specified in body
-            "params" or "docs".  Default: True
-        :arg preference: Specify the node or shard the operation should
-            be performed on (default: random) .Applies to all returned documents
-            unless otherwise specified in body "params" or "docs".
-        :arg realtime: Specifies if requests are real-time as opposed to
-            near-real-time (default: true).
-        :arg routing: Specific routing value. Applies to all returned
-            documents unless otherwise specified in body "params" or "docs".
-        :arg term_statistics: Specifies if total term frequency and
-            document frequency should be returned. Applies to all returned documents
-            unless otherwise specified in body "params" or "docs".
-        :arg version: Explicit version number for concurrency control
-        :arg version_type: Specific version type  Valid choices:
-            internal, external, external_gte, force
-        """
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, doc_type, "_mtermvectors"),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
     @query_params("master_timeout", "timeout")
     def put_script(self, id, body, context=None, params=None, headers=None):
         """
@@ -1301,7 +1199,9 @@ class Elasticsearch(object):
             body=body,
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "search_type"
+    )
     def rank_eval(self, body, index=None, params=None, headers=None):
         """
         Allows to evaluate the quality of ranked search results over a set of typical
@@ -1320,6 +1220,8 @@ class Elasticsearch(object):
             closed, none, all  Default: open
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
+        :arg search_type: Search operation type  Valid choices:
+            query_then_fetch, dfs_query_then_fetch
         """
         if body in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'body'.")
@@ -1353,7 +1255,7 @@ class Elasticsearch(object):
             prototype for the index request.
         :arg max_docs: Maximum number of documents to process (default:
             all documents)
-        :arg refresh: Should the effected indexes be refreshed?
+        :arg refresh: Should the affected indexes be refreshed?
         :arg requests_per_second: The throttle to set on this request in
             sub-requests per second. -1 means no throttle.
         :arg scroll: Control how long to keep the search context alive
@@ -1649,7 +1551,225 @@ class Elasticsearch(object):
         )
 
     @query_params(
+        "_source",
+        "_source_excludes",
+        "_source_includes",
+        "if_primary_term",
+        "if_seq_no",
+        "lang",
+        "refresh",
+        "retry_on_conflict",
+        "routing",
+        "timeout",
+        "wait_for_active_shards",
+    )
+    def update(self, index, id, body, doc_type=None, params=None, headers=None):
+        """
+        Updates a document with a script or partial document.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
+
+        :arg index: The name of the index
+        :arg id: Document ID
+        :arg body: The request definition requires either `script` or
+            partial `doc`
+        :arg doc_type: The type of the document
+        :arg _source: True or false to return the _source field or not,
+            or a list of fields to return
+        :arg _source_excludes: A list of fields to exclude from the
+            returned _source field
+        :arg _source_includes: A list of fields to extract and return
+            from the _source field
+        :arg if_primary_term: only perform the update operation if the
+            last operation that has changed the document has the specified primary
+            term
+        :arg if_seq_no: only perform the update operation if the last
+            operation that has changed the document has the specified sequence
+            number
+        :arg lang: The script language (default: painless)
+        :arg refresh: If `true` then refresh the affected shards to make
+            this operation visible to search, if `wait_for` then wait for a refresh
+            to make this operation visible to search, if `false` (the default) then
+            do nothing with refreshes.  Valid choices: true, false, wait_for
+        :arg retry_on_conflict: Specify how many times should the
+            operation be retried when a conflict occurs (default: 0)
+        :arg routing: Specific routing value
+        :arg timeout: Explicit operation timeout
+        :arg wait_for_active_shards: Sets the number of shard copies
+            that must be active before proceeding with the update operation.
+            Defaults to 1, meaning the primary shard only. Set to `all` for all
+            shard copies, otherwise set to any non-negative value less than or equal
+            to the total number of copies for the shard (number of replicas + 1)
+        """
+        for param in (index, id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        if doc_type in SKIP_IN_PATH:
+            doc_type = "_doc"
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(index, doc_type, id, "_update"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("requests_per_second")
+    def update_by_query_rethrottle(self, task_id, params=None, headers=None):
+        """
+        Changes the number of requests per second for a particular Update By Query
+        operation.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html>`_
+
+        :arg task_id: The task id to rethrottle
+        :arg requests_per_second: The throttle to set on this request in
+            floating sub-requests per second. -1 means set no throttle.
+        """
+        if task_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'task_id'.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path("_update_by_query", task_id, "_rethrottle"),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params()
+    def get_script_context(self, params=None, headers=None):
+        """
+        Returns all script contexts.
+
+        """
+        return self.transport.perform_request(
+            "GET", "/_script_context", params=params, headers=headers
+        )
+
+    @query_params()
+    def get_script_languages(self, params=None, headers=None):
+        """
+        Returns available script types, languages and contexts
+
+        """
+        return self.transport.perform_request(
+            "GET", "/_script_language", params=params, headers=headers
+        )
+
+    @query_params(
+        "ccs_minimize_roundtrips",
+        "max_concurrent_searches",
+        "rest_total_hits_as_int",
+        "search_type",
+        "typed_keys",
+    )
+    def msearch_template(
+        self, body, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Allows to execute several search template operations in one request.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html>`_
+
+        :arg body: The request definitions (metadata-search request
+            definition pairs), separated by newlines
+        :arg index: A comma-separated list of index names to use as
+            default
+        :arg doc_type: A comma-separated list of document types to use
+            as default
+        :arg ccs_minimize_roundtrips: Indicates whether network round-
+            trips should be minimized as part of cross-cluster search requests
+            execution  Default: true
+        :arg max_concurrent_searches: Controls the maximum number of
+            concurrent searches the multi search api will execute
+        :arg rest_total_hits_as_int: Indicates whether hits.total should
+            be rendered as an integer or an object in the rest search response
+        :arg search_type: Search operation type  Valid choices:
+            query_then_fetch, query_and_fetch, dfs_query_then_fetch,
+            dfs_query_and_fetch
+        :arg typed_keys: Specify whether aggregation and suggester names
+            should be prefixed by their respective types in the response
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        body = _bulk_body(self.transport.serializer, body)
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, doc_type, "_msearch", "template"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params(
+        "field_statistics",
+        "fields",
+        "ids",
+        "offsets",
+        "payloads",
+        "positions",
+        "preference",
+        "realtime",
+        "routing",
+        "term_statistics",
+        "version",
+        "version_type",
+    )
+    def mtermvectors(
+        self, body=None, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Returns multiple termvectors in one request.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
+
+        :arg body: Define ids, documents, parameters or a list of
+            parameters per document here. You must at least provide a list of
+            document ids. See documentation.
+        :arg index: The index in which the document resides.
+        :arg doc_type: The type of the document.
+        :arg field_statistics: Specifies if document count, sum of
+            document frequencies and sum of total term frequencies should be
+            returned. Applies to all returned documents unless otherwise specified
+            in body "params" or "docs".  Default: True
+        :arg fields: A comma-separated list of fields to return. Applies
+            to all returned documents unless otherwise specified in body "params" or
+            "docs".
+        :arg ids: A comma-separated list of documents ids. You must
+            define ids as parameter or set "ids" or "docs" in the request body
+        :arg offsets: Specifies if term offsets should be returned.
+            Applies to all returned documents unless otherwise specified in body
+            "params" or "docs".  Default: True
+        :arg payloads: Specifies if term payloads should be returned.
+            Applies to all returned documents unless otherwise specified in body
+            "params" or "docs".  Default: True
+        :arg positions: Specifies if term positions should be returned.
+            Applies to all returned documents unless otherwise specified in body
+            "params" or "docs".  Default: True
+        :arg preference: Specify the node or shard the operation should
+            be performed on (default: random) .Applies to all returned documents
+            unless otherwise specified in body "params" or "docs".
+        :arg realtime: Specifies if requests are real-time as opposed to
+            near-real-time (default: true).
+        :arg routing: Specific routing value. Applies to all returned
+            documents unless otherwise specified in body "params" or "docs".
+        :arg term_statistics: Specifies if total term frequency and
+            document frequency should be returned. Applies to all returned documents
+            unless otherwise specified in body "params" or "docs".
+        :arg version: Explicit version number for concurrency control
+        :arg version_type: Specific version type  Valid choices:
+            internal, external, external_gte, force
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, doc_type, "_mtermvectors"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params(
         "allow_no_indices",
+        "ccs_minimize_roundtrips",
         "expand_wildcards",
         "explain",
         "ignore_throttled",
@@ -1677,6 +1797,9 @@ class Elasticsearch(object):
         :arg allow_no_indices: Whether to ignore if a wildcard indices
             expression resolves into no concrete indices. (This includes `_all`
             string or when no indices have been specified)
+        :arg ccs_minimize_roundtrips: Indicates whether network round-
+            trips should be minimized as part of cross-cluster search requests
+            execution  Default: true
         :arg expand_wildcards: Whether to expand wildcard expression to
             concrete indices that are open, closed or both.  Valid choices: open,
             closed, none, all  Default: open
@@ -1777,71 +1900,6 @@ class Elasticsearch(object):
         "_source",
         "_source_excludes",
         "_source_includes",
-        "if_primary_term",
-        "if_seq_no",
-        "lang",
-        "refresh",
-        "retry_on_conflict",
-        "routing",
-        "timeout",
-        "wait_for_active_shards",
-    )
-    def update(self, index, id, body, doc_type=None, params=None, headers=None):
-        """
-        Updates a document with a script or partial document.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
-
-        :arg index: The name of the index
-        :arg id: Document ID
-        :arg body: The request definition requires either `script` or
-            partial `doc`
-        :arg doc_type: The type of the document
-        :arg _source: True or false to return the _source field or not,
-            or a list of fields to return
-        :arg _source_excludes: A list of fields to exclude from the
-            returned _source field
-        :arg _source_includes: A list of fields to extract and return
-            from the _source field
-        :arg if_primary_term: only perform the update operation if the
-            last operation that has changed the document has the specified primary
-            term
-        :arg if_seq_no: only perform the update operation if the last
-            operation that has changed the document has the specified sequence
-            number
-        :arg lang: The script language (default: painless)
-        :arg refresh: If `true` then refresh the effected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh
-            to make this operation visible to search, if `false` (the default) then
-            do nothing with refreshes.  Valid choices: true, false, wait_for
-        :arg retry_on_conflict: Specify how many times should the
-            operation be retried when a conflict occurs (default: 0)
-        :arg routing: Specific routing value
-        :arg timeout: Explicit operation timeout
-        :arg wait_for_active_shards: Sets the number of shard copies
-            that must be active before proceeding with the update operation.
-            Defaults to 1, meaning the primary shard only. Set to `all` for all
-            shard copies, otherwise set to any non-negative value less than or equal
-            to the total number of copies for the shard (number of replicas + 1)
-        """
-        for param in (index, id, body):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
-
-        if doc_type in SKIP_IN_PATH:
-            doc_type = "_doc"
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(index, doc_type, id, "_update"),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params(
-        "_source",
-        "_source_excludes",
-        "_source_includes",
         "allow_no_indices",
         "analyze_wildcard",
         "analyzer",
@@ -1921,7 +1979,7 @@ class Elasticsearch(object):
         :arg preference: Specify the node or shard the operation should
             be performed on (default: random)
         :arg q: Query in the Lucene query string syntax
-        :arg refresh: Should the effected indexes be refreshed?
+        :arg refresh: Should the affected indexes be refreshed?
         :arg request_cache: Specify if request cache should be used for
             this request or not, defaults to index level setting
         :arg requests_per_second: The throttle to set on this request in
@@ -1973,25 +2031,4 @@ class Elasticsearch(object):
             params=params,
             headers=headers,
             body=body,
-        )
-
-    @query_params("requests_per_second")
-    def update_by_query_rethrottle(self, task_id, params=None, headers=None):
-        """
-        Changes the number of requests per second for a particular Update By Query
-        operation.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html>`_
-
-        :arg task_id: The task id to rethrottle
-        :arg requests_per_second: The throttle to set on this request in
-            floating sub-requests per second. -1 means set no throttle.
-        """
-        if task_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'task_id'.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path("_update_by_query", task_id, "_rethrottle"),
-            params=params,
-            headers=headers,
         )

--- a/elasticsearch/client/__init__.pyi
+++ b/elasticsearch/client/__init__.pyi
@@ -1,0 +1,682 @@
+from typing import Any, Optional, Mapping
+
+from ..transport import Transport
+from .indices import IndicesClient
+from .ingest import IngestClient
+from .cluster import ClusterClient
+from .cat import CatClient
+from .nodes import NodesClient
+from .remote import RemoteClient
+from .snapshot import SnapshotClient
+from .tasks import TasksClient
+from .xpack import XPackClient
+from .ccr import CcrClient
+from .data_frame import Data_FrameClient
+from .deprecation import DeprecationClient
+from .graph import GraphClient
+from .ilm import IlmClient
+from .license import LicenseClient
+from .migration import MigrationClient
+from .ml import MlClient
+from .monitoring import MonitoringClient
+from .rollup import RollupClient
+from .security import SecurityClient
+from .sql import SqlClient
+from .ssl import SslClient
+from .watcher import WatcherClient
+from .enrich import EnrichClient
+from .slm import SlmClient
+from .transform import TransformClient
+
+class Elasticsearch(object):
+    transport: Transport
+    indices: IndicesClient
+    ingest: IngestClient
+    cluster: ClusterClient
+    cat: CatClient
+    nodes: NodesClient
+    remote: RemoteClient
+    snapshot: SnapshotClient
+    tasks: TasksClient
+
+    xpack: XPackClient
+    ccr: CcrClient
+    data_frame: Data_FrameClient
+    deprecation: DeprecationClient
+    graph: GraphClient
+    ilm: IlmClient
+    license: LicenseClient
+    migration: MigrationClient
+    ml: MlClient
+    monitoring: MonitoringClient
+    rollup: RollupClient
+    security: SecurityClient
+    sql: SqlClient
+    ssl: SslClient
+    watcher: WatcherClient
+    enrich: EnrichClient
+    slm: SlmClient
+    transform: TransformClient
+    def __init__(self, hosts=None, transport_class=Transport, **kwargs) -> None: ...
+    def __repr__(self) -> str: ...
+    # AUTO-GENERATED-API-DEFINITIONS #
+    def ping(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def info(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def create(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        body: Any,
+        doc_type: Optional[Any] = None,
+        pipeline: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def index(
+        self,
+        *,
+        index: Any,
+        body: Any,
+        doc_type: Optional[Any] = None,
+        id: Optional[Any] = None,
+        if_primary_term: Optional[Any] = None,
+        if_seq_no: Optional[Any] = None,
+        op_type: Optional[Any] = None,
+        pipeline: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def bulk(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        pipeline: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def clear_scroll(
+        self,
+        *,
+        body: Optional[Any] = None,
+        scroll_id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def count(
+        self,
+        *,
+        body: Optional[Any] = None,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        analyze_wildcard: Optional[Any] = None,
+        analyzer: Optional[Any] = None,
+        default_operator: Optional[Any] = None,
+        df: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_throttled: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        lenient: Optional[Any] = None,
+        min_score: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        q: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        terminate_after: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        doc_type: Optional[Any] = None,
+        if_primary_term: Optional[Any] = None,
+        if_seq_no: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_by_query(
+        self,
+        *,
+        index: Any,
+        body: Any,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        analyze_wildcard: Optional[Any] = None,
+        analyzer: Optional[Any] = None,
+        conflicts: Optional[Any] = None,
+        default_operator: Optional[Any] = None,
+        df: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        lenient: Optional[Any] = None,
+        max_docs: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        q: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        request_cache: Optional[Any] = None,
+        requests_per_second: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        scroll: Optional[Any] = None,
+        scroll_size: Optional[Any] = None,
+        search_timeout: Optional[Any] = None,
+        search_type: Optional[Any] = None,
+        size: Optional[Any] = None,
+        slices: Optional[Any] = None,
+        sort: Optional[Any] = None,
+        stats: Optional[Any] = None,
+        terminate_after: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        version: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_by_query_rethrottle(
+        self,
+        *,
+        task_id: Any,
+        requests_per_second: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_script(
+        self,
+        *,
+        id: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def exists(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        realtime: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        stored_fields: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def exists_source(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        realtime: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def explain(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        body: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        analyze_wildcard: Optional[Any] = None,
+        analyzer: Optional[Any] = None,
+        default_operator: Optional[Any] = None,
+        df: Optional[Any] = None,
+        lenient: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        q: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        stored_fields: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def field_caps(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        fields: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        include_unmapped: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        realtime: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        stored_fields: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_script(
+        self,
+        *,
+        id: Any,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_source(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        realtime: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def mget(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        realtime: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        stored_fields: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def msearch(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        ccs_minimize_roundtrips: Optional[Any] = None,
+        max_concurrent_searches: Optional[Any] = None,
+        max_concurrent_shard_requests: Optional[Any] = None,
+        pre_filter_shard_size: Optional[Any] = None,
+        rest_total_hits_as_int: Optional[Any] = None,
+        search_type: Optional[Any] = None,
+        typed_keys: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_script(
+        self,
+        *,
+        id: Any,
+        body: Any,
+        context: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def rank_eval(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        search_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def reindex(
+        self,
+        *,
+        body: Any,
+        max_docs: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        requests_per_second: Optional[Any] = None,
+        scroll: Optional[Any] = None,
+        slices: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def reindex_rethrottle(
+        self,
+        *,
+        task_id: Any,
+        requests_per_second: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def render_search_template(
+        self,
+        *,
+        body: Optional[Any] = None,
+        id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def scripts_painless_execute(
+        self,
+        *,
+        body: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def scroll(
+        self,
+        *,
+        body: Optional[Any] = None,
+        scroll_id: Optional[Any] = None,
+        rest_total_hits_as_int: Optional[Any] = None,
+        scroll: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def search(
+        self,
+        *,
+        body: Optional[Any] = None,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        allow_partial_search_results: Optional[Any] = None,
+        analyze_wildcard: Optional[Any] = None,
+        analyzer: Optional[Any] = None,
+        batched_reduce_size: Optional[Any] = None,
+        ccs_minimize_roundtrips: Optional[Any] = None,
+        default_operator: Optional[Any] = None,
+        df: Optional[Any] = None,
+        docvalue_fields: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        explain: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        ignore_throttled: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        lenient: Optional[Any] = None,
+        max_concurrent_shard_requests: Optional[Any] = None,
+        pre_filter_shard_size: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        q: Optional[Any] = None,
+        request_cache: Optional[Any] = None,
+        rest_total_hits_as_int: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        scroll: Optional[Any] = None,
+        search_type: Optional[Any] = None,
+        seq_no_primary_term: Optional[Any] = None,
+        size: Optional[Any] = None,
+        sort: Optional[Any] = None,
+        stats: Optional[Any] = None,
+        stored_fields: Optional[Any] = None,
+        suggest_field: Optional[Any] = None,
+        suggest_mode: Optional[Any] = None,
+        suggest_size: Optional[Any] = None,
+        suggest_text: Optional[Any] = None,
+        terminate_after: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        track_scores: Optional[Any] = None,
+        track_total_hits: Optional[Any] = None,
+        typed_keys: Optional[Any] = None,
+        version: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def search_shards(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        local: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update(
+        self,
+        *,
+        index: Any,
+        id: Any,
+        body: Any,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        if_primary_term: Optional[Any] = None,
+        if_seq_no: Optional[Any] = None,
+        lang: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        retry_on_conflict: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_by_query_rethrottle(
+        self,
+        *,
+        task_id: Any,
+        requests_per_second: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_script_context(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_script_languages(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def msearch_template(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        ccs_minimize_roundtrips: Optional[Any] = None,
+        max_concurrent_searches: Optional[Any] = None,
+        rest_total_hits_as_int: Optional[Any] = None,
+        search_type: Optional[Any] = None,
+        typed_keys: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def mtermvectors(
+        self,
+        *,
+        body: Optional[Any] = None,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        field_statistics: Optional[Any] = None,
+        fields: Optional[Any] = None,
+        ids: Optional[Any] = None,
+        offsets: Optional[Any] = None,
+        payloads: Optional[Any] = None,
+        positions: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        realtime: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        term_statistics: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def search_template(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        ccs_minimize_roundtrips: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        explain: Optional[Any] = None,
+        ignore_throttled: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        profile: Optional[Any] = None,
+        rest_total_hits_as_int: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        scroll: Optional[Any] = None,
+        search_type: Optional[Any] = None,
+        typed_keys: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def termvectors(
+        self,
+        *,
+        index: Any,
+        body: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        id: Optional[Any] = None,
+        field_statistics: Optional[Any] = None,
+        fields: Optional[Any] = None,
+        offsets: Optional[Any] = None,
+        payloads: Optional[Any] = None,
+        positions: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        realtime: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        term_statistics: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_by_query(
+        self,
+        *,
+        index: Any,
+        body: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        _source: Optional[Any] = None,
+        _source_excludes: Optional[Any] = None,
+        _source_includes: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        analyze_wildcard: Optional[Any] = None,
+        analyzer: Optional[Any] = None,
+        conflicts: Optional[Any] = None,
+        default_operator: Optional[Any] = None,
+        df: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        lenient: Optional[Any] = None,
+        max_docs: Optional[Any] = None,
+        pipeline: Optional[Any] = None,
+        preference: Optional[Any] = None,
+        q: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        request_cache: Optional[Any] = None,
+        requests_per_second: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        scroll: Optional[Any] = None,
+        scroll_size: Optional[Any] = None,
+        search_timeout: Optional[Any] = None,
+        search_type: Optional[Any] = None,
+        size: Optional[Any] = None,
+        slices: Optional[Any] = None,
+        sort: Optional[Any] = None,
+        stats: Optional[Any] = None,
+        terminate_after: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        version: Optional[Any] = None,
+        version_type: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -134,7 +134,7 @@ class CatClient(NamespacedClient):
         :arg index: A comma-separated list of index names to limit the
             returned information
         :arg bytes: The unit in which to display byte values  Valid
-            choices: b, k, m, g
+            choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg format: a short version of the Accept header, e.g. json,
             yaml
         :arg h: Comma-separated list of column names to display
@@ -208,8 +208,8 @@ class CatClient(NamespacedClient):
             version (default: false)
         :arg h: Comma-separated list of column names to display
         :arg help: Return help information
-        :arg local: Return local information, do not retrieve the state
-            from master node (default: false)
+        :arg local: Calculate the selected nodes using the local cluster
+            state rather than the state from master node (default: false)
         :arg master_timeout: Explicit operation timeout for connection
             to master node
         :arg s: Comma-separated list of column names or column aliases

--- a/elasticsearch/client/cat.pyi
+++ b/elasticsearch/client/cat.pyi
@@ -1,0 +1,284 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class CatClient(NamespacedClient):
+    def aliases(
+        self,
+        *,
+        name: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def allocation(
+        self,
+        *,
+        node_id: Optional[Any] = None,
+        bytes: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def count(
+        self,
+        *,
+        index: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def health(
+        self,
+        *,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        ts: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def help(
+        self,
+        *,
+        help: Optional[Any] = None,
+        s: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def indices(
+        self,
+        *,
+        index: Optional[Any] = None,
+        bytes: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        health: Optional[Any] = None,
+        help: Optional[Any] = None,
+        include_unloaded_segments: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        pri: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def master(
+        self,
+        *,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def nodes(
+        self,
+        *,
+        bytes: Optional[Any] = None,
+        format: Optional[Any] = None,
+        full_id: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def recovery(
+        self,
+        *,
+        index: Optional[Any] = None,
+        active_only: Optional[Any] = None,
+        bytes: Optional[Any] = None,
+        detailed: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def shards(
+        self,
+        *,
+        index: Optional[Any] = None,
+        bytes: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def segments(
+        self,
+        *,
+        index: Optional[Any] = None,
+        bytes: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def pending_tasks(
+        self,
+        *,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def thread_pool(
+        self,
+        *,
+        thread_pool_patterns: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        size: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def fielddata(
+        self,
+        *,
+        fields: Optional[Any] = None,
+        bytes: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def plugins(
+        self,
+        *,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def nodeattrs(
+        self,
+        *,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def repositories(
+        self,
+        *,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def snapshots(
+        self,
+        *,
+        repository: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def tasks(
+        self,
+        *,
+        actions: Optional[Any] = None,
+        detailed: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        node_id: Optional[Any] = None,
+        parent_task: Optional[Any] = None,
+        s: Optional[Any] = None,
+        time: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def templates(
+        self,
+        *,
+        name: Optional[Any] = None,
+        format: Optional[Any] = None,
+        h: Optional[Any] = None,
+        help: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        s: Optional[Any] = None,
+        v: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/ccr.pyi
+++ b/elasticsearch/client/ccr.pyi
@@ -1,0 +1,99 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class CcrClient(NamespacedClient):
+    def delete_auto_follow_pattern(
+        self,
+        *,
+        name: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def follow(
+        self,
+        *,
+        index: Any,
+        body: Any,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def follow_info(
+        self,
+        *,
+        index: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def follow_stats(
+        self,
+        *,
+        index: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def forget_follower(
+        self,
+        *,
+        index: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_auto_follow_pattern(
+        self,
+        *,
+        name: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def pause_follow(
+        self,
+        *,
+        index: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_auto_follow_pattern(
+        self,
+        *,
+        name: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def resume_follow(
+        self,
+        *,
+        index: Any,
+        body: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stats(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def unfollow(
+        self,
+        *,
+        index: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def pause_auto_follow_pattern(
+        self,
+        *,
+        name: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def resume_auto_follow_pattern(
+        self,
+        *,
+        name: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/cluster.pyi
+++ b/elasticsearch/client/cluster.pyi
@@ -1,0 +1,103 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class ClusterClient(NamespacedClient):
+    def health(
+        self,
+        *,
+        index: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        level: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        wait_for_events: Optional[Any] = None,
+        wait_for_no_initializing_shards: Optional[Any] = None,
+        wait_for_no_relocating_shards: Optional[Any] = None,
+        wait_for_nodes: Optional[Any] = None,
+        wait_for_status: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def pending_tasks(
+        self,
+        *,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def state(
+        self,
+        *,
+        metric: Optional[Any] = None,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        wait_for_metadata_version: Optional[Any] = None,
+        wait_for_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stats(
+        self,
+        *,
+        node_id: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def reroute(
+        self,
+        *,
+        body: Optional[Any] = None,
+        dry_run: Optional[Any] = None,
+        explain: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        metric: Optional[Any] = None,
+        retry_failed: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_settings(
+        self,
+        *,
+        flat_settings: Optional[Any] = None,
+        include_defaults: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_settings(
+        self,
+        *,
+        body: Any,
+        flat_settings: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def remote_info(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def allocation_explain(
+        self,
+        *,
+        body: Optional[Any] = None,
+        include_disk_info: Optional[Any] = None,
+        include_yes_decisions: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/enrich.py
+++ b/elasticsearch/client/enrich.py
@@ -43,7 +43,7 @@ class EnrichClient(NamespacedClient):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-get-policy.html>`_
 
-        :arg name: The name of the enrich policy
+        :arg name: A comma-separated list of enrich policy names
         """
         return self.transport.perform_request(
             "GET", _make_path("_enrich", "policy", name), params=params, headers=headers

--- a/elasticsearch/client/enrich.pyi
+++ b/elasticsearch/client/enrich.pyi
@@ -1,0 +1,40 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class EnrichClient(NamespacedClient):
+    def delete_policy(
+        self,
+        *,
+        name: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def execute_policy(
+        self,
+        *,
+        name: Any,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_policy(
+        self,
+        *,
+        name: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_policy(
+        self,
+        *,
+        name: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stats(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/graph.pyi
+++ b/elasticsearch/client/graph.pyi
@@ -1,0 +1,15 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class GraphClient(NamespacedClient):
+    def explore(
+        self,
+        *,
+        index: Any,
+        body: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        routing: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/ilm.pyi
+++ b/elasticsearch/client/ilm.pyi
@@ -1,0 +1,75 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class IlmClient(NamespacedClient):
+    def delete_lifecycle(
+        self,
+        *,
+        policy: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def explain_lifecycle(
+        self,
+        *,
+        index: Any,
+        only_errors: Optional[Any] = None,
+        only_managed: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_lifecycle(
+        self,
+        *,
+        policy: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_status(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def move_to_step(
+        self,
+        *,
+        index: Any,
+        body: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_lifecycle(
+        self,
+        *,
+        policy: Any,
+        body: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def remove_policy(
+        self,
+        *,
+        index: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def retry(
+        self,
+        *,
+        index: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def start(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stop(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -418,49 +418,6 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params(
-        "allow_no_indices",
-        "expand_wildcards",
-        "ignore_unavailable",
-        "include_defaults",
-        "include_type_name",
-        "local",
-    )
-    def get_field_mapping(
-        self, fields, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Returns mapping for one or more fields.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
-
-        :arg fields: A comma-separated list of fields
-        :arg index: A comma-separated list of index names
-        :arg doc_type: A comma-separated list of document types
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
-        :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both.  Valid choices: open,
-            closed, none, all  Default: open
-        :arg ignore_unavailable: Whether specified concrete indices
-            should be ignored when unavailable (missing or closed)
-        :arg include_defaults: Whether the default mapping values should
-            be returned as well
-        :arg include_type_name: Whether a type should be returned in the
-            body of the mappings.
-        :arg local: Return local information, do not retrieve the state
-            from master node (default: false)
-        """
-        if fields in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'fields'.")
-
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, "_mapping", doc_type, "field", fields),
-            params=params,
-            headers=headers,
-        )
-
     @query_params("master_timeout", "timeout")
     def put_alias(self, index, name, body=None, params=None, headers=None):
         """
@@ -832,66 +789,6 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "all_shards",
-        "allow_no_indices",
-        "analyze_wildcard",
-        "analyzer",
-        "default_operator",
-        "df",
-        "expand_wildcards",
-        "explain",
-        "ignore_unavailable",
-        "lenient",
-        "q",
-        "rewrite",
-    )
-    def validate_query(
-        self, body=None, index=None, doc_type=None, params=None, headers=None
-    ):
-        """
-        Allows a user to validate a potentially expensive query without executing it.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
-
-        :arg body: The query definition specified with the Query DSL
-        :arg index: A comma-separated list of index names to restrict
-            the operation; use `_all` or empty string to perform the operation on
-            all indices
-        :arg doc_type: A comma-separated list of document types to
-            restrict the operation; leave empty to perform the operation on all
-            types
-        :arg all_shards: Execute validation on all shards instead of one
-            random shard per index
-        :arg allow_no_indices: Whether to ignore if a wildcard indices
-            expression resolves into no concrete indices. (This includes `_all`
-            string or when no indices have been specified)
-        :arg analyze_wildcard: Specify whether wildcard and prefix
-            queries should be analyzed (default: false)
-        :arg analyzer: The analyzer to use for the query string
-        :arg default_operator: The default operator for query string
-            query (AND or OR)  Valid choices: AND, OR  Default: OR
-        :arg df: The field to use as default where no field prefix is
-            given in the query string
-        :arg expand_wildcards: Whether to expand wildcard expression to
-            concrete indices that are open, closed or both.  Valid choices: open,
-            closed, none, all  Default: open
-        :arg explain: Return detailed information about the error
-        :arg ignore_unavailable: Whether specified concrete indices
-            should be ignored when unavailable (missing or closed)
-        :arg lenient: Specify whether format-based query failures (such
-            as providing text to a numeric field) should be ignored
-        :arg q: Query in the Lucene query string syntax
-        :arg rewrite: Provide a more detailed explanation showing the
-            actual Lucene query that will be executed.
-        """
-        return self.transport.perform_request(
-            "GET",
-            _make_path(index, doc_type, "_validate", "query"),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params(
         "allow_no_indices",
         "expand_wildcards",
         "fielddata",
@@ -999,7 +896,8 @@ class IndicesClient(NamespacedClient):
     @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
     def flush_synced(self, index=None, params=None, headers=None):
         """
-        Performs a synced flush operation on one or more indices.
+        Performs a synced flush operation on one or more indices. Synced flush is
+        deprecated and will be removed in 8.0. Use flush instead
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -1272,4 +1170,107 @@ class IndicesClient(NamespacedClient):
             _make_path(index, "_reload_search_analyzers"),
             params=params,
             headers=headers,
+        )
+
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "include_defaults",
+        "include_type_name",
+        "local",
+    )
+    def get_field_mapping(
+        self, fields, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Returns mapping for one or more fields.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
+
+        :arg fields: A comma-separated list of fields
+        :arg index: A comma-separated list of index names
+        :arg doc_type: A comma-separated list of document types
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
+        :arg ignore_unavailable: Whether specified concrete indices
+            should be ignored when unavailable (missing or closed)
+        :arg include_defaults: Whether the default mapping values should
+            be returned as well
+        :arg include_type_name: Whether a type should be returned in the
+            body of the mappings.
+        :arg local: Return local information, do not retrieve the state
+            from master node (default: false)
+        """
+        if fields in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'fields'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, "_mapping", doc_type, "field", fields),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
+        "all_shards",
+        "allow_no_indices",
+        "analyze_wildcard",
+        "analyzer",
+        "default_operator",
+        "df",
+        "expand_wildcards",
+        "explain",
+        "ignore_unavailable",
+        "lenient",
+        "q",
+        "rewrite",
+    )
+    def validate_query(
+        self, body=None, index=None, doc_type=None, params=None, headers=None
+    ):
+        """
+        Allows a user to validate a potentially expensive query without executing it.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
+
+        :arg body: The query definition specified with the Query DSL
+        :arg index: A comma-separated list of index names to restrict
+            the operation; use `_all` or empty string to perform the operation on
+            all indices
+        :arg doc_type: A comma-separated list of document types to
+            restrict the operation; leave empty to perform the operation on all
+            types
+        :arg all_shards: Execute validation on all shards instead of one
+            random shard per index
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg analyze_wildcard: Specify whether wildcard and prefix
+            queries should be analyzed (default: false)
+        :arg analyzer: The analyzer to use for the query string
+        :arg default_operator: The default operator for query string
+            query (AND or OR)  Valid choices: AND, OR  Default: OR
+        :arg df: The field to use as default where no field prefix is
+            given in the query string
+        :arg expand_wildcards: Whether to expand wildcard expression to
+            concrete indices that are open, closed or both.  Valid choices: open,
+            closed, none, all  Default: open
+        :arg explain: Return detailed information about the error
+        :arg ignore_unavailable: Whether specified concrete indices
+            should be ignored when unavailable (missing or closed)
+        :arg lenient: Specify whether format-based query failures (such
+            as providing text to a numeric field) should be ignored
+        :arg q: Query in the Lucene query string syntax
+        :arg rewrite: Provide a more detailed explanation showing the
+            actual Lucene query that will be executed.
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path(index, doc_type, "_validate", "query"),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/elasticsearch/client/indices.pyi
+++ b/elasticsearch/client/indices.pyi
@@ -1,0 +1,513 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class IndicesClient(NamespacedClient):
+    def analyze(
+        self,
+        *,
+        body: Optional[Any] = None,
+        index: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def refresh(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def flush(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        force: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        wait_if_ongoing: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def create(
+        self,
+        *,
+        index: Any,
+        body: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def clone(
+        self,
+        *,
+        index: Any,
+        target: Any,
+        body: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        include_defaults: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def open(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def close(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def exists(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        include_defaults: Optional[Any] = None,
+        local: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def exists_type(
+        self,
+        *,
+        index: Any,
+        doc_type: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        local: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_mapping(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_mapping(
+        self,
+        *,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_alias(
+        self,
+        *,
+        index: Any,
+        name: Any,
+        body: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def exists_alias(
+        self,
+        *,
+        name: Any,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        local: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_alias(
+        self,
+        *,
+        index: Optional[Any] = None,
+        name: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        local: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_aliases(
+        self,
+        *,
+        body: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_alias(
+        self,
+        *,
+        index: Any,
+        name: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_template(
+        self,
+        *,
+        name: Any,
+        body: Any,
+        create: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        order: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def exists_template(
+        self,
+        *,
+        name: Any,
+        flat_settings: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_template(
+        self,
+        *,
+        name: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_template(
+        self,
+        *,
+        name: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_settings(
+        self,
+        *,
+        index: Optional[Any] = None,
+        name: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        include_defaults: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_settings(
+        self,
+        *,
+        body: Any,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        preserve_existing: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stats(
+        self,
+        *,
+        index: Optional[Any] = None,
+        metric: Optional[Any] = None,
+        completion_fields: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        fielddata_fields: Optional[Any] = None,
+        fields: Optional[Any] = None,
+        forbid_closed_indices: Optional[Any] = None,
+        groups: Optional[Any] = None,
+        include_segment_file_sizes: Optional[Any] = None,
+        include_unloaded_segments: Optional[Any] = None,
+        level: Optional[Any] = None,
+        types: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def segments(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        verbose: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def clear_cache(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        fielddata: Optional[Any] = None,
+        fields: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        query: Optional[Any] = None,
+        request: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def recovery(
+        self,
+        *,
+        index: Optional[Any] = None,
+        active_only: Optional[Any] = None,
+        detailed: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def upgrade(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        only_ancient_segments: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_upgrade(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def flush_synced(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def shard_stores(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        status: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def forcemerge(
+        self,
+        *,
+        index: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        flush: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        max_num_segments: Optional[Any] = None,
+        only_expunge_deletes: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def shrink(
+        self,
+        *,
+        index: Any,
+        target: Any,
+        body: Optional[Any] = None,
+        copy_settings: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def split(
+        self,
+        *,
+        index: Any,
+        target: Any,
+        body: Optional[Any] = None,
+        copy_settings: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def rollover(
+        self,
+        *,
+        alias: Any,
+        body: Optional[Any] = None,
+        new_index: Optional[Any] = None,
+        dry_run: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def freeze(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def unfreeze(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_active_shards: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def reload_search_analyzers(
+        self,
+        *,
+        index: Any,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_field_mapping(
+        self,
+        *,
+        fields: Any,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        include_defaults: Optional[Any] = None,
+        include_type_name: Optional[Any] = None,
+        local: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def validate_query(
+        self,
+        *,
+        body: Optional[Any] = None,
+        index: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        all_shards: Optional[Any] = None,
+        allow_no_indices: Optional[Any] = None,
+        analyze_wildcard: Optional[Any] = None,
+        analyzer: Optional[Any] = None,
+        default_operator: Optional[Any] = None,
+        df: Optional[Any] = None,
+        expand_wildcards: Optional[Any] = None,
+        explain: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        lenient: Optional[Any] = None,
+        q: Optional[Any] = None,
+        rewrite: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/ingest.pyi
+++ b/elasticsearch/client/ingest.pyi
@@ -1,0 +1,46 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class IngestClient(NamespacedClient):
+    def get_pipeline(
+        self,
+        *,
+        id: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_pipeline(
+        self,
+        *,
+        id: Any,
+        body: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_pipeline(
+        self,
+        *,
+        id: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def simulate(
+        self,
+        *,
+        body: Any,
+        id: Optional[Any] = None,
+        verbose: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def processor_grok(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/license.py
+++ b/elasticsearch/client/license.py
@@ -12,11 +12,13 @@ class LicenseClient(NamespacedClient):
             "DELETE", "/_license", params=params, headers=headers
         )
 
-    @query_params("local")
+    @query_params("accept_enterprise", "local")
     def get(self, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
 
+        :arg accept_enterprise: If the active license is an enterprise
+            license, return type as 'enterprise' (default: false)
         :arg local: Return local information, do not retrieve the state
             from master node (default: false)
         """

--- a/elasticsearch/client/license.pyi
+++ b/elasticsearch/client/license.pyi
@@ -1,0 +1,53 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class LicenseClient(NamespacedClient):
+    def delete(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get(
+        self,
+        *,
+        accept_enterprise: Optional[Any] = None,
+        local: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_basic_status(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_trial_status(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def post(
+        self,
+        *,
+        body: Optional[Any] = None,
+        acknowledge: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def post_start_basic(
+        self,
+        *,
+        acknowledge: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def post_start_trial(
+        self,
+        *,
+        acknowledge: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/migration.pyi
+++ b/elasticsearch/client/migration.pyi
@@ -1,0 +1,11 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class MigrationClient(NamespacedClient):
+    def deprecations(
+        self,
+        *,
+        index: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -399,37 +399,6 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("from_", "size")
-    def get_categories(
-        self, job_id, body=None, category_id=None, params=None, headers=None
-    ):
-        """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
-
-        :arg job_id: The name of the job
-        :arg body: Category selection details if not provided in URI
-        :arg category_id: The identifier of the category definition of
-            interest
-        :arg from_: skips a number of categories
-        :arg size: specifies a max number of categories to get
-        """
-        # from is a reserved word so it cannot be used, use from_ instead
-        if "from_" in params:
-            params["from"] = params.pop("from_")
-
-        if job_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'job_id'.")
-
-        return self.transport.perform_request(
-            "GET",
-            _make_path(
-                "_ml", "anomaly_detectors", job_id, "results", "categories", category_id
-            ),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
     @query_params("allow_no_datafeeds")
     def get_datafeed_stats(self, datafeed_id=None, params=None, headers=None):
         """
@@ -557,42 +526,6 @@ class MlClient(NamespacedClient):
             _make_path("_ml", "anomaly_detectors", job_id),
             params=params,
             headers=headers,
-        )
-
-    @query_params("desc", "end", "from_", "size", "sort", "start")
-    def get_model_snapshots(
-        self, job_id, body=None, snapshot_id=None, params=None, headers=None
-    ):
-        """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
-
-        :arg job_id: The ID of the job to fetch
-        :arg body: Model snapshot selection criteria
-        :arg snapshot_id: The ID of the snapshot to fetch
-        :arg desc: True if the results should be sorted in descending
-            order
-        :arg end: The filter 'end' query parameter
-        :arg from_: Skips a number of documents
-        :arg size: The default number of documents returned in queries
-            as a string.
-        :arg sort: Name of the field to sort on
-        :arg start: The filter 'start' query parameter
-        """
-        # from is a reserved word so it cannot be used, use from_ instead
-        if "from_" in params:
-            params["from"] = params.pop("from_")
-
-        if job_id in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'job_id'.")
-
-        return self.transport.perform_request(
-            "GET",
-            _make_path(
-                "_ml", "anomaly_detectors", job_id, "model_snapshots", snapshot_id
-            ),
-            params=params,
-            headers=headers,
-            body=body,
         )
 
     @query_params(
@@ -867,38 +800,6 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("delete_intervening_results")
-    def revert_model_snapshot(
-        self, job_id, snapshot_id, body=None, params=None, headers=None
-    ):
-        """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html>`_
-
-        :arg job_id: The ID of the job to fetch
-        :arg snapshot_id: The ID of the snapshot to revert to
-        :arg body: Reversion options
-        :arg delete_intervening_results: Should we reset the results
-            back to the time of the snapshot?
-        """
-        for param in (job_id, snapshot_id):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(
-                "_ml",
-                "anomaly_detectors",
-                job_id,
-                "model_snapshots",
-                snapshot_id,
-                "_revert",
-            ),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
     @query_params("enabled", "timeout")
     def set_upgrade_mode(self, params=None, headers=None):
         """
@@ -1024,36 +925,6 @@ class MlClient(NamespacedClient):
         )
 
     @query_params()
-    def update_model_snapshot(
-        self, job_id, snapshot_id, body, params=None, headers=None
-    ):
-        """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html>`_
-
-        :arg job_id: The ID of the job to fetch
-        :arg snapshot_id: The ID of the snapshot to update
-        :arg body: The model snapshot properties to update
-        """
-        for param in (job_id, snapshot_id, body):
-            if param in SKIP_IN_PATH:
-                raise ValueError("Empty value passed for a required argument.")
-
-        return self.transport.perform_request(
-            "POST",
-            _make_path(
-                "_ml",
-                "anomaly_detectors",
-                job_id,
-                "model_snapshots",
-                snapshot_id,
-                "_update",
-            ),
-            params=params,
-            headers=headers,
-            body=body,
-        )
-
-    @query_params()
     def validate(self, body, params=None, headers=None):
         """
 
@@ -1087,12 +958,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params("force")
     def delete_data_frame_analytics(self, id, params=None, headers=None):
         """
         `<http://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to delete
+        :arg force: True if the job should be forcefully deleted
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for a required argument 'id'.")
@@ -1102,24 +974,6 @@ class MlClient(NamespacedClient):
             _make_path("_ml", "data_frame", "analytics", id),
             params=params,
             headers=headers,
-        )
-
-    @query_params()
-    def estimate_memory_usage(self, body, params=None, headers=None):
-        """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/estimate-memory-usage-dfanalytics.html>`_
-
-        :arg body: Memory usage estimation definition
-        """
-        if body in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for a required argument 'body'.")
-
-        return self.transport.perform_request(
-            "POST",
-            "/_ml/data_frame/analytics/_estimate_memory_usage",
-            params=params,
-            headers=headers,
-            body=body,
         )
 
     @query_params()
@@ -1250,6 +1104,250 @@ class MlClient(NamespacedClient):
         return self.transport.perform_request(
             "POST",
             _make_path("_ml", "data_frame", "analytics", id, "_stop"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params()
+    def delete_trained_model(self, model_id, params=None, headers=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-inference.html>`_
+
+        :arg model_id: The ID of the trained model to delete
+        """
+        if model_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'model_id'.")
+
+        return self.transport.perform_request(
+            "DELETE",
+            _make_path("_ml", "inference", model_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
+        "allow_no_match",
+        "decompress_definition",
+        "from_",
+        "include_model_definition",
+        "size",
+    )
+    def get_trained_models(self, model_id=None, params=None, headers=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference.html>`_
+
+        :arg model_id: The ID of the trained models to fetch
+        :arg allow_no_match: Whether to ignore if a wildcard expression
+            matches no trained models. (This includes `_all` string or when no
+            trained models have been specified)  Default: True
+        :arg decompress_definition: Should the model definition be
+            decompressed into valid JSON or returned in a custom compressed format.
+            Defaults to true.  Default: True
+        :arg from_: skips a number of trained models
+        :arg include_model_definition: Should the full model definition
+            be included in the results. These definitions can be large. So be
+            cautious when including them. Defaults to false.
+        :arg size: specifies a max number of trained models to get
+            Default: 100
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_ml", "inference", model_id),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("allow_no_match", "from_", "size")
+    def get_trained_models_stats(self, model_id=None, params=None, headers=None):
+        """
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference-stats.html>`_
+
+        :arg model_id: The ID of the trained models stats to fetch
+        :arg allow_no_match: Whether to ignore if a wildcard expression
+            matches no trained models. (This includes `_all` string or when no
+            trained models have been specified)  Default: True
+        :arg from_: skips a number of trained models
+        :arg size: specifies a max number of trained models to get
+            Default: 100
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_ml", "inference", model_id, "_stats"),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params()
+    def put_trained_model(self, model_id, body, params=None, headers=None):
+        """
+        `<TODO>`_
+
+        :arg model_id: The ID of the trained models to store
+        :arg body: The trained model configuration
+        """
+        for param in (model_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "PUT",
+            _make_path("_ml", "inference", model_id),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params()
+    def explain_data_frame_analytics(
+        self, body=None, id=None, params=None, headers=None
+    ):
+        """
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html>`_
+
+        :arg body: The data frame analytics config to explain
+        :arg id: The ID of the data frame analytics to explain
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_ml", "data_frame", "analytics", id, "_explain"),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("from_", "size")
+    def get_categories(
+        self, job_id, body=None, category_id=None, params=None, headers=None
+    ):
+        """
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html>`_
+
+        :arg job_id: The name of the job
+        :arg body: Category selection details if not provided in URI
+        :arg category_id: The identifier of the category definition of
+            interest
+        :arg from_: skips a number of categories
+        :arg size: specifies a max number of categories to get
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path(
+                "_ml", "anomaly_detectors", job_id, "results", "categories", category_id
+            ),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("desc", "end", "from_", "size", "sort", "start")
+    def get_model_snapshots(
+        self, job_id, body=None, snapshot_id=None, params=None, headers=None
+    ):
+        """
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg body: Model snapshot selection criteria
+        :arg snapshot_id: The ID of the snapshot to fetch
+        :arg desc: True if the results should be sorted in descending
+            order
+        :arg end: The filter 'end' query parameter
+        :arg from_: Skips a number of documents
+        :arg size: The default number of documents returned in queries
+            as a string.
+        :arg sort: Name of the field to sort on
+        :arg start: The filter 'start' query parameter
+        """
+        # from is a reserved word so it cannot be used, use from_ instead
+        if "from_" in params:
+            params["from"] = params.pop("from_")
+
+        if job_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'job_id'.")
+
+        return self.transport.perform_request(
+            "GET",
+            _make_path(
+                "_ml", "anomaly_detectors", job_id, "model_snapshots", snapshot_id
+            ),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params("delete_intervening_results")
+    def revert_model_snapshot(
+        self, job_id, snapshot_id, body=None, params=None, headers=None
+    ):
+        """
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to revert to
+        :arg body: Reversion options
+        :arg delete_intervening_results: Should we reset the results
+            back to the time of the snapshot?
+        """
+        for param in (job_id, snapshot_id):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_ml",
+                "anomaly_detectors",
+                job_id,
+                "model_snapshots",
+                snapshot_id,
+                "_revert",
+            ),
+            params=params,
+            headers=headers,
+            body=body,
+        )
+
+    @query_params()
+    def update_model_snapshot(
+        self, job_id, snapshot_id, body, params=None, headers=None
+    ):
+        """
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html>`_
+
+        :arg job_id: The ID of the job to fetch
+        :arg snapshot_id: The ID of the snapshot to update
+        :arg body: The model snapshot properties to update
+        """
+        for param in (job_id, snapshot_id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path(
+                "_ml",
+                "anomaly_detectors",
+                job_id,
+                "model_snapshots",
+                snapshot_id,
+                "_update",
+            ),
             params=params,
             headers=headers,
             body=body,

--- a/elasticsearch/client/ml.pyi
+++ b/elasticsearch/client/ml.pyi
@@ -1,0 +1,555 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class MlClient(NamespacedClient):
+    def close_job(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        allow_no_jobs: Optional[Any] = None,
+        force: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_calendar(
+        self,
+        *,
+        calendar_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_calendar_event(
+        self,
+        *,
+        calendar_id: Any,
+        event_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_calendar_job(
+        self,
+        *,
+        calendar_id: Any,
+        job_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_datafeed(
+        self,
+        *,
+        datafeed_id: Any,
+        force: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_expired_data(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_filter(
+        self,
+        *,
+        filter_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_forecast(
+        self,
+        *,
+        job_id: Any,
+        forecast_id: Optional[Any] = None,
+        allow_no_forecasts: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_job(
+        self,
+        *,
+        job_id: Any,
+        force: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_model_snapshot(
+        self,
+        *,
+        job_id: Any,
+        snapshot_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def find_file_structure(
+        self,
+        *,
+        body: Any,
+        charset: Optional[Any] = None,
+        column_names: Optional[Any] = None,
+        delimiter: Optional[Any] = None,
+        explain: Optional[Any] = None,
+        format: Optional[Any] = None,
+        grok_pattern: Optional[Any] = None,
+        has_header_row: Optional[Any] = None,
+        line_merge_size_limit: Optional[Any] = None,
+        lines_to_sample: Optional[Any] = None,
+        quote: Optional[Any] = None,
+        should_trim_fields: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        timestamp_field: Optional[Any] = None,
+        timestamp_format: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def flush_job(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        advance_time: Optional[Any] = None,
+        calc_interim: Optional[Any] = None,
+        end: Optional[Any] = None,
+        skip_time: Optional[Any] = None,
+        start: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def forecast(
+        self,
+        *,
+        job_id: Any,
+        duration: Optional[Any] = None,
+        expires_in: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_buckets(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        timestamp: Optional[Any] = None,
+        anomaly_score: Optional[Any] = None,
+        desc: Optional[Any] = None,
+        end: Optional[Any] = None,
+        exclude_interim: Optional[Any] = None,
+        expand: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        sort: Optional[Any] = None,
+        start: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_calendar_events(
+        self,
+        *,
+        calendar_id: Any,
+        end: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        job_id: Optional[Any] = None,
+        size: Optional[Any] = None,
+        start: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_calendars(
+        self,
+        *,
+        body: Optional[Any] = None,
+        calendar_id: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_datafeed_stats(
+        self,
+        *,
+        datafeed_id: Optional[Any] = None,
+        allow_no_datafeeds: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_datafeeds(
+        self,
+        *,
+        datafeed_id: Optional[Any] = None,
+        allow_no_datafeeds: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_filters(
+        self,
+        *,
+        filter_id: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_influencers(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        desc: Optional[Any] = None,
+        end: Optional[Any] = None,
+        exclude_interim: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        influencer_score: Optional[Any] = None,
+        size: Optional[Any] = None,
+        sort: Optional[Any] = None,
+        start: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_job_stats(
+        self,
+        *,
+        job_id: Optional[Any] = None,
+        allow_no_jobs: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_jobs(
+        self,
+        *,
+        job_id: Optional[Any] = None,
+        allow_no_jobs: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_overall_buckets(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        allow_no_jobs: Optional[Any] = None,
+        bucket_span: Optional[Any] = None,
+        end: Optional[Any] = None,
+        exclude_interim: Optional[Any] = None,
+        overall_score: Optional[Any] = None,
+        start: Optional[Any] = None,
+        top_n: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_records(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        desc: Optional[Any] = None,
+        end: Optional[Any] = None,
+        exclude_interim: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        record_score: Optional[Any] = None,
+        size: Optional[Any] = None,
+        sort: Optional[Any] = None,
+        start: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def info(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def open_job(
+        self,
+        *,
+        job_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def post_calendar_events(
+        self,
+        *,
+        calendar_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def post_data(
+        self,
+        *,
+        job_id: Any,
+        body: Any,
+        reset_end: Optional[Any] = None,
+        reset_start: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def preview_datafeed(
+        self,
+        *,
+        datafeed_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_calendar(
+        self,
+        *,
+        calendar_id: Any,
+        body: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_calendar_job(
+        self,
+        *,
+        calendar_id: Any,
+        job_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_datafeed(
+        self,
+        *,
+        datafeed_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_filter(
+        self,
+        *,
+        filter_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_job(
+        self,
+        *,
+        job_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def set_upgrade_mode(
+        self,
+        *,
+        enabled: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def start_datafeed(
+        self,
+        *,
+        datafeed_id: Any,
+        body: Optional[Any] = None,
+        end: Optional[Any] = None,
+        start: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stop_datafeed(
+        self,
+        *,
+        datafeed_id: Any,
+        allow_no_datafeeds: Optional[Any] = None,
+        force: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_datafeed(
+        self,
+        *,
+        datafeed_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_filter(
+        self,
+        *,
+        filter_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_job(
+        self,
+        *,
+        job_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def validate(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def validate_detector(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_data_frame_analytics(
+        self,
+        *,
+        id: Any,
+        force: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def evaluate_data_frame(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_data_frame_analytics(
+        self,
+        *,
+        id: Optional[Any] = None,
+        allow_no_match: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_data_frame_analytics_stats(
+        self,
+        *,
+        id: Optional[Any] = None,
+        allow_no_match: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_data_frame_analytics(
+        self,
+        *,
+        id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def start_data_frame_analytics(
+        self,
+        *,
+        id: Any,
+        body: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stop_data_frame_analytics(
+        self,
+        *,
+        id: Any,
+        body: Optional[Any] = None,
+        allow_no_match: Optional[Any] = None,
+        force: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_trained_model(
+        self,
+        *,
+        model_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_trained_models(
+        self,
+        *,
+        model_id: Optional[Any] = None,
+        allow_no_match: Optional[Any] = None,
+        decompress_definition: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        include_model_definition: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_trained_models_stats(
+        self,
+        *,
+        model_id: Optional[Any] = None,
+        allow_no_match: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_trained_model(
+        self,
+        *,
+        model_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def explain_data_frame_analytics(
+        self,
+        *,
+        body: Optional[Any] = None,
+        id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_categories(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        category_id: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_model_snapshots(
+        self,
+        *,
+        job_id: Any,
+        body: Optional[Any] = None,
+        snapshot_id: Optional[Any] = None,
+        desc: Optional[Any] = None,
+        end: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        sort: Optional[Any] = None,
+        start: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def revert_model_snapshot(
+        self,
+        *,
+        job_id: Any,
+        snapshot_id: Any,
+        body: Optional[Any] = None,
+        delete_intervening_results: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_model_snapshot(
+        self,
+        *,
+        job_id: Any,
+        snapshot_id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/monitoring.py
+++ b/elasticsearch/client/monitoring.py
@@ -5,7 +5,7 @@ class MonitoringClient(NamespacedClient):
     @query_params("interval", "system_api_version", "system_id")
     def bulk(self, body, doc_type=None, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
 
         :arg body: The operation definition and data (action-data
             pairs), separated by newlines

--- a/elasticsearch/client/monitoring.pyi
+++ b/elasticsearch/client/monitoring.pyi
@@ -1,0 +1,15 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class MonitoringClient(NamespacedClient):
+    def bulk(
+        self,
+        *,
+        body: Any,
+        doc_type: Optional[Any] = None,
+        interval: Optional[Any] = None,
+        system_api_version: Optional[Any] = None,
+        system_id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/nodes.py
+++ b/elasticsearch/client/nodes.py
@@ -42,59 +42,6 @@ class NodesClient(NamespacedClient):
         )
 
     @query_params(
-        "completion_fields",
-        "fielddata_fields",
-        "fields",
-        "groups",
-        "include_segment_file_sizes",
-        "level",
-        "timeout",
-        "types",
-    )
-    def stats(
-        self, node_id=None, metric=None, index_metric=None, params=None, headers=None
-    ):
-        """
-        Returns statistical information about nodes in the cluster.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
-
-        :arg node_id: A comma-separated list of node IDs or names to
-            limit the returned information; use `_local` to return information from
-            the node you're connecting to, leave empty to get information from all
-            nodes
-        :arg metric: Limit the information returned to the specified
-            metrics  Valid choices: _all, breaker, fs, http, indices, jvm, os,
-            process, thread_pool, transport, discovery
-        :arg index_metric: Limit the information returned for `indices`
-            metric to the specific index metrics. Isn't used if `indices` (or `all`)
-            metric isn't specified.  Valid choices: _all, completion, docs,
-            fielddata, query_cache, flush, get, indexing, merge, request_cache,
-            refresh, search, segments, store, warmer, suggest
-        :arg completion_fields: A comma-separated list of fields for
-            `fielddata` and `suggest` index metric (supports wildcards)
-        :arg fielddata_fields: A comma-separated list of fields for
-            `fielddata` index metric (supports wildcards)
-        :arg fields: A comma-separated list of fields for `fielddata`
-            and `completion` index metric (supports wildcards)
-        :arg groups: A comma-separated list of search groups for
-            `search` index metric
-        :arg include_segment_file_sizes: Whether to report the
-            aggregated disk usage of each one of the Lucene index files (only
-            applies if segment stats are requested)
-        :arg level: Return indices stats aggregated at index, node or
-            shard level  Valid choices: indices, node, shards  Default: node
-        :arg timeout: Explicit operation timeout
-        :arg types: A comma-separated list of document types for the
-            `indexing` index metric
-        """
-        return self.transport.perform_request(
-            "GET",
-            _make_path("_nodes", node_id, "stats", metric, index_metric),
-            params=params,
-            headers=headers,
-        )
-
-    @query_params(
         "doc_type", "ignore_idle_threads", "interval", "snapshots", "threads", "timeout"
     )
     def hot_threads(self, node_id=None, params=None, headers=None):
@@ -146,6 +93,59 @@ class NodesClient(NamespacedClient):
         return self.transport.perform_request(
             "GET",
             _make_path("_nodes", node_id, "usage", metric),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params(
+        "completion_fields",
+        "fielddata_fields",
+        "fields",
+        "groups",
+        "include_segment_file_sizes",
+        "level",
+        "timeout",
+        "types",
+    )
+    def stats(
+        self, node_id=None, metric=None, index_metric=None, params=None, headers=None
+    ):
+        """
+        Returns statistical information about nodes in the cluster.
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
+
+        :arg node_id: A comma-separated list of node IDs or names to
+            limit the returned information; use `_local` to return information from
+            the node you're connecting to, leave empty to get information from all
+            nodes
+        :arg metric: Limit the information returned to the specified
+            metrics  Valid choices: _all, breaker, fs, http, indices, jvm, os,
+            process, thread_pool, transport, discovery
+        :arg index_metric: Limit the information returned for `indices`
+            metric to the specific index metrics. Isn't used if `indices` (or `all`)
+            metric isn't specified.  Valid choices: _all, completion, docs,
+            fielddata, query_cache, flush, get, indexing, merge, request_cache,
+            refresh, search, segments, store, warmer, suggest
+        :arg completion_fields: A comma-separated list of fields for
+            `fielddata` and `suggest` index metric (supports wildcards)
+        :arg fielddata_fields: A comma-separated list of fields for
+            `fielddata` index metric (supports wildcards)
+        :arg fields: A comma-separated list of fields for `fielddata`
+            and `completion` index metric (supports wildcards)
+        :arg groups: A comma-separated list of search groups for
+            `search` index metric
+        :arg include_segment_file_sizes: Whether to report the
+            aggregated disk usage of each one of the Lucene index files (only
+            applies if segment stats are requested)
+        :arg level: Return indices stats aggregated at index, node or
+            shard level  Valid choices: indices, node, shards  Default: node
+        :arg timeout: Explicit operation timeout
+        :arg types: A comma-separated list of document types for the
+            `indexing` index metric
+        """
+        return self.transport.perform_request(
+            "GET",
+            _make_path("_nodes", node_id, "stats", metric, index_metric),
             params=params,
             headers=headers,
         )

--- a/elasticsearch/client/nodes.pyi
+++ b/elasticsearch/client/nodes.pyi
@@ -1,0 +1,61 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class NodesClient(NamespacedClient):
+    def reload_secure_settings(
+        self,
+        *,
+        node_id: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def info(
+        self,
+        *,
+        node_id: Optional[Any] = None,
+        metric: Optional[Any] = None,
+        flat_settings: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def hot_threads(
+        self,
+        *,
+        node_id: Optional[Any] = None,
+        doc_type: Optional[Any] = None,
+        ignore_idle_threads: Optional[Any] = None,
+        interval: Optional[Any] = None,
+        snapshots: Optional[Any] = None,
+        threads: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def usage(
+        self,
+        *,
+        node_id: Optional[Any] = None,
+        metric: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stats(
+        self,
+        *,
+        node_id: Optional[Any] = None,
+        metric: Optional[Any] = None,
+        index_metric: Optional[Any] = None,
+        completion_fields: Optional[Any] = None,
+        fielddata_fields: Optional[Any] = None,
+        fields: Optional[Any] = None,
+        groups: Optional[Any] = None,
+        include_segment_file_sizes: Optional[Any] = None,
+        level: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        types: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/rollup.pyi
+++ b/elasticsearch/client/rollup.pyi
@@ -1,0 +1,67 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class RollupClient(NamespacedClient):
+    def delete_job(
+        self,
+        *,
+        id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_jobs(
+        self,
+        *,
+        id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_rollup_caps(
+        self,
+        *,
+        id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_rollup_index_caps(
+        self,
+        *,
+        index: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_job(
+        self,
+        *,
+        id: Any,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def rollup_search(
+        self,
+        *,
+        index: Any,
+        body: Any,
+        doc_type: Optional[Any] = None,
+        rest_total_hits_as_int: Optional[Any] = None,
+        typed_keys: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def start_job(
+        self,
+        *,
+        id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stop_job(
+        self,
+        *,
+        id: Any,
+        timeout: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/security.pyi
+++ b/elasticsearch/client/security.pyi
@@ -1,0 +1,207 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class SecurityClient(NamespacedClient):
+    def authenticate(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def change_password(
+        self,
+        *,
+        body: Any,
+        username: Optional[Any] = None,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def clear_cached_realms(
+        self,
+        *,
+        realms: Any,
+        usernames: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def clear_cached_roles(
+        self,
+        *,
+        name: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def create_api_key(
+        self,
+        *,
+        body: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_privileges(
+        self,
+        *,
+        application: Any,
+        name: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_role(
+        self,
+        *,
+        name: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_role_mapping(
+        self,
+        *,
+        name: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_user(
+        self,
+        *,
+        username: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def disable_user(
+        self,
+        *,
+        username: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def enable_user(
+        self,
+        *,
+        username: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_api_key(
+        self,
+        *,
+        id: Optional[Any] = None,
+        name: Optional[Any] = None,
+        owner: Optional[Any] = None,
+        realm_name: Optional[Any] = None,
+        username: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_privileges(
+        self,
+        *,
+        application: Optional[Any] = None,
+        name: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_role(
+        self,
+        *,
+        name: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_role_mapping(
+        self,
+        *,
+        name: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_token(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_user(
+        self,
+        *,
+        username: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_user_privileges(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def has_privileges(
+        self,
+        *,
+        body: Any,
+        user: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def invalidate_api_key(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def invalidate_token(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_privileges(
+        self,
+        *,
+        body: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_role(
+        self,
+        *,
+        name: Any,
+        body: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_role_mapping(
+        self,
+        *,
+        name: Any,
+        body: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_user(
+        self,
+        *,
+        username: Any,
+        body: Any,
+        refresh: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_builtin_privileges(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/slm.py
+++ b/elasticsearch/client/slm.py
@@ -5,7 +5,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def delete_lifecycle(self, policy_id, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to
             remove
@@ -23,7 +23,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def execute_lifecycle(self, policy_id, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-lifecycle.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to be
             executed
@@ -51,7 +51,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def get_lifecycle(self, policy_id=None, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-policy.html>`_
 
         :arg policy_id: Comma-separated list of snapshot lifecycle
             policies to retrieve
@@ -66,7 +66,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def get_stats(self, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
 
         """
         return self.transport.perform_request(
@@ -76,7 +76,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def put_lifecycle(self, policy_id, body=None, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy
         :arg body: The snapshot lifecycle policy definition to register
@@ -95,7 +95,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def get_status(self, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-status.html>`_
 
         """
         return self.transport.perform_request(
@@ -105,7 +105,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def start(self, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-start.html>`_
 
         """
         return self.transport.perform_request(
@@ -115,7 +115,7 @@ class SlmClient(NamespacedClient):
     @query_params()
     def stop(self, params=None, headers=None):
         """
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-stop.html>`_
 
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/slm.pyi
+++ b/elasticsearch/client/slm.pyi
@@ -1,0 +1,63 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class SlmClient(NamespacedClient):
+    def delete_lifecycle(
+        self,
+        *,
+        policy_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def execute_lifecycle(
+        self,
+        *,
+        policy_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def execute_retention(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_lifecycle(
+        self,
+        *,
+        policy_id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_stats(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_lifecycle(
+        self,
+        *,
+        policy_id: Any,
+        body: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_status(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def start(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stop(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/snapshot.pyi
+++ b/elasticsearch/client/snapshot.pyi
@@ -1,0 +1,103 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class SnapshotClient(NamespacedClient):
+    def create(
+        self,
+        *,
+        repository: Any,
+        snapshot: Any,
+        body: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete(
+        self,
+        *,
+        repository: Any,
+        snapshot: Any,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get(
+        self,
+        *,
+        repository: Any,
+        snapshot: Any,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        verbose: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_repository(
+        self,
+        *,
+        repository: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_repository(
+        self,
+        *,
+        repository: Optional[Any] = None,
+        local: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def create_repository(
+        self,
+        *,
+        repository: Any,
+        body: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        verify: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def restore(
+        self,
+        *,
+        repository: Any,
+        snapshot: Any,
+        body: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def status(
+        self,
+        *,
+        repository: Optional[Any] = None,
+        snapshot: Optional[Any] = None,
+        ignore_unavailable: Optional[Any] = None,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def verify_repository(
+        self,
+        *,
+        repository: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def cleanup_repository(
+        self,
+        *,
+        repository: Any,
+        master_timeout: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/sql.pyi
+++ b/elasticsearch/client/sql.pyi
@@ -1,0 +1,26 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class SqlClient(NamespacedClient):
+    def clear_cursor(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def query(
+        self,
+        *,
+        body: Any,
+        format: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def translate(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/ssl.pyi
+++ b/elasticsearch/client/ssl.pyi
@@ -1,0 +1,10 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class SslClient(NamespacedClient):
+    def certificates(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/tasks.pyi
+++ b/elasticsearch/client/tasks.pyi
@@ -1,0 +1,36 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class TasksClient(NamespacedClient):
+    def list(
+        self,
+        *,
+        actions: Optional[Any] = None,
+        detailed: Optional[Any] = None,
+        group_by: Optional[Any] = None,
+        nodes: Optional[Any] = None,
+        parent_task_id: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def cancel(
+        self,
+        *,
+        task_id: Optional[Any] = None,
+        actions: Optional[Any] = None,
+        nodes: Optional[Any] = None,
+        parent_task_id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get(
+        self,
+        *,
+        task_id: Any,
+        timeout: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/transform.py
+++ b/elasticsearch/client/transform.py
@@ -137,7 +137,13 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "timeout", "wait_for_completion")
+    @query_params(
+        "allow_no_match",
+        "force",
+        "timeout",
+        "wait_for_checkpoint",
+        "wait_for_completion",
+    )
     def stop_transform(self, transform_id, params=None, headers=None):
         """
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html>`_
@@ -146,8 +152,12 @@ class TransformClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no transforms. (This includes `_all` string or when no
             transforms have been specified)
+        :arg force: Whether to force stop a failed transform or not.
+            Default to false
         :arg timeout: Controls the time to wait until the transform has
             stopped. Default to 30 seconds
+        :arg wait_for_checkpoint: Whether to wait for the transform to
+            reach a checkpoint before stopping. Default to false
         :arg wait_for_completion: Whether to wait for the transform to
             fully stop before returning or not. Default to false
         """

--- a/elasticsearch/client/transform.pyi
+++ b/elasticsearch/client/transform.pyi
@@ -1,0 +1,77 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class TransformClient(NamespacedClient):
+    def delete_transform(
+        self,
+        *,
+        transform_id: Any,
+        force: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_transform(
+        self,
+        *,
+        transform_id: Optional[Any] = None,
+        allow_no_match: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_transform_stats(
+        self,
+        *,
+        transform_id: Any,
+        allow_no_match: Optional[Any] = None,
+        from_: Optional[Any] = None,
+        size: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def preview_transform(
+        self,
+        *,
+        body: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_transform(
+        self,
+        *,
+        transform_id: Any,
+        body: Any,
+        defer_validation: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def start_transform(
+        self,
+        *,
+        transform_id: Any,
+        timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stop_transform(
+        self,
+        *,
+        transform_id: Any,
+        allow_no_match: Optional[Any] = None,
+        force: Optional[Any] = None,
+        timeout: Optional[Any] = None,
+        wait_for_checkpoint: Optional[Any] = None,
+        wait_for_completion: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def update_transform(
+        self,
+        *,
+        transform_id: Any,
+        body: Any,
+        defer_validation: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/watcher.pyi
+++ b/elasticsearch/client/watcher.pyi
@@ -1,0 +1,81 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class WatcherClient(NamespacedClient):
+    def ack_watch(
+        self,
+        *,
+        watch_id: Any,
+        action_id: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def activate_watch(
+        self,
+        *,
+        watch_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def deactivate_watch(
+        self,
+        *,
+        watch_id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def delete_watch(
+        self,
+        *,
+        id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def execute_watch(
+        self,
+        *,
+        body: Optional[Any] = None,
+        id: Optional[Any] = None,
+        debug: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def get_watch(
+        self,
+        *,
+        id: Any,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def put_watch(
+        self,
+        *,
+        id: Any,
+        body: Optional[Any] = None,
+        active: Optional[Any] = None,
+        if_primary_term: Optional[Any] = None,
+        if_seq_no: Optional[Any] = None,
+        version: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def start(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stats(
+        self,
+        *,
+        metric: Optional[Any] = None,
+        emit_stacktraces: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def stop(
+        self,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/elasticsearch/client/xpack.py
+++ b/elasticsearch/client/xpack.py
@@ -21,7 +21,7 @@ class XPackClient(NamespacedClient):
     @query_params("master_timeout")
     def usage(self, params=None, headers=None):
         """
-        `<Retrieve information about xpack features usage>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/current/usage-api.html>`_
 
         :arg master_timeout: Specify timeout for watch write operation
         """

--- a/elasticsearch/client/xpack.pyi
+++ b/elasticsearch/client/xpack.pyi
@@ -1,0 +1,21 @@
+from typing import Any, Optional, Mapping
+from .utils import NamespacedClient
+
+class XPackClient(NamespacedClient):
+    def __getattr__(self, attr_name):
+        return getattr(self.client, attr_name)
+    # AUTO-GENERATED-API-DEFINITIONS #
+    def info(
+        self,
+        *,
+        categories: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...
+    def usage(
+        self,
+        *,
+        master_timeout: Optional[Any] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Any: ...

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     maintainer="Seth Michael Larson",
     maintainer_email="seth.larson@elastic.co",
     packages=find_packages(where=".", exclude=("test_elasticsearch*",)),
+    package_data={"elasticsearch": ["py.typed"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",

--- a/utils/templates/base_pyi
+++ b/utils/templates/base_pyi
@@ -1,0 +1,3 @@
+
+    def {{ api.name }}(self, {% include "func_params_pyi" %}) -> Any:
+        ...

--- a/utils/templates/func_params_pyi
+++ b/utils/templates/func_params_pyi
@@ -1,0 +1,20 @@
+*,
+
+{% for p, info in api.all_parts.items() %}
+  {% if info.required %}{{ p }}: Any, {% endif %}
+{% endfor %}
+
+{% if api.body %}
+  body:{% if not api.body.required %} Optional[Any]=None{% else %} Any{% endif %},
+{% endif %}
+
+{% for p, info in api.all_parts.items() %}
+  {% if not info.required %}{{ p }}: Optional[Any]=None, {% endif %}
+{% endfor %}
+
+{% for p in api.query_params %}
+  {{ p }}: Optional[Any]=None,
+{% endfor %}
+
+params: Optional[Mapping[str, str]]=None,
+headers: Optional[Mapping[str, str]]=None


### PR DESCRIPTION
This will allow us to overcome the issue with `query_params` in that it cloaks the signature of each API function when it comes to query params. Also nowadays Python libraries are moving towards type checking and the community will start desiring this functionality.

Using type stubs means we don't have to break Python 2 support as inline type hints are only possible in 3.6+

TODO:
- [ ] Verify everything works as expected with an IDE
- [ ] Document type-checkability as well as 
- [ ] Pull type information from REST API spec
- [ ] Create stubs for all non-generated APIs
- [ ] Test the implementation with mypy, pyre, etc
- [ ] Add type checking to CI