### PR TITLE
Need to propagate headers from the scan API to the clear_scroll API

### DIFF
--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -535,7 +535,7 @@ def scan(
                         ),
                     )
             resp = client.scroll(
-                body={"scroll_id": scroll_id, "scroll": scroll}, **scroll_kwargs
+                body={"scroll_id": scroll_id, "scroll": scroll}, headers=kwargs.get('headers', None), **scroll_kwargs
             )
             scroll_id = resp.get("_scroll_id")
 

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -535,13 +535,20 @@ def scan(
                         ),
                     )
             resp = client.scroll(
-                body={"scroll_id": scroll_id, "scroll": scroll}, headers=kwargs.get('headers', None), **scroll_kwargs
+                body={"scroll_id": scroll_id, "scroll": scroll},
+                headers=kwargs.get("headers", None),
+                **scroll_kwargs
             )
             scroll_id = resp.get("_scroll_id")
 
     finally:
         if scroll_id and clear_scroll:
-            client.clear_scroll(body={"scroll_id": [scroll_id]}, ignore=(404,), headers=kwargs.get('headers', None))
+            client.clear_scroll(
+                body={"scroll_id": [scroll_id]},
+                ignore=(404,),
+                headers=kwargs.get("headers", None),
+                **scroll_kwargs
+            )
 
 
 def reindex(

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -541,7 +541,7 @@ def scan(
 
     finally:
         if scroll_id and clear_scroll:
-            client.clear_scroll(body={"scroll_id": [scroll_id]}, ignore=(404,))
+            client.clear_scroll(body={"scroll_id": [scroll_id]}, ignore=(404,), headers=kwargs.get('headers', None))
 
 
 def reindex(


### PR DESCRIPTION
When headers (say an oauth2 token for authentication) are passed to the helper scan API, that header/token should be passed down to the clear_scroll API. Else, an authentication exception will ensue. The user can avoid this error by explicitly setting 'clear_scroll' to False - it is True by default of course.  The error message

AuthenticationException(401, 'security_exception',
{ 
  "error": {
    "root_cause": [
      {
        "type": "security_exception",
        "reason": "missing authentication credentials for REST request [/_search/scroll]",
        "header": {
          "WWW-Authenticate": [
            "Bearer realm=\"security\"",
            "ApiKey"
          ]
        }
      }
    ],
    "type": "security_exception",
    "reason": "missing authentication credentials for REST request [/_search/scroll]",
    "header": {
      "WWW-Authenticate": [
        "Bearer realm=\"security\"",
        "ApiKey"
      ]
    }
  },
  "status": 401
}

The fix here is to simply check if the incoming 'kwargs' to the scan API have headers, and pass it down. Simple