### PR TITLE
Allow bytestring for bulk body

### DIFF
--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -102,8 +102,9 @@ def _bulk_body(serializer, body):
         body = "\n".join(map(serializer.dumps, body))
 
     # bulk body must end with a newline
-    if isinstance(body, bytes) and not body.endswith(b"\n"):
-        body += b"\n"
+    if isinstance(body, bytes):
+        if not body.endswith(b"\n"):
+            body += b"\n"
     elif isinstance(body, string_types) and not body.endswith("\n"):
         body += "\n"
 

--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -104,7 +104,7 @@ def _bulk_body(serializer, body):
     # bulk body must end with a newline
     if isinstance(body, bytes) and not body.endswith(b"\n"):
         body += b"\n"
-    elif isinstance(body, str) and not body.endswith("\n"):
+    elif isinstance(body, string_types) and not body.endswith("\n"):
         body += "\n"
 
     return body

--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -102,7 +102,9 @@ def _bulk_body(serializer, body):
         body = "\n".join(map(serializer.dumps, body))
 
     # bulk body must end with a newline
-    if not body.endswith("\n"):
+    if isinstance(body, bytes) and not body.endswith(b"\n"):
+        body += b"\n"
+    elif isinstance(body, str) and not body.endswith("\n"):
         body += "\n"
 
     return body

--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from elasticsearch.client.utils import _make_path, _escape, query_params
+from elasticsearch.client.utils import _bulk_body, _make_path, _escape, query_params
 from elasticsearch.compat import PY2
 
 from ..test_cases import TestCase, SkipTest
@@ -71,3 +71,21 @@ class TestEscape(TestCase):
     def test_handles_bytestring(self):
         string = b"celery-task-meta-c4f1201f-eb7b-41d5-9318-a75a8cfbdaa0"
         self.assertEquals(string, _escape(string))
+
+
+class TestBulkBody(TestCase):
+    def test_proper_bulk_body_as_string_is_not_modified(self):
+        string_body = '"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n'
+        self.assertEqual(string_body, _bulk_body(None, string_body))
+
+    def test_proper_bulk_body_as_bytestring_is_not_modified(self):
+        bytestring_body = b'"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n'
+        self.assertEqual(bytestring_body, _bulk_body(None, bytestring_body))
+
+    def test_bulk_body_as_string_adds_trailing_newline(self):
+        string_body = '"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"'
+        self.assertEqual('"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n', _bulk_body(None, string_body))
+
+    def test_bulk_body_as_bytestring_adds_trailing_newline(self):
+        bytestring_body = b'"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"'
+        self.assertEqual(b'"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n', _bulk_body(None, bytestring_body))

--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -84,8 +84,14 @@ class TestBulkBody(TestCase):
 
     def test_bulk_body_as_string_adds_trailing_newline(self):
         string_body = '"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"'
-        self.assertEqual('"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n', _bulk_body(None, string_body))
+        self.assertEqual(
+            '"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n',
+            _bulk_body(None, string_body),
+        )
 
     def test_bulk_body_as_bytestring_adds_trailing_newline(self):
         bytestring_body = b'"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"'
-        self.assertEqual(b'"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n', _bulk_body(None, bytestring_body))
+        self.assertEqual(
+            b'"{"index":{ "_index" : "test"}}\n{"field1": "value1"}"\n',
+            _bulk_body(None, bytestring_body),
+        )

--- a/test_elasticsearch/test_server/test_client.py
+++ b/test_elasticsearch/test_server/test_client.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from . import ElasticsearchTestCase
-
-
-class TestUnicode(ElasticsearchTestCase):
-    def test_indices_analyze(self):
-        self.client.indices.analyze(body='{"text": "привет"}')

--- a/test_elasticsearch/test_server/test_clients.py
+++ b/test_elasticsearch/test_server/test_clients.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from . import ElasticsearchTestCase
+
+
+class TestUnicode(ElasticsearchTestCase):
+    def test_indices_analyze(self):
+        self.client.indices.analyze(body='{"text": "привет"}')
+
+
+class TestBulk(ElasticsearchTestCase):
+    def test_bulk_works_with_string_body(self):
+        docs = '{ "index" : { "_index" : "bulk_test_index", "_id" : "1" } }\n{"answer": 42}'
+        response = self.client.bulk(body=docs)
+
+        self.assertFalse(response["errors"])
+        self.assertEqual(1, len(response["items"]))
+
+    def test_bulk_works_with_bytestring_body(self):
+        docs = b'{ "index" : { "_index" : "bulk_test_index", "_id" : "2" } }\n{"answer": 42}'
+        response = self.client.bulk(body=docs)
+
+        self.assertFalse(response["errors"])
+        self.assertEqual(1, len(response["items"]))


### PR DESCRIPTION
With this commit we allow users to pass bytestrings for bulk bodies.
This was already allowed previously but the client attempted to ensure a
trailing newline which failed for bytestrings.

Closes #919