### PR TITLE
Fix docs

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -653,7 +653,7 @@ class Elasticsearch(object):
         :arg expand_wildcards: Whether to expand wildcard expression to
             concrete indices that are open, closed or both.  Valid choices: open,
             closed, hidden, none, all  Default: open
-        :arg from_: Starting offset (default: 0)
+        :arg from\\_: Starting offset (default: 0)
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg lenient: Specify whether format-based query failures (such
@@ -1408,7 +1408,7 @@ class Elasticsearch(object):
             closed, hidden, none, all  Default: open
         :arg explain: Specify whether to return detailed information
             about score computation as part of a hit
-        :arg from_: Starting offset (default: 0)
+        :arg from\\_: Starting offset (default: 0)
         :arg ignore_throttled: Whether specified concrete, expanded or
             aliased indices should be ignored when throttled
         :arg ignore_unavailable: Whether specified concrete indices
@@ -1904,7 +1904,7 @@ class Elasticsearch(object):
         :arg expand_wildcards: Whether to expand wildcard expression to
             concrete indices that are open, closed or both.  Valid choices: open,
             closed, hidden, none, all  Default: open
-        :arg from_: Starting offset (default: 0)
+        :arg from\\_: Starting offset (default: 0)
         :arg ignore_unavailable: Whether specified concrete indices
             should be ignored when unavailable (missing or closed)
         :arg lenient: Specify whether format-based query failures (such

--- a/elasticsearch/client/async_search.py
+++ b/elasticsearch/client/async_search.py
@@ -121,7 +121,7 @@ class AsyncSearchClient(NamespacedClient):
             closed, hidden, none, all  Default: open
         :arg explain: Specify whether to return detailed information
             about score computation as part of a hit
-        :arg from_: Starting offset (default: 0)
+        :arg from\\_: Starting offset (default: 0)
         :arg ignore_throttled: Whether specified concrete, expanded or
             aliased indices should be ignored when throttled
         :arg ignore_unavailable: Whether specified concrete indices

--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -649,7 +649,7 @@ class CatClient(NamespacedClient):
             choices: b, k, kb, m, mb, g, gb, t, tb, p, pb
         :arg format: a short version of the Accept header, e.g. json,
             yaml
-        :arg from_: skips a number of trained models
+        :arg from\\_: skips a number of trained models
         :arg h: Comma-separated list of column names to display
         :arg help: Return help information
         :arg s: Comma-separated list of column names or column aliases
@@ -686,7 +686,7 @@ class CatClient(NamespacedClient):
             transforms have been specified)
         :arg format: a short version of the Accept header, e.g. json,
             yaml
-        :arg from_: skips a number of transform configs, defaults to 0
+        :arg from\\_: skips a number of transform configs, defaults to 0
         :arg h: Comma-separated list of column names to display
         :arg help: Return help information
         :arg s: Comma-separated list of column names or column aliases

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -348,7 +348,7 @@ class MlClient(NamespacedClient):
         :arg end: End time filter for buckets
         :arg exclude_interim: Exclude interim results
         :arg expand: Include anomaly records
-        :arg from_: skips a number of buckets
+        :arg from\\_: skips a number of buckets
         :arg size: specifies a max number of buckets to get
         :arg sort: Sort buckets by a particular field
         :arg start: Start time filter for buckets
@@ -378,7 +378,7 @@ class MlClient(NamespacedClient):
 
         :arg calendar_id: The ID of the calendar containing the events
         :arg end: Get events before this time
-        :arg from_: Skips a number of events
+        :arg from\\_: Skips a number of events
         :arg job_id: Get events for the job. When this option is used
             calendar_id must be '_all'
         :arg size: Specifies a max number of events to get
@@ -409,7 +409,7 @@ class MlClient(NamespacedClient):
         :arg body: The from and size parameters optionally sent in the
             body
         :arg calendar_id: The ID of the calendar to fetch
-        :arg from_: skips a number of calendars
+        :arg from\\_: skips a number of calendars
         :arg size: specifies a max number of calendars to get
         """
         # from is a reserved word so it cannot be used, use from_ instead
@@ -467,7 +467,7 @@ class MlClient(NamespacedClient):
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html>`_
 
         :arg filter_id: The ID of the filter to fetch
-        :arg from_: skips a number of filters
+        :arg from\\_: skips a number of filters
         :arg size: specifies a max number of filters to get
         """
         # from is a reserved word so it cannot be used, use from_ instead
@@ -502,7 +502,7 @@ class MlClient(NamespacedClient):
             order
         :arg end: end timestamp for the requested influencers
         :arg exclude_interim: Exclude interim results
-        :arg from_: skips a number of influencers
+        :arg from\\_: skips a number of influencers
         :arg influencer_score: influencer score threshold for the
             requested influencers
         :arg size: specifies a max number of influencers to get
@@ -628,7 +628,7 @@ class MlClient(NamespacedClient):
         :arg desc: Set the sort direction
         :arg end: End time filter for records
         :arg exclude_interim: Exclude interim results
-        :arg from_: skips a number of records
+        :arg from\\_: skips a number of records
         :arg record_score: Returns records with anomaly scores greater
             or equal than this value
         :arg size: specifies a max number of records to get
@@ -1088,7 +1088,7 @@ class MlClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no data frame analytics. (This includes `_all` string or when no
             data frame analytics have been specified)  Default: True
-        :arg from_: skips a number of analytics
+        :arg from\\_: skips a number of analytics
         :arg size: specifies a max number of analytics to get  Default:
             100
         """
@@ -1113,7 +1113,7 @@ class MlClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no data frame analytics. (This includes `_all` string or when no
             data frame analytics have been specified)  Default: True
-        :arg from_: skips a number of analytics
+        :arg from\\_: skips a number of analytics
         :arg size: specifies a max number of analytics to get  Default:
             100
         """
@@ -1237,7 +1237,7 @@ class MlClient(NamespacedClient):
         :arg decompress_definition: Should the model definition be
             decompressed into valid JSON or returned in a custom compressed format.
             Defaults to true.  Default: True
-        :arg from_: skips a number of trained models
+        :arg from\\_: skips a number of trained models
         :arg include_model_definition: Should the full model definition
             be included in the results. These definitions can be large. So be
             cautious when including them. Defaults to false.
@@ -1267,7 +1267,7 @@ class MlClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no trained models. (This includes `_all` string or when no
             trained models have been specified)  Default: True
-        :arg from_: skips a number of trained models
+        :arg from\\_: skips a number of trained models
         :arg size: specifies a max number of trained models to get
             Default: 100
         """
@@ -1354,7 +1354,7 @@ class MlClient(NamespacedClient):
         :arg body: Category selection details if not provided in URI
         :arg category_id: The identifier of the category definition of
             interest
-        :arg from_: skips a number of categories
+        :arg from\\_: skips a number of categories
         :arg size: specifies a max number of categories to get
         """
         # from is a reserved word so it cannot be used, use from_ instead
@@ -1388,7 +1388,7 @@ class MlClient(NamespacedClient):
         :arg desc: True if the results should be sorted in descending
             order
         :arg end: The filter 'end' query parameter
-        :arg from_: Skips a number of documents
+        :arg from\\_: Skips a number of documents
         :arg size: The default number of documents returned in queries
             as a string.
         :arg sort: Name of the field to sort on

--- a/elasticsearch/client/transform.py
+++ b/elasticsearch/client/transform.py
@@ -37,7 +37,7 @@ class TransformClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no transforms. (This includes `_all` string or when no
             transforms have been specified)
-        :arg from_: skips a number of transform configs, defaults to 0
+        :arg from\\_: skips a number of transform configs, defaults to 0
         :arg size: specifies a max number of transforms to get, defaults
             to 100
         """
@@ -63,7 +63,7 @@ class TransformClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no transforms. (This includes `_all` string or when no
             transforms have been specified)
-        :arg from_: skips a number of transform stats, defaults to 0
+        :arg from\\_: skips a number of transform stats, defaults to 0
         :arg size: specifies a max number of transform stats to get,
             defaults to 100
         """

--- a/utils/templates/base
+++ b/utils/templates/base
@@ -12,7 +12,7 @@
 
         {% for p, info in api.params %}
         {% filter wordwrap(72, wrapstring="\n            ") %}
-        :arg {{ p }}: {{ info.description }} {% if info.options %}  Valid choices: {{ info.options|join(", ") }}{% endif %} {% if info.default %}  Default: {{ info.default }}{% endif %}
+        :arg {{ 'from\\\\_' if p == 'from_' else p }}: {{ info.description }} {% if info.options %}  Valid choices: {{ info.options|join(", ") }}{% endif %} {% if info.default %}  Default: {{ info.default }}{% endif %}
         {% endfilter %}
 
         {% endfor %}


### PR DESCRIPTION
This PR attempts to close issue #1196

As discussed in the issue, `from` is a reserved Python keyword, and parameters are passed with `from_` to avoid a syntax error. See a example below:

https://github.com/elastic/elasticsearch-py/blob/7dec9e3dbaabb2b7cc5cdb1a49370c89de72fa12/elasticsearch/client/__init__.py#L702-L704

Docs were not rendering the `_` underscore character and it would causes a syntax error if you use `from` instead of `from_`.

To correcly output underscore character it just needs a `\` before it.

Resume of changes:
- Change inside the utils/ directory as all of the code including docstrings under elasticsearch/clients/ is generated from utils/generate_api.py

Hope it helps :)