### PR TITLE
Catch sniff errors during sniff on fail if retrying the request

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -365,13 +365,18 @@ class Transport(object):
                     retry = True
 
                 if retry:
-                    # only mark as dead if we are retrying
-                    self.mark_dead(connection)
+                    try:
+                        # only mark as dead if we are retrying
+                        self.mark_dead(connection)
+                    except TransportError:
+                        # If sniffing on failure, it could fail too. Catch the
+                        # exception not to interrupt the retries.
+                        pass
                     # raise exception on last retry
                     if attempt == self.max_retries:
-                        raise
+                        raise e
                 else:
-                    raise
+                    raise e
 
             else:
                 # connection didn't fail, confirm it's live status


### PR DESCRIPTION
If the request timed out, it seems likely that sniffing right after might also fail. And when it does, it used to interrupt the retry logic. This fix will make it proceed to retry the original request as configured.

Here's a sample of what that would look like in the wild (from es-py 7.0.5 on py2.7):
```
[application code calling .save() on a doc instance]

/srv/app/scs/env/local/lib/python2.7/site-packages/elasticsearch_dsl/document.pyc in save(self, using, index, validate, skip_empty, **kwargs)
    454             index=self._get_index(index),
    455             body=self.to_dict(skip_empty=skip_empty),
--> 456             **doc_meta
    457         )
    458         # update meta information from ES
         
/srv/app/scs/env/local/lib/python2.7/site-packages/elasticsearch/client/utils.pyc in _wrapped(*args, **kwargs)
     82                 if p in kwargs:
     83                     params[p] = kwargs.pop(p)
---> 84             return func(*args, params=params, **kwargs)
     85  
     86         return _wrapped
         
/srv/app/scs/env/local/lib/python2.7/site-packages/elasticsearch/client/__init__.pyc in index(self, index, body, doc_type, id, params)
    362                 raise ValueError("Empty value passed for a required argument.")
    363         return self.transport.perform_request(
--> 364             "POST", _make_path(index, doc_type, id), params=params, body=body
    365         )
    366  
         
/srv/app/scs/env/local/lib/python2.7/site-packages/elasticsearch/transport.pyc in perform_request(self, method, url, headers, params, body)
    365                 if retry:
    366                     # only mark as dead if we are retrying
--> 367                     self.mark_dead(connection)
    368                     # raise exception on last retry
    369                     if attempt == self.max_retries:
         
/srv/app/scs/env/local/lib/python2.7/site-packages/elasticsearch/transport.pyc in mark_dead(self, connection)
    284         self.connection_pool.mark_dead(connection)
    285         if self.sniff_on_connection_fail:
--> 286             self.sniff_hosts()
    287  
    288     def perform_request(self, method, url, headers=None, params=None, body=None):
         
/srv/app/scs/env/local/lib/python2.7/site-packages/elasticsearch/transport.pyc in sniff_hosts(self, initial)
    261             (``sniff_on_start``), ignore the ``sniff_timeout`` if ``True``
    262         """
--> 263         node_info = self._get_sniff_data(initial)
    264  
    265         hosts = list(filter(None, (self._get_host_info(n) for n in node_info)))
         
/srv/app/scs/env/local/lib/python2.7/site-packages/elasticsearch/transport.pyc in _get_sniff_data(self, initial)
    230                     pass
    231             else:
--> 232                 raise TransportError("N/A", "Unable to sniff hosts.")
    233         except:
    234             # keep the previous value on error
         
TransportError: TransportError(N/A, 'Unable to sniff hosts.')
```