### PR TITLE
[7.x] Allow for passing params=None or headers=None

### DIFF
--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -68,14 +68,12 @@ def query_params(*es_query_params):
     def _wrapper(func):
         @wraps(func)
         def _wrapped(*args, **kwargs):
-            params = {}
-            headers = {}
-            if "params" in kwargs:
-                params = kwargs.pop("params").copy()
-            if "headers" in kwargs:
-                headers = {
-                    k.lower(): v for k, v in (kwargs.pop("headers") or {}).items()
-                }
+            params = (kwargs.pop("params", None) or {}).copy()
+            headers = {
+                k.lower(): v
+                for k, v in (kwargs.pop("headers", None) or {}).copy().items()
+            }
+
             if "opaque_id" in kwargs:
                 headers["x-opaque-id"] = kwargs.pop("opaque_id")
 

--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -42,6 +42,22 @@ class TestQueryParams(TestCase):
             self.calls, [((), {"params": {}, "headers": {"x-opaque-id": "request-id"}})]
         )
 
+    def test_handles_empty_none_and_normalization(self):
+        self.func_to_wrap(params=None)
+        self.assertEqual(self.calls[-1], ((), {"params": {}, "headers": {}}))
+
+        self.func_to_wrap(headers=None)
+        self.assertEqual(self.calls[-1], ((), {"params": {}, "headers": {}}))
+
+        self.func_to_wrap(headers=None, params=None)
+        self.assertEqual(self.calls[-1], ((), {"params": {}, "headers": {}}))
+
+        self.func_to_wrap(headers={}, params={})
+        self.assertEqual(self.calls[-1], ((), {"params": {}, "headers": {}}))
+
+        self.func_to_wrap(headers={"X": "y"})
+        self.assertEqual(self.calls[-1], ((), {"params": {}, "headers": {"x": "y"}}))
+
 
 class TestMakePath(TestCase):
     def test_handles_unicode(self):


### PR DESCRIPTION
Backported from cc96b0723bb53206a5b3b0bb7ea6439a7eef769a