### PR TITLE
Minor documentation formatting fix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -263,6 +263,8 @@ API Key Authentication
 You can configure the client to use Elasticsearch's `API Key`_ for connecting to your cluster.
 Please note this authentication method has been introduced with release of Elasticsearch ``6.7.0``.
 
+.. code-block:: python
+
     from elasticsearch import Elasticsearch
 
     # you can use the api key tuple


### PR DESCRIPTION
Without this, the formatting is wrong for the code block under "API Key Authentication" ([link](https://elasticsearch-py.readthedocs.io/en/master/#api-key-authentication))