### PR TITLE
Log scroll response failures

### DIFF
--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -528,23 +528,30 @@ def scan(
                 resp_failures = resp["_shards"].get("failures")
                 failures = []
                 if resp_failures is not None:
-                    for resp_failure in resp_failures:
-                        failure = "Failure type[%s] received with reason: %s" % (
-                            resp_failure["reason"]["type"],
-                            resp_failure["reason"]["reason"],
+                    for i in range(5):
+                        if i < len(resp_failures):
+                            failure = "Failure type[%s] received with reason: %s" % (
+                                resp_failures[i]["reason"]["type"],
+                                resp_failures[i]["reason"]["reason"],
+                            )
+                            failures.append(failure)
+                            logger.warning(failure)
+
+                    if len(resp_failures) > 5:
+                        omitted_failures = len(resp_failures) - 5
+                        failures.append(
+                            "...and %d more omitted failures" % omitted_failures
                         )
-                        failures.append(failure)
-                        logger.warning(failure)
                 if raise_on_error:
                     raise ScanError(
                         scroll_id,
-                        "Scroll request has only succeeded on %d (+%d skiped) shards out of %d.\n"
+                        "Scroll request has only succeeded on %d (+%d skipped) shards out of %d.\n"
                         "%s"
                         % (
                             resp["_shards"]["successful"],
                             resp["_shards"]["skipped"],
                             resp["_shards"]["total"],
-                            "".join(failures),
+                            "\n".join(failures),
                         ),
                     )
             resp = client.scroll(

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -525,12 +525,14 @@ def scan(
                     resp["_shards"]["total"],
                 )
 
-                resp_failures = resp['_shards'].get('failures')
+                resp_failures = resp["_shards"].get("failures")
                 failures = []
                 if resp_failures is not None:
                     for resp_failure in resp_failures:
-                        failure = "Failure type[%s] received with reason: %s" % \
-                                  (resp_failure["reason"]['type'], resp_failure["reason"]['reason'])
+                        failure = "Failure type[%s] received with reason: %s" % (
+                            resp_failure["reason"]["type"],
+                            resp_failure["reason"]["reason"],
+                        )
                         failures.append(failure)
                         logger.warning(failure)
                 if raise_on_error:
@@ -542,7 +544,7 @@ def scan(
                             resp["_shards"]["successful"],
                             resp["_shards"]["skipped"],
                             resp["_shards"]["total"],
-                            ''.join(failures)
+                            "".join(failures),
                         ),
                     )
             resp = client.scroll(

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -524,14 +524,25 @@ def scan(
                     resp["_shards"]["skipped"],
                     resp["_shards"]["total"],
                 )
+
+                resp_failures = resp['_shards'].get('failures')
+                failures = []
+                if resp_failures is not None:
+                    for resp_failure in resp_failures:
+                        failure = "Failure type[%s] received with reason: %s" % \
+                                  (resp_failure["reason"]['type'], resp_failure["reason"]['reason'])
+                        failures.append(failure)
+                        logger.warning(failure)
                 if raise_on_error:
                     raise ScanError(
                         scroll_id,
-                        "Scroll request has only succeeded on %d (+%d skiped) shards out of %d."
+                        "Scroll request has only succeeded on %d (+%d skiped) shards out of %d.\n"
+                        "%s"
                         % (
                             resp["_shards"]["successful"],
                             resp["_shards"]["skipped"],
                             resp["_shards"]["total"],
+                            ''.join(failures)
                         ),
                     )
             resp = client.scroll(


### PR DESCRIPTION
As raised by issue #1261, when the endpoint POST /_search/scroll answers with failures indications they are not provided in the exception or log to help troubleshoot the root cause.

This PR intends to solve this adding failures indications like the example below:
![image](https://user-images.githubusercontent.com/18057391/87096534-71f3de80-c219-11ea-9bce-344052067524.png)

A reason limit (5) is set to avoid the exception end up massive as pointed by @tommyzli