### PR TITLE
Release v7.6.0a1

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,25 @@
 Changelog
 =========
 
+7.6.0a1 (2020-03-13)
+------------------
+  * Added support for ES 7.6 APIs
+  * Added support for `X-Opaque-Id`_ to identify long-running tasks
+  * Added support for HTTP compression to ``RequestsHttpConnection``
+  * Updated default setting of ``http_compress`` when using ``cloud_id`` to ``True``
+  * Updated default setting of ``sniffing`` when using ``cloud_id`` to ``False``
+  * Updated default port to ``443`` if ``cloud_id`` and no other port is defined
+    on the client or within ``cloud_id``
+  * Fix regression of ``client.cluster.state()`` where the default ``metric``
+    should be set to ``"_all"`` if an index is given (See `#1143`_)
+  * Fix regression of ``client.tasks.get()`` without a ``task_id``
+    having similar functionality to ``client.tasks.list()`` This will
+    be removed in ``v8.0`` of ``elasticsearch-py`` (See `#1157`_)
+
+  .. _X-Opaque-Id: https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html#_identifying_running_tasks
+  .. _#1143: https://github.com/elastic/elasticsearch-py/pull/1143
+  .. _#1157: https://github.com/elastic/elasticsearch-py/pull/1157
+
 7.5.1 (2020-01-19)
 ------------------
   * ``7.5.0`` tag was not released so retagging

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include README
 include tox.ini
 include setup.py
 recursive-include docs *
+recursive-exclude docs/examples *
 
 prune docs/_build
 prune test_elasticsearch

--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from __future__ import absolute_import
 
-VERSION = (7, 5, 1)
+VERSION = (7, 6, 0)
 __version__ = VERSION
 __versionstr__ = ".".join(map(str, VERSION))
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from os.path import join, dirname
 from setuptools import setup, find_packages
 import sys
 
-VERSION = (7, 5, 1)
+VERSION = (7, 6, 0)
 __version__ = VERSION
-__versionstr__ = ".".join(map(str, VERSION))
+__versionstr__ = "7.6.0a1"
 
 with open(join(dirname(__file__), "README")) as f:
     long_description = f.read().strip()


### PR DESCRIPTION
As far as I can tell this package hasn't done an alpha release, I've kept the `__versionstr__` exactly equal to the package version while leaving `__version__` a comparable tuple.