### PR TITLE
Prepare release of v6.8.1

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+6.8.1 (2020-03-31)
+------------------
+  * Added support for serializing ``numpy`` and ``pandas``
+    data types to ``JSONSerializer``. (See `#1180`_)
+  * Fixed a namespace conflict in ``elasticsearch6`` wheel
+    distribution for ``v6.8.0`` (See `#1186`_)
+
+  .. _#1180: https://github.com/elastic/elasticsearch-py/issues/1180
+  .. _#1186: https://github.com/elastic/elasticsearch-py/issues/1186
+
 6.8.0 (2020-03-12)
 -----------
   * Added support for HTTP compression to ``RequestsHttpConnection``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -43,7 +44,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Elasticsearch"
-copyright = u"2013, Honza Král"
+copyright = u"%d, Elasticsearch B.V." % datetime.date.today().year
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from __future__ import absolute_import
 
-VERSION = (6, 8, 0)
+VERSION = (6, 8, 1)
 __version__ = VERSION
 __versionstr__ = ".".join(map(str, VERSION))
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 from setuptools import setup, find_packages
 import sys
 
-VERSION = (6, 8, 0)
+VERSION = (6, 8, 1)
 __version__ = VERSION
 __versionstr__ = ".".join(map(str, VERSION))
 


### PR DESCRIPTION
Found an issue with the `elasticsearch6` wheel distribution for v6.8.0 where it contained both the `elasticsearch` and `elasticsearch6` namespace.

Closes #1186 