### PR TITLE
Don't raise sniffing error when retrying request

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -378,13 +378,18 @@ class Transport(object):
                     retry = True
 
                 if retry:
-                    # only mark as dead if we are retrying
-                    self.mark_dead(connection)
+                    try:
+                        # only mark as dead if we are retrying
+                        self.mark_dead(connection)
+                    except TransportError:
+                        # If sniffing on failure, it could fail too. Catch the
+                        # exception not to interrupt the retries.
+                        pass
                     # raise exception on last retry
                     if attempt == self.max_retries:
-                        raise
+                        raise e
                 else:
-                    raise
+                    raise e
 
             else:
                 # connection didn't fail, confirm it's live status


### PR DESCRIPTION
When an HTTP request fails and we decide to retry the request, `mark_dead()` can cause a sniff attempt to start if `sniff_on_connection_fail=True`. We don't want to interrupt a retry if a sniff request fails, instead we'd rather retry or raise the original exception that occurred.

Related: #1279