### PR TITLE
Remove yarl from [async] extra

### DIFF
--- a/elasticsearch/_async/_extra_imports.py
+++ b/elasticsearch/_async/_extra_imports.py
@@ -31,6 +31,14 @@
 
 import aiohttp
 import aiohttp.client_exceptions as aiohttp_exceptions
-import yarl
+
+
+# We do this because we don't explicitly require 'yarl'
+# within our [async] extra any more.
+# See AIOHttpConnection.request() for more information why.
+try:
+    import yarl
+except ImportError:
+    yarl = False
 
 __all__ = ["aiohttp", "aiohttp_exceptions", "yarl"]

--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -231,15 +231,30 @@ class AIOHttpConnection(AsyncConnection):
             method = "GET"
             is_head = True
 
-        # Provide correct URL object to avoid string parsing in low-level code
-        url = yarl.URL.build(
-            scheme=self.scheme,
-            host=self.hostname,
-            port=self.port,
-            path=url_path,
-            query_string=query_string,
-            encoded=True,
-        )
+        # Top-tier tip-toeing happening here. Basically
+        # because Pip's old resolver is bad and wipes out
+        # strict pins in favor of non-strict pins of extras
+        # our [async] extra overrides aiohttp's pin of
+        # yarl. yarl released breaking changes, aiohttp pinned
+        # defensively afterwards, but our users don't get
+        # that nice pin that aiohttp set. :( So to play around
+        # this super-defensively we try to import yarl, if we can't
+        # then we pass a string into ClientSession.request() instead.
+        if yarl:
+            # Provide correct URL object to avoid string parsing in low-level code
+            url = yarl.URL.build(
+                scheme=self.scheme,
+                host=self.hostname,
+                port=self.port,
+                path=url_path,
+                query_string=query_string,
+                encoded=True,
+            )
+        else:
+            url = self.url_prefix + url
+            if query_string:
+                url = "%s?%s" % (url, query_string)
+            url = self.host + url
 
         timeout = aiohttp.ClientTimeout(
             total=timeout if timeout is not None else self.timeout

--- a/noxfile.py
+++ b/noxfile.py
@@ -63,7 +63,7 @@ def lint(session):
 
     # Make sure we don't require aiohttp to be installed for users to
     # receive type hint information from mypy.
-    session.run("python", "-m", "pip", "uninstall", "--yes", "aiohttp", "yarl")
+    session.run("python", "-m", "pip", "uninstall", "--yes", "aiohttp")
     session.run("mypy", "--strict", "elasticsearch/")
     session.run("mypy", "--strict", "test_elasticsearch/test_types/sync_types.py")
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ packages = [
 ]
 
 install_requires = [
-    "urllib3>=1.21.1",
+    "urllib3>=1.21.1, <2",
     "certifi",
 ]
 tests_require = [
@@ -50,7 +50,7 @@ tests_require = [
     "pytest",
     "pytest-cov",
 ]
-async_require = ["aiohttp>=3,<4", "yarl"]
+async_require = ["aiohttp>=3,<4"]
 
 docs_require = ["sphinx<1.7", "sphinx_rtd_theme"]
 generate_require = ["black", "jinja2"]

--- a/test_elasticsearch/test_async/test_server/test_clients.py
+++ b/test_elasticsearch/test_async/test_server/test_clients.py
@@ -41,3 +41,16 @@ class TestBulk:
 
         assert response["errors"] is False
         assert len(response["items"]) == 1
+
+
+class TestYarlMissing:
+    async def test_aiohttp_connection_works_without_yarl(
+        self, async_client, monkeypatch
+    ):
+        # This is a defensive test case for if aiohttp suddenly stops using yarl.
+        from elasticsearch._async import http_aiohttp
+
+        monkeypatch.setattr(http_aiohttp, "yarl", False)
+
+        resp = await async_client.info(pretty=True)
+        assert isinstance(resp, dict)


### PR DESCRIPTION
A series of unfortunate events:

- yarl released breaking changes in a minor (1.6.0)
- aiohttp upon realizing this started pinning yarl to `<1.6`
- We require aiohttp and yarl in our `[async]` extra because being explicit is good
- Pip's old resolver doesn't combine pins very well so upon seeing `yarl<1.6` from `aiohttp` and `yarl` from `[async]` it settles on `yarl` without a pin.
- Pip installs a bad version of yarl

Technically aiohttp+yarl still "works" in this situation but Pip complains and it can break things if users do stuff with `pkg_resources`.

So to "fix" things on our side we:
- Drop yarl from our `[async]` extra
- If we are somehow installed with aiohttp and not yarl (shouldn't happen because aiohttp depends on yarl)
  then we pass in raw strings to aiohttp instead of nicely built `yarl.URL` instances.
- The above scenario shouldn't happen unless aiohttp drops yarl as a dependency which is unlikely.