### PR TITLE
Replaces deprecated function in run_tests.py

### DIFF
--- a/test_elasticsearch/run_tests.py
+++ b/test_elasticsearch/run_tests.py
@@ -5,6 +5,7 @@
 
 from __future__ import print_function
 
+import atexit
 import sys
 from os import environ
 from os.path import dirname, join, pardir, abspath, exists
@@ -61,7 +62,7 @@ def fetch_es_repo():
 
 
 def run_all(argv=None):
-    sys.exitfunc = lambda: sys.stderr.write("Shutting down....\n")
+    atexit.register(lambda: sys.stderr.write("Shutting down....\n"))
 
     # fetch yaml tests
     fetch_es_repo()


### PR DESCRIPTION
The sys.exitfunc has been deprecated since Python 2.4 (https://docs.python.org/2/library/sys.html#sys.exitfunc). This uses the atexit module to register cleanup functions.

See https://docs.python.org/2/library/atexit.html#atexit.register for additional information.