### PR TITLE
fix params is None, avoid raising AttributeError

### DIFF
--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -71,7 +71,7 @@ def query_params(*es_query_params):
             params = {}
             headers = {}
             if "params" in kwargs:
-                params = kwargs.pop("params").copy()
+                params = (kwargs.pop("params") or params).copy()
             if "headers" in kwargs:
                 headers = {
                     k.lower(): v for k, v in (kwargs.pop("headers") or {}).items()


### PR DESCRIPTION
fix params is None, avoid raising AttributeError:'NoneType' object has no attribute 'copy'