### PR TITLE
Fix typo in helpers docs: "abstract ... or the raw" -> "of the raw"

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -3,8 +3,7 @@
 Helpers
 =======
 
-Collection of simple helper functions that abstract some specifics or the raw
-API.
+Collection of simple helper functions that abstract some specifics of the raw API.
 
 
 Bulk helpers


### PR DESCRIPTION
It could be _over_ the raw API as well? 🤔 