### PR TITLE
Raise warnings when receiving the 'Warning' header for AIOHttpConnection

### DIFF
--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -254,6 +254,10 @@ class AIOHttpConnection(Connection):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
             raise ConnectionError("N/A", str(e), e)
 
+        # raise warnings if any from the 'Warnings' header.
+        warning_headers = response.headers.getall("warning", ())
+        self._raise_warnings(warning_headers)
+
         # raise errors based on http status codes, let the client handle those if needed
         if not (200 <= response.status < 300) and response.status not in ignore:
             self.log_request_fail(

--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -174,9 +174,7 @@ class Connection(object):
                 warning_messages.append(header)
 
         for message in warning_messages:
-            warnings.warn(
-                message, category=ElasticsearchDeprecationWarning, stacklevel=6
-            )
+            warnings.warn(message, category=ElasticsearchDeprecationWarning)
 
     def _pretty_json(self, data):
         # pretty JSON in tracer curl logs


### PR DESCRIPTION
There must not be any `warnings` usage within the REST API spec tests for 8.0.0
Discovered while backporting async to 7.x