### PR TITLE
Change assertEquals -> assertEqual

### DIFF
--- a/test_elasticsearch/test_cases.py
+++ b/test_elasticsearch/test_cases.py
@@ -26,12 +26,12 @@ class ElasticsearchTestCase(TestCase):
         self.client = Elasticsearch(transport_class=DummyTransport)
 
     def assert_call_count_equals(self, count):
-        self.assertEquals(count, self.client.transport.call_count)
+        self.assertEqual(count, self.client.transport.call_count)
 
     def assert_url_called(self, method, url, count=1):
         self.assertIn((method, url), self.client.transport.calls)
         calls = self.client.transport.calls[(method, url)]
-        self.assertEquals(count, len(calls))
+        self.assertEqual(count, len(calls))
         return calls
 
 
@@ -46,6 +46,6 @@ class TestElasticsearchTestCase(ElasticsearchTestCase):
         self.client.transport.perform_request("GET", "/")
         self.client.transport.perform_request("DELETE", "/42", params={}, body="body")
         self.assert_call_count_equals(2)
-        self.assertEquals(
+        self.assertEqual(
             [({}, None, "body")], self.assert_url_called("DELETE", "/42", 1)
         )

--- a/test_elasticsearch/test_client/__init__.py
+++ b/test_elasticsearch/test_client/__init__.py
@@ -7,13 +7,13 @@ from ..test_cases import TestCase, ElasticsearchTestCase
 
 class TestNormalizeHosts(TestCase):
     def test_none_uses_defaults(self):
-        self.assertEquals([{}], _normalize_hosts(None))
+        self.assertEqual([{}], _normalize_hosts(None))
 
     def test_strings_are_used_as_hostnames(self):
-        self.assertEquals([{"host": "elastic.co"}], _normalize_hosts(["elastic.co"]))
+        self.assertEqual([{"host": "elastic.co"}], _normalize_hosts(["elastic.co"]))
 
     def test_strings_are_parsed_for_port_and_user(self):
-        self.assertEquals(
+        self.assertEqual(
             [
                 {"host": "elastic.co", "port": 42},
                 {"host": "elastic.co", "http_auth": "user:secre]"},
@@ -22,7 +22,7 @@ class TestNormalizeHosts(TestCase):
         )
 
     def test_strings_are_parsed_for_scheme(self):
-        self.assertEquals(
+        self.assertEqual(
             [
                 {"host": "elastic.co", "port": 42, "use_ssl": True},
                 {
@@ -39,20 +39,20 @@ class TestNormalizeHosts(TestCase):
         )
 
     def test_dicts_are_left_unchanged(self):
-        self.assertEquals(
+        self.assertEqual(
             [{"host": "local", "extra": 123}],
             _normalize_hosts([{"host": "local", "extra": 123}]),
         )
 
     def test_single_string_is_wrapped_in_list(self):
-        self.assertEquals([{"host": "elastic.co"}], _normalize_hosts("elastic.co"))
+        self.assertEqual([{"host": "elastic.co"}], _normalize_hosts("elastic.co"))
 
 
 class TestClient(ElasticsearchTestCase):
     def test_request_timeout_is_passed_through_unescaped(self):
         self.client.ping(request_timeout=0.1)
         calls = self.assert_url_called("HEAD", "/")
-        self.assertEquals([({"request_timeout": 0.1}, {}, None)], calls)
+        self.assertEqual([({"request_timeout": 0.1}, {}, None)], calls)
 
     def test_params_is_copied_when(self):
         rt = object()
@@ -60,7 +60,7 @@ class TestClient(ElasticsearchTestCase):
         self.client.ping(params=params)
         self.client.ping(params=params)
         calls = self.assert_url_called("HEAD", "/", 2)
-        self.assertEquals(
+        self.assertEqual(
             [({"request_timeout": rt}, {}, None), ({"request_timeout": rt}, {}, None)],
             calls,
         )
@@ -72,7 +72,7 @@ class TestClient(ElasticsearchTestCase):
         self.client.ping(headers=headers)
         self.client.ping(headers=headers)
         calls = self.assert_url_called("HEAD", "/", 2)
-        self.assertEquals(
+        self.assertEqual(
             [({}, {"authentication": hv}, None), ({}, {"authentication": hv}, None)],
             calls,
         )
@@ -81,10 +81,10 @@ class TestClient(ElasticsearchTestCase):
     def test_from_in_search(self):
         self.client.search(index="i", from_=10)
         calls = self.assert_url_called("POST", "/i/_search")
-        self.assertEquals([({"from": "10"}, {}, None)], calls)
+        self.assertEqual([({"from": "10"}, {}, None)], calls)
 
     def test_repr_contains_hosts(self):
-        self.assertEquals("<Elasticsearch([{}])>", repr(self.client))
+        self.assertEqual("<Elasticsearch([{}])>", repr(self.client))
 
     def test_repr_subclass(self):
         class OtherElasticsearch(Elasticsearch):

--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -62,7 +62,7 @@ class TestQueryParams(TestCase):
 class TestMakePath(TestCase):
     def test_handles_unicode(self):
         id = "中文"
-        self.assertEquals(
+        self.assertEqual(
             "/some-index/type/%E4%B8%AD%E6%96%87", _make_path("some-index", "type", id)
         )
 
@@ -70,7 +70,7 @@ class TestMakePath(TestCase):
         if not PY2:
             raise SkipTest("Only relevant for py2")
         id = "中文".encode("utf-8")
-        self.assertEquals(
+        self.assertEqual(
             "/some-index/type/%E4%B8%AD%E6%96%87", _make_path("some-index", "type", id)
         )
 
@@ -78,15 +78,15 @@ class TestMakePath(TestCase):
 class TestEscape(TestCase):
     def test_handles_ascii(self):
         string = "abc123"
-        self.assertEquals(b"abc123", _escape(string))
+        self.assertEqual(b"abc123", _escape(string))
 
     def test_handles_unicode(self):
         string = "中文"
-        self.assertEquals(b"\xe4\xb8\xad\xe6\x96\x87", _escape(string))
+        self.assertEqual(b"\xe4\xb8\xad\xe6\x96\x87", _escape(string))
 
     def test_handles_bytestring(self):
         string = b"celery-task-meta-c4f1201f-eb7b-41d5-9318-a75a8cfbdaa0"
-        self.assertEquals(string, _escape(string))
+        self.assertEqual(string, _escape(string))
 
 
 class TestBulkBody(TestCase):

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -94,7 +94,7 @@ class TestBaseConnection(TestCase):
             con._raise_warnings(())
             con._raise_warnings([])
 
-        self.assertEquals(w, [])
+        self.assertEqual(w, [])
 
     def test_raises_warnings(self):
         con = Connection()
@@ -102,7 +102,7 @@ class TestBaseConnection(TestCase):
         with warnings.catch_warnings(record=True) as warn:
             con._raise_warnings(['299 Elasticsearch-7.6.1-aa751 "this is deprecated"'])
 
-        self.assertEquals([str(w.message) for w in warn], ["this is deprecated"])
+        self.assertEqual([str(w.message) for w in warn], ["this is deprecated"])
 
         with warnings.catch_warnings(record=True) as warn:
             con._raise_warnings(
@@ -113,7 +113,7 @@ class TestBaseConnection(TestCase):
                 ]
             )
 
-        self.assertEquals(
+        self.assertEqual(
             [str(w.message) for w in warn],
             ["this is also deprecated", "guess what? deprecated"],
         )
@@ -128,7 +128,7 @@ class TestBaseConnection(TestCase):
                 ]
             )
 
-        self.assertEquals([str(w.message) for w in warn], ["warning", "folded"])
+        self.assertEqual([str(w.message) for w in warn], ["warning", "folded"])
 
 
 class TestUrllib3Connection(TestCase):
@@ -171,11 +171,11 @@ class TestUrllib3Connection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng=="
         )
         self.assertTrue(con.use_ssl)
-        self.assertEquals(
+        self.assertEqual(
             con.host, "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
-        self.assertEquals(con.port, None)
-        self.assertEquals(
+        self.assertEqual(con.port, None)
+        self.assertEqual(
             con.hostname, "4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
         self.assertTrue(con.http_compress)
@@ -184,12 +184,12 @@ class TestUrllib3Connection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             port=9243,
         )
-        self.assertEquals(
+        self.assertEqual(
             con.host,
             "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io:9243",
         )
-        self.assertEquals(con.port, 9243)
-        self.assertEquals(
+        self.assertEqual(con.port, 9243)
+        self.assertEqual(
             con.hostname, "4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
 
@@ -199,10 +199,10 @@ class TestUrllib3Connection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             api_key=("elastic", "changeme1"),
         )
-        self.assertEquals(
+        self.assertEqual(
             con.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTE="
         )
-        self.assertEquals(
+        self.assertEqual(
             con.host, "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
 
@@ -211,10 +211,10 @@ class TestUrllib3Connection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             api_key="ZWxhc3RpYzpjaGFuZ2VtZTI=",
         )
-        self.assertEquals(
+        self.assertEqual(
             con.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTI="
         )
-        self.assertEquals(
+        self.assertEqual(
             con.host, "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
 
@@ -262,34 +262,34 @@ class TestUrllib3Connection(TestCase):
         con = Urllib3HttpConnection(
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
         )
-        self.assertEquals(con.http_compress, True)
+        self.assertEqual(con.http_compress, True)
 
         con = Urllib3HttpConnection(
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             http_compress=False,
         )
-        self.assertEquals(con.http_compress, False)
+        self.assertEqual(con.http_compress, False)
 
         con = Urllib3HttpConnection(
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             http_compress=True,
         )
-        self.assertEquals(con.http_compress, True)
+        self.assertEqual(con.http_compress, True)
 
     def test_default_user_agent(self):
         con = Urllib3HttpConnection()
-        self.assertEquals(
+        self.assertEqual(
             con._get_default_user_agent(),
             "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version()),
         )
 
     def test_timeout_set(self):
         con = Urllib3HttpConnection(timeout=42)
-        self.assertEquals(42, con.timeout)
+        self.assertEqual(42, con.timeout)
 
     def test_keep_alive_is_on_by_default(self):
         con = Urllib3HttpConnection()
-        self.assertEquals(
+        self.assertEqual(
             {
                 "connection": "keep-alive",
                 "content-type": "application/json",
@@ -300,7 +300,7 @@ class TestUrllib3Connection(TestCase):
 
     def test_http_auth(self):
         con = Urllib3HttpConnection(http_auth="username:secret")
-        self.assertEquals(
+        self.assertEqual(
             {
                 "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
                 "connection": "keep-alive",
@@ -312,7 +312,7 @@ class TestUrllib3Connection(TestCase):
 
     def test_http_auth_tuple(self):
         con = Urllib3HttpConnection(http_auth=("username", "secret"))
-        self.assertEquals(
+        self.assertEqual(
             {
                 "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
                 "content-type": "application/json",
@@ -324,7 +324,7 @@ class TestUrllib3Connection(TestCase):
 
     def test_http_auth_list(self):
         con = Urllib3HttpConnection(http_auth=["username", "secret"])
-        self.assertEquals(
+        self.assertEqual(
             {
                 "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
                 "content-type": "application/json",
@@ -337,8 +337,8 @@ class TestUrllib3Connection(TestCase):
     def test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
             con = Urllib3HttpConnection(use_ssl=True, verify_certs=False)
-            self.assertEquals(1, len(w))
-            self.assertEquals(
+            self.assertEqual(1, len(w))
+            self.assertEqual(
                 "Connecting to https://localhost:9200 using SSL with verify_certs=False is insecure.",
                 str(w[0].message),
             )
@@ -350,7 +350,7 @@ class TestUrllib3Connection(TestCase):
             con = Urllib3HttpConnection(
                 use_ssl=True, verify_certs=False, ssl_show_warn=False
             )
-            self.assertEquals(0, len(w))
+            self.assertEqual(0, len(w))
 
         self.assertIsInstance(con.pool, urllib3.HTTPSConnectionPool)
 
@@ -362,7 +362,7 @@ class TestUrllib3Connection(TestCase):
         ctx = ssl.create_default_context()
         with warnings.catch_warnings(record=True) as w:
             Urllib3HttpConnection(ssl_context=ctx)
-            self.assertEquals(0, len(w))
+            self.assertEqual(0, len(w))
 
     def test_warns_if_using_non_default_ssl_kwargs_with_ssl_context(self):
         for kwargs in (
@@ -380,8 +380,8 @@ class TestUrllib3Connection(TestCase):
 
                 Urllib3HttpConnection(**kwargs)
 
-                self.assertEquals(1, len(w))
-                self.assertEquals(
+                self.assertEqual(1, len(w))
+                self.assertEqual(
                     "When using `ssl_context`, all other SSL related kwargs are ignored",
                     str(w[0].message),
                 )
@@ -391,17 +391,17 @@ class TestUrllib3Connection(TestCase):
         con = self._get_mock_connection(connection_params={"http_compress": True})
         con.perform_request("GET", "/", body=b'{"example": "body"}')
 
-        self.assertEquals(2, logger.debug.call_count)
+        self.assertEqual(2, logger.debug.call_count)
         req, resp = logger.debug.call_args_list
 
-        self.assertEquals('> {"example": "body"}', req[0][0] % req[0][1:])
-        self.assertEquals("< {}", resp[0][0] % resp[0][1:])
+        self.assertEqual('> {"example": "body"}', req[0][0] % req[0][1:])
+        self.assertEqual("< {}", resp[0][0] % resp[0][1:])
 
     def test_surrogatepass_into_bytes(self):
         buf = b"\xe4\xbd\xa0\xe5\xa5\xbd\xed\xa9\xaa"
         con = self._get_mock_connection(response_body=buf)
         status, headers, data = con.perform_request("GET", "/")
-        self.assertEqual("你好\uda6a", data)
+        self.assertEqual(u"你好\uda6a", data)
 
 
 class TestRequestsConnection(TestCase):
@@ -428,24 +428,24 @@ class TestRequestsConnection(TestCase):
             kwargs["body"] = kwargs["body"].encode("utf-8")
 
         status, headers, data = connection.perform_request(*args, **kwargs)
-        self.assertEquals(200, status)
-        self.assertEquals("{}", data)
+        self.assertEqual(200, status)
+        self.assertEqual("{}", data)
 
         timeout = kwargs.pop("timeout", connection.timeout)
         args, kwargs = connection.session.send.call_args
-        self.assertEquals(timeout, kwargs["timeout"])
-        self.assertEquals(1, len(args))
+        self.assertEqual(timeout, kwargs["timeout"])
+        self.assertEqual(1, len(args))
         return args[0]
 
     def test_custom_http_auth_is_allowed(self):
         auth = AuthBase()
         c = RequestsHttpConnection(http_auth=auth)
 
-        self.assertEquals(auth, c.session.auth)
+        self.assertEqual(auth, c.session.auth)
 
     def test_timeout_set(self):
         con = RequestsHttpConnection(timeout=42)
-        self.assertEquals(42, con.timeout)
+        self.assertEqual(42, con.timeout)
 
     def test_opaque_id(self):
         con = RequestsHttpConnection(opaque_id="app-1")
@@ -456,11 +456,11 @@ class TestRequestsConnection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng=="
         )
         self.assertTrue(con.use_ssl)
-        self.assertEquals(
+        self.assertEqual(
             con.host, "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
-        self.assertEquals(con.port, None)
-        self.assertEquals(
+        self.assertEqual(con.port, None)
+        self.assertEqual(
             con.hostname, "4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
         self.assertTrue(con.http_compress)
@@ -469,12 +469,12 @@ class TestRequestsConnection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             port=9243,
         )
-        self.assertEquals(
+        self.assertEqual(
             con.host,
             "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io:9243",
         )
-        self.assertEquals(con.port, 9243)
-        self.assertEquals(
+        self.assertEqual(con.port, 9243)
+        self.assertEqual(
             con.hostname, "4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
 
@@ -484,10 +484,10 @@ class TestRequestsConnection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             api_key=("elastic", "changeme1"),
         )
-        self.assertEquals(
+        self.assertEqual(
             con.session.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTE="
         )
-        self.assertEquals(
+        self.assertEqual(
             con.host, "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
 
@@ -496,10 +496,10 @@ class TestRequestsConnection(TestCase):
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             api_key="ZWxhc3RpYzpjaGFuZ2VtZTI=",
         )
-        self.assertEquals(
+        self.assertEqual(
             con.session.headers["authorization"], "ApiKey ZWxhc3RpYzpjaGFuZ2VtZTI="
         )
-        self.assertEquals(
+        self.assertEqual(
             con.host, "https://4fa8821e75634032bed1cf22110e2f97.us-east-1.aws.found.io"
         )
 
@@ -542,36 +542,36 @@ class TestRequestsConnection(TestCase):
         con = RequestsHttpConnection(
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
         )
-        self.assertEquals(con.http_compress, True)
+        self.assertEqual(con.http_compress, True)
 
         con = RequestsHttpConnection(
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             http_compress=False,
         )
-        self.assertEquals(con.http_compress, False)
+        self.assertEqual(con.http_compress, False)
 
         con = RequestsHttpConnection(
             cloud_id="cluster:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5NyQ0ZmE4ODIxZTc1NjM0MDMyYmVkMWNmMjIxMTBlMmY5Ng==",
             http_compress=True,
         )
-        self.assertEquals(con.http_compress, True)
+        self.assertEqual(con.http_compress, True)
 
     def test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
             con = self._get_mock_connection(
                 {"use_ssl": True, "url_prefix": "url", "verify_certs": False}
             )
-            self.assertEquals(1, len(w))
-            self.assertEquals(
+            self.assertEqual(1, len(w))
+            self.assertEqual(
                 "Connecting to https://localhost:9200 using SSL with verify_certs=False is insecure.",
                 str(w[0].message),
             )
 
         request = self._get_request(con, "GET", "/")
 
-        self.assertEquals("https://localhost:9200/url/", request.url)
-        self.assertEquals("GET", request.method)
-        self.assertEquals(None, request.body)
+        self.assertEqual("https://localhost:9200/url/", request.url)
+        self.assertEqual("GET", request.method)
+        self.assertEqual(None, request.body)
 
     def nowarn_when_test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
@@ -583,28 +583,28 @@ class TestRequestsConnection(TestCase):
                     "ssl_show_warn": False,
                 }
             )
-            self.assertEquals(0, len(w))
+            self.assertEqual(0, len(w))
 
         request = self._get_request(con, "GET", "/")
 
-        self.assertEquals("https://localhost:9200/url/", request.url)
-        self.assertEquals("GET", request.method)
-        self.assertEquals(None, request.body)
+        self.assertEqual("https://localhost:9200/url/", request.url)
+        self.assertEqual("GET", request.method)
+        self.assertEqual(None, request.body)
 
     def test_merge_headers(self):
         con = self._get_mock_connection(
             connection_params={"headers": {"h1": "v1", "h2": "v2"}}
         )
         req = self._get_request(con, "GET", "/", headers={"h2": "v2p", "h3": "v3"})
-        self.assertEquals(req.headers["h1"], "v1")
-        self.assertEquals(req.headers["h2"], "v2p")
-        self.assertEquals(req.headers["h3"], "v3")
+        self.assertEqual(req.headers["h1"], "v1")
+        self.assertEqual(req.headers["h2"], "v2p")
+        self.assertEqual(req.headers["h3"], "v3")
 
     def test_default_headers(self):
         con = self._get_mock_connection()
         req = self._get_request(con, "GET", "/")
-        self.assertEquals(req.headers["content-type"], "application/json")
-        self.assertEquals(req.headers["user-agent"], con._get_default_user_agent())
+        self.assertEqual(req.headers["content-type"], "application/json")
+        self.assertEqual(req.headers["user-agent"], con._get_default_user_agent())
 
     def test_custom_headers(self):
         con = self._get_mock_connection()
@@ -617,24 +617,24 @@ class TestRequestsConnection(TestCase):
                 "user-agent": "custom-agent/1.2.3",
             },
         )
-        self.assertEquals(req.headers["content-type"], "application/x-ndjson")
-        self.assertEquals(req.headers["user-agent"], "custom-agent/1.2.3")
+        self.assertEqual(req.headers["content-type"], "application/x-ndjson")
+        self.assertEqual(req.headers["user-agent"], "custom-agent/1.2.3")
 
     def test_http_auth(self):
         con = RequestsHttpConnection(http_auth="username:secret")
-        self.assertEquals(("username", "secret"), con.session.auth)
+        self.assertEqual(("username", "secret"), con.session.auth)
 
     def test_http_auth_tuple(self):
         con = RequestsHttpConnection(http_auth=("username", "secret"))
-        self.assertEquals(("username", "secret"), con.session.auth)
+        self.assertEqual(("username", "secret"), con.session.auth)
 
     def test_http_auth_list(self):
         con = RequestsHttpConnection(http_auth=["username", "secret"])
-        self.assertEquals(("username", "secret"), con.session.auth)
+        self.assertEqual(("username", "secret"), con.session.auth)
 
     def test_repr(self):
         con = self._get_mock_connection({"host": "elasticsearch.com", "port": 443})
-        self.assertEquals(
+        self.assertEqual(
             "<RequestsHttpConnection: http://elasticsearch.com:443>", repr(con)
         )
 
@@ -654,7 +654,7 @@ class TestRequestsConnection(TestCase):
     def test_head_with_404_doesnt_get_logged(self, logger):
         con = self._get_mock_connection(status_code=404)
         self.assertRaises(NotFoundError, con.perform_request, "HEAD", "/", {}, "")
-        self.assertEquals(0, logger.warning.call_count)
+        self.assertEqual(0, logger.warning.call_count)
 
     @patch("elasticsearch.connection.base.tracer")
     @patch("elasticsearch.connection.base.logger")
@@ -672,11 +672,11 @@ class TestRequestsConnection(TestCase):
         )
 
         # trace request
-        self.assertEquals(1, tracer.info.call_count)
+        self.assertEqual(1, tracer.info.call_count)
         # trace response
-        self.assertEquals(1, tracer.debug.call_count)
+        self.assertEqual(1, tracer.debug.call_count)
         # log url and duration
-        self.assertEquals(1, logger.warning.call_count)
+        self.assertEqual(1, logger.warning.call_count)
         self.assertTrue(
             re.match(
                 r"^GET http://localhost:9200/\?param=42 \[status:500 request:0.[0-9]{3}s\]",
@@ -696,13 +696,13 @@ class TestRequestsConnection(TestCase):
         )
 
         # trace request
-        self.assertEquals(1, tracer.info.call_count)
-        self.assertEquals(
+        self.assertEqual(1, tracer.info.call_count)
+        self.assertEqual(
             """curl -H 'Content-Type: application/json' -XGET 'http://localhost:9200/?pretty&param=42' -d '{\n  "question": "what\\u0027s that?"\n}'""",
             tracer.info.call_args[0][0] % tracer.info.call_args[0][1:],
         )
         # trace response
-        self.assertEquals(1, tracer.debug.call_count)
+        self.assertEqual(1, tracer.debug.call_count)
         self.assertTrue(
             re.match(
                 r'#\[200\] \(0.[0-9]{3}s\)\n#{\n#  "answer": "that\\u0027s it!"\n#}',
@@ -711,7 +711,7 @@ class TestRequestsConnection(TestCase):
         )
 
         # log url and duration
-        self.assertEquals(1, logger.info.call_count)
+        self.assertEqual(1, logger.info.call_count)
         self.assertTrue(
             re.match(
                 r"GET http://localhost:9200/\?param=42 \[status:200 request:0.[0-9]{3}s\]",
@@ -719,28 +719,28 @@ class TestRequestsConnection(TestCase):
             )
         )
         # log request body and response
-        self.assertEquals(2, logger.debug.call_count)
+        self.assertEqual(2, logger.debug.call_count)
         req, resp = logger.debug.call_args_list
-        self.assertEquals('> {"question": "what\'s that?"}', req[0][0] % req[0][1:])
-        self.assertEquals('< {"answer": "that\'s it!"}', resp[0][0] % resp[0][1:])
+        self.assertEqual('> {"question": "what\'s that?"}', req[0][0] % req[0][1:])
+        self.assertEqual('< {"answer": "that\'s it!"}', resp[0][0] % resp[0][1:])
 
     @patch("elasticsearch.connection.base.logger")
     def test_uncompressed_body_logged(self, logger):
         con = self._get_mock_connection(connection_params={"http_compress": True})
         con.perform_request("GET", "/", body=b'{"example": "body"}')
 
-        self.assertEquals(2, logger.debug.call_count)
+        self.assertEqual(2, logger.debug.call_count)
         req, resp = logger.debug.call_args_list
-        self.assertEquals('> {"example": "body"}', req[0][0] % req[0][1:])
-        self.assertEquals("< {}", resp[0][0] % resp[0][1:])
+        self.assertEqual('> {"example": "body"}', req[0][0] % req[0][1:])
+        self.assertEqual("< {}", resp[0][0] % resp[0][1:])
 
     def test_defaults(self):
         con = self._get_mock_connection()
         request = self._get_request(con, "GET", "/")
 
-        self.assertEquals("http://localhost:9200/", request.url)
-        self.assertEquals("GET", request.method)
-        self.assertEquals(None, request.body)
+        self.assertEqual("http://localhost:9200/", request.url)
+        self.assertEqual("GET", request.method)
+        self.assertEqual(None, request.body)
 
     def test_params_properly_encoded(self):
         con = self._get_mock_connection()
@@ -748,25 +748,23 @@ class TestRequestsConnection(TestCase):
             con, "GET", "/", params={"param": "value with spaces"}
         )
 
-        self.assertEquals("http://localhost:9200/?param=value+with+spaces", request.url)
-        self.assertEquals("GET", request.method)
-        self.assertEquals(None, request.body)
+        self.assertEqual("http://localhost:9200/?param=value+with+spaces", request.url)
+        self.assertEqual("GET", request.method)
+        self.assertEqual(None, request.body)
 
     def test_body_attached(self):
         con = self._get_mock_connection()
         request = self._get_request(con, "GET", "/", body='{"answer": 42}')
 
-        self.assertEquals("http://localhost:9200/", request.url)
-        self.assertEquals("GET", request.method)
-        self.assertEquals('{"answer": 42}'.encode("utf-8"), request.body)
+        self.assertEqual("http://localhost:9200/", request.url)
+        self.assertEqual("GET", request.method)
+        self.assertEqual('{"answer": 42}'.encode("utf-8"), request.body)
 
     def test_http_auth_attached(self):
         con = self._get_mock_connection({"http_auth": "username:secret"})
         request = self._get_request(con, "GET", "/")
 
-        self.assertEquals(
-            request.headers["authorization"], "Basic dXNlcm5hbWU6c2VjcmV0"
-        )
+        self.assertEqual(request.headers["authorization"], "Basic dXNlcm5hbWU6c2VjcmV0")
 
     @patch("elasticsearch.connection.base.tracer")
     def test_url_prefix(self, tracer):
@@ -775,13 +773,13 @@ class TestRequestsConnection(TestCase):
             con, "GET", "/_search", body='{"answer": 42}', timeout=0.1
         )
 
-        self.assertEquals("http://localhost:9200/some-prefix/_search", request.url)
-        self.assertEquals("GET", request.method)
-        self.assertEquals('{"answer": 42}'.encode("utf-8"), request.body)
+        self.assertEqual("http://localhost:9200/some-prefix/_search", request.url)
+        self.assertEqual("GET", request.method)
+        self.assertEqual('{"answer": 42}'.encode("utf-8"), request.body)
 
         # trace request
-        self.assertEquals(1, tracer.info.call_count)
-        self.assertEquals(
+        self.assertEqual(1, tracer.info.call_count)
+        self.assertEqual(
             "curl -H 'Content-Type: application/json' -XGET 'http://localhost:9200/_search?pretty' -d '{\n  \"answer\": 42\n}'",
             tracer.info.call_args[0][0] % tracer.info.call_args[0][1:],
         )
@@ -790,4 +788,4 @@ class TestRequestsConnection(TestCase):
         buf = b"\xe4\xbd\xa0\xe5\xa5\xbd\xed\xa9\xaa"
         con = self._get_mock_connection(response_body=buf)
         status, headers, data = con.perform_request("GET", "/")
-        self.assertEqual("你好\uda6a", data)
+        self.assertEqual(u"你好\uda6a", data)

--- a/test_elasticsearch/test_connection_pool.py
+++ b/test_elasticsearch/test_connection_pool.py
@@ -27,7 +27,7 @@ class TestConnectionPool(TestCase):
         connections = set()
         for _ in range(100):
             connections.add(pool.get_connection())
-        self.assertEquals(connections, set(range(100)))
+        self.assertEqual(connections, set(range(100)))
 
     def test_disable_shuffling(self):
         pool = ConnectionPool([(x, {}) for x in range(100)], randomize_hosts=False)
@@ -35,7 +35,7 @@ class TestConnectionPool(TestCase):
         connections = []
         for _ in range(100):
             connections.append(pool.get_connection())
-        self.assertEquals(connections, list(range(100)))
+        self.assertEqual(connections, list(range(100)))
 
     def test_selectors_have_access_to_connection_opts(self):
         class MySelector(RoundRobinSelector):
@@ -53,22 +53,22 @@ class TestConnectionPool(TestCase):
         connections = []
         for _ in range(100):
             connections.append(pool.get_connection())
-        self.assertEquals(connections, [x * x for x in range(100)])
+        self.assertEqual(connections, [x * x for x in range(100)])
 
     def test_dead_nodes_are_removed_from_active_connections(self):
         pool = ConnectionPool([(x, {}) for x in range(100)])
 
         now = time.time()
         pool.mark_dead(42, now=now)
-        self.assertEquals(99, len(pool.connections))
-        self.assertEquals(1, pool.dead.qsize())
-        self.assertEquals((now + 60, 42), pool.dead.get())
+        self.assertEqual(99, len(pool.connections))
+        self.assertEqual(1, pool.dead.qsize())
+        self.assertEqual((now + 60, 42), pool.dead.get())
 
     def test_connection_is_skipped_when_dead(self):
         pool = ConnectionPool([(x, {}) for x in range(2)])
         pool.mark_dead(0)
 
-        self.assertEquals(
+        self.assertEqual(
             [1, 1, 1],
             [pool.get_connection(), pool.get_connection(), pool.get_connection()],
         )
@@ -82,7 +82,7 @@ class TestConnectionPool(TestCase):
         pool.mark_dead(new_connection)
 
         # Nothing should be marked dead
-        self.assertEquals(0, len(pool.dead_count))
+        self.assertEqual(0, len(pool.dead_count))
 
     def test_connection_is_forcibly_resurrected_when_no_live_ones_are_availible(self):
         pool = ConnectionPool([(x, {}) for x in range(2)])
@@ -90,9 +90,9 @@ class TestConnectionPool(TestCase):
         pool.mark_dead(0)  # failed twice, longer timeout
         pool.mark_dead(1)  # failed the first time, first to be resurrected
 
-        self.assertEquals([], pool.connections)
-        self.assertEquals(1, pool.get_connection())
-        self.assertEquals([1], pool.connections)
+        self.assertEqual([], pool.connections)
+        self.assertEqual(1, pool.get_connection())
+        self.assertEqual([1], pool.connections)
 
     def test_connection_is_resurrected_after_its_timeout(self):
         pool = ConnectionPool([(x, {}) for x in range(100)])
@@ -100,15 +100,15 @@ class TestConnectionPool(TestCase):
         now = time.time()
         pool.mark_dead(42, now=now - 61)
         pool.get_connection()
-        self.assertEquals(42, pool.connections[-1])
-        self.assertEquals(100, len(pool.connections))
+        self.assertEqual(42, pool.connections[-1])
+        self.assertEqual(100, len(pool.connections))
 
     def test_force_resurrect_always_returns_a_connection(self):
         pool = ConnectionPool([(0, {})])
 
         pool.connections = []
-        self.assertEquals(0, pool.get_connection())
-        self.assertEquals([], pool.connections)
+        self.assertEqual(0, pool.get_connection())
+        self.assertEqual([], pool.connections)
         self.assertTrue(pool.dead.empty())
 
     def test_already_failed_connection_has_longer_timeout(self):
@@ -117,8 +117,8 @@ class TestConnectionPool(TestCase):
         pool.dead_count[42] = 2
         pool.mark_dead(42, now=now)
 
-        self.assertEquals(3, pool.dead_count[42])
-        self.assertEquals((now + 4 * 60, 42), pool.dead.get())
+        self.assertEqual(3, pool.dead_count[42])
+        self.assertEqual((now + 4 * 60, 42), pool.dead.get())
 
     def test_timeout_for_failed_connections_is_limitted(self):
         pool = ConnectionPool([(x, {}) for x in range(100)])
@@ -126,8 +126,8 @@ class TestConnectionPool(TestCase):
         pool.dead_count[42] = 245
         pool.mark_dead(42, now=now)
 
-        self.assertEquals(246, pool.dead_count[42])
-        self.assertEquals((now + 32 * 60, 42), pool.dead.get())
+        self.assertEqual(246, pool.dead_count[42])
+        self.assertEqual((now + 32 * 60, 42), pool.dead.get())
 
     def test_dead_count_is_wiped_clean_for_connection_if_marked_live(self):
         pool = ConnectionPool([(x, {}) for x in range(100)])
@@ -135,6 +135,6 @@ class TestConnectionPool(TestCase):
         pool.dead_count[42] = 2
         pool.mark_dead(42, now=now)
 
-        self.assertEquals(3, pool.dead_count[42])
+        self.assertEqual(3, pool.dead_count[42])
         pool.mark_live(42)
         self.assertNotIn(42, pool.dead_count)

--- a/test_elasticsearch/test_helpers.py
+++ b/test_elasticsearch/test_helpers.py
@@ -35,7 +35,7 @@ class TestParallelBulk(TestCase):
         actions = ({"x": i} for i in range(100))
         list(helpers.parallel_bulk(Elasticsearch(), actions, chunk_size=2))
 
-        self.assertEquals(50, mock_process_bulk_chunk.call_count)
+        self.assertEqual(50, mock_process_bulk_chunk.call_count)
 
     @SkipTest
     @mock.patch(
@@ -61,7 +61,7 @@ class TestChunkActions(TestCase):
         self.actions = [({"index": {}}, {"some": u"datá", "i": i}) for i in range(100)]
 
     def test_chunks_are_chopped_by_byte_size(self):
-        self.assertEquals(
+        self.assertEqual(
             100,
             len(
                 list(helpers._chunk_actions(self.actions, 100000, 1, JSONSerializer()))
@@ -69,7 +69,7 @@ class TestChunkActions(TestCase):
         )
 
     def test_chunks_are_chopped_by_chunk_size(self):
-        self.assertEquals(
+        self.assertEqual(
             10,
             len(
                 list(
@@ -85,7 +85,7 @@ class TestChunkActions(TestCase):
                 self.actions, 100000, max_byte_size, JSONSerializer()
             )
         )
-        self.assertEquals(25, len(chunks))
+        self.assertEqual(25, len(chunks))
         for chunk_data, chunk_actions in chunks:
             chunk = u"".join(chunk_actions)
             chunk = chunk if isinstance(chunk, str) else chunk.encode("utf-8")
@@ -94,6 +94,6 @@ class TestChunkActions(TestCase):
 
 class TestExpandActions(TestCase):
     def test_string_actions_are_marked_as_simple_inserts(self):
-        self.assertEquals(
+        self.assertEqual(
             ('{"index":{}}', "whatever"), helpers.expand_action("whatever")
         )

--- a/test_elasticsearch/test_serializer.py
+++ b/test_elasticsearch/test_serializer.py
@@ -21,7 +21,7 @@ from .test_cases import TestCase, SkipTest
 
 class TestJSONSerializer(TestCase):
     def test_datetime_serialization(self):
-        self.assertEquals(
+        self.assertEqual(
             '{"d":"2010-10-01T02:30:00"}',
             JSONSerializer().dumps({"d": datetime(2010, 10, 1, 2, 30)}),
         )
@@ -29,10 +29,10 @@ class TestJSONSerializer(TestCase):
     def test_decimal_serialization(self):
         if sys.version_info[:2] == (2, 6):
             raise SkipTest("Float rounding is broken in 2.6.")
-        self.assertEquals('{"d":3.8}', JSONSerializer().dumps({"d": Decimal("3.8")}))
+        self.assertEqual('{"d":3.8}', JSONSerializer().dumps({"d": Decimal("3.8")}))
 
     def test_uuid_serialization(self):
-        self.assertEquals(
+        self.assertEqual(
             '{"d":"00000000-0000-0000-0000-000000000003"}',
             JSONSerializer().dumps(
                 {"d": uuid.UUID("00000000-0000-0000-0000-000000000003")}
@@ -40,7 +40,7 @@ class TestJSONSerializer(TestCase):
         )
 
     def test_serializes_numpy_bool(self):
-        self.assertEquals('{"d":true}', JSONSerializer().dumps({"d": np.bool_(True)}))
+        self.assertEqual('{"d":true}', JSONSerializer().dumps({"d": np.bool_(True)}))
 
     def test_serializes_numpy_integers(self):
         ser = JSONSerializer()
@@ -51,7 +51,7 @@ class TestJSONSerializer(TestCase):
             np.int32,
             np.int64,
         ):
-            self.assertEquals(ser.dumps({"d": np_type(-1)}), '{"d":-1}')
+            self.assertEqual(ser.dumps({"d": np_type(-1)}), '{"d":-1}')
 
         for np_type in (
             np.uint8,
@@ -59,7 +59,7 @@ class TestJSONSerializer(TestCase):
             np.uint32,
             np.uint64,
         ):
-            self.assertEquals(ser.dumps({"d": np_type(1)}), '{"d":1}')
+            self.assertEqual(ser.dumps({"d": np_type(1)}), '{"d":1}')
 
     def test_serializes_numpy_floats(self):
         ser = JSONSerializer()
@@ -73,30 +73,30 @@ class TestJSONSerializer(TestCase):
             )
 
     def test_serializes_numpy_datetime(self):
-        self.assertEquals(
+        self.assertEqual(
             '{"d":"2010-10-01T02:30:00"}',
             JSONSerializer().dumps({"d": np.datetime64("2010-10-01T02:30:00")}),
         )
 
     def test_serializes_numpy_ndarray(self):
-        self.assertEquals(
+        self.assertEqual(
             '{"d":[0,0,0,0,0]}',
             JSONSerializer().dumps({"d": np.zeros((5,), dtype=np.uint8)}),
         )
         # This isn't useful for Elasticsearch, just want to make sure it works.
-        self.assertEquals(
+        self.assertEqual(
             '{"d":[[0,0],[0,0]]}',
             JSONSerializer().dumps({"d": np.zeros((2, 2), dtype=np.uint8)}),
         )
 
     def test_serializes_pandas_timestamp(self):
-        self.assertEquals(
+        self.assertEqual(
             '{"d":"2010-10-01T02:30:00"}',
             JSONSerializer().dumps({"d": pd.Timestamp("2010-10-01T02:30:00")}),
         )
 
     def test_serializes_pandas_series(self):
-        self.assertEquals(
+        self.assertEqual(
             '{"d":["a","b","c","d"]}',
             JSONSerializer().dumps({"d": pd.Series(["a", "b", "c", "d"])}),
         )
@@ -104,18 +104,18 @@ class TestJSONSerializer(TestCase):
     def test_serializes_pandas_na(self):
         if not hasattr(pd, "NA"):  # pandas.NA added in v1
             raise SkipTest("pandas.NA required")
-        self.assertEquals(
+        self.assertEqual(
             '{"d":null}', JSONSerializer().dumps({"d": pd.NA}),
         )
 
     def test_serializes_pandas_category(self):
         cat = pd.Categorical(["a", "c", "b", "a"], categories=["a", "b", "c"])
-        self.assertEquals(
+        self.assertEqual(
             '{"d":["a","c","b","a"]}', JSONSerializer().dumps({"d": cat}),
         )
 
         cat = pd.Categorical([1, 2, 3], categories=[1, 2, 3])
-        self.assertEquals(
+        self.assertEqual(
             '{"d":[1,2,3]}', JSONSerializer().dumps({"d": cat}),
         )
 
@@ -128,12 +128,12 @@ class TestJSONSerializer(TestCase):
         self.assertRaises(SerializationError, JSONSerializer().loads, "{{")
 
     def test_strings_are_left_untouched(self):
-        self.assertEquals("你好", JSONSerializer().dumps("你好"))
+        self.assertEqual("你好", JSONSerializer().dumps("你好"))
 
 
 class TestTextSerializer(TestCase):
     def test_strings_are_left_untouched(self):
-        self.assertEquals("你好", TextSerializer().dumps("你好"))
+        self.assertEqual("你好", TextSerializer().dumps("你好"))
 
     def test_raises_serialization_error_on_dump_error(self):
         self.assertRaises(SerializationError, TextSerializer().dumps, {})
@@ -145,13 +145,13 @@ class TestDeserializer(TestCase):
         self.de = Deserializer(DEFAULT_SERIALIZERS)
 
     def test_deserializes_json_by_default(self):
-        self.assertEquals({"some": "data"}, self.de.loads('{"some":"data"}'))
+        self.assertEqual({"some": "data"}, self.de.loads('{"some":"data"}'))
 
     def test_deserializes_text_with_correct_ct(self):
-        self.assertEquals(
+        self.assertEqual(
             '{"some":"data"}', self.de.loads('{"some":"data"}', "text/plain")
         )
-        self.assertEquals(
+        self.assertEqual(
             '{"some":"data"}',
             self.de.loads('{"some":"data"}', "text/plain; charset=whatever"),
         )

--- a/test_elasticsearch/test_server/test_common.py
+++ b/test_elasticsearch/test_server/test_common.py
@@ -151,7 +151,7 @@ class YamlTestCase(ElasticsearchTestCase):
         """ Execute an instruction based on it's type. """
         print(test)
         for action in test:
-            self.assertEquals(1, len(action))
+            self.assertEqual(1, len(action))
             action_type, action = list(action.items())[0]
 
             if hasattr(self, "run_" + action_type):
@@ -165,7 +165,7 @@ class YamlTestCase(ElasticsearchTestCase):
         headers = action.pop("headers", None)
         catch = action.pop("catch", None)
         warn = action.pop("warnings", ())
-        self.assertEquals(1, len(action))
+        self.assertEqual(1, len(action))
 
         method, args = list(action.items())[0]
         args["headers"] = headers
@@ -272,7 +272,7 @@ class YamlTestCase(ElasticsearchTestCase):
 
         self.assertIsInstance(exception, TransportError)
         if catch in CATCH_CODES:
-            self.assertEquals(CATCH_CODES[catch], exception.status_code)
+            self.assertEqual(CATCH_CODES[catch], exception.status_code)
         elif catch[0] == "/" and catch[-1] == "/":
             self.assertTrue(
                 re.search(catch[1:-1], exception.error + " " + repr(exception.info)),
@@ -321,7 +321,7 @@ class YamlTestCase(ElasticsearchTestCase):
         for path, expected in action.items():
             value = self._lookup(path)
             expected = self._resolve(expected)
-            self.assertEquals(expected, len(value))
+            self.assertEqual(expected, len(value))
 
     def run_match(self, action):
         for path, expected in action.items():
@@ -338,7 +338,7 @@ class YamlTestCase(ElasticsearchTestCase):
                     expected.search(value), "%r does not match %r" % (value, expected)
                 )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     expected, value, "%r does not match %r" % (value, expected)
                 )
 

--- a/test_elasticsearch/test_server/test_helpers.py
+++ b/test_elasticsearch/test_server/test_helpers.py
@@ -31,7 +31,7 @@ class TestStreamingBulk(ElasticsearchTestCase):
             self.client, actions, index="test-index"
         ):
             self.assertTrue(ok)
-        self.assertEquals([{"_id": 1}, {"_id": 2}], actions)
+        self.assertEqual([{"_id": 1}, {"_id": 2}], actions)
 
     def test_all_documents_get_inserted(self):
         docs = [{"answer": x, "_id": x} for x in range(100)]
@@ -40,8 +40,8 @@ class TestStreamingBulk(ElasticsearchTestCase):
         ):
             self.assertTrue(ok)
 
-        self.assertEquals(100, self.client.count(index="test-index")["count"])
-        self.assertEquals(
+        self.assertEqual(100, self.client.count(index="test-index")["count"])
+        self.assertEqual(
             {"answer": 42}, self.client.get(index="test-index", id=42)["_source"]
         )
 
@@ -61,7 +61,7 @@ class TestStreamingBulk(ElasticsearchTestCase):
             ):
                 self.assertTrue(ok)
         except helpers.BulkIndexError as e:
-            self.assertEquals(2, len(e.errors))
+            self.assertEqual(2, len(e.errors))
         else:
             assert False, "exception should have been raised"
 
@@ -79,8 +79,8 @@ class TestStreamingBulk(ElasticsearchTestCase):
             self.assertTrue(ok)
 
         self.assertFalse(self.client.exists(index="i", id=45))
-        self.assertEquals({"answer": 42}, self.client.get(index="i", id=42)["_source"])
-        self.assertEquals({"f": "v"}, self.client.get(index="i", id=47)["_source"])
+        self.assertEqual({"answer": 42}, self.client.get(index="i", id=42)["_source"])
+        self.assertEqual({"f": "v"}, self.client.get(index="i", id=47)["_source"])
 
     def test_transport_error_can_becaught(self):
         failing_client = FailingBulkClient(self.client)
@@ -99,13 +99,13 @@ class TestStreamingBulk(ElasticsearchTestCase):
                 chunk_size=1,
             )
         )
-        self.assertEquals(3, len(results))
-        self.assertEquals([True, False, True], [r[0] for r in results])
+        self.assertEqual(3, len(results))
+        self.assertEqual([True, False, True], [r[0] for r in results])
 
         exc = results[1][1]["index"].pop("exception")
         self.assertIsInstance(exc, TransportError)
-        self.assertEquals(599, exc.status_code)
-        self.assertEquals(
+        self.assertEqual(599, exc.status_code)
+        self.assertEqual(
             {
                 "index": {
                     "_index": "i",
@@ -138,12 +138,12 @@ class TestStreamingBulk(ElasticsearchTestCase):
                 initial_backoff=0,
             )
         )
-        self.assertEquals(3, len(results))
-        self.assertEquals([True, True, True], [r[0] for r in results])
+        self.assertEqual(3, len(results))
+        self.assertEqual([True, True, True], [r[0] for r in results])
         self.client.indices.refresh(index="i")
         res = self.client.search(index="i")
-        self.assertEquals({"value": 3, "relation": "eq"}, res["hits"]["total"])
-        self.assertEquals(4, failing_client._called)
+        self.assertEqual({"value": 3, "relation": "eq"}, res["hits"]["total"])
+        self.assertEqual(4, failing_client._called)
 
     def test_rejected_documents_are_retried_at_most_max_retries_times(self):
         failing_client = FailingBulkClient(
@@ -166,12 +166,12 @@ class TestStreamingBulk(ElasticsearchTestCase):
                 initial_backoff=0,
             )
         )
-        self.assertEquals(3, len(results))
-        self.assertEquals([False, True, True], [r[0] for r in results])
+        self.assertEqual(3, len(results))
+        self.assertEqual([False, True, True], [r[0] for r in results])
         self.client.indices.refresh(index="i")
         res = self.client.search(index="i")
-        self.assertEquals({"value": 2, "relation": "eq"}, res["hits"]["total"])
-        self.assertEquals(4, failing_client._called)
+        self.assertEqual({"value": 2, "relation": "eq"}, res["hits"]["total"])
+        self.assertEqual(4, failing_client._called)
 
     def test_transport_error_is_raised_with_max_retries(self):
         failing_client = FailingBulkClient(
@@ -193,7 +193,7 @@ class TestStreamingBulk(ElasticsearchTestCase):
             return results
 
         self.assertRaises(TransportError, streaming_bulk)
-        self.assertEquals(4, failing_client._called)
+        self.assertEqual(4, failing_client._called)
 
 
 class TestBulk(ElasticsearchTestCase):
@@ -203,10 +203,10 @@ class TestBulk(ElasticsearchTestCase):
             self.client, docs, index="test-index", refresh=True
         )
 
-        self.assertEquals(1, success)
+        self.assertEqual(1, success)
         self.assertFalse(failed)
-        self.assertEquals(1, self.client.count(index="test-index")["count"])
-        self.assertEquals(
+        self.assertEqual(1, self.client.count(index="test-index")["count"])
+        self.assertEqual(
             {"answer": 42}, self.client.get(index="test-index", id=1)["_source"]
         )
 
@@ -216,10 +216,10 @@ class TestBulk(ElasticsearchTestCase):
             self.client, docs, index="test-index", refresh=True
         )
 
-        self.assertEquals(100, success)
+        self.assertEqual(100, success)
         self.assertFalse(failed)
-        self.assertEquals(100, self.client.count(index="test-index")["count"])
-        self.assertEquals(
+        self.assertEqual(100, self.client.count(index="test-index")["count"])
+        self.assertEqual(
             {"answer": 42}, self.client.get(index="test-index", id=42)["_source"]
         )
 
@@ -229,9 +229,9 @@ class TestBulk(ElasticsearchTestCase):
             self.client, docs, index="test-index", refresh=True, stats_only=True
         )
 
-        self.assertEquals(100, success)
-        self.assertEquals(0, failed)
-        self.assertEquals(100, self.client.count(index="test-index")["count"])
+        self.assertEqual(100, success)
+        self.assertEqual(0, failed)
+        self.assertEqual(100, self.client.count(index="test-index")["count"])
 
     def test_errors_are_reported_correctly(self):
         self.client.indices.create(
@@ -249,11 +249,11 @@ class TestBulk(ElasticsearchTestCase):
             index="i",
             raise_on_error=False,
         )
-        self.assertEquals(1, success)
-        self.assertEquals(1, len(failed))
+        self.assertEqual(1, success)
+        self.assertEqual(1, len(failed))
         error = failed[0]
-        self.assertEquals("42", error["index"]["_id"])
-        self.assertEquals("i", error["index"]["_index"])
+        self.assertEqual("42", error["index"]["_id"])
+        self.assertEqual("i", error["index"]["_index"])
         print(error["index"]["error"])
         self.assertTrue(
             "MapperParsingException" in repr(error["index"]["error"])
@@ -295,8 +295,8 @@ class TestBulk(ElasticsearchTestCase):
             stats_only=True,
             raise_on_error=False,
         )
-        self.assertEquals(1, success)
-        self.assertEquals(1, failed)
+        self.assertEqual(1, success)
+        self.assertEqual(1, failed)
 
 
 class TestScan(ElasticsearchTestCase):
@@ -334,9 +334,9 @@ class TestScan(ElasticsearchTestCase):
             )
         )
 
-        self.assertEquals(100, len(docs))
-        self.assertEquals(list(map(str, range(100))), list(d["_id"] for d in docs))
-        self.assertEquals(list(range(100)), list(d["_source"]["answer"] for d in docs))
+        self.assertEqual(100, len(docs))
+        self.assertEqual(list(map(str, range(100))), list(d["_id"] for d in docs))
+        self.assertEqual(list(range(100)), list(d["_source"]["answer"] for d in docs))
 
     def test_all_documents_are_read(self):
         bulk = []
@@ -347,9 +347,9 @@ class TestScan(ElasticsearchTestCase):
 
         docs = list(helpers.scan(self.client, index="test_index", size=2))
 
-        self.assertEquals(100, len(docs))
-        self.assertEquals(set(map(str, range(100))), set(d["_id"] for d in docs))
-        self.assertEquals(set(range(100)), set(d["_source"]["answer"] for d in docs))
+        self.assertEqual(100, len(docs))
+        self.assertEqual(set(map(str, range(100))), set(d["_id"] for d in docs))
+        self.assertEqual(set(range(100)), set(d["_source"]["answer"] for d in docs))
 
     def test_scroll_error(self):
         bulk = []
@@ -510,11 +510,11 @@ class TestReindex(ElasticsearchTestCase):
         )
 
         self.assertTrue(self.client.indices.exists("prod_index"))
-        self.assertEquals(
+        self.assertEqual(
             50, self.client.count(index="prod_index", q="type:answers")["count"]
         )
 
-        self.assertEquals(
+        self.assertEqual(
             {"answer": 42, "correct": True, "type": "answers"},
             self.client.get(index="prod_index", id=42)["_source"],
         )
@@ -529,11 +529,11 @@ class TestReindex(ElasticsearchTestCase):
         self.client.indices.refresh()
 
         self.assertTrue(self.client.indices.exists("prod_index"))
-        self.assertEquals(
+        self.assertEqual(
             50, self.client.count(index="prod_index", q="type:answers")["count"]
         )
 
-        self.assertEquals(
+        self.assertEqual(
             {"answer": 42, "correct": True, "type": "answers"},
             self.client.get(index="prod_index", id=42)["_source"],
         )
@@ -543,14 +543,14 @@ class TestReindex(ElasticsearchTestCase):
         self.client.indices.refresh()
 
         self.assertTrue(self.client.indices.exists("prod_index"))
-        self.assertEquals(
+        self.assertEqual(
             50, self.client.count(index="prod_index", q="type:questions")["count"]
         )
-        self.assertEquals(
+        self.assertEqual(
             50, self.client.count(index="prod_index", q="type:answers")["count"]
         )
 
-        self.assertEquals(
+        self.assertEqual(
             {"answer": 42, "correct": True, "type": "answers"},
             self.client.get(index="prod_index", id=42)["_source"],
         )
@@ -588,7 +588,7 @@ class TestParentChildReindex(ElasticsearchTestCase):
         helpers.reindex(self.client, "test-index", "real-index")
 
         q = self.client.get(index="real-index", id=42)
-        self.assertEquals(
+        self.assertEqual(
             {
                 "_id": "42",
                 "_index": "real-index",
@@ -601,7 +601,7 @@ class TestParentChildReindex(ElasticsearchTestCase):
             q,
         )
         q = self.client.get(index="test-index", id=47, routing=42)
-        self.assertEquals(
+        self.assertEqual(
             {
                 "_routing": "42",
                 "_id": "47",

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -91,7 +91,7 @@ class TestHostsInfoCallback(TestCase):
             for i, node_info in enumerate(nodes)
             if get_host_info(node_info, i) is not None
         ]
-        self.assertEquals([1, 2, 3, 4], chosen)
+        self.assertEqual([1, 2, 3, 4], chosen)
 
 
 class TestTransport(TestCase):
@@ -105,9 +105,9 @@ class TestTransport(TestCase):
         t = Transport([{}], connection_class=DummyConnection)
 
         t.perform_request("GET", "/", params={"request_timeout": 42})
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(("GET", "/", {}, None), t.get_connection().calls[0][0])
-        self.assertEquals(
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(("GET", "/", {}, None), t.get_connection().calls[0][0])
+        self.assertEqual(
             {"timeout": 42, "ignore": (), "headers": None},
             t.get_connection().calls[0][1],
         )
@@ -116,18 +116,18 @@ class TestTransport(TestCase):
         t = Transport([{}], opaque_id="app-1", connection_class=DummyConnection)
 
         t.perform_request("GET", "/")
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(("GET", "/", None, None), t.get_connection().calls[0][0])
-        self.assertEquals(
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(("GET", "/", None, None), t.get_connection().calls[0][0])
+        self.assertEqual(
             {"timeout": None, "ignore": (), "headers": None},
             t.get_connection().calls[0][1],
         )
 
         # Now try with an 'x-opaque-id' set on perform_request().
         t.perform_request("GET", "/", headers={"x-opaque-id": "request-1"})
-        self.assertEquals(2, len(t.get_connection().calls))
-        self.assertEquals(("GET", "/", None, None), t.get_connection().calls[1][0])
-        self.assertEquals(
+        self.assertEqual(2, len(t.get_connection().calls))
+        self.assertEqual(("GET", "/", None, None), t.get_connection().calls[1][0])
+        self.assertEqual(
             {"timeout": None, "ignore": (), "headers": {"x-opaque-id": "request-1"}},
             t.get_connection().calls[1][1],
         )
@@ -136,8 +136,8 @@ class TestTransport(TestCase):
         t = Transport([{}], connection_class=DummyConnection)
 
         t.perform_request("GET", "/", headers={"user-agent": "my-custom-value/1.2.3"})
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(
             {
                 "timeout": None,
                 "ignore": (),
@@ -150,8 +150,8 @@ class TestTransport(TestCase):
         t = Transport([{}], send_get_body_as="source", connection_class=DummyConnection)
 
         t.perform_request("GET", "/", body={})
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(
             ("GET", "/", {"source": "{}"}, None), t.get_connection().calls[0][0]
         )
 
@@ -159,15 +159,15 @@ class TestTransport(TestCase):
         t = Transport([{}], send_get_body_as="POST", connection_class=DummyConnection)
 
         t.perform_request("GET", "/", body={})
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(("POST", "/", None, b"{}"), t.get_connection().calls[0][0])
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(("POST", "/", None, b"{}"), t.get_connection().calls[0][0])
 
     def test_body_gets_encoded_into_bytes(self):
         t = Transport([{}], connection_class=DummyConnection)
 
         t.perform_request("GET", "/", body="你好")
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(
             ("GET", "/", None, b"\xe4\xbd\xa0\xe5\xa5\xbd"),
             t.get_connection().calls[0][0],
         )
@@ -177,25 +177,23 @@ class TestTransport(TestCase):
 
         body = b"\xe4\xbd\xa0\xe5\xa5\xbd"
         t.perform_request("GET", "/", body=body)
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(("GET", "/", None, body), t.get_connection().calls[0][0])
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(("GET", "/", None, body), t.get_connection().calls[0][0])
 
     def test_body_surrogates_replaced_encoded_into_bytes(self):
         t = Transport([{}], connection_class=DummyConnection)
 
         t.perform_request("GET", "/", body="你好\uda6a")
-        self.assertEquals(1, len(t.get_connection().calls))
-        self.assertEquals(
+        self.assertEqual(1, len(t.get_connection().calls))
+        self.assertEqual(
             ("GET", "/", None, b"\xe4\xbd\xa0\xe5\xa5\xbd\xed\xa9\xaa"),
             t.get_connection().calls[0][0],
         )
 
     def test_kwargs_passed_on_to_connections(self):
         t = Transport([{"host": "google.com"}], port=123)
-        self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals(
-            "http://google.com:123", t.connection_pool.connections[0].host
-        )
+        self.assertEqual(1, len(t.connection_pool.connections))
+        self.assertEqual("http://google.com:123", t.connection_pool.connections[0].host)
 
     def test_kwargs_passed_on_to_connection_pool(self):
         dt = object()
@@ -208,15 +206,15 @@ class TestTransport(TestCase):
                 self.kwargs = kwargs
 
         t = Transport([{}], connection_class=MyConnection)
-        self.assertEquals(1, len(t.connection_pool.connections))
+        self.assertEqual(1, len(t.connection_pool.connections))
         self.assertIsInstance(t.connection_pool.connections[0], MyConnection)
 
     def test_add_connection(self):
         t = Transport([{}], randomize_hosts=False)
         t.add_connection({"host": "google.com", "port": 1234})
 
-        self.assertEquals(2, len(t.connection_pool.connections))
-        self.assertEquals(
+        self.assertEqual(2, len(t.connection_pool.connections))
+        self.assertEqual(
             "http://google.com:1234", t.connection_pool.connections[1].host
         )
 
@@ -227,7 +225,7 @@ class TestTransport(TestCase):
         )
 
         self.assertRaises(ConnectionError, t.perform_request, "GET", "/")
-        self.assertEquals(4, len(t.get_connection().calls))
+        self.assertEqual(4, len(t.get_connection().calls))
 
     def test_failed_connection_will_be_marked_as_dead(self):
         t = Transport(
@@ -236,7 +234,7 @@ class TestTransport(TestCase):
         )
 
         self.assertRaises(ConnectionError, t.perform_request, "GET", "/")
-        self.assertEquals(0, len(t.connection_pool.connections))
+        self.assertEqual(0, len(t.connection_pool.connections))
 
     def test_resurrected_connection_will_be_marked_as_live_on_success(self):
         t = Transport([{}, {}], connection_class=DummyConnection)
@@ -246,16 +244,16 @@ class TestTransport(TestCase):
         t.connection_pool.mark_dead(con2)
 
         t.perform_request("GET", "/")
-        self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals(1, len(t.connection_pool.dead_count))
+        self.assertEqual(1, len(t.connection_pool.connections))
+        self.assertEqual(1, len(t.connection_pool.dead_count))
 
     def test_sniff_will_use_seed_connections(self):
         t = Transport([{"data": CLUSTER_NODES}], connection_class=DummyConnection)
         t.set_connections([{"data": "invalid"}])
 
         t.sniff_hosts()
-        self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals("http://1.1.1.1:123", t.get_connection().host)
+        self.assertEqual(1, len(t.connection_pool.connections))
+        self.assertEqual("http://1.1.1.1:123", t.get_connection().host)
 
     def test_sniff_on_start_fetches_and_uses_nodes_list(self):
         t = Transport(
@@ -263,8 +261,8 @@ class TestTransport(TestCase):
             connection_class=DummyConnection,
             sniff_on_start=True,
         )
-        self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals("http://1.1.1.1:123", t.get_connection().host)
+        self.assertEqual(1, len(t.connection_pool.connections))
+        self.assertEqual("http://1.1.1.1:123", t.get_connection().host)
 
     def test_sniff_on_start_ignores_sniff_timeout(self):
         t = Transport(
@@ -273,7 +271,7 @@ class TestTransport(TestCase):
             sniff_on_start=True,
             sniff_timeout=12,
         )
-        self.assertEquals(
+        self.assertEqual(
             (("GET", "/_nodes/_all/http"), {"timeout": None}),
             t.seed_connections[0].calls[0],
         )
@@ -285,7 +283,7 @@ class TestTransport(TestCase):
             sniff_timeout=42,
         )
         t.sniff_hosts()
-        self.assertEquals(
+        self.assertEqual(
             (("GET", "/_nodes/_all/http"), {"timeout": 42}),
             t.seed_connections[0].calls[0],
         )
@@ -299,7 +297,7 @@ class TestTransport(TestCase):
         connection = t.connection_pool.connections[1]
 
         t.sniff_hosts()
-        self.assertEquals(1, len(t.connection_pool.connections))
+        self.assertEqual(1, len(t.connection_pool.connections))
         self.assertIs(connection, t.get_connection())
 
     def test_sniff_on_fail_triggers_sniffing_on_fail(self):
@@ -312,8 +310,8 @@ class TestTransport(TestCase):
         )
 
         self.assertRaises(ConnectionError, t.perform_request, "GET", "/")
-        self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals("http://1.1.1.1:123", t.get_connection().host)
+        self.assertEqual(1, len(t.connection_pool.connections))
+        self.assertEqual("http://1.1.1.1:123", t.get_connection().host)
 
     def test_sniff_after_n_seconds(self):
         t = Transport(
@@ -324,13 +322,13 @@ class TestTransport(TestCase):
 
         for _ in range(4):
             t.perform_request("GET", "/")
-        self.assertEquals(1, len(t.connection_pool.connections))
+        self.assertEqual(1, len(t.connection_pool.connections))
         self.assertIsInstance(t.get_connection(), DummyConnection)
         t.last_sniff = time.time() - 5.1
 
         t.perform_request("GET", "/")
-        self.assertEquals(1, len(t.connection_pool.connections))
-        self.assertEquals("http://1.1.1.1:123", t.get_connection().host)
+        self.assertEqual(1, len(t.connection_pool.connections))
+        self.assertEqual("http://1.1.1.1:123", t.get_connection().host)
         self.assertTrue(time.time() - 1 < t.last_sniff < time.time() + 0.01)
 
     def test_sniff_7x_publish_host(self):


### PR DESCRIPTION
`assertEquals` is deprecated and we use it everywhere so there's tons of useless warnings being raised.