### PR TITLE
[7.9] Don't raise sniffing errors when retrying a request

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -378,13 +378,18 @@ class Transport(object):
                     retry = True
 
                 if retry:
-                    # only mark as dead if we are retrying
-                    self.mark_dead(connection)
+                    try:
+                        # only mark as dead if we are retrying
+                        self.mark_dead(connection)
+                    except TransportError:
+                        # If sniffing on failure, it could fail too. Catch the
+                        # exception not to interrupt the retries.
+                        pass
                     # raise exception on last retry
                     if attempt == self.max_retries:
-                        raise
+                        raise e
                 else:
-                    raise
+                    raise e
 
             else:
                 # connection didn't fail, confirm it's live status


### PR DESCRIPTION
Backported from 8106c0eefc023990a7bf7eb6bc3887bd815e41c4