### PR TITLE
Remove duplicate argument

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -434,8 +434,6 @@ class Elasticsearch(object):
             the returned _source field, can be overridden on each sub-request
         :arg _source_includes: Default list of fields to extract and
             return from the _source field, can be overridden on each sub-request
-        :arg doc_type: Default document type for items which don't
-            provide one
         :arg pipeline: The pipeline id to preprocess incoming documents
             with
         :arg refresh: If `true` then refresh the effected shards to make


### PR DESCRIPTION
Looking at the [documentation](https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.bulk), `doc_type` is listed twice for the `bulk` function

![Duplicate doc_type](https://static.easir.com/morten/Screen-Shot-2020-03-19-10-37-27-1584610667.png)