### PR TITLE
Test typing metadata in build-dist script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include MANIFEST.in
 include README.rst
 include README
 include setup.py
-recursive-include elasticsearch* py.typed
+recursive-include elasticsearch* py.typed *.pyi
 recursive-include docs/sphinx *
 
 prune docs/sphinx/_build

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -262,6 +262,7 @@ class AsyncElasticsearch(object):
     async def ping(self, params=None, headers=None):
         """
         Returns whether the cluster is running.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
         """
         try:
@@ -275,6 +276,7 @@ class AsyncElasticsearch(object):
     async def info(self, params=None, headers=None):
         """
         Returns basic information about the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
         """
         return await self.transport.perform_request(
@@ -294,6 +296,7 @@ class AsyncElasticsearch(object):
         """
         Creates a new document in the index.  Returns a 409 response when a document
         with a same ID already exists in the index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
 
         :arg index: The name of the index
@@ -350,6 +353,7 @@ class AsyncElasticsearch(object):
     async def index(self, index, body, id=None, params=None, headers=None):
         """
         Creates or updates a document in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
 
         :arg index: The name of the index
@@ -409,6 +413,7 @@ class AsyncElasticsearch(object):
     async def bulk(self, body, index=None, doc_type=None, params=None, headers=None):
         """
         Allows to perform multiple index/update/delete operations in a single request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html>`_
 
         :arg body: The operation definition and data (action-data
@@ -455,6 +460,7 @@ class AsyncElasticsearch(object):
     async def clear_scroll(self, body=None, scroll_id=None, params=None, headers=None):
         """
         Explicitly clears the search context for a scroll.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html>`_
 
         :arg body: A comma-separated list of scroll IDs to clear if none
@@ -491,6 +497,7 @@ class AsyncElasticsearch(object):
     async def count(self, body=None, index=None, params=None, headers=None):
         """
         Returns number of documents matching a query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
 
         :arg body: A query to restrict the results specified with the
@@ -546,6 +553,7 @@ class AsyncElasticsearch(object):
     async def delete(self, index, id, doc_type=None, params=None, headers=None):
         """
         Removes a document from the index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html>`_
 
         :arg index: The name of the index
@@ -620,6 +628,7 @@ class AsyncElasticsearch(object):
     async def delete_by_query(self, index, body, params=None, headers=None):
         """
         Deletes documents matching the provided query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
 
         :arg index: A comma-separated list of index names to search; use
@@ -713,6 +722,7 @@ class AsyncElasticsearch(object):
         """
         Changes the number of requests per second for a particular Delete By Query
         operation.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
 
         :arg task_id: The task id to rethrottle
@@ -733,6 +743,7 @@ class AsyncElasticsearch(object):
     async def delete_script(self, id, params=None, headers=None):
         """
         Deletes a script.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
 
         :arg id: Script ID
@@ -761,6 +772,7 @@ class AsyncElasticsearch(object):
     async def exists(self, index, id, params=None, headers=None):
         """
         Returns information about whether a document exists in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -806,6 +818,7 @@ class AsyncElasticsearch(object):
     async def exists_source(self, index, id, doc_type=None, params=None, headers=None):
         """
         Returns information about whether a document source exists in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -857,6 +870,7 @@ class AsyncElasticsearch(object):
     async def explain(self, index, id, body=None, params=None, headers=None):
         """
         Returns information about why a specific matches (or doesn't match) a query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html>`_
 
         :arg index: The name of the index
@@ -907,6 +921,7 @@ class AsyncElasticsearch(object):
         """
         Returns the information about the capabilities of fields among multiple
         indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html>`_
 
         :arg body: An index filter specified with the Query DSL
@@ -947,6 +962,7 @@ class AsyncElasticsearch(object):
     async def get(self, index, id, params=None, headers=None):
         """
         Returns a document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -982,6 +998,7 @@ class AsyncElasticsearch(object):
     async def get_script(self, id, params=None, headers=None):
         """
         Returns a script.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
 
         :arg id: Script ID
@@ -1008,6 +1025,7 @@ class AsyncElasticsearch(object):
     async def get_source(self, index, id, params=None, headers=None):
         """
         Returns the source of a document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -1050,6 +1068,7 @@ class AsyncElasticsearch(object):
     async def mget(self, body, index=None, params=None, headers=None):
         """
         Allows to get multiple documents in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html>`_
 
         :arg body: Document identifiers; can be either `docs`
@@ -1095,6 +1114,7 @@ class AsyncElasticsearch(object):
     async def msearch(self, body, index=None, params=None, headers=None):
         """
         Allows to execute several search operations in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
 
         :arg body: The request definitions (metadata-search request
@@ -1141,6 +1161,7 @@ class AsyncElasticsearch(object):
     async def put_script(self, id, body, context=None, params=None, headers=None):
         """
         Creates or updates a script.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
 
         :arg id: Script ID
@@ -1168,6 +1189,7 @@ class AsyncElasticsearch(object):
         """
         Allows to evaluate the quality of ranked search results over a set of typical
         search queries
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html>`_
 
         :arg body: The ranking evaluation search definition, including
@@ -1211,6 +1233,7 @@ class AsyncElasticsearch(object):
         Allows to copy documents from one index to another, optionally filtering the
         source documents by a query, changing the destination index settings, or
         fetching the documents from a remote cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
 
         :arg body: The search definition using the Query DSL and the
@@ -1246,6 +1269,7 @@ class AsyncElasticsearch(object):
     async def reindex_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Reindex operation.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
 
         :arg task_id: The task id to rethrottle
@@ -1268,6 +1292,7 @@ class AsyncElasticsearch(object):
     ):
         """
         Allows to use the Mustache language to pre-render a search definition.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html#_validating_templates>`_
 
         :arg body: The search definition template and its params
@@ -1285,6 +1310,7 @@ class AsyncElasticsearch(object):
     async def scripts_painless_execute(self, body=None, params=None, headers=None):
         """
         Allows an arbitrary script to be executed and a result to be returned
+
         `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html>`_
 
         :arg body: The script to execute
@@ -1301,6 +1327,7 @@ class AsyncElasticsearch(object):
     async def scroll(self, body=None, scroll_id=None, params=None, headers=None):
         """
         Allows to retrieve a large numbers of results from a single search request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll>`_
 
         :arg body: The scroll ID if not passed by URL or query
@@ -1369,6 +1396,7 @@ class AsyncElasticsearch(object):
     async def search(self, body=None, index=None, params=None, headers=None):
         """
         Returns results matching a query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
 
         :arg body: The search definition using the Query DSL
@@ -1490,6 +1518,7 @@ class AsyncElasticsearch(object):
         """
         Returns information about the indices and shards that a search request would be
         executed against.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html>`_
 
         :arg index: A comma-separated list of index names to search; use
@@ -1529,6 +1558,7 @@ class AsyncElasticsearch(object):
     async def update(self, index, id, body, doc_type=None, params=None, headers=None):
         """
         Updates a document with a script or partial document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
 
         :arg index: The name of the index
@@ -1583,6 +1613,7 @@ class AsyncElasticsearch(object):
         """
         Changes the number of requests per second for a particular Update By Query
         operation.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
 
         :arg task_id: The task id to rethrottle
@@ -1603,6 +1634,7 @@ class AsyncElasticsearch(object):
     async def get_script_context(self, params=None, headers=None):
         """
         Returns all script contexts.
+
         `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
         """
         return await self.transport.perform_request(
@@ -1613,6 +1645,7 @@ class AsyncElasticsearch(object):
     async def get_script_languages(self, params=None, headers=None):
         """
         Returns available script types, languages and contexts
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
         """
         return await self.transport.perform_request(
@@ -1629,6 +1662,7 @@ class AsyncElasticsearch(object):
     async def msearch_template(self, body, index=None, params=None, headers=None):
         """
         Allows to execute several search template operations in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
 
         :arg body: The request definitions (metadata-search request
@@ -1677,6 +1711,7 @@ class AsyncElasticsearch(object):
     async def mtermvectors(self, body=None, index=None, params=None, headers=None):
         """
         Returns multiple termvectors in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
 
         :arg body: Define ids, documents, parameters or a list of
@@ -1741,6 +1776,7 @@ class AsyncElasticsearch(object):
     async def search_template(self, body, index=None, params=None, headers=None):
         """
         Allows to use the Mustache language to pre-render a search definition.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html>`_
 
         :arg body: The search definition template and its params
@@ -1803,6 +1839,7 @@ class AsyncElasticsearch(object):
         """
         Returns information and statistics about terms in the fields of a particular
         document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html>`_
 
         :arg index: The index in which the document resides.
@@ -1882,6 +1919,7 @@ class AsyncElasticsearch(object):
         """
         Performs an update on every document in the index without changing the source,
         for example to pick up a mapping change.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
 
         :arg index: A comma-separated list of index names to search; use
@@ -1977,6 +2015,7 @@ class AsyncElasticsearch(object):
     async def close_point_in_time(self, body=None, params=None, headers=None):
         """
         Close a point in time
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
 
         :arg body: a point-in-time id to close
@@ -1991,6 +2030,7 @@ class AsyncElasticsearch(object):
     async def open_point_in_time(self, index=None, params=None, headers=None):
         """
         Open a point in time that can be used in subsequent searches
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
 
         :arg index: A comma-separated list of index names to open point

--- a/elasticsearch/_async/client/__init__.pyi
+++ b/elasticsearch/_async/client/__init__.pyi
@@ -102,6 +102,7 @@ class AsyncElasticsearch(object):
     # AUTO-GENERATED-API-DEFINITIONS #
     async def ping(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -111,10 +112,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def info(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -124,12 +126,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def create(
         self,
         index: Any,
         id: Any,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         pipeline: Optional[Any] = ...,
@@ -148,11 +151,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def index(
         self,
         index: Any,
+        *,
         body: Any,
         id: Optional[Any] = ...,
         if_primary_term: Optional[Any] = ...,
@@ -175,10 +179,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def bulk(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
@@ -200,10 +205,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def clear_scroll(
         self,
+        *,
         body: Optional[Any] = ...,
         scroll_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -215,10 +221,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def count(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -244,12 +251,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete(
         self,
         index: Any,
         id: Any,
+        *,
         doc_type: Optional[Any] = ...,
         if_primary_term: Optional[Any] = ...,
         if_seq_no: Optional[Any] = ...,
@@ -268,11 +276,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_by_query(
         self,
         index: Any,
+        *,
         body: Any,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -315,11 +324,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_by_query_rethrottle(
         self,
         task_id: Any,
+        *,
         requests_per_second: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -330,11 +340,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_script(
         self,
         id: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -346,12 +357,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def exists(
         self,
         index: Any,
         id: Any,
+        *,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
         _source_includes: Optional[Any] = ...,
@@ -371,12 +383,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def exists_source(
         self,
         index: Any,
         id: Any,
+        *,
         doc_type: Optional[Any] = ...,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -396,12 +409,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def explain(
         self,
         index: Any,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -424,10 +438,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def field_caps(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -444,12 +459,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get(
         self,
         index: Any,
         id: Any,
+        *,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
         _source_includes: Optional[Any] = ...,
@@ -469,11 +485,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_script(
         self,
         id: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -484,12 +501,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_source(
         self,
         index: Any,
         id: Any,
+        *,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
         _source_includes: Optional[Any] = ...,
@@ -508,10 +526,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def mget(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -531,10 +550,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def msearch(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         ccs_minimize_roundtrips: Optional[Any] = ...,
@@ -553,11 +573,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_script(
         self,
         id: Any,
+        *,
         body: Any,
         context: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -571,10 +592,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def rank_eval(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -590,10 +612,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def reindex(
         self,
+        *,
         body: Any,
         max_docs: Optional[Any] = ...,
         refresh: Optional[Any] = ...,
@@ -612,11 +635,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def reindex_rethrottle(
         self,
         task_id: Any,
+        *,
         requests_per_second: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -627,10 +651,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def render_search_template(
         self,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -642,10 +667,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def scripts_painless_execute(
         self,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -656,10 +682,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def scroll(
         self,
+        *,
         body: Optional[Any] = ...,
         scroll_id: Optional[Any] = ...,
         rest_total_hits_as_int: Optional[Any] = ...,
@@ -673,10 +700,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def search(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -730,10 +758,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def search_shards(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -750,12 +779,13 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update(
         self,
         index: Any,
         id: Any,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -779,11 +809,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_by_query_rethrottle(
         self,
         task_id: Any,
+        *,
         requests_per_second: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -794,10 +825,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_script_context(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -807,10 +839,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_script_languages(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -820,10 +853,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def msearch_template(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         ccs_minimize_roundtrips: Optional[Any] = ...,
@@ -840,10 +874,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def mtermvectors(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         field_statistics: Optional[Any] = ...,
@@ -867,10 +902,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def search_template(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -895,11 +931,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def termvectors(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         field_statistics: Optional[Any] = ...,
@@ -922,11 +959,12 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_by_query(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -971,10 +1009,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def close_point_in_time(
         self,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -985,10 +1024,11 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def open_point_in_time(
         self,
+        *,
         index: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -1004,5 +1044,5 @@ class AsyncElasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -24,6 +24,7 @@ class AsyncSearchClient(NamespacedClient):
         """
         Deletes an async search by ID. If the search is still running, the search
         request will be cancelled. Otherwise, the saved search results are deleted.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :arg id: The async search ID
@@ -40,6 +41,7 @@ class AsyncSearchClient(NamespacedClient):
         """
         Retrieves the results of a previously submitted async search request given its
         ID.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :arg id: The async search ID
@@ -103,6 +105,7 @@ class AsyncSearchClient(NamespacedClient):
     async def submit(self, body=None, index=None, params=None, headers=None):
         """
         Executes a search request asynchronously.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :arg body: The search definition using the Query DSL

--- a/elasticsearch/_async/client/async_search.pyi
+++ b/elasticsearch/_async/client/async_search.pyi
@@ -22,6 +22,7 @@ class AsyncSearchClient(NamespacedClient):
     async def delete(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class AsyncSearchClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get(
         self,
         id: Any,
+        *,
         keep_alive: Optional[Any] = ...,
         typed_keys: Optional[Any] = ...,
         wait_for_completion_timeout: Optional[Any] = ...,
@@ -48,10 +50,11 @@ class AsyncSearchClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def submit(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -104,5 +107,5 @@ class AsyncSearchClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/autoscaling.py
+++ b/elasticsearch/_async/client/autoscaling.py
@@ -24,6 +24,7 @@ class AutoscalingClient(NamespacedClient):
         """
         Gets the current autoscaling decision based on the configured autoscaling
         policy, indicating whether or not autoscaling is needed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-decision.html>`_
         """
         return await self.transport.perform_request(
@@ -34,6 +35,7 @@ class AutoscalingClient(NamespacedClient):
     async def delete_autoscaling_policy(self, name, params=None, headers=None):
         """
         Deletes an autoscaling policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-delete-autoscaling-policy.html>`_
 
         :arg name: the name of the autoscaling policy
@@ -52,6 +54,7 @@ class AutoscalingClient(NamespacedClient):
     async def put_autoscaling_policy(self, name, body, params=None, headers=None):
         """
         Creates a new autoscaling policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-put-autoscaling-policy.html>`_
 
         :arg name: the name of the autoscaling policy
@@ -73,6 +76,7 @@ class AutoscalingClient(NamespacedClient):
     async def get_autoscaling_policy(self, name, params=None, headers=None):
         """
         Retrieves an autoscaling policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-policy.html>`_
 
         :arg name: the name of the autoscaling policy

--- a/elasticsearch/_async/client/autoscaling.pyi
+++ b/elasticsearch/_async/client/autoscaling.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class AutoscalingClient(NamespacedClient):
     async def get_autoscaling_decision(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,11 +31,12 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_autoscaling_policy(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -44,11 +46,12 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_autoscaling_policy(
         self,
         name: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -59,11 +62,12 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_autoscaling_policy(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -73,5 +77,5 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/cat.py
+++ b/elasticsearch/_async/client/cat.py
@@ -24,6 +24,7 @@ class CatClient(NamespacedClient):
         """
         Shows information about currently configured aliases to indices including
         filter and routing infos.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html>`_
 
         :arg name: A comma-separated list of alias names to return
@@ -49,6 +50,7 @@ class CatClient(NamespacedClient):
         """
         Provides a snapshot of how many shards are allocated to each data node and how
         much disk space they are using.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -79,6 +81,7 @@ class CatClient(NamespacedClient):
         """
         Provides quick access to the document count of the entire cluster, or
         individual indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -99,6 +102,7 @@ class CatClient(NamespacedClient):
     async def health(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster health.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -120,6 +124,7 @@ class CatClient(NamespacedClient):
     async def help(self, params=None, headers=None):
         """
         Returns help for the Cat APIs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html>`_
 
         :arg help: Return help information
@@ -149,6 +154,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about indices: number of primaries and replicas, document
         counts, disk size, ...
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -187,6 +193,7 @@ class CatClient(NamespacedClient):
     async def master(self, params=None, headers=None):
         """
         Returns information about the master node.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -211,6 +218,7 @@ class CatClient(NamespacedClient):
     async def nodes(self, params=None, headers=None):
         """
         Returns basic statistics about performance of cluster nodes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html>`_
 
         :arg bytes: The unit in which to display byte values  Valid
@@ -239,6 +247,7 @@ class CatClient(NamespacedClient):
     async def recovery(self, index=None, params=None, headers=None):
         """
         Returns information about index shard recoveries, both on-going completed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html>`_
 
         :arg index: Comma-separated list or wildcard expression of index
@@ -269,6 +278,7 @@ class CatClient(NamespacedClient):
     async def shards(self, index=None, params=None, headers=None):
         """
         Provides a detailed view of shard allocation on nodes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -297,6 +307,7 @@ class CatClient(NamespacedClient):
     async def segments(self, index=None, params=None, headers=None):
         """
         Provides low-level information about the segments in the shards of an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -319,6 +330,7 @@ class CatClient(NamespacedClient):
     async def pending_tasks(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster pending tasks.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -344,6 +356,7 @@ class CatClient(NamespacedClient):
         """
         Returns cluster-wide thread pool statistics per node. By default the active,
         queue and rejected statistics are returned for all thread pools.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html>`_
 
         :arg thread_pool_patterns: A comma-separated list of regular-
@@ -374,6 +387,7 @@ class CatClient(NamespacedClient):
         """
         Shows how much heap memory is currently being used by fielddata on every data
         node in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html>`_
 
         :arg fields: A comma-separated list of fields to return in the
@@ -399,6 +413,7 @@ class CatClient(NamespacedClient):
     async def plugins(self, params=None, headers=None):
         """
         Returns information about installed plugins across nodes node.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -421,6 +436,7 @@ class CatClient(NamespacedClient):
     async def nodeattrs(self, params=None, headers=None):
         """
         Returns information about custom node attributes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -443,6 +459,7 @@ class CatClient(NamespacedClient):
     async def repositories(self, params=None, headers=None):
         """
         Returns information about snapshot repositories registered in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -467,6 +484,7 @@ class CatClient(NamespacedClient):
     async def snapshots(self, repository=None, params=None, headers=None):
         """
         Returns all snapshots in a specific repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html>`_
 
         :arg repository: Name of repository from which to fetch the
@@ -508,6 +526,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about the tasks currently executing on one or more nodes in
         the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg actions: A comma-separated list of actions that should be
@@ -537,6 +556,7 @@ class CatClient(NamespacedClient):
     async def templates(self, name=None, params=None, headers=None):
         """
         Returns information about existing templates.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html>`_
 
         :arg name: A pattern that returned template names must match
@@ -560,6 +580,7 @@ class CatClient(NamespacedClient):
     async def ml_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Gets configuration and usage information about data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to fetch
@@ -591,6 +612,7 @@ class CatClient(NamespacedClient):
     async def ml_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html>`_
 
         :arg datafeed_id: The ID of the datafeeds stats to fetch
@@ -631,6 +653,7 @@ class CatClient(NamespacedClient):
     async def ml_jobs(self, job_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html>`_
 
         :arg job_id: The ID of the jobs stats to fetch
@@ -674,6 +697,7 @@ class CatClient(NamespacedClient):
     async def ml_trained_models(self, model_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about inference trained models.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html>`_
 
         :arg model_id: The ID of the trained models stats to fetch
@@ -712,6 +736,7 @@ class CatClient(NamespacedClient):
     async def transforms(self, transform_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html>`_
 
         :arg transform_id: The id of the transform for which to get

--- a/elasticsearch/_async/client/cat.pyi
+++ b/elasticsearch/_async/client/cat.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class CatClient(NamespacedClient):
     async def aliases(
         self,
+        *,
         name: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -37,10 +38,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def allocation(
         self,
+        *,
         node_id: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -58,10 +60,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def count(
         self,
+        *,
         index: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -76,10 +79,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def health(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -95,10 +99,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def help(
         self,
+        *,
         help: Optional[Any] = ...,
         s: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -110,10 +115,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def indices(
         self,
+        *,
         index: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -136,10 +142,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def master(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -155,10 +162,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def nodes(
         self,
+        *,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
         full_id: Optional[Any] = ...,
@@ -176,10 +184,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def recovery(
         self,
+        *,
         index: Optional[Any] = ...,
         active_only: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
@@ -198,10 +207,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def shards(
         self,
+        *,
         index: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -220,10 +230,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def segments(
         self,
+        *,
         index: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -239,10 +250,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def pending_tasks(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -259,10 +271,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def thread_pool(
         self,
+        *,
         thread_pool_patterns: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -280,10 +293,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def fielddata(
         self,
+        *,
         fields: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -299,10 +313,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def plugins(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -318,10 +333,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def nodeattrs(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -337,10 +353,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def repositories(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -356,10 +373,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def snapshots(
         self,
+        *,
         repository: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -377,10 +395,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def tasks(
         self,
+        *,
         actions: Optional[Any] = ...,
         detailed: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -399,10 +418,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def templates(
         self,
+        *,
         name: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -419,10 +439,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def ml_data_frame_analytics(
         self,
+        *,
         id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
@@ -440,10 +461,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def ml_datafeeds(
         self,
+        *,
         datafeed_id: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -461,10 +483,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def ml_jobs(
         self,
+        *,
         job_id: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -483,10 +506,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def ml_trained_models(
         self,
+        *,
         model_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
@@ -506,10 +530,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def transforms(
         self,
+        *,
         transform_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -528,5 +553,5 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -23,6 +23,7 @@ class CcrClient(NamespacedClient):
     async def delete_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Deletes auto-follow patterns.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern.
@@ -41,6 +42,7 @@ class CcrClient(NamespacedClient):
     async def follow(self, index, body, params=None, headers=None):
         """
         Creates a new follower index configured to follow the referenced leader index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html>`_
 
         :arg index: The name of the follower index
@@ -69,6 +71,7 @@ class CcrClient(NamespacedClient):
         """
         Retrieves information about all follower indices, including parameters and
         status for each follower index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html>`_
 
         :arg index: A comma-separated list of index patterns; use `_all`
@@ -86,6 +89,7 @@ class CcrClient(NamespacedClient):
         """
         Retrieves follower stats. return shard-level stats about the following tasks
         associated with each shard for the specified indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html>`_
 
         :arg index: A comma-separated list of index patterns; use `_all`
@@ -102,6 +106,7 @@ class CcrClient(NamespacedClient):
     async def forget_follower(self, index, body, params=None, headers=None):
         """
         Removes the follower retention leases from the leader.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html>`_
 
         :arg index: the name of the leader index for which specified
@@ -128,6 +133,7 @@ class CcrClient(NamespacedClient):
         """
         Gets configured auto-follow patterns. Returns the specified auto-follow pattern
         collection.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern.
@@ -144,6 +150,7 @@ class CcrClient(NamespacedClient):
         """
         Pauses a follower index. The follower index will not fetch any additional
         operations from the leader index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html>`_
 
         :arg index: The name of the follower index that should pause
@@ -165,6 +172,7 @@ class CcrClient(NamespacedClient):
         Creates a new named collection of auto-follow patterns against a specified
         remote cluster. Newly created indices on the remote cluster matching any of the
         specified patterns will be automatically configured as follower indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern.
@@ -186,6 +194,7 @@ class CcrClient(NamespacedClient):
     async def resume_follow(self, index, body=None, params=None, headers=None):
         """
         Resumes a follower index that has been paused
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html>`_
 
         :arg index: The name of the follow index to resume following.
@@ -207,6 +216,7 @@ class CcrClient(NamespacedClient):
     async def stats(self, params=None, headers=None):
         """
         Gets all stats related to cross-cluster replication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
         """
         return await self.transport.perform_request(
@@ -218,6 +228,7 @@ class CcrClient(NamespacedClient):
         """
         Stops the following task associated with a follower index and removes index
         metadata and settings associated with cross-cluster replication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html>`_
 
         :arg index: The name of the follower index that should be turned
@@ -237,6 +248,7 @@ class CcrClient(NamespacedClient):
     async def pause_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Pauses an auto-follow pattern
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern that should pause
@@ -256,6 +268,7 @@ class CcrClient(NamespacedClient):
     async def resume_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Resumes an auto-follow pattern that has been paused
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern to resume

--- a/elasticsearch/_async/client/ccr.pyi
+++ b/elasticsearch/_async/client/ccr.pyi
@@ -22,6 +22,7 @@ class CcrClient(NamespacedClient):
     async def delete_auto_follow_pattern(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def follow(
         self,
         index: Any,
+        *,
         body: Any,
         wait_for_active_shards: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -47,11 +49,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def follow_info(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -61,11 +64,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def follow_stats(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -75,11 +79,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def forget_follower(
         self,
         index: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -90,10 +95,11 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_auto_follow_pattern(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -104,11 +110,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def pause_follow(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -118,11 +125,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_auto_follow_pattern(
         self,
         name: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -133,11 +141,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def resume_follow(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -148,10 +157,11 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stats(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -161,11 +171,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def unfollow(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -175,11 +186,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def pause_auto_follow_pattern(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -189,11 +201,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def resume_auto_follow_pattern(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -203,5 +216,5 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -35,6 +35,7 @@ class ClusterClient(NamespacedClient):
     async def health(self, index=None, params=None, headers=None):
         """
         Returns basic information about the health of the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html>`_
 
         :arg index: Limit the information returned to a specific index
@@ -74,6 +75,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns a list of any cluster-level changes (e.g. create index, update mapping,
         allocate or fail shard) which have not yet been executed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html>`_
 
         :arg local: Return local information, do not retrieve the state
@@ -97,6 +99,7 @@ class ClusterClient(NamespacedClient):
     async def state(self, metric=None, index=None, params=None, headers=None):
         """
         Returns a comprehensive information about the state of the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html>`_
 
         :arg metric: Limit the information returned to the specified
@@ -136,6 +139,7 @@ class ClusterClient(NamespacedClient):
     async def stats(self, node_id=None, params=None, headers=None):
         """
         Returns high-level overview of cluster statistics.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -161,6 +165,7 @@ class ClusterClient(NamespacedClient):
     async def reroute(self, body=None, params=None, headers=None):
         """
         Allows to manually change the allocation of individual shards in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html>`_
 
         :arg body: The definition of `commands` to perform (`move`,
@@ -186,6 +191,7 @@ class ClusterClient(NamespacedClient):
     async def get_settings(self, params=None, headers=None):
         """
         Returns cluster settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
 
         :arg flat_settings: Return settings in flat format (default:
@@ -204,6 +210,7 @@ class ClusterClient(NamespacedClient):
     async def put_settings(self, body, params=None, headers=None):
         """
         Updates the cluster settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
 
         :arg body: The settings to be updated. Can be either `transient`
@@ -225,6 +232,7 @@ class ClusterClient(NamespacedClient):
     async def remote_info(self, params=None, headers=None):
         """
         Returns the information about configured remote clusters.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
         """
         return await self.transport.perform_request(
@@ -235,6 +243,7 @@ class ClusterClient(NamespacedClient):
     async def allocation_explain(self, body=None, params=None, headers=None):
         """
         Provides explanations for shard allocations in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html>`_
 
         :arg body: The index, shard, and primary flag to explain. Empty
@@ -256,6 +265,7 @@ class ClusterClient(NamespacedClient):
     async def delete_component_template(self, name, params=None, headers=None):
         """
         Deletes a component template
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The name of the template
@@ -276,6 +286,7 @@ class ClusterClient(NamespacedClient):
     async def get_component_template(self, name=None, params=None, headers=None):
         """
         Returns one or more component templates
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The comma separated names of the component templates
@@ -295,6 +306,7 @@ class ClusterClient(NamespacedClient):
     async def put_component_template(self, name, body, params=None, headers=None):
         """
         Creates or updates a component template
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The name of the template
@@ -320,6 +332,7 @@ class ClusterClient(NamespacedClient):
     async def exists_component_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular component template exist
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The name of the template
@@ -342,6 +355,7 @@ class ClusterClient(NamespacedClient):
     async def delete_voting_config_exclusions(self, params=None, headers=None):
         """
         Clears cluster voting config exclusions.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
 
         :arg wait_for_removal: Specifies whether to wait for all
@@ -359,6 +373,7 @@ class ClusterClient(NamespacedClient):
     async def post_voting_config_exclusions(self, params=None, headers=None):
         """
         Updates the cluster voting config exclusions by node ids or node names.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
 
         :arg node_ids: A comma-separated list of the persistent ids of

--- a/elasticsearch/_async/client/cluster.pyi
+++ b/elasticsearch/_async/client/cluster.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class ClusterClient(NamespacedClient):
     async def health(
         self,
+        *,
         index: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         level: Optional[Any] = ...,
@@ -42,10 +43,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def pending_tasks(
         self,
+        *,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -57,10 +59,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def state(
         self,
+        *,
         metric: Optional[Any] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -80,10 +83,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stats(
         self,
+        *,
         node_id: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -96,10 +100,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def reroute(
         self,
+        *,
         body: Optional[Any] = ...,
         dry_run: Optional[Any] = ...,
         explain: Optional[Any] = ...,
@@ -116,10 +121,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_settings(
         self,
+        *,
         flat_settings: Optional[Any] = ...,
         include_defaults: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -133,10 +139,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_settings(
         self,
+        *,
         body: Any,
         flat_settings: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -150,10 +157,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def remote_info(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -163,10 +171,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def allocation_explain(
         self,
+        *,
         body: Optional[Any] = ...,
         include_disk_info: Optional[Any] = ...,
         include_yes_decisions: Optional[Any] = ...,
@@ -179,11 +188,12 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_component_template(
         self,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -195,10 +205,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_component_template(
         self,
+        *,
         name: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -211,11 +222,12 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_component_template(
         self,
         name: Any,
+        *,
         body: Any,
         create: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -229,11 +241,12 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def exists_component_template(
         self,
         name: Any,
+        *,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -245,10 +258,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def delete_voting_config_exclusions(
         self,
+        *,
         wait_for_removal: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -259,10 +273,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def post_voting_config_exclusions(
         self,
+        *,
         node_ids: Optional[Any] = ...,
         node_names: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -275,5 +290,5 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/dangling_indices.py
+++ b/elasticsearch/_async/client/dangling_indices.py
@@ -23,6 +23,7 @@ class DanglingIndicesClient(NamespacedClient):
     async def delete_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Deletes the specified dangling index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
 
         :arg index_uuid: The UUID of the dangling index
@@ -45,6 +46,7 @@ class DanglingIndicesClient(NamespacedClient):
     async def import_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Imports the specified dangling index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
 
         :arg index_uuid: The UUID of the dangling index
@@ -64,6 +66,7 @@ class DanglingIndicesClient(NamespacedClient):
     async def list_dangling_indices(self, params=None, headers=None):
         """
         Returns all dangling indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
         """
         return await self.transport.perform_request(

--- a/elasticsearch/_async/client/dangling_indices.pyi
+++ b/elasticsearch/_async/client/dangling_indices.pyi
@@ -22,6 +22,7 @@ class DanglingIndicesClient(NamespacedClient):
     async def delete_dangling_index(
         self,
         index_uuid: Any,
+        *,
         accept_data_loss: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -34,11 +35,12 @@ class DanglingIndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def import_dangling_index(
         self,
         index_uuid: Any,
+        *,
         accept_data_loss: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -51,10 +53,11 @@ class DanglingIndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def list_dangling_indices(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -64,5 +67,5 @@ class DanglingIndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/enrich.py
+++ b/elasticsearch/_async/client/enrich.py
@@ -23,6 +23,7 @@ class EnrichClient(NamespacedClient):
     async def delete_policy(self, name, params=None, headers=None):
         """
         Deletes an existing enrich policy and its enrich index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-enrich-policy-api.html>`_
 
         :arg name: The name of the enrich policy
@@ -41,6 +42,7 @@ class EnrichClient(NamespacedClient):
     async def execute_policy(self, name, params=None, headers=None):
         """
         Creates the enrich index for an existing enrich policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
 
         :arg name: The name of the enrich policy
@@ -61,6 +63,7 @@ class EnrichClient(NamespacedClient):
     async def get_policy(self, name=None, params=None, headers=None):
         """
         Gets information about an enrich policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-enrich-policy-api.html>`_
 
         :arg name: A comma-separated list of enrich policy names
@@ -73,6 +76,7 @@ class EnrichClient(NamespacedClient):
     async def put_policy(self, name, body, params=None, headers=None):
         """
         Creates a new enrich policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-enrich-policy-api.html>`_
 
         :arg name: The name of the enrich policy
@@ -95,6 +99,7 @@ class EnrichClient(NamespacedClient):
         """
         Gets enrich coordinator statistics and information about enrich policies that
         are currently executing.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
         """
         return await self.transport.perform_request(

--- a/elasticsearch/_async/client/enrich.pyi
+++ b/elasticsearch/_async/client/enrich.pyi
@@ -22,6 +22,7 @@ class EnrichClient(NamespacedClient):
     async def delete_policy(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def execute_policy(
         self,
         name: Any,
+        *,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -46,10 +48,11 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_policy(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -60,11 +63,12 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_policy(
         self,
         name: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -75,10 +79,11 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stats(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -88,5 +93,5 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/eql.py
+++ b/elasticsearch/_async/client/eql.py
@@ -23,6 +23,7 @@ class EqlClient(NamespacedClient):
     async def search(self, index, body, params=None, headers=None):
         """
         Returns results matching a query expressed in Event Query Language (EQL)
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
         :arg index: The name of the index to scope the operation
@@ -53,6 +54,7 @@ class EqlClient(NamespacedClient):
         """
         Deletes an async EQL search by ID. If the search is still running, the search
         request will be cancelled. Otherwise, the saved search results are deleted.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
         :arg id: The async search ID
@@ -69,6 +71,7 @@ class EqlClient(NamespacedClient):
         """
         Returns async results from previously executed Event Query Language (EQL)
         search
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
         :arg id: The async search ID

--- a/elasticsearch/_async/client/eql.pyi
+++ b/elasticsearch/_async/client/eql.pyi
@@ -22,6 +22,7 @@ class EqlClient(NamespacedClient):
     async def search(
         self,
         index: Any,
+        *,
         body: Any,
         keep_alive: Optional[Any] = ...,
         keep_on_completion: Optional[Any] = ...,
@@ -35,11 +36,12 @@ class EqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -49,11 +51,12 @@ class EqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get(
         self,
         id: Any,
+        *,
         keep_alive: Optional[Any] = ...,
         wait_for_completion_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -65,5 +68,5 @@ class EqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/graph.py
+++ b/elasticsearch/_async/client/graph.py
@@ -24,6 +24,7 @@ class GraphClient(NamespacedClient):
         """
         Explore extracted and summarized information about the documents and terms in
         an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
 
         :arg index: A comma-separated list of index names to search; use

--- a/elasticsearch/_async/client/graph.pyi
+++ b/elasticsearch/_async/client/graph.pyi
@@ -22,6 +22,7 @@ class GraphClient(NamespacedClient):
     async def explore(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         routing: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -34,5 +35,5 @@ class GraphClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/ilm.py
+++ b/elasticsearch/_async/client/ilm.py
@@ -24,6 +24,7 @@ class IlmClient(NamespacedClient):
         """
         Deletes the specified lifecycle policy definition. A currently used policy
         cannot be deleted.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-delete-lifecycle.html>`_
 
         :arg policy: The name of the index lifecycle policy
@@ -43,6 +44,7 @@ class IlmClient(NamespacedClient):
         """
         Retrieves information about the index's current lifecycle state, such as the
         currently executing phase, action, and step.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-explain-lifecycle.html>`_
 
         :arg index: The name of the index to explain
@@ -63,6 +65,7 @@ class IlmClient(NamespacedClient):
         """
         Returns the specified policy definition. Includes the policy version and last
         modified date.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-lifecycle.html>`_
 
         :arg policy: The name of the index lifecycle policy
@@ -75,6 +78,7 @@ class IlmClient(NamespacedClient):
     async def get_status(self, params=None, headers=None):
         """
         Retrieves the current index lifecycle management (ILM) status.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
         """
         return await self.transport.perform_request(
@@ -85,6 +89,7 @@ class IlmClient(NamespacedClient):
     async def move_to_step(self, index, body=None, params=None, headers=None):
         """
         Manually moves an index into the specified step and executes that step.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-move-to-step.html>`_
 
         :arg index: The name of the index whose lifecycle step is to
@@ -106,6 +111,7 @@ class IlmClient(NamespacedClient):
     async def put_lifecycle(self, policy, body=None, params=None, headers=None):
         """
         Creates a lifecycle policy
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-put-lifecycle.html>`_
 
         :arg policy: The name of the index lifecycle policy
@@ -126,6 +132,7 @@ class IlmClient(NamespacedClient):
     async def remove_policy(self, index, params=None, headers=None):
         """
         Removes the assigned lifecycle policy and stops managing the specified index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-remove-policy.html>`_
 
         :arg index: The name of the index to remove policy on
@@ -141,6 +148,7 @@ class IlmClient(NamespacedClient):
     async def retry(self, index, params=None, headers=None):
         """
         Retries executing the policy for an index that is in the ERROR step.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-retry-policy.html>`_
 
         :arg index: The name of the indices (comma-separated) whose
@@ -157,6 +165,7 @@ class IlmClient(NamespacedClient):
     async def start(self, params=None, headers=None):
         """
         Start the index lifecycle management (ILM) plugin.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-start.html>`_
         """
         return await self.transport.perform_request(
@@ -168,6 +177,7 @@ class IlmClient(NamespacedClient):
         """
         Halts all lifecycle management operations and stops the index lifecycle
         management (ILM) plugin
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-stop.html>`_
         """
         return await self.transport.perform_request(

--- a/elasticsearch/_async/client/ilm.pyi
+++ b/elasticsearch/_async/client/ilm.pyi
@@ -22,6 +22,7 @@ class IlmClient(NamespacedClient):
     async def delete_lifecycle(
         self,
         policy: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def explain_lifecycle(
         self,
         index: Any,
+        *,
         only_errors: Optional[Any] = ...,
         only_managed: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -47,10 +49,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_lifecycle(
         self,
+        *,
         policy: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -61,10 +64,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -74,11 +78,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def move_to_step(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -89,11 +94,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_lifecycle(
         self,
         policy: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -104,11 +110,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def remove_policy(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -118,11 +125,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def retry(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -132,10 +140,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def start(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -145,10 +154,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stop(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -158,5 +168,5 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -24,6 +24,7 @@ class IndicesClient(NamespacedClient):
         """
         Performs the analysis process on a text and return the tokens breakdown of the
         text.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html>`_
 
         :arg body: Define analyzer/tokenizer parameters and the text on
@@ -42,6 +43,7 @@ class IndicesClient(NamespacedClient):
     async def refresh(self, index=None, params=None, headers=None):
         """
         Performs the refresh operation in one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -69,6 +71,7 @@ class IndicesClient(NamespacedClient):
     async def flush(self, index=None, params=None, headers=None):
         """
         Performs the flush operation on one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -99,6 +102,7 @@ class IndicesClient(NamespacedClient):
     async def create(self, index, body=None, params=None, headers=None):
         """
         Creates an index with optional settings and mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html>`_
 
         :arg index: The name of the index
@@ -120,6 +124,7 @@ class IndicesClient(NamespacedClient):
     async def clone(self, index, target, body=None, params=None, headers=None):
         """
         Clones an index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html>`_
 
         :arg index: The name of the source index to clone
@@ -155,6 +160,7 @@ class IndicesClient(NamespacedClient):
     async def get(self, index, params=None, headers=None):
         """
         Returns information about one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html>`_
 
         :arg index: A comma-separated list of index names
@@ -191,6 +197,7 @@ class IndicesClient(NamespacedClient):
     async def open(self, index, params=None, headers=None):
         """
         Opens an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
 
         :arg index: A comma separated list of indices to open
@@ -225,6 +232,7 @@ class IndicesClient(NamespacedClient):
     async def close(self, index, params=None, headers=None):
         """
         Closes an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
 
         :arg index: A comma separated list of indices to close
@@ -258,6 +266,7 @@ class IndicesClient(NamespacedClient):
     async def delete(self, index, params=None, headers=None):
         """
         Deletes an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html>`_
 
         :arg index: A comma-separated list of indices to delete; use
@@ -290,6 +299,7 @@ class IndicesClient(NamespacedClient):
     async def exists(self, index, params=None, headers=None):
         """
         Returns information about whether a particular index exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html>`_
 
         :arg index: A comma-separated list of index names
@@ -319,6 +329,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular document type exists.
         (DEPRECATED)
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` to
@@ -357,6 +368,7 @@ class IndicesClient(NamespacedClient):
     async def put_mapping(self, index, body, params=None, headers=None):
         """
         Updates the index mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html>`_
 
         :arg index: A comma-separated list of index names the mapping
@@ -398,6 +410,7 @@ class IndicesClient(NamespacedClient):
     async def get_mapping(self, index=None, params=None, headers=None):
         """
         Returns mappings for one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html>`_
 
         :arg index: A comma-separated list of index names
@@ -421,6 +434,7 @@ class IndicesClient(NamespacedClient):
     async def put_alias(self, index, name, body=None, params=None, headers=None):
         """
         Creates or updates an alias.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg index: A comma-separated list of index names the alias
@@ -448,6 +462,7 @@ class IndicesClient(NamespacedClient):
     async def exists_alias(self, name, index=None, params=None, headers=None):
         """
         Returns information about whether a particular alias exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg name: A comma-separated list of alias names to return
@@ -475,6 +490,7 @@ class IndicesClient(NamespacedClient):
     async def get_alias(self, index=None, name=None, params=None, headers=None):
         """
         Returns an alias.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg index: A comma-separated list of index names to filter
@@ -499,6 +515,7 @@ class IndicesClient(NamespacedClient):
     async def update_aliases(self, body, params=None, headers=None):
         """
         Updates index aliases.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg body: The definition of `actions` to perform
@@ -516,6 +533,7 @@ class IndicesClient(NamespacedClient):
     async def delete_alias(self, index, name, params=None, headers=None):
         """
         Deletes an alias.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg index: A comma-separated list of index names (supports
@@ -537,6 +555,7 @@ class IndicesClient(NamespacedClient):
     async def put_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -564,6 +583,7 @@ class IndicesClient(NamespacedClient):
     async def exists_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The comma separated names of the index templates
@@ -585,6 +605,7 @@ class IndicesClient(NamespacedClient):
     async def get_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The comma separated names of the index templates
@@ -603,6 +624,7 @@ class IndicesClient(NamespacedClient):
     async def delete_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -628,6 +650,7 @@ class IndicesClient(NamespacedClient):
     async def get_settings(self, index=None, name=None, params=None, headers=None):
         """
         Returns settings for one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -665,6 +688,7 @@ class IndicesClient(NamespacedClient):
     async def put_settings(self, body, index=None, params=None, headers=None):
         """
         Updates the index settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html>`_
 
         :arg body: The index settings to be updated
@@ -712,6 +736,7 @@ class IndicesClient(NamespacedClient):
     async def stats(self, index=None, metric=None, params=None, headers=None):
         """
         Provides statistics on operations happening in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -755,6 +780,7 @@ class IndicesClient(NamespacedClient):
     async def segments(self, index=None, params=None, headers=None):
         """
         Provides low-level information about segments in a Lucene index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -785,6 +811,7 @@ class IndicesClient(NamespacedClient):
     async def clear_cache(self, index=None, params=None, headers=None):
         """
         Clears all or specific caches for one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html>`_
 
         :arg index: A comma-separated list of index name to limit the
@@ -811,6 +838,7 @@ class IndicesClient(NamespacedClient):
     async def recovery(self, index=None, params=None, headers=None):
         """
         Returns information about ongoing index shard recoveries.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -834,6 +862,7 @@ class IndicesClient(NamespacedClient):
     async def upgrade(self, index=None, params=None, headers=None):
         """
         DEPRECATED Upgrades to the current version of Lucene.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -859,6 +888,7 @@ class IndicesClient(NamespacedClient):
     async def get_upgrade(self, index=None, params=None, headers=None):
         """
         DEPRECATED Returns a progress status of current upgrade.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -882,6 +912,7 @@ class IndicesClient(NamespacedClient):
     async def shard_stores(self, index=None, params=None, headers=None):
         """
         Provides store information for shard copies of indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -913,6 +944,7 @@ class IndicesClient(NamespacedClient):
     async def forcemerge(self, index=None, params=None, headers=None):
         """
         Performs the force merge operation on one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -940,6 +972,7 @@ class IndicesClient(NamespacedClient):
     async def shrink(self, index, target, body=None, params=None, headers=None):
         """
         Allow to shrink an existing index into a new index with fewer primary shards.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html>`_
 
         :arg index: The name of the source index to shrink
@@ -968,6 +1001,7 @@ class IndicesClient(NamespacedClient):
         """
         Allows you to split an existing index into a new index with more primary
         shards.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html>`_
 
         :arg index: The name of the source index to split
@@ -998,6 +1032,7 @@ class IndicesClient(NamespacedClient):
         """
         Updates an alias to point to a new index when the existing index is considered
         to be too large or too old.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html>`_
 
         :arg alias: The name of the alias to rollover
@@ -1036,6 +1071,7 @@ class IndicesClient(NamespacedClient):
         """
         Freezes an index. A frozen index has almost no overhead on the cluster (except
         for maintaining its metadata in memory) and is read-only.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/freeze-index-api.html>`_
 
         :arg index: The name of the index to freeze
@@ -1071,6 +1107,7 @@ class IndicesClient(NamespacedClient):
         """
         Unfreezes an index. When a frozen index is unfrozen, the index goes through the
         normal recovery process and becomes writeable again.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/unfreeze-index-api.html>`_
 
         :arg index: The name of the index to unfreeze
@@ -1098,6 +1135,7 @@ class IndicesClient(NamespacedClient):
     async def reload_search_analyzers(self, index, params=None, headers=None):
         """
         Reloads an index's search analyzers and their resources.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html>`_
 
         :arg index: A comma-separated list of index names to reload
@@ -1131,6 +1169,7 @@ class IndicesClient(NamespacedClient):
     async def get_field_mapping(self, fields, index=None, params=None, headers=None):
         """
         Returns mapping for one or more fields.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
 
         :arg fields: A comma-separated list of fields
@@ -1177,6 +1216,7 @@ class IndicesClient(NamespacedClient):
     ):
         """
         Allows a user to validate a potentially expensive query without executing it.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
 
         :arg body: The query definition specified with the Query DSL
@@ -1222,6 +1262,7 @@ class IndicesClient(NamespacedClient):
     async def create_data_stream(self, name, params=None, headers=None):
         """
         Creates a data stream
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: The name of the data stream
@@ -1237,6 +1278,7 @@ class IndicesClient(NamespacedClient):
     async def delete_data_stream(self, name, params=None, headers=None):
         """
         Deletes a data stream.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: A comma-separated list of data streams to delete; use
@@ -1253,6 +1295,7 @@ class IndicesClient(NamespacedClient):
     async def delete_index_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -1273,6 +1316,7 @@ class IndicesClient(NamespacedClient):
     async def get_index_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The comma separated names of the index templates
@@ -1291,6 +1335,7 @@ class IndicesClient(NamespacedClient):
     async def put_index_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -1317,6 +1362,7 @@ class IndicesClient(NamespacedClient):
     async def exists_index_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -1339,6 +1385,7 @@ class IndicesClient(NamespacedClient):
         """
         Simulate matching the given index name against the index templates in the
         system
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the index (it must be a concrete index
@@ -1367,6 +1414,7 @@ class IndicesClient(NamespacedClient):
     async def get_data_stream(self, name=None, params=None, headers=None):
         """
         Returns data streams.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: A comma-separated list of data streams to get; use
@@ -1380,6 +1428,7 @@ class IndicesClient(NamespacedClient):
     async def simulate_template(self, body=None, name=None, params=None, headers=None):
         """
         Simulate resolving the given template name or body
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg body: New index template definition to be simulated, if no
@@ -1404,6 +1453,7 @@ class IndicesClient(NamespacedClient):
     async def resolve_index(self, name, params=None, headers=None):
         """
         Returns information about any matching indices, aliases, and data streams
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
 
         :arg name: A comma-separated list of names or wildcard
@@ -1429,6 +1479,7 @@ class IndicesClient(NamespacedClient):
     async def add_block(self, index, block, params=None, headers=None):
         """
         Adds a block to an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html>`_
 
         :arg index: A comma separated list of indices to add a block to
@@ -1457,6 +1508,7 @@ class IndicesClient(NamespacedClient):
     async def data_streams_stats(self, name=None, params=None, headers=None):
         """
         Provides statistics on operations happening in a data stream.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: A comma-separated list of data stream names; use

--- a/elasticsearch/_async/client/indices.pyi
+++ b/elasticsearch/_async/client/indices.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class IndicesClient(NamespacedClient):
     async def analyze(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -32,10 +33,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def refresh(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -49,10 +51,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def flush(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -68,11 +71,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def create(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -86,12 +90,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def clone(
         self,
         index: Any,
         target: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -105,11 +110,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
@@ -126,11 +132,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def open(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -146,11 +153,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def close(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -166,11 +174,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -185,11 +194,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def exists(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
@@ -205,12 +215,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def exists_type(
         self,
         index: Any,
         doc_type: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -224,11 +235,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def put_mapping(
         self,
         index: Any,
+        *,
         body: Any,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -245,10 +257,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_mapping(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -264,12 +277,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_alias(
         self,
         index: Any,
         name: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -282,11 +296,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def exists_alias(
         self,
         name: Any,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -301,10 +316,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def get_alias(
         self,
+        *,
         index: Optional[Any] = ...,
         name: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -320,10 +336,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_aliases(
         self,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -336,12 +353,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_alias(
         self,
         index: Any,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -353,11 +371,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_template(
         self,
         name: Any,
+        *,
         body: Any,
         create: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -371,11 +390,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def exists_template(
         self,
         name: Any,
+        *,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -388,10 +408,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def get_template(
         self,
+        *,
         name: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
@@ -405,11 +426,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_template(
         self,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -421,10 +443,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_settings(
         self,
+        *,
         index: Optional[Any] = ...,
         name: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -443,10 +466,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_settings(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -465,10 +489,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stats(
         self,
+        *,
         index: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         completion_fields: Optional[Any] = ...,
@@ -490,10 +515,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def segments(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -508,10 +534,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def clear_cache(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -529,10 +556,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def recovery(
         self,
+        *,
         index: Optional[Any] = ...,
         active_only: Optional[Any] = ...,
         detailed: Optional[Any] = ...,
@@ -545,10 +573,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def upgrade(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -564,10 +593,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_upgrade(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -581,10 +611,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def shard_stores(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -599,10 +630,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def forcemerge(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -619,12 +651,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def shrink(
         self,
         index: Any,
         target: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -638,12 +671,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def split(
         self,
         index: Any,
         target: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -657,11 +691,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def rollover(
         self,
         alias: Any,
+        *,
         body: Optional[Any] = ...,
         new_index: Optional[Any] = ...,
         dry_run: Optional[Any] = ...,
@@ -677,11 +712,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def freeze(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -697,11 +733,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def unfreeze(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -717,11 +754,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def reload_search_analyzers(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -734,11 +772,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_field_mapping(
         self,
         fields: Any,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -754,10 +793,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def validate_query(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
@@ -782,11 +822,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def create_data_stream(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -796,11 +837,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_data_stream(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -810,11 +852,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_index_template(
         self,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -826,10 +869,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_index_template(
         self,
+        *,
         name: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
@@ -843,11 +887,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_index_template(
         self,
         name: Any,
+        *,
         body: Any,
         cause: Optional[Any] = ...,
         create: Optional[Any] = ...,
@@ -861,11 +906,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def exists_index_template(
         self,
         name: Any,
+        *,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -878,11 +924,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     async def simulate_index_template(
         self,
         name: Any,
+        *,
         body: Optional[Any] = ...,
         cause: Optional[Any] = ...,
         create: Optional[Any] = ...,
@@ -896,10 +943,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_data_stream(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -910,10 +958,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def simulate_template(
         self,
+        *,
         body: Optional[Any] = ...,
         name: Optional[Any] = ...,
         cause: Optional[Any] = ...,
@@ -928,11 +977,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def resolve_index(
         self,
         name: Any,
+        *,
         expand_wildcards: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -943,12 +993,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def add_block(
         self,
         index: Any,
         block: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -963,10 +1014,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def data_streams_stats(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -977,5 +1029,5 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/ingest.py
+++ b/elasticsearch/_async/client/ingest.py
@@ -23,6 +23,7 @@ class IngestClient(NamespacedClient):
     async def get_pipeline(self, id=None, params=None, headers=None):
         """
         Returns a pipeline.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
 
         :arg id: Comma separated list of pipeline ids. Wildcards
@@ -38,6 +39,7 @@ class IngestClient(NamespacedClient):
     async def put_pipeline(self, id, body, params=None, headers=None):
         """
         Creates or updates a pipeline.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html>`_
 
         :arg id: Pipeline ID
@@ -62,6 +64,7 @@ class IngestClient(NamespacedClient):
     async def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes a pipeline.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
 
         :arg id: Pipeline ID
@@ -83,6 +86,7 @@ class IngestClient(NamespacedClient):
     async def simulate(self, body, id=None, params=None, headers=None):
         """
         Allows to simulate a pipeline with example documents.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
 
         :arg body: The simulate definition
@@ -105,6 +109,7 @@ class IngestClient(NamespacedClient):
     async def processor_grok(self, params=None, headers=None):
         """
         Returns a list of the built-in patterns.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get>`_
         """
         return await self.transport.perform_request(

--- a/elasticsearch/_async/client/ingest.pyi
+++ b/elasticsearch/_async/client/ingest.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class IngestClient(NamespacedClient):
     async def get_pipeline(
         self,
+        *,
         id: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -32,11 +33,12 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_pipeline(
         self,
         id: Any,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -49,11 +51,12 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_pipeline(
         self,
         id: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -65,10 +68,11 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def simulate(
         self,
+        *,
         body: Any,
         id: Optional[Any] = ...,
         verbose: Optional[Any] = ...,
@@ -81,10 +85,11 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def processor_grok(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -94,5 +99,5 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -23,6 +23,7 @@ class LicenseClient(NamespacedClient):
     async def delete(self, params=None, headers=None):
         """
         Deletes licensing information for the cluster
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
         """
         return await self.transport.perform_request(
@@ -33,6 +34,7 @@ class LicenseClient(NamespacedClient):
     async def get(self, params=None, headers=None):
         """
         Retrieves licensing information for the cluster
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
 
         :arg accept_enterprise: Supported for backwards compatibility
@@ -48,6 +50,7 @@ class LicenseClient(NamespacedClient):
     async def get_basic_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the basic license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
         """
         return await self.transport.perform_request(
@@ -58,6 +61,7 @@ class LicenseClient(NamespacedClient):
     async def get_trial_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the trial license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
         """
         return await self.transport.perform_request(
@@ -68,6 +72,7 @@ class LicenseClient(NamespacedClient):
     async def post(self, body=None, params=None, headers=None):
         """
         Updates the license for the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html>`_
 
         :arg body: licenses to be installed
@@ -82,6 +87,7 @@ class LicenseClient(NamespacedClient):
     async def post_start_basic(self, params=None, headers=None):
         """
         Starts an indefinite basic license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html>`_
 
         :arg acknowledge: whether the user has acknowledged acknowledge
@@ -95,6 +101,7 @@ class LicenseClient(NamespacedClient):
     async def post_start_trial(self, params=None, headers=None):
         """
         starts a limited time trial license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html>`_
 
         :arg acknowledge: whether the user has acknowledged acknowledge

--- a/elasticsearch/_async/client/license.pyi
+++ b/elasticsearch/_async/client/license.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class LicenseClient(NamespacedClient):
     async def delete(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,10 +31,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get(
         self,
+        *,
         accept_enterprise: Optional[Any] = ...,
         local: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_basic_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -58,10 +61,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_trial_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -71,10 +75,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def post(
         self,
+        *,
         body: Optional[Any] = ...,
         acknowledge: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -86,10 +91,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def post_start_basic(
         self,
+        *,
         acknowledge: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -100,10 +106,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def post_start_trial(
         self,
+        *,
         acknowledge: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -115,5 +122,5 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/migration.py
+++ b/elasticsearch/_async/client/migration.py
@@ -25,6 +25,7 @@ class MigrationClient(NamespacedClient):
         Retrieves information about different cluster, node, and index level settings
         that use deprecated features that will be removed or changed in the next major
         version.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html>`_
 
         :arg index: Index pattern

--- a/elasticsearch/_async/client/migration.pyi
+++ b/elasticsearch/_async/client/migration.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class MigrationClient(NamespacedClient):
     async def deprecations(
         self,
+        *,
         index: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -31,5 +32,5 @@ class MigrationClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -24,6 +24,7 @@ class MlClient(NamespacedClient):
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed
         multiple times throughout its lifecycle.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html>`_
 
         :arg job_id: The name of the job to close
@@ -53,6 +54,7 @@ class MlClient(NamespacedClient):
     async def delete_calendar(self, calendar_id, params=None, headers=None):
         """
         Deletes a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html>`_
 
         :arg calendar_id: The ID of the calendar to delete
@@ -75,6 +77,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Deletes scheduled events from a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -95,6 +98,7 @@ class MlClient(NamespacedClient):
     async def delete_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Deletes anomaly detection jobs from a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -115,6 +119,7 @@ class MlClient(NamespacedClient):
     async def delete_datafeed(self, datafeed_id, params=None, headers=None):
         """
         Deletes an existing datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to delete
@@ -138,6 +143,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Deletes expired and unused machine learning data.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-expired-data.html>`_
 
         :arg body: deleting expired data parameters
@@ -160,6 +166,7 @@ class MlClient(NamespacedClient):
     async def delete_filter(self, filter_id, params=None, headers=None):
         """
         Deletes a filter.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-filter.html>`_
 
         :arg filter_id: The ID of the filter to delete
@@ -180,6 +187,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Deletes forecasts from a machine learning job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-forecast.html>`_
 
         :arg job_id: The ID of the job from which to delete forecasts
@@ -204,6 +212,7 @@ class MlClient(NamespacedClient):
     async def delete_job(self, job_id, params=None, headers=None):
         """
         Deletes an existing anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-job.html>`_
 
         :arg job_id: The ID of the job to delete
@@ -227,6 +236,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Deletes an existing model snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -265,6 +275,7 @@ class MlClient(NamespacedClient):
         """
         Finds the structure of a text file. The text file must contain data that is
         suitable to be ingested into Elasticsearch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-find-file-structure.html>`_
 
         :arg body: The contents of the file to be analyzed
@@ -316,6 +327,7 @@ class MlClient(NamespacedClient):
     async def flush_job(self, job_id, body=None, params=None, headers=None):
         """
         Forces any buffered data to be processed by the job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-flush-job.html>`_
 
         :arg job_id: The name of the job to flush
@@ -346,6 +358,7 @@ class MlClient(NamespacedClient):
     async def forecast(self, job_id, params=None, headers=None):
         """
         Predicts the future behavior of a time series by using its historical behavior.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-forecast.html>`_
 
         :arg job_id: The ID of the job to forecast for
@@ -381,6 +394,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Retrieves anomaly detection job results for one or more buckets.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-bucket.html>`_
 
         :arg job_id: ID of the job to get bucket results from
@@ -418,6 +432,7 @@ class MlClient(NamespacedClient):
     async def get_calendar_events(self, calendar_id, params=None, headers=None):
         """
         Retrieves information about the scheduled events in calendars.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html>`_
 
         :arg calendar_id: The ID of the calendar containing the events
@@ -450,6 +465,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Retrieves configuration information for calendars.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html>`_
 
         :arg body: The from and size parameters optionally sent in the
@@ -474,6 +490,7 @@ class MlClient(NamespacedClient):
     async def get_datafeed_stats(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves usage information for datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html>`_
 
         :arg datafeed_id: The ID of the datafeeds stats to fetch
@@ -491,10 +508,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match")
+    @query_params("allow_no_datafeeds", "allow_no_match", "exclude_generated")
     async def get_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves configuration information for datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeeds to fetch
@@ -504,6 +522,8 @@ class MlClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no datafeeds. (This includes `_all` string or when no datafeeds
             have been specified)
+        :arg exclude_generated: Omits fields that are illegal to set on
+            datafeed PUT
         """
         return await self.transport.perform_request(
             "GET",
@@ -516,6 +536,7 @@ class MlClient(NamespacedClient):
     async def get_filters(self, filter_id=None, params=None, headers=None):
         """
         Retrieves filters.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-filter.html>`_
 
         :arg filter_id: The ID of the filter to fetch
@@ -546,6 +567,7 @@ class MlClient(NamespacedClient):
     async def get_influencers(self, job_id, body=None, params=None, headers=None):
         """
         Retrieves anomaly detection job results for one or more influencers.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-influencer.html>`_
 
         :arg job_id: Identifier for the anomaly detection job
@@ -580,6 +602,7 @@ class MlClient(NamespacedClient):
     async def get_job_stats(self, job_id=None, params=None, headers=None):
         """
         Retrieves usage information for anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html>`_
 
         :arg job_id: The ID of the jobs stats to fetch
@@ -597,10 +620,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_jobs", "allow_no_match")
+    @query_params("allow_no_jobs", "allow_no_match", "exclude_generated")
     async def get_jobs(self, job_id=None, params=None, headers=None):
         """
         Retrieves configuration information for anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job.html>`_
 
         :arg job_id: The ID of the jobs to fetch
@@ -610,6 +634,8 @@ class MlClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no jobs. (This includes `_all` string or when no jobs have been
             specified)
+        :arg exclude_generated: Omits fields that are illegal to set on
+            job PUT
         """
         return await self.transport.perform_request(
             "GET",
@@ -632,6 +658,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves overall bucket results that summarize the bucket results of multiple
         anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-overall-buckets.html>`_
 
         :arg job_id: The job IDs for which to calculate overall bucket
@@ -683,6 +710,7 @@ class MlClient(NamespacedClient):
     async def get_records(self, job_id, body=None, params=None, headers=None):
         """
         Retrieves anomaly records for an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-record.html>`_
 
         :arg job_id: The ID of the job
@@ -716,6 +744,7 @@ class MlClient(NamespacedClient):
     async def info(self, params=None, headers=None):
         """
         Returns defaults and limits used by machine learning.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
         """
         return await self.transport.perform_request(
@@ -726,6 +755,7 @@ class MlClient(NamespacedClient):
     async def open_job(self, job_id, params=None, headers=None):
         """
         Opens one or more anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-open-job.html>`_
 
         :arg job_id: The ID of the job to open
@@ -744,6 +774,7 @@ class MlClient(NamespacedClient):
     async def post_calendar_events(self, calendar_id, body, params=None, headers=None):
         """
         Posts scheduled events in a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-calendar-event.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -765,6 +796,7 @@ class MlClient(NamespacedClient):
     async def post_data(self, job_id, body, params=None, headers=None):
         """
         Sends data to an anomaly detection job for analysis.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-data.html>`_
 
         :arg job_id: The name of the job receiving the data
@@ -791,6 +823,7 @@ class MlClient(NamespacedClient):
     async def preview_datafeed(self, datafeed_id, params=None, headers=None):
         """
         Previews a datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-preview-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to preview
@@ -811,6 +844,7 @@ class MlClient(NamespacedClient):
     async def put_calendar(self, calendar_id, body=None, params=None, headers=None):
         """
         Instantiates a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar.html>`_
 
         :arg calendar_id: The ID of the calendar to create
@@ -833,6 +867,7 @@ class MlClient(NamespacedClient):
     async def put_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Adds an anomaly detection job to a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar-job.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -855,6 +890,7 @@ class MlClient(NamespacedClient):
     async def put_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
         Instantiates a datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to create
@@ -885,6 +921,7 @@ class MlClient(NamespacedClient):
     async def put_filter(self, filter_id, body, params=None, headers=None):
         """
         Instantiates a filter.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-filter.html>`_
 
         :arg filter_id: The ID of the filter to create
@@ -906,6 +943,7 @@ class MlClient(NamespacedClient):
     async def put_job(self, job_id, body, params=None, headers=None):
         """
         Instantiates an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html>`_
 
         :arg job_id: The ID of the job to create
@@ -928,6 +966,7 @@ class MlClient(NamespacedClient):
         """
         Sets a cluster wide upgrade_mode setting that prepares machine learning indices
         for an upgrade.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-set-upgrade-mode.html>`_
 
         :arg enabled: Whether to enable upgrade_mode ML setting or not.
@@ -943,6 +982,7 @@ class MlClient(NamespacedClient):
     async def start_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Starts one or more datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to start
@@ -970,6 +1010,7 @@ class MlClient(NamespacedClient):
     async def stop_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Stops one or more datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-stop-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to stop
@@ -1003,6 +1044,7 @@ class MlClient(NamespacedClient):
     async def update_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
         Updates certain properties of a datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to update
@@ -1033,6 +1075,7 @@ class MlClient(NamespacedClient):
     async def update_filter(self, filter_id, body, params=None, headers=None):
         """
         Updates the description of a filter, adds items, or removes items.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-filter.html>`_
 
         :arg filter_id: The ID of the filter to update
@@ -1054,6 +1097,7 @@ class MlClient(NamespacedClient):
     async def update_job(self, job_id, body, params=None, headers=None):
         """
         Updates certain properties of an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-job.html>`_
 
         :arg job_id: The ID of the job to create
@@ -1075,6 +1119,7 @@ class MlClient(NamespacedClient):
     async def validate(self, body, params=None, headers=None):
         """
         Validates an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html>`_
 
         :arg body: The job config
@@ -1094,6 +1139,7 @@ class MlClient(NamespacedClient):
     async def validate_detector(self, body, params=None, headers=None):
         """
         Validates an anomaly detection detector.
+
         `<https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html>`_
 
         :arg body: The detector
@@ -1113,6 +1159,7 @@ class MlClient(NamespacedClient):
     async def delete_data_frame_analytics(self, id, params=None, headers=None):
         """
         Deletes an existing data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to delete
@@ -1134,6 +1181,7 @@ class MlClient(NamespacedClient):
     async def evaluate_data_frame(self, body, params=None, headers=None):
         """
         Evaluates the data frame analytics for an annotated index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html>`_
 
         :arg body: The evaluation definition
@@ -1149,16 +1197,19 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params("allow_no_match", "exclude_generated", "from_", "size")
     async def get_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Retrieves configuration information for data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no data frame analytics. (This includes `_all` string or when no
             data frame analytics have been specified)  Default: True
+        :arg exclude_generated: Omits fields that are illegal to set on
+            data frame analytics PUT
         :arg from\\_: skips a number of analytics
         :arg size: specifies a max number of analytics to get  Default:
             100
@@ -1178,6 +1229,7 @@ class MlClient(NamespacedClient):
     async def get_data_frame_analytics_stats(self, id=None, params=None, headers=None):
         """
         Retrieves usage information for data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html>`_
 
         :arg id: The ID of the data frame analytics stats to fetch
@@ -1204,6 +1256,7 @@ class MlClient(NamespacedClient):
     async def put_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Instantiates a data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to create
@@ -1227,6 +1280,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Starts a data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to start
@@ -1249,6 +1303,7 @@ class MlClient(NamespacedClient):
     async def stop_data_frame_analytics(self, id, body=None, params=None, headers=None):
         """
         Stops one or more data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to stop
@@ -1277,7 +1332,8 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing trained inference model that is currently not referenced by
         an ingest pipeline.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models.html>`_
 
         :arg model_id: The ID of the trained model to delete
         """
@@ -1286,7 +1342,7 @@ class MlClient(NamespacedClient):
 
         return await self.transport.perform_request(
             "DELETE",
-            _make_path("_ml", "inference", model_id),
+            _make_path("_ml", "trained_models", model_id),
             params=params,
             headers=headers,
         )
@@ -1294,7 +1350,7 @@ class MlClient(NamespacedClient):
     @query_params(
         "allow_no_match",
         "decompress_definition",
-        "for_export",
+        "exclude_generated",
         "from_",
         "include",
         "include_model_definition",
@@ -1304,7 +1360,8 @@ class MlClient(NamespacedClient):
     async def get_trained_models(self, model_id=None, params=None, headers=None):
         """
         Retrieves configuration information for a trained inference model.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models.html>`_
 
         :arg model_id: The ID of the trained models to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
@@ -1313,8 +1370,8 @@ class MlClient(NamespacedClient):
         :arg decompress_definition: Should the model definition be
             decompressed into valid JSON or returned in a custom compressed format.
             Defaults to true.  Default: True
-        :arg for_export: Omits fields that are illegal to set on model
-            PUT
+        :arg exclude_generated: Omits fields that are illegal to set on
+            model PUT
         :arg from\\_: skips a number of trained models
         :arg include: A comma-separate list of fields to optionally
             include. Valid options are 'definition' and 'total_feature_importance'.
@@ -1333,7 +1390,7 @@ class MlClient(NamespacedClient):
 
         return await self.transport.perform_request(
             "GET",
-            _make_path("_ml", "inference", model_id),
+            _make_path("_ml", "trained_models", model_id),
             params=params,
             headers=headers,
         )
@@ -1342,7 +1399,8 @@ class MlClient(NamespacedClient):
     async def get_trained_models_stats(self, model_id=None, params=None, headers=None):
         """
         Retrieves usage information for trained inference models.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-stats.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html>`_
 
         :arg model_id: The ID of the trained models stats to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
@@ -1358,7 +1416,7 @@ class MlClient(NamespacedClient):
 
         return await self.transport.perform_request(
             "GET",
-            _make_path("_ml", "inference", model_id, "_stats"),
+            _make_path("_ml", "trained_models", model_id, "_stats"),
             params=params,
             headers=headers,
         )
@@ -1367,7 +1425,8 @@ class MlClient(NamespacedClient):
     async def put_trained_model(self, model_id, body, params=None, headers=None):
         """
         Creates an inference trained model.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models.html>`_
 
         :arg model_id: The ID of the trained models to store
         :arg body: The trained model configuration
@@ -1378,7 +1437,7 @@ class MlClient(NamespacedClient):
 
         return await self.transport.perform_request(
             "PUT",
-            _make_path("_ml", "inference", model_id),
+            _make_path("_ml", "trained_models", model_id),
             params=params,
             headers=headers,
             body=body,
@@ -1388,6 +1447,7 @@ class MlClient(NamespacedClient):
     async def estimate_model_memory(self, body, params=None, headers=None):
         """
         Estimates the model memory
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-apis.html>`_
 
         :arg body: The analysis config, plus cardinality estimates for
@@ -1410,6 +1470,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Explains a data frame analytics config.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html>`_
 
         :arg body: The data frame analytics config to explain
@@ -1429,6 +1490,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Retrieves anomaly detection job results for one or more categories.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-category.html>`_
 
         :arg job_id: The name of the job
@@ -1464,6 +1526,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Retrieves information about model snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -1501,6 +1564,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Reverts to a specific snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-revert-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -1534,6 +1598,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Updates certain properties of a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -1563,6 +1628,7 @@ class MlClient(NamespacedClient):
     async def update_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Updates certain properties of a data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to update

--- a/elasticsearch/_async/client/ml.pyi
+++ b/elasticsearch/_async/client/ml.pyi
@@ -22,6 +22,7 @@ class MlClient(NamespacedClient):
     async def close_job(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -36,11 +37,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_calendar(
         self,
         calendar_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -50,12 +52,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_calendar_event(
         self,
         calendar_id: Any,
         event_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -65,12 +68,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_calendar_job(
         self,
         calendar_id: Any,
         job_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -80,11 +84,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_datafeed(
         self,
         datafeed_id: Any,
+        *,
         force: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -95,10 +100,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_expired_data(
         self,
+        *,
         body: Optional[Any] = ...,
         job_id: Optional[Any] = ...,
         requests_per_second: Optional[Any] = ...,
@@ -112,11 +118,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_filter(
         self,
         filter_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -126,11 +133,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_forecast(
         self,
         job_id: Any,
+        *,
         forecast_id: Optional[Any] = ...,
         allow_no_forecasts: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -143,11 +151,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_job(
         self,
         job_id: Any,
+        *,
         force: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -159,12 +168,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_model_snapshot(
         self,
         job_id: Any,
         snapshot_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -174,10 +184,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def find_file_structure(
         self,
+        *,
         body: Any,
         charset: Optional[Any] = ...,
         column_names: Optional[Any] = ...,
@@ -201,11 +212,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def flush_job(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         advance_time: Optional[Any] = ...,
         calc_interim: Optional[Any] = ...,
@@ -221,11 +233,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def forecast(
         self,
         job_id: Any,
+        *,
         duration: Optional[Any] = ...,
         expires_in: Optional[Any] = ...,
         max_model_memory: Optional[Any] = ...,
@@ -238,11 +251,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_buckets(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         timestamp: Optional[Any] = ...,
         anomaly_score: Optional[Any] = ...,
@@ -263,11 +277,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_calendar_events(
         self,
         calendar_id: Any,
+        *,
         end: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         job_id: Optional[Any] = ...,
@@ -282,10 +297,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_calendars(
         self,
+        *,
         body: Optional[Any] = ...,
         calendar_id: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -299,10 +315,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_datafeed_stats(
         self,
+        *,
         datafeed_id: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -315,13 +332,15 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_datafeeds(
         self,
+        *,
         datafeed_id: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -331,10 +350,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_filters(
         self,
+        *,
         filter_id: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
@@ -347,11 +367,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_influencers(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         desc: Optional[Any] = ...,
         end: Optional[Any] = ...,
@@ -370,10 +391,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_job_stats(
         self,
+        *,
         job_id: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -386,13 +408,15 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_jobs(
         self,
+        *,
         job_id: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -402,11 +426,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_overall_buckets(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -425,11 +450,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_records(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         desc: Optional[Any] = ...,
         end: Optional[Any] = ...,
@@ -448,10 +474,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def info(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -461,11 +488,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def open_job(
         self,
         job_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -475,11 +503,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def post_calendar_events(
         self,
         calendar_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -490,11 +519,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def post_data(
         self,
         job_id: Any,
+        *,
         body: Any,
         reset_end: Optional[Any] = ...,
         reset_start: Optional[Any] = ...,
@@ -507,11 +537,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def preview_datafeed(
         self,
         datafeed_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -521,11 +552,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_calendar(
         self,
         calendar_id: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -536,12 +568,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_calendar_job(
         self,
         calendar_id: Any,
         job_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -551,11 +584,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Any,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -570,11 +604,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_filter(
         self,
         filter_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -585,11 +620,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_job(
         self,
         job_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -600,10 +636,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def set_upgrade_mode(
         self,
+        *,
         enabled: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -615,11 +652,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def start_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Optional[Any] = ...,
         end: Optional[Any] = ...,
         start: Optional[Any] = ...,
@@ -633,11 +671,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stop_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -652,11 +691,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Any,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -671,11 +711,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_filter(
         self,
         filter_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -686,11 +727,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_job(
         self,
         job_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -701,10 +743,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def validate(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -715,10 +758,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def validate_detector(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -729,11 +773,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_data_frame_analytics(
         self,
         id: Any,
+        *,
         force: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -745,10 +790,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def evaluate_data_frame(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -759,12 +805,14 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_data_frame_analytics(
         self,
+        *,
         id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -776,10 +824,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_data_frame_analytics_stats(
         self,
+        *,
         id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -794,11 +843,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -809,11 +859,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def start_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -825,11 +876,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stop_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         force: Optional[Any] = ...,
@@ -843,11 +895,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_trained_model(
         self,
         model_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -857,14 +910,15 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_trained_models(
         self,
+        *,
         model_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         decompress_definition: Optional[Any] = ...,
-        for_export: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         include: Optional[Any] = ...,
         include_model_definition: Optional[Any] = ...,
@@ -879,10 +933,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_trained_models_stats(
         self,
+        *,
         model_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -896,11 +951,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_trained_model(
         self,
         model_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -911,10 +967,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def estimate_model_memory(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -925,10 +982,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def explain_data_frame_analytics(
         self,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -940,11 +998,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_categories(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         category_id: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -959,11 +1018,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_model_snapshots(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         snapshot_id: Optional[Any] = ...,
         desc: Optional[Any] = ...,
@@ -981,12 +1041,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def revert_model_snapshot(
         self,
         job_id: Any,
         snapshot_id: Any,
+        *,
         body: Optional[Any] = ...,
         delete_intervening_results: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -998,12 +1059,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_model_snapshot(
         self,
         job_id: Any,
         snapshot_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -1014,11 +1076,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -1029,5 +1092,5 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/monitoring.py
+++ b/elasticsearch/_async/client/monitoring.py
@@ -23,6 +23,7 @@ class MonitoringClient(NamespacedClient):
     async def bulk(self, body, doc_type=None, params=None, headers=None):
         """
         Used by the monitoring features to send monitoring data.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
 
         :arg body: The operation definition and data (action-data

--- a/elasticsearch/_async/client/monitoring.pyi
+++ b/elasticsearch/_async/client/monitoring.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class MonitoringClient(NamespacedClient):
     async def bulk(
         self,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         interval: Optional[Any] = ...,
@@ -35,5 +36,5 @@ class MonitoringClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/nodes.py
+++ b/elasticsearch/_async/client/nodes.py
@@ -25,6 +25,7 @@ class NodesClient(NamespacedClient):
     ):
         """
         Reloads secure settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings>`_
 
         :arg body: An object containing the password for the
@@ -46,6 +47,7 @@ class NodesClient(NamespacedClient):
     async def info(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns information about nodes in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -69,6 +71,7 @@ class NodesClient(NamespacedClient):
     async def hot_threads(self, node_id=None, params=None, headers=None):
         """
         Returns information about hot threads on each node in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -102,6 +105,7 @@ class NodesClient(NamespacedClient):
     async def usage(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns low-level information about REST actions usage on nodes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -134,6 +138,7 @@ class NodesClient(NamespacedClient):
     ):
         """
         Returns statistical information about nodes in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to

--- a/elasticsearch/_async/client/nodes.pyi
+++ b/elasticsearch/_async/client/nodes.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class NodesClient(NamespacedClient):
     async def reload_secure_settings(
         self,
+        *,
         body: Optional[Any] = ...,
         node_id: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -33,10 +34,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def info(
         self,
+        *,
         node_id: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
@@ -50,10 +52,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def hot_threads(
         self,
+        *,
         node_id: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
         ignore_idle_threads: Optional[Any] = ...,
@@ -70,10 +73,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def usage(
         self,
+        *,
         node_id: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -86,10 +90,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stats(
         self,
+        *,
         node_id: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         index_metric: Optional[Any] = ...,
@@ -110,5 +115,5 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/remote.py
+++ b/elasticsearch/_async/client/remote.py
@@ -22,7 +22,7 @@ class RemoteClient(NamespacedClient):
     @query_params()
     def info(self, params=None, headers=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
         """
         return self.transport.perform_request(
             "GET", "/_remote/info", params=params, headers=headers

--- a/elasticsearch/_async/client/remote.pyi
+++ b/elasticsearch/_async/client/remote.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class RemoteClient(NamespacedClient):
     async def info(
         self,
+        *,
         timeout: Optional[Any] = None,
         pretty: Optional[bool] = None,
         human: Optional[bool] = None,

--- a/elasticsearch/_async/client/rollup.py
+++ b/elasticsearch/_async/client/rollup.py
@@ -23,6 +23,7 @@ class RollupClient(NamespacedClient):
     async def delete_job(self, id, params=None, headers=None):
         """
         Deletes an existing rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html>`_
 
         :arg id: The ID of the job to delete
@@ -38,6 +39,7 @@ class RollupClient(NamespacedClient):
     async def get_jobs(self, id=None, params=None, headers=None):
         """
         Retrieves the configuration, stats, and status of rollup jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html>`_
 
         :arg id: The ID of the job(s) to fetch. Accepts glob patterns,
@@ -52,6 +54,7 @@ class RollupClient(NamespacedClient):
         """
         Returns the capabilities of any rollup jobs that have been configured for a
         specific index or index pattern.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html>`_
 
         :arg id: The ID of the index to check rollup capabilities on, or
@@ -66,6 +69,7 @@ class RollupClient(NamespacedClient):
         """
         Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
         index where rollup data is stored).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html>`_
 
         :arg index: The rollup index or index pattern to obtain rollup
@@ -82,6 +86,7 @@ class RollupClient(NamespacedClient):
     async def put_job(self, id, body, params=None, headers=None):
         """
         Creates a rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html>`_
 
         :arg id: The ID of the job to create
@@ -105,6 +110,7 @@ class RollupClient(NamespacedClient):
     ):
         """
         Enables searching rolled-up data using the standard query DSL.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html>`_
 
         :arg index: The indices or index-pattern(s) (containing rollup
@@ -132,6 +138,7 @@ class RollupClient(NamespacedClient):
     async def start_job(self, id, params=None, headers=None):
         """
         Starts an existing, stopped rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html>`_
 
         :arg id: The ID of the job to start
@@ -150,6 +157,7 @@ class RollupClient(NamespacedClient):
     async def stop_job(self, id, params=None, headers=None):
         """
         Stops an existing, started rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html>`_
 
         :arg id: The ID of the job to stop

--- a/elasticsearch/_async/client/rollup.pyi
+++ b/elasticsearch/_async/client/rollup.pyi
@@ -22,6 +22,7 @@ class RollupClient(NamespacedClient):
     async def delete_job(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,10 +32,11 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_jobs(
         self,
+        *,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_rollup_caps(
         self,
+        *,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -59,11 +62,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_rollup_index_caps(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -73,11 +77,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_job(
         self,
         id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -88,11 +93,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def rollup_search(
         self,
         index: Any,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         rest_total_hits_as_int: Optional[Any] = ...,
@@ -106,11 +112,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def start_job(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -120,11 +127,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stop_job(
         self,
         id: Any,
+        *,
         timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -136,5 +144,5 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/searchable_snapshots.py
+++ b/elasticsearch/_async/client/searchable_snapshots.py
@@ -23,6 +23,7 @@ class SearchableSnapshotsClient(NamespacedClient):
     async def clear_cache(self, index=None, params=None, headers=None):
         """
         Clear the cache of searchable snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
 
         :arg index: A comma-separated list of index name to limit the
@@ -47,6 +48,7 @@ class SearchableSnapshotsClient(NamespacedClient):
     async def mount(self, repository, snapshot, body, params=None, headers=None):
         """
         Mount a snapshot as a searchable index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html>`_
 
         :arg repository: The name of the repository containing the
@@ -75,6 +77,7 @@ class SearchableSnapshotsClient(NamespacedClient):
     async def stats(self, index=None, params=None, headers=None):
         """
         Retrieve various statistics about searchable snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
 
         :arg index: A comma-separated list of index names

--- a/elasticsearch/_async/client/searchable_snapshots.pyi
+++ b/elasticsearch/_async/client/searchable_snapshots.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SearchableSnapshotsClient(NamespacedClient):
     async def clear_cache(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -34,12 +35,13 @@ class SearchableSnapshotsClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def mount(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
@@ -52,10 +54,11 @@ class SearchableSnapshotsClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stats(
         self,
+        *,
         index: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -66,5 +69,5 @@ class SearchableSnapshotsClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -24,6 +24,7 @@ class SecurityClient(NamespacedClient):
         """
         Enables authentication as a user and retrieve information about the
         authenticated user.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
         """
         return await self.transport.perform_request(
@@ -34,6 +35,7 @@ class SecurityClient(NamespacedClient):
     async def change_password(self, body, username=None, params=None, headers=None):
         """
         Changes the passwords of users in the native realm and built-in users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-change-password.html>`_
 
         :arg body: the new password for the user
@@ -60,6 +62,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts users from the user cache. Can completely clear the cache or evict
         specific users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-cache.html>`_
 
         :arg realms: Comma-separated list of realms to clear
@@ -80,6 +83,7 @@ class SecurityClient(NamespacedClient):
     async def clear_cached_roles(self, name, params=None, headers=None):
         """
         Evicts roles from the native role cache.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-role-cache.html>`_
 
         :arg name: Role name
@@ -98,6 +102,7 @@ class SecurityClient(NamespacedClient):
     async def create_api_key(self, body, params=None, headers=None):
         """
         Creates an API key for access without requiring basic authentication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-api-key.html>`_
 
         :arg body: The api key request to create an API key
@@ -117,6 +122,7 @@ class SecurityClient(NamespacedClient):
     async def delete_privileges(self, application, name, params=None, headers=None):
         """
         Removes application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-privilege.html>`_
 
         :arg application: Application name
@@ -141,6 +147,7 @@ class SecurityClient(NamespacedClient):
     async def delete_role(self, name, params=None, headers=None):
         """
         Removes roles in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role.html>`_
 
         :arg name: Role name
@@ -163,6 +170,7 @@ class SecurityClient(NamespacedClient):
     async def delete_role_mapping(self, name, params=None, headers=None):
         """
         Removes role mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role-mapping.html>`_
 
         :arg name: Role-mapping name
@@ -185,6 +193,7 @@ class SecurityClient(NamespacedClient):
     async def delete_user(self, username, params=None, headers=None):
         """
         Deletes users from the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-user.html>`_
 
         :arg username: username
@@ -207,6 +216,7 @@ class SecurityClient(NamespacedClient):
     async def disable_user(self, username, params=None, headers=None):
         """
         Disables users in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user.html>`_
 
         :arg username: The username of the user to disable
@@ -229,6 +239,7 @@ class SecurityClient(NamespacedClient):
     async def enable_user(self, username, params=None, headers=None):
         """
         Enables users in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user.html>`_
 
         :arg username: The username of the user to enable
@@ -251,6 +262,7 @@ class SecurityClient(NamespacedClient):
     async def get_api_key(self, params=None, headers=None):
         """
         Retrieves information for one or more API keys.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-api-key.html>`_
 
         :arg id: API key id of the API key to be retrieved
@@ -272,6 +284,7 @@ class SecurityClient(NamespacedClient):
     ):
         """
         Retrieves application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
 
         :arg application: Application name
@@ -288,6 +301,7 @@ class SecurityClient(NamespacedClient):
     async def get_role(self, name=None, params=None, headers=None):
         """
         Retrieves roles in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role.html>`_
 
         :arg name: A comma-separated list of role names
@@ -300,6 +314,7 @@ class SecurityClient(NamespacedClient):
     async def get_role_mapping(self, name=None, params=None, headers=None):
         """
         Retrieves role mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role-mapping.html>`_
 
         :arg name: A comma-separated list of role-mapping names
@@ -315,6 +330,7 @@ class SecurityClient(NamespacedClient):
     async def get_token(self, body, params=None, headers=None):
         """
         Creates a bearer token for access without requiring basic authentication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html>`_
 
         :arg body: The token request to get
@@ -330,6 +346,7 @@ class SecurityClient(NamespacedClient):
     async def get_user(self, username=None, params=None, headers=None):
         """
         Retrieves information about users in the native realm and built-in users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user.html>`_
 
         :arg username: A comma-separated list of usernames
@@ -345,6 +362,7 @@ class SecurityClient(NamespacedClient):
     async def get_user_privileges(self, params=None, headers=None):
         """
         Retrieves application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
         """
         return await self.transport.perform_request(
@@ -355,6 +373,7 @@ class SecurityClient(NamespacedClient):
     async def has_privileges(self, body, user=None, params=None, headers=None):
         """
         Determines whether the specified user has a specified list of privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges.html>`_
 
         :arg body: The privileges to test
@@ -375,6 +394,7 @@ class SecurityClient(NamespacedClient):
     async def invalidate_api_key(self, body, params=None, headers=None):
         """
         Invalidates one or more API keys.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-api-key.html>`_
 
         :arg body: The api key request to invalidate API key(s)
@@ -390,6 +410,7 @@ class SecurityClient(NamespacedClient):
     async def invalidate_token(self, body, params=None, headers=None):
         """
         Invalidates one or more access tokens or refresh tokens.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-token.html>`_
 
         :arg body: The token to invalidate
@@ -409,6 +430,7 @@ class SecurityClient(NamespacedClient):
     async def put_privileges(self, body, params=None, headers=None):
         """
         Adds or updates application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-privileges.html>`_
 
         :arg body: The privilege(s) to add
@@ -428,6 +450,7 @@ class SecurityClient(NamespacedClient):
     async def put_role(self, name, body, params=None, headers=None):
         """
         Adds and updates roles in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role.html>`_
 
         :arg name: Role name
@@ -453,6 +476,7 @@ class SecurityClient(NamespacedClient):
     async def put_role_mapping(self, name, body, params=None, headers=None):
         """
         Creates and updates role mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role-mapping.html>`_
 
         :arg name: Role-mapping name
@@ -479,6 +503,7 @@ class SecurityClient(NamespacedClient):
         """
         Adds and updates users in the native realm. These users are commonly referred
         to as native users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-user.html>`_
 
         :arg username: The username of the User
@@ -505,6 +530,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves the list of cluster privileges and index privileges that are
         available in this version of Elasticsearch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
         """
         return await self.transport.perform_request(
@@ -515,6 +541,7 @@ class SecurityClient(NamespacedClient):
     async def clear_cached_privileges(self, application, params=None, headers=None):
         """
         Evicts application privileges from the native application privileges cache.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-privilege-cache.html>`_
 
         :arg application: A comma-separated list of application names
@@ -529,4 +556,48 @@ class SecurityClient(NamespacedClient):
             _make_path("_security", "privilege", application, "_clear_cache"),
             params=params,
             headers=headers,
+        )
+
+    @query_params()
+    async def clear_api_key_cache(self, ids, params=None, headers=None):
+        """
+        Clear a subset or all entries from the API key cache.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-api-key-cache.html>`_
+
+        :arg ids: A comma-separated list of IDs of API keys to clear
+            from the cache
+        """
+        if ids in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'ids'.")
+
+        return await self.transport.perform_request(
+            "POST",
+            _make_path("_security", "api_key", ids, "_clear_cache"),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("refresh")
+    async def grant_api_key(self, body, params=None, headers=None):
+        """
+        Creates an API key on behalf of another user.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-grant-api-key.html>`_
+
+        :arg body: The api key request to create an API key
+        :arg refresh: If `true` (the default) then refresh the affected
+            shards to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false` then
+            do nothing with refreshes.  Valid choices: true, false, wait_for
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        return await self.transport.perform_request(
+            "POST",
+            "/_security/api_key/grant",
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/elasticsearch/_async/client/security.pyi
+++ b/elasticsearch/_async/client/security.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SecurityClient(NamespacedClient):
     async def authenticate(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,10 +31,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def change_password(
         self,
+        *,
         body: Any,
         username: Optional[Any] = ...,
         refresh: Optional[Any] = ...,
@@ -46,11 +48,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def clear_cached_realms(
         self,
         realms: Any,
+        *,
         usernames: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -61,11 +64,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def clear_cached_roles(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -75,10 +79,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def create_api_key(
         self,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -90,12 +95,13 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_privileges(
         self,
         application: Any,
         name: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -106,11 +112,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_role(
         self,
         name: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -121,11 +128,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_role_mapping(
         self,
         name: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -136,11 +144,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_user(
         self,
         username: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -151,11 +160,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def disable_user(
         self,
         username: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -166,11 +176,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def enable_user(
         self,
         username: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -181,10 +192,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_api_key(
         self,
+        *,
         id: Optional[Any] = ...,
         name: Optional[Any] = ...,
         owner: Optional[Any] = ...,
@@ -199,10 +211,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_privileges(
         self,
+        *,
         application: Optional[Any] = ...,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -214,10 +227,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_role(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -228,10 +242,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_role_mapping(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -242,10 +257,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_token(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -256,10 +272,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_user(
         self,
+        *,
         username: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -270,10 +287,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_user_privileges(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -283,10 +301,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def has_privileges(
         self,
+        *,
         body: Any,
         user: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -298,10 +317,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def invalidate_api_key(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -312,10 +332,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def invalidate_token(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -326,10 +347,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_privileges(
         self,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -341,11 +363,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_role(
         self,
         name: Any,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -357,11 +380,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_role_mapping(
         self,
         name: Any,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -373,11 +397,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_user(
         self,
         username: Any,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -389,10 +414,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_builtin_privileges(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -402,11 +428,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def clear_cached_privileges(
         self,
         application: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -416,5 +443,36 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
+    ) -> Any: ...
+    async def clear_api_key_cache(
+        self,
+        ids: Any,
+        *,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
+    ) -> Any: ...
+    async def grant_api_key(
+        self,
+        *,
+        body: Any,
+        refresh: Optional[Any] = ...,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/slm.py
+++ b/elasticsearch/_async/client/slm.py
@@ -23,6 +23,7 @@ class SlmClient(NamespacedClient):
     async def delete_lifecycle(self, policy_id, params=None, headers=None):
         """
         Deletes an existing snapshot lifecycle policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-delete-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to
@@ -43,6 +44,7 @@ class SlmClient(NamespacedClient):
         """
         Immediately creates a snapshot according to the lifecycle policy, without
         waiting for the scheduled time.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-lifecycle.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to be
@@ -63,6 +65,7 @@ class SlmClient(NamespacedClient):
         """
         Deletes any snapshots that are expired according to the policy's retention
         rules.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
         """
         return await self.transport.perform_request(
@@ -74,6 +77,7 @@ class SlmClient(NamespacedClient):
         """
         Retrieves one or more snapshot lifecycle policy definitions and information
         about the latest snapshot attempts.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-policy.html>`_
 
         :arg policy_id: Comma-separated list of snapshot lifecycle
@@ -91,6 +95,7 @@ class SlmClient(NamespacedClient):
         """
         Returns global and policy-level statistics about actions taken by snapshot
         lifecycle management.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
         """
         return await self.transport.perform_request(
@@ -101,6 +106,7 @@ class SlmClient(NamespacedClient):
     async def put_lifecycle(self, policy_id, body=None, params=None, headers=None):
         """
         Creates or updates a snapshot lifecycle policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-put-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy
@@ -121,6 +127,7 @@ class SlmClient(NamespacedClient):
     async def get_status(self, params=None, headers=None):
         """
         Retrieves the status of snapshot lifecycle management (SLM).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
         """
         return await self.transport.perform_request(
@@ -131,6 +138,7 @@ class SlmClient(NamespacedClient):
     async def start(self, params=None, headers=None):
         """
         Turns on snapshot lifecycle management (SLM).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
         """
         return await self.transport.perform_request(
@@ -141,6 +149,7 @@ class SlmClient(NamespacedClient):
     async def stop(self, params=None, headers=None):
         """
         Turns off snapshot lifecycle management (SLM).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
         """
         return await self.transport.perform_request(

--- a/elasticsearch/_async/client/slm.pyi
+++ b/elasticsearch/_async/client/slm.pyi
@@ -22,6 +22,7 @@ class SlmClient(NamespacedClient):
     async def delete_lifecycle(
         self,
         policy_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def execute_lifecycle(
         self,
         policy_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def execute_retention(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -58,10 +61,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_lifecycle(
         self,
+        *,
         policy_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -72,10 +76,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_stats(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -85,11 +90,12 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_lifecycle(
         self,
         policy_id: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -100,10 +106,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -113,10 +120,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def start(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -126,10 +134,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stop(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -139,5 +148,5 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -23,6 +23,7 @@ class SnapshotClient(NamespacedClient):
     async def create(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Creates a snapshot in a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -49,6 +50,7 @@ class SnapshotClient(NamespacedClient):
     async def delete(self, repository, snapshot, params=None, headers=None):
         """
         Deletes one or more snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -71,6 +73,7 @@ class SnapshotClient(NamespacedClient):
     async def get(self, repository, snapshot, params=None, headers=None):
         """
         Returns information about a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -98,6 +101,7 @@ class SnapshotClient(NamespacedClient):
     async def delete_repository(self, repository, params=None, headers=None):
         """
         Deletes a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: Name of the snapshot repository to unregister.
@@ -120,6 +124,7 @@ class SnapshotClient(NamespacedClient):
     async def get_repository(self, repository=None, params=None, headers=None):
         """
         Returns information about a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A comma-separated list of repository names
@@ -136,6 +141,7 @@ class SnapshotClient(NamespacedClient):
     async def create_repository(self, repository, body, params=None, headers=None):
         """
         Creates a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -161,6 +167,7 @@ class SnapshotClient(NamespacedClient):
     async def restore(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Restores a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -187,6 +194,7 @@ class SnapshotClient(NamespacedClient):
     async def status(self, repository=None, snapshot=None, params=None, headers=None):
         """
         Returns information about the status of a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -208,6 +216,7 @@ class SnapshotClient(NamespacedClient):
     async def verify_repository(self, repository, params=None, headers=None):
         """
         Verifies a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -229,6 +238,7 @@ class SnapshotClient(NamespacedClient):
     async def cleanup_repository(self, repository, params=None, headers=None):
         """
         Removes stale data from repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html>`_
 
         :arg repository: A repository name
@@ -244,4 +254,32 @@ class SnapshotClient(NamespacedClient):
             _make_path("_snapshot", repository, "_cleanup"),
             params=params,
             headers=headers,
+        )
+
+    @query_params("master_timeout")
+    async def clone(
+        self, repository, snapshot, target_snapshot, body, params=None, headers=None
+    ):
+        """
+        Clones indices from one snapshot into another snapshot in the same repository.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+
+        :arg repository: A repository name
+        :arg snapshot: The name of the snapshot to clone from
+        :arg target_snapshot: The name of the cloned snapshot to create
+        :arg body: The snapshot clone definition
+        :arg master_timeout: Explicit operation timeout for connection
+            to master node
+        """
+        for param in (repository, snapshot, target_snapshot, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return await self.transport.perform_request(
+            "PUT",
+            _make_path("_snapshot", repository, snapshot, "_clone", target_snapshot),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/elasticsearch/_async/client/snapshot.pyi
+++ b/elasticsearch/_async/client/snapshot.pyi
@@ -23,6 +23,7 @@ class SnapshotClient(NamespacedClient):
         self,
         repository: Any,
         snapshot: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
@@ -35,12 +36,13 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -51,12 +53,13 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         ignore_unavailable: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         verbose: Optional[Any] = ...,
@@ -69,11 +72,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_repository(
         self,
         repository: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -85,10 +89,11 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_repository(
         self,
+        *,
         repository: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -101,11 +106,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def create_repository(
         self,
         repository: Any,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -119,12 +125,13 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def restore(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
@@ -137,10 +144,11 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def status(
         self,
+        *,
         repository: Optional[Any] = ...,
         snapshot: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -154,11 +162,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def verify_repository(
         self,
         repository: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -170,11 +179,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def cleanup_repository(
         self,
         repository: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -186,5 +196,24 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
+    ) -> Any: ...
+    async def clone(
+        self,
+        repository: Any,
+        snapshot: Any,
+        target_snapshot: Any,
+        *,
+        body: Any,
+        master_timeout: Optional[Any] = ...,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -23,6 +23,7 @@ class SqlClient(NamespacedClient):
     async def clear_cursor(self, body, params=None, headers=None):
         """
         Clears the SQL cursor
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-pagination.html>`_
 
         :arg body: Specify the cursor value in the `cursor` element to
@@ -39,6 +40,7 @@ class SqlClient(NamespacedClient):
     async def query(self, body, params=None, headers=None):
         """
         Executes a SQL request
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-rest-overview.html>`_
 
         :arg body: Use the `query` element to start a query. Use the
@@ -57,6 +59,7 @@ class SqlClient(NamespacedClient):
     async def translate(self, body, params=None, headers=None):
         """
         Translates SQL into Elasticsearch queries
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate.html>`_
 
         :arg body: Specify the query in the `query` element.

--- a/elasticsearch/_async/client/sql.pyi
+++ b/elasticsearch/_async/client/sql.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SqlClient(NamespacedClient):
     async def clear_cursor(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -31,10 +32,11 @@ class SqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def query(
         self,
+        *,
         body: Any,
         format: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class SqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def translate(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -59,5 +62,5 @@ class SqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/ssl.py
+++ b/elasticsearch/_async/client/ssl.py
@@ -24,6 +24,7 @@ class SslClient(NamespacedClient):
         """
         Retrieves information about the X.509 certificates used to encrypt
         communications in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
         """
         return await self.transport.perform_request(

--- a/elasticsearch/_async/client/ssl.pyi
+++ b/elasticsearch/_async/client/ssl.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SslClient(NamespacedClient):
     async def certificates(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,5 +31,5 @@ class SslClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/tasks.py
+++ b/elasticsearch/_async/client/tasks.py
@@ -31,6 +31,7 @@ class TasksClient(NamespacedClient):
     async def list(self, params=None, headers=None):
         """
         Returns a list of tasks.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg actions: A comma-separated list of actions that should be
@@ -55,6 +56,7 @@ class TasksClient(NamespacedClient):
     async def cancel(self, task_id=None, params=None, headers=None):
         """
         Cancels a task, if it can be cancelled through an API.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg task_id: Cancel the task with specified task id
@@ -81,6 +83,7 @@ class TasksClient(NamespacedClient):
     async def get(self, task_id, params=None, headers=None):
         """
         Returns information about a task.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg task_id: Return the task with specified id

--- a/elasticsearch/_async/client/tasks.pyi
+++ b/elasticsearch/_async/client/tasks.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class TasksClient(NamespacedClient):
     async def list(
         self,
+        *,
         actions: Optional[Any] = ...,
         detailed: Optional[Any] = ...,
         group_by: Optional[Any] = ...,
@@ -37,10 +38,11 @@ class TasksClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def cancel(
         self,
+        *,
         task_id: Optional[Any] = ...,
         actions: Optional[Any] = ...,
         nodes: Optional[Any] = ...,
@@ -55,11 +57,12 @@ class TasksClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get(
         self,
         task_id: Any,
+        *,
         timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -71,5 +74,5 @@ class TasksClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -23,6 +23,7 @@ class TransformClient(NamespacedClient):
     async def delete_transform(self, transform_id, params=None, headers=None):
         """
         Deletes an existing transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-transform.html>`_
 
         :arg transform_id: The id of the transform to delete
@@ -42,10 +43,11 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params("allow_no_match", "exclude_generated", "from_", "size")
     async def get_transform(self, transform_id=None, params=None, headers=None):
         """
         Retrieves configuration information for transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform.html>`_
 
         :arg transform_id: The id or comma delimited list of id
@@ -54,6 +56,8 @@ class TransformClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no transforms. (This includes `_all` string or when no
             transforms have been specified)
+        :arg exclude_generated: Omits fields that are illegal to set on
+            transform PUT
         :arg from\\_: skips a number of transform configs, defaults to 0
         :arg size: specifies a max number of transforms to get, defaults
             to 100
@@ -73,6 +77,7 @@ class TransformClient(NamespacedClient):
     async def get_transform_stats(self, transform_id, params=None, headers=None):
         """
         Retrieves usage information for transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform-stats.html>`_
 
         :arg transform_id: The id of the transform for which to get
@@ -104,6 +109,7 @@ class TransformClient(NamespacedClient):
     async def preview_transform(self, body, params=None, headers=None):
         """
         Previews a transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-transform.html>`_
 
         :arg body: The definition for the transform to preview
@@ -119,6 +125,7 @@ class TransformClient(NamespacedClient):
     async def put_transform(self, transform_id, body, params=None, headers=None):
         """
         Instantiates a transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-transform.html>`_
 
         :arg transform_id: The id of the new transform.
@@ -142,6 +149,7 @@ class TransformClient(NamespacedClient):
     async def start_transform(self, transform_id, params=None, headers=None):
         """
         Starts one or more transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
 
         :arg transform_id: The id of the transform to start
@@ -170,6 +178,7 @@ class TransformClient(NamespacedClient):
     async def stop_transform(self, transform_id, params=None, headers=None):
         """
         Stops one or more transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html>`_
 
         :arg transform_id: The id of the transform to stop
@@ -201,6 +210,7 @@ class TransformClient(NamespacedClient):
     async def update_transform(self, transform_id, body, params=None, headers=None):
         """
         Updates certain properties of a transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html>`_
 
         :arg transform_id: The id of the transform.

--- a/elasticsearch/_async/client/transform.pyi
+++ b/elasticsearch/_async/client/transform.pyi
@@ -22,6 +22,7 @@ class TransformClient(NamespacedClient):
     async def delete_transform(
         self,
         transform_id: Any,
+        *,
         force: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -32,12 +33,14 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_transform(
         self,
+        *,
         transform_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -49,11 +52,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_transform_stats(
         self,
         transform_id: Any,
+        *,
         allow_no_match: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
@@ -66,10 +70,11 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def preview_transform(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -80,11 +85,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_transform(
         self,
         transform_id: Any,
+        *,
         body: Any,
         defer_validation: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -96,11 +102,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def start_transform(
         self,
         transform_id: Any,
+        *,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -111,11 +118,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stop_transform(
         self,
         transform_id: Any,
+        *,
         allow_no_match: Optional[Any] = ...,
         force: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -130,11 +138,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def update_transform(
         self,
         transform_id: Any,
+        *,
         body: Any,
         defer_validation: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -146,5 +155,5 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -23,6 +23,7 @@ class WatcherClient(NamespacedClient):
     async def ack_watch(self, watch_id, action_id=None, params=None, headers=None):
         """
         Acknowledges a watch, manually throttling the execution of the watch's actions.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-ack-watch.html>`_
 
         :arg watch_id: Watch ID
@@ -43,6 +44,7 @@ class WatcherClient(NamespacedClient):
     async def activate_watch(self, watch_id, params=None, headers=None):
         """
         Activates a currently inactive watch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-activate-watch.html>`_
 
         :arg watch_id: Watch ID
@@ -61,6 +63,7 @@ class WatcherClient(NamespacedClient):
     async def deactivate_watch(self, watch_id, params=None, headers=None):
         """
         Deactivates a currently active watch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-deactivate-watch.html>`_
 
         :arg watch_id: Watch ID
@@ -79,6 +82,7 @@ class WatcherClient(NamespacedClient):
     async def delete_watch(self, id, params=None, headers=None):
         """
         Removes a watch from Watcher.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-delete-watch.html>`_
 
         :arg id: Watch ID
@@ -97,6 +101,7 @@ class WatcherClient(NamespacedClient):
     async def execute_watch(self, body=None, id=None, params=None, headers=None):
         """
         Forces the execution of a stored watch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-execute-watch.html>`_
 
         :arg body: Execution control
@@ -116,6 +121,7 @@ class WatcherClient(NamespacedClient):
     async def get_watch(self, id, params=None, headers=None):
         """
         Retrieves a watch by its ID.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-watch.html>`_
 
         :arg id: Watch ID
@@ -131,6 +137,7 @@ class WatcherClient(NamespacedClient):
     async def put_watch(self, id, body=None, params=None, headers=None):
         """
         Creates a new watch, or updates an existing one.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-put-watch.html>`_
 
         :arg id: Watch ID
@@ -157,6 +164,7 @@ class WatcherClient(NamespacedClient):
     async def start(self, params=None, headers=None):
         """
         Starts Watcher if it is not already running.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
         """
         return await self.transport.perform_request(
@@ -167,6 +175,7 @@ class WatcherClient(NamespacedClient):
     async def stats(self, metric=None, params=None, headers=None):
         """
         Retrieves the current Watcher metrics.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stats.html>`_
 
         :arg metric: Controls what additional stat metrics should be
@@ -186,6 +195,7 @@ class WatcherClient(NamespacedClient):
     async def stop(self, params=None, headers=None):
         """
         Stops Watcher if it is running.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
         """
         return await self.transport.perform_request(

--- a/elasticsearch/_async/client/watcher.pyi
+++ b/elasticsearch/_async/client/watcher.pyi
@@ -22,6 +22,7 @@ class WatcherClient(NamespacedClient):
     async def ack_watch(
         self,
         watch_id: Any,
+        *,
         action_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -32,11 +33,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def activate_watch(
         self,
         watch_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -46,11 +48,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def deactivate_watch(
         self,
         watch_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -60,11 +63,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def delete_watch(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -74,10 +78,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def execute_watch(
         self,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         debug: Optional[Any] = ...,
@@ -90,11 +95,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def get_watch(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -104,11 +110,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def put_watch(
         self,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         active: Optional[Any] = ...,
         if_primary_term: Optional[Any] = ...,
@@ -123,10 +130,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def start(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -136,10 +144,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stats(
         self,
+        *,
         metric: Optional[Any] = ...,
         emit_stacktraces: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -151,10 +160,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def stop(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -164,5 +174,5 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/_async/client/xpack.py
+++ b/elasticsearch/_async/client/xpack.py
@@ -27,6 +27,7 @@ class XPackClient(NamespacedClient):
     async def info(self, params=None, headers=None):
         """
         Retrieves information about the installed X-Pack features.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/info-api.html>`_
 
         :arg accept_enterprise: If this param is used it must be set to
@@ -42,6 +43,7 @@ class XPackClient(NamespacedClient):
     async def usage(self, params=None, headers=None):
         """
         Retrieves usage information about the installed X-Pack features.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/usage-api.html>`_
 
         :arg master_timeout: Specify timeout for watch write operation

--- a/elasticsearch/_async/client/xpack.pyi
+++ b/elasticsearch/_async/client/xpack.pyi
@@ -24,6 +24,7 @@ class XPackClient(NamespacedClient):
     # AUTO-GENERATED-API-DEFINITIONS #
     async def info(
         self,
+        *,
         accept_enterprise: Optional[Any] = ...,
         categories: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -35,10 +36,11 @@ class XPackClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     async def usage(
         self,
+        *,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -49,5 +51,5 @@ class XPackClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -262,6 +262,7 @@ class Elasticsearch(object):
     def ping(self, params=None, headers=None):
         """
         Returns whether the cluster is running.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
         """
         try:
@@ -275,6 +276,7 @@ class Elasticsearch(object):
     def info(self, params=None, headers=None):
         """
         Returns basic information about the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
         """
         return self.transport.perform_request(
@@ -294,6 +296,7 @@ class Elasticsearch(object):
         """
         Creates a new document in the index.  Returns a 409 response when a document
         with a same ID already exists in the index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
 
         :arg index: The name of the index
@@ -350,6 +353,7 @@ class Elasticsearch(object):
     def index(self, index, body, id=None, params=None, headers=None):
         """
         Creates or updates a document in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
 
         :arg index: The name of the index
@@ -409,6 +413,7 @@ class Elasticsearch(object):
     def bulk(self, body, index=None, doc_type=None, params=None, headers=None):
         """
         Allows to perform multiple index/update/delete operations in a single request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html>`_
 
         :arg body: The operation definition and data (action-data
@@ -455,6 +460,7 @@ class Elasticsearch(object):
     def clear_scroll(self, body=None, scroll_id=None, params=None, headers=None):
         """
         Explicitly clears the search context for a scroll.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html>`_
 
         :arg body: A comma-separated list of scroll IDs to clear if none
@@ -491,6 +497,7 @@ class Elasticsearch(object):
     def count(self, body=None, index=None, params=None, headers=None):
         """
         Returns number of documents matching a query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
 
         :arg body: A query to restrict the results specified with the
@@ -546,6 +553,7 @@ class Elasticsearch(object):
     def delete(self, index, id, doc_type=None, params=None, headers=None):
         """
         Removes a document from the index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html>`_
 
         :arg index: The name of the index
@@ -620,6 +628,7 @@ class Elasticsearch(object):
     def delete_by_query(self, index, body, params=None, headers=None):
         """
         Deletes documents matching the provided query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
 
         :arg index: A comma-separated list of index names to search; use
@@ -713,6 +722,7 @@ class Elasticsearch(object):
         """
         Changes the number of requests per second for a particular Delete By Query
         operation.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
 
         :arg task_id: The task id to rethrottle
@@ -733,6 +743,7 @@ class Elasticsearch(object):
     def delete_script(self, id, params=None, headers=None):
         """
         Deletes a script.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
 
         :arg id: Script ID
@@ -761,6 +772,7 @@ class Elasticsearch(object):
     def exists(self, index, id, params=None, headers=None):
         """
         Returns information about whether a document exists in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -806,6 +818,7 @@ class Elasticsearch(object):
     def exists_source(self, index, id, doc_type=None, params=None, headers=None):
         """
         Returns information about whether a document source exists in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -857,6 +870,7 @@ class Elasticsearch(object):
     def explain(self, index, id, body=None, params=None, headers=None):
         """
         Returns information about why a specific matches (or doesn't match) a query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html>`_
 
         :arg index: The name of the index
@@ -907,6 +921,7 @@ class Elasticsearch(object):
         """
         Returns the information about the capabilities of fields among multiple
         indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html>`_
 
         :arg body: An index filter specified with the Query DSL
@@ -947,6 +962,7 @@ class Elasticsearch(object):
     def get(self, index, id, params=None, headers=None):
         """
         Returns a document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -982,6 +998,7 @@ class Elasticsearch(object):
     def get_script(self, id, params=None, headers=None):
         """
         Returns a script.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
 
         :arg id: Script ID
@@ -1008,6 +1025,7 @@ class Elasticsearch(object):
     def get_source(self, index, id, params=None, headers=None):
         """
         Returns the source of a document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
 
         :arg index: The name of the index
@@ -1050,6 +1068,7 @@ class Elasticsearch(object):
     def mget(self, body, index=None, params=None, headers=None):
         """
         Allows to get multiple documents in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html>`_
 
         :arg body: Document identifiers; can be either `docs`
@@ -1095,6 +1114,7 @@ class Elasticsearch(object):
     def msearch(self, body, index=None, params=None, headers=None):
         """
         Allows to execute several search operations in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
 
         :arg body: The request definitions (metadata-search request
@@ -1141,6 +1161,7 @@ class Elasticsearch(object):
     def put_script(self, id, body, context=None, params=None, headers=None):
         """
         Creates or updates a script.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
 
         :arg id: Script ID
@@ -1168,6 +1189,7 @@ class Elasticsearch(object):
         """
         Allows to evaluate the quality of ranked search results over a set of typical
         search queries
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html>`_
 
         :arg body: The ranking evaluation search definition, including
@@ -1211,6 +1233,7 @@ class Elasticsearch(object):
         Allows to copy documents from one index to another, optionally filtering the
         source documents by a query, changing the destination index settings, or
         fetching the documents from a remote cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
 
         :arg body: The search definition using the Query DSL and the
@@ -1246,6 +1269,7 @@ class Elasticsearch(object):
     def reindex_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Reindex operation.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
 
         :arg task_id: The task id to rethrottle
@@ -1266,6 +1290,7 @@ class Elasticsearch(object):
     def render_search_template(self, body=None, id=None, params=None, headers=None):
         """
         Allows to use the Mustache language to pre-render a search definition.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html#_validating_templates>`_
 
         :arg body: The search definition template and its params
@@ -1283,6 +1308,7 @@ class Elasticsearch(object):
     def scripts_painless_execute(self, body=None, params=None, headers=None):
         """
         Allows an arbitrary script to be executed and a result to be returned
+
         `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html>`_
 
         :arg body: The script to execute
@@ -1299,6 +1325,7 @@ class Elasticsearch(object):
     def scroll(self, body=None, scroll_id=None, params=None, headers=None):
         """
         Allows to retrieve a large numbers of results from a single search request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll>`_
 
         :arg body: The scroll ID if not passed by URL or query
@@ -1367,6 +1394,7 @@ class Elasticsearch(object):
     def search(self, body=None, index=None, params=None, headers=None):
         """
         Returns results matching a query.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
 
         :arg body: The search definition using the Query DSL
@@ -1488,6 +1516,7 @@ class Elasticsearch(object):
         """
         Returns information about the indices and shards that a search request would be
         executed against.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html>`_
 
         :arg index: A comma-separated list of index names to search; use
@@ -1527,6 +1556,7 @@ class Elasticsearch(object):
     def update(self, index, id, body, doc_type=None, params=None, headers=None):
         """
         Updates a document with a script or partial document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
 
         :arg index: The name of the index
@@ -1581,6 +1611,7 @@ class Elasticsearch(object):
         """
         Changes the number of requests per second for a particular Update By Query
         operation.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
 
         :arg task_id: The task id to rethrottle
@@ -1601,6 +1632,7 @@ class Elasticsearch(object):
     def get_script_context(self, params=None, headers=None):
         """
         Returns all script contexts.
+
         `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
         """
         return self.transport.perform_request(
@@ -1611,6 +1643,7 @@ class Elasticsearch(object):
     def get_script_languages(self, params=None, headers=None):
         """
         Returns available script types, languages and contexts
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
         """
         return self.transport.perform_request(
@@ -1627,6 +1660,7 @@ class Elasticsearch(object):
     def msearch_template(self, body, index=None, params=None, headers=None):
         """
         Allows to execute several search template operations in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
 
         :arg body: The request definitions (metadata-search request
@@ -1675,6 +1709,7 @@ class Elasticsearch(object):
     def mtermvectors(self, body=None, index=None, params=None, headers=None):
         """
         Returns multiple termvectors in one request.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
 
         :arg body: Define ids, documents, parameters or a list of
@@ -1739,6 +1774,7 @@ class Elasticsearch(object):
     def search_template(self, body, index=None, params=None, headers=None):
         """
         Allows to use the Mustache language to pre-render a search definition.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html>`_
 
         :arg body: The search definition template and its params
@@ -1801,6 +1837,7 @@ class Elasticsearch(object):
         """
         Returns information and statistics about terms in the fields of a particular
         document.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html>`_
 
         :arg index: The index in which the document resides.
@@ -1880,6 +1917,7 @@ class Elasticsearch(object):
         """
         Performs an update on every document in the index without changing the source,
         for example to pick up a mapping change.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
 
         :arg index: A comma-separated list of index names to search; use
@@ -1975,6 +2013,7 @@ class Elasticsearch(object):
     def close_point_in_time(self, body=None, params=None, headers=None):
         """
         Close a point in time
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
 
         :arg body: a point-in-time id to close
@@ -1989,6 +2028,7 @@ class Elasticsearch(object):
     def open_point_in_time(self, index=None, params=None, headers=None):
         """
         Open a point in time that can be used in subsequent searches
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
 
         :arg index: A comma-separated list of index names to open point

--- a/elasticsearch/client/__init__.pyi
+++ b/elasticsearch/client/__init__.pyi
@@ -99,6 +99,7 @@ class Elasticsearch(object):
     # AUTO-GENERATED-API-DEFINITIONS #
     def ping(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -108,10 +109,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def info(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -121,12 +123,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def create(
         self,
         index: Any,
         id: Any,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         pipeline: Optional[Any] = ...,
@@ -145,11 +148,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def index(
         self,
         index: Any,
+        *,
         body: Any,
         id: Optional[Any] = ...,
         if_primary_term: Optional[Any] = ...,
@@ -172,10 +176,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def bulk(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
@@ -197,10 +202,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def clear_scroll(
         self,
+        *,
         body: Optional[Any] = ...,
         scroll_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -212,10 +218,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def count(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -241,12 +248,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete(
         self,
         index: Any,
         id: Any,
+        *,
         doc_type: Optional[Any] = ...,
         if_primary_term: Optional[Any] = ...,
         if_seq_no: Optional[Any] = ...,
@@ -265,11 +273,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_by_query(
         self,
         index: Any,
+        *,
         body: Any,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -312,11 +321,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_by_query_rethrottle(
         self,
         task_id: Any,
+        *,
         requests_per_second: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -327,11 +337,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_script(
         self,
         id: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -343,12 +354,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def exists(
         self,
         index: Any,
         id: Any,
+        *,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
         _source_includes: Optional[Any] = ...,
@@ -368,12 +380,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def exists_source(
         self,
         index: Any,
         id: Any,
+        *,
         doc_type: Optional[Any] = ...,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -393,12 +406,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def explain(
         self,
         index: Any,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -421,10 +435,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def field_caps(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -441,12 +456,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get(
         self,
         index: Any,
         id: Any,
+        *,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
         _source_includes: Optional[Any] = ...,
@@ -466,11 +482,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_script(
         self,
         id: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -481,12 +498,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_source(
         self,
         index: Any,
         id: Any,
+        *,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
         _source_includes: Optional[Any] = ...,
@@ -505,10 +523,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def mget(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -528,10 +547,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def msearch(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         ccs_minimize_roundtrips: Optional[Any] = ...,
@@ -550,11 +570,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_script(
         self,
         id: Any,
+        *,
         body: Any,
         context: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -568,10 +589,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def rank_eval(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -587,10 +609,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def reindex(
         self,
+        *,
         body: Any,
         max_docs: Optional[Any] = ...,
         refresh: Optional[Any] = ...,
@@ -609,11 +632,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def reindex_rethrottle(
         self,
         task_id: Any,
+        *,
         requests_per_second: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -624,10 +648,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def render_search_template(
         self,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -639,10 +664,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def scripts_painless_execute(
         self,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -653,10 +679,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def scroll(
         self,
+        *,
         body: Optional[Any] = ...,
         scroll_id: Optional[Any] = ...,
         rest_total_hits_as_int: Optional[Any] = ...,
@@ -670,10 +697,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def search(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -727,10 +755,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def search_shards(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -747,12 +776,13 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update(
         self,
         index: Any,
         id: Any,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -776,11 +806,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_by_query_rethrottle(
         self,
         task_id: Any,
+        *,
         requests_per_second: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -791,10 +822,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_script_context(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -804,10 +836,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_script_languages(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -817,10 +850,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def msearch_template(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         ccs_minimize_roundtrips: Optional[Any] = ...,
@@ -837,10 +871,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def mtermvectors(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         field_statistics: Optional[Any] = ...,
@@ -864,10 +899,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def search_template(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -892,11 +928,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def termvectors(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         field_statistics: Optional[Any] = ...,
@@ -919,11 +956,12 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_by_query(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         _source: Optional[Any] = ...,
         _source_excludes: Optional[Any] = ...,
@@ -968,10 +1006,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def close_point_in_time(
         self,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -982,10 +1021,11 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def open_point_in_time(
         self,
+        *,
         index: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -1001,5 +1041,5 @@ class Elasticsearch(object):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/async_search.py
+++ b/elasticsearch/client/async_search.py
@@ -24,6 +24,7 @@ class AsyncSearchClient(NamespacedClient):
         """
         Deletes an async search by ID. If the search is still running, the search
         request will be cancelled. Otherwise, the saved search results are deleted.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :arg id: The async search ID
@@ -40,6 +41,7 @@ class AsyncSearchClient(NamespacedClient):
         """
         Retrieves the results of a previously submitted async search request given its
         ID.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :arg id: The async search ID
@@ -103,6 +105,7 @@ class AsyncSearchClient(NamespacedClient):
     def submit(self, body=None, index=None, params=None, headers=None):
         """
         Executes a search request asynchronously.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :arg body: The search definition using the Query DSL

--- a/elasticsearch/client/async_search.pyi
+++ b/elasticsearch/client/async_search.pyi
@@ -22,6 +22,7 @@ class AsyncSearchClient(NamespacedClient):
     def delete(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class AsyncSearchClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get(
         self,
         id: Any,
+        *,
         keep_alive: Optional[Any] = ...,
         typed_keys: Optional[Any] = ...,
         wait_for_completion_timeout: Optional[Any] = ...,
@@ -48,10 +50,11 @@ class AsyncSearchClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def submit(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         _source: Optional[Any] = ...,
@@ -104,5 +107,5 @@ class AsyncSearchClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/autoscaling.py
+++ b/elasticsearch/client/autoscaling.py
@@ -24,6 +24,7 @@ class AutoscalingClient(NamespacedClient):
         """
         Gets the current autoscaling decision based on the configured autoscaling
         policy, indicating whether or not autoscaling is needed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-decision.html>`_
         """
         return self.transport.perform_request(
@@ -34,6 +35,7 @@ class AutoscalingClient(NamespacedClient):
     def delete_autoscaling_policy(self, name, params=None, headers=None):
         """
         Deletes an autoscaling policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-delete-autoscaling-policy.html>`_
 
         :arg name: the name of the autoscaling policy
@@ -52,6 +54,7 @@ class AutoscalingClient(NamespacedClient):
     def put_autoscaling_policy(self, name, body, params=None, headers=None):
         """
         Creates a new autoscaling policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-put-autoscaling-policy.html>`_
 
         :arg name: the name of the autoscaling policy
@@ -73,6 +76,7 @@ class AutoscalingClient(NamespacedClient):
     def get_autoscaling_policy(self, name, params=None, headers=None):
         """
         Retrieves an autoscaling policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-policy.html>`_
 
         :arg name: the name of the autoscaling policy

--- a/elasticsearch/client/autoscaling.pyi
+++ b/elasticsearch/client/autoscaling.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class AutoscalingClient(NamespacedClient):
     def get_autoscaling_decision(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,11 +31,12 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_autoscaling_policy(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -44,11 +46,12 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_autoscaling_policy(
         self,
         name: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -59,11 +62,12 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_autoscaling_policy(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -73,5 +77,5 @@ class AutoscalingClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -24,6 +24,7 @@ class CatClient(NamespacedClient):
         """
         Shows information about currently configured aliases to indices including
         filter and routing infos.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html>`_
 
         :arg name: A comma-separated list of alias names to return
@@ -49,6 +50,7 @@ class CatClient(NamespacedClient):
         """
         Provides a snapshot of how many shards are allocated to each data node and how
         much disk space they are using.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -79,6 +81,7 @@ class CatClient(NamespacedClient):
         """
         Provides quick access to the document count of the entire cluster, or
         individual indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -99,6 +102,7 @@ class CatClient(NamespacedClient):
     def health(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster health.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -120,6 +124,7 @@ class CatClient(NamespacedClient):
     def help(self, params=None, headers=None):
         """
         Returns help for the Cat APIs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html>`_
 
         :arg help: Return help information
@@ -149,6 +154,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about indices: number of primaries and replicas, document
         counts, disk size, ...
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -187,6 +193,7 @@ class CatClient(NamespacedClient):
     def master(self, params=None, headers=None):
         """
         Returns information about the master node.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -211,6 +218,7 @@ class CatClient(NamespacedClient):
     def nodes(self, params=None, headers=None):
         """
         Returns basic statistics about performance of cluster nodes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html>`_
 
         :arg bytes: The unit in which to display byte values  Valid
@@ -239,6 +247,7 @@ class CatClient(NamespacedClient):
     def recovery(self, index=None, params=None, headers=None):
         """
         Returns information about index shard recoveries, both on-going completed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html>`_
 
         :arg index: Comma-separated list or wildcard expression of index
@@ -269,6 +278,7 @@ class CatClient(NamespacedClient):
     def shards(self, index=None, params=None, headers=None):
         """
         Provides a detailed view of shard allocation on nodes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -297,6 +307,7 @@ class CatClient(NamespacedClient):
     def segments(self, index=None, params=None, headers=None):
         """
         Provides low-level information about the segments in the shards of an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html>`_
 
         :arg index: A comma-separated list of index names to limit the
@@ -319,6 +330,7 @@ class CatClient(NamespacedClient):
     def pending_tasks(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster pending tasks.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -344,6 +356,7 @@ class CatClient(NamespacedClient):
         """
         Returns cluster-wide thread pool statistics per node. By default the active,
         queue and rejected statistics are returned for all thread pools.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html>`_
 
         :arg thread_pool_patterns: A comma-separated list of regular-
@@ -374,6 +387,7 @@ class CatClient(NamespacedClient):
         """
         Shows how much heap memory is currently being used by fielddata on every data
         node in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html>`_
 
         :arg fields: A comma-separated list of fields to return in the
@@ -399,6 +413,7 @@ class CatClient(NamespacedClient):
     def plugins(self, params=None, headers=None):
         """
         Returns information about installed plugins across nodes node.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -421,6 +436,7 @@ class CatClient(NamespacedClient):
     def nodeattrs(self, params=None, headers=None):
         """
         Returns information about custom node attributes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -443,6 +459,7 @@ class CatClient(NamespacedClient):
     def repositories(self, params=None, headers=None):
         """
         Returns information about snapshot repositories registered in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html>`_
 
         :arg format: a short version of the Accept header, e.g. json,
@@ -467,6 +484,7 @@ class CatClient(NamespacedClient):
     def snapshots(self, repository=None, params=None, headers=None):
         """
         Returns all snapshots in a specific repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html>`_
 
         :arg repository: Name of repository from which to fetch the
@@ -508,6 +526,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about the tasks currently executing on one or more nodes in
         the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg actions: A comma-separated list of actions that should be
@@ -537,6 +556,7 @@ class CatClient(NamespacedClient):
     def templates(self, name=None, params=None, headers=None):
         """
         Returns information about existing templates.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html>`_
 
         :arg name: A pattern that returned template names must match
@@ -560,6 +580,7 @@ class CatClient(NamespacedClient):
     def ml_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Gets configuration and usage information about data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to fetch
@@ -591,6 +612,7 @@ class CatClient(NamespacedClient):
     def ml_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html>`_
 
         :arg datafeed_id: The ID of the datafeeds stats to fetch
@@ -631,6 +653,7 @@ class CatClient(NamespacedClient):
     def ml_jobs(self, job_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html>`_
 
         :arg job_id: The ID of the jobs stats to fetch
@@ -674,6 +697,7 @@ class CatClient(NamespacedClient):
     def ml_trained_models(self, model_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about inference trained models.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html>`_
 
         :arg model_id: The ID of the trained models stats to fetch
@@ -712,6 +736,7 @@ class CatClient(NamespacedClient):
     def transforms(self, transform_id=None, params=None, headers=None):
         """
         Gets configuration and usage information about transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html>`_
 
         :arg transform_id: The id of the transform for which to get

--- a/elasticsearch/client/cat.pyi
+++ b/elasticsearch/client/cat.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class CatClient(NamespacedClient):
     def aliases(
         self,
+        *,
         name: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -37,10 +38,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def allocation(
         self,
+        *,
         node_id: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -58,10 +60,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def count(
         self,
+        *,
         index: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -76,10 +79,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def health(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -95,10 +99,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def help(
         self,
+        *,
         help: Optional[Any] = ...,
         s: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -110,10 +115,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def indices(
         self,
+        *,
         index: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -136,10 +142,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def master(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -155,10 +162,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def nodes(
         self,
+        *,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
         full_id: Optional[Any] = ...,
@@ -176,10 +184,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def recovery(
         self,
+        *,
         index: Optional[Any] = ...,
         active_only: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
@@ -198,10 +207,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def shards(
         self,
+        *,
         index: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -220,10 +230,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def segments(
         self,
+        *,
         index: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -239,10 +250,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def pending_tasks(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -259,10 +271,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def thread_pool(
         self,
+        *,
         thread_pool_patterns: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -280,10 +293,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def fielddata(
         self,
+        *,
         fields: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -299,10 +313,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def plugins(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -318,10 +333,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def nodeattrs(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -337,10 +353,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def repositories(
         self,
+        *,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
         help: Optional[Any] = ...,
@@ -356,10 +373,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def snapshots(
         self,
+        *,
         repository: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -377,10 +395,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def tasks(
         self,
+        *,
         actions: Optional[Any] = ...,
         detailed: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -399,10 +418,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def templates(
         self,
+        *,
         name: Optional[Any] = ...,
         format: Optional[Any] = ...,
         h: Optional[Any] = ...,
@@ -419,10 +439,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def ml_data_frame_analytics(
         self,
+        *,
         id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
@@ -440,10 +461,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def ml_datafeeds(
         self,
+        *,
         datafeed_id: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -461,10 +483,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def ml_jobs(
         self,
+        *,
         job_id: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -483,10 +506,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def ml_trained_models(
         self,
+        *,
         model_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         bytes: Optional[Any] = ...,
@@ -506,10 +530,11 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def transforms(
         self,
+        *,
         transform_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         format: Optional[Any] = ...,
@@ -528,5 +553,5 @@ class CatClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/ccr.py
+++ b/elasticsearch/client/ccr.py
@@ -23,6 +23,7 @@ class CcrClient(NamespacedClient):
     def delete_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Deletes auto-follow patterns.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern.
@@ -41,6 +42,7 @@ class CcrClient(NamespacedClient):
     def follow(self, index, body, params=None, headers=None):
         """
         Creates a new follower index configured to follow the referenced leader index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html>`_
 
         :arg index: The name of the follower index
@@ -69,6 +71,7 @@ class CcrClient(NamespacedClient):
         """
         Retrieves information about all follower indices, including parameters and
         status for each follower index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html>`_
 
         :arg index: A comma-separated list of index patterns; use `_all`
@@ -86,6 +89,7 @@ class CcrClient(NamespacedClient):
         """
         Retrieves follower stats. return shard-level stats about the following tasks
         associated with each shard for the specified indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html>`_
 
         :arg index: A comma-separated list of index patterns; use `_all`
@@ -102,6 +106,7 @@ class CcrClient(NamespacedClient):
     def forget_follower(self, index, body, params=None, headers=None):
         """
         Removes the follower retention leases from the leader.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html>`_
 
         :arg index: the name of the leader index for which specified
@@ -128,6 +133,7 @@ class CcrClient(NamespacedClient):
         """
         Gets configured auto-follow patterns. Returns the specified auto-follow pattern
         collection.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern.
@@ -144,6 +150,7 @@ class CcrClient(NamespacedClient):
         """
         Pauses a follower index. The follower index will not fetch any additional
         operations from the leader index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html>`_
 
         :arg index: The name of the follower index that should pause
@@ -165,6 +172,7 @@ class CcrClient(NamespacedClient):
         Creates a new named collection of auto-follow patterns against a specified
         remote cluster. Newly created indices on the remote cluster matching any of the
         specified patterns will be automatically configured as follower indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern.
@@ -186,6 +194,7 @@ class CcrClient(NamespacedClient):
     def resume_follow(self, index, body=None, params=None, headers=None):
         """
         Resumes a follower index that has been paused
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html>`_
 
         :arg index: The name of the follow index to resume following.
@@ -207,6 +216,7 @@ class CcrClient(NamespacedClient):
     def stats(self, params=None, headers=None):
         """
         Gets all stats related to cross-cluster replication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
         """
         return self.transport.perform_request(
@@ -218,6 +228,7 @@ class CcrClient(NamespacedClient):
         """
         Stops the following task associated with a follower index and removes index
         metadata and settings associated with cross-cluster replication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html>`_
 
         :arg index: The name of the follower index that should be turned
@@ -237,6 +248,7 @@ class CcrClient(NamespacedClient):
     def pause_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Pauses an auto-follow pattern
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern that should pause
@@ -256,6 +268,7 @@ class CcrClient(NamespacedClient):
     def resume_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Resumes an auto-follow pattern that has been paused
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html>`_
 
         :arg name: The name of the auto follow pattern to resume

--- a/elasticsearch/client/ccr.pyi
+++ b/elasticsearch/client/ccr.pyi
@@ -22,6 +22,7 @@ class CcrClient(NamespacedClient):
     def delete_auto_follow_pattern(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def follow(
         self,
         index: Any,
+        *,
         body: Any,
         wait_for_active_shards: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -47,11 +49,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def follow_info(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -61,11 +64,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def follow_stats(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -75,11 +79,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def forget_follower(
         self,
         index: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -90,10 +95,11 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_auto_follow_pattern(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -104,11 +110,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def pause_follow(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -118,11 +125,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_auto_follow_pattern(
         self,
         name: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -133,11 +141,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def resume_follow(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -148,10 +157,11 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stats(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -161,11 +171,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def unfollow(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -175,11 +186,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def pause_auto_follow_pattern(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -189,11 +201,12 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def resume_auto_follow_pattern(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -203,5 +216,5 @@ class CcrClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/cluster.py
+++ b/elasticsearch/client/cluster.py
@@ -35,6 +35,7 @@ class ClusterClient(NamespacedClient):
     def health(self, index=None, params=None, headers=None):
         """
         Returns basic information about the health of the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html>`_
 
         :arg index: Limit the information returned to a specific index
@@ -74,6 +75,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns a list of any cluster-level changes (e.g. create index, update mapping,
         allocate or fail shard) which have not yet been executed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html>`_
 
         :arg local: Return local information, do not retrieve the state
@@ -97,6 +99,7 @@ class ClusterClient(NamespacedClient):
     def state(self, metric=None, index=None, params=None, headers=None):
         """
         Returns a comprehensive information about the state of the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html>`_
 
         :arg metric: Limit the information returned to the specified
@@ -136,6 +139,7 @@ class ClusterClient(NamespacedClient):
     def stats(self, node_id=None, params=None, headers=None):
         """
         Returns high-level overview of cluster statistics.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -161,6 +165,7 @@ class ClusterClient(NamespacedClient):
     def reroute(self, body=None, params=None, headers=None):
         """
         Allows to manually change the allocation of individual shards in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html>`_
 
         :arg body: The definition of `commands` to perform (`move`,
@@ -186,6 +191,7 @@ class ClusterClient(NamespacedClient):
     def get_settings(self, params=None, headers=None):
         """
         Returns cluster settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
 
         :arg flat_settings: Return settings in flat format (default:
@@ -204,6 +210,7 @@ class ClusterClient(NamespacedClient):
     def put_settings(self, body, params=None, headers=None):
         """
         Updates the cluster settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
 
         :arg body: The settings to be updated. Can be either `transient`
@@ -225,6 +232,7 @@ class ClusterClient(NamespacedClient):
     def remote_info(self, params=None, headers=None):
         """
         Returns the information about configured remote clusters.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
         """
         return self.transport.perform_request(
@@ -235,6 +243,7 @@ class ClusterClient(NamespacedClient):
     def allocation_explain(self, body=None, params=None, headers=None):
         """
         Provides explanations for shard allocations in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html>`_
 
         :arg body: The index, shard, and primary flag to explain. Empty
@@ -256,6 +265,7 @@ class ClusterClient(NamespacedClient):
     def delete_component_template(self, name, params=None, headers=None):
         """
         Deletes a component template
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The name of the template
@@ -276,6 +286,7 @@ class ClusterClient(NamespacedClient):
     def get_component_template(self, name=None, params=None, headers=None):
         """
         Returns one or more component templates
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The comma separated names of the component templates
@@ -295,6 +306,7 @@ class ClusterClient(NamespacedClient):
     def put_component_template(self, name, body, params=None, headers=None):
         """
         Creates or updates a component template
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The name of the template
@@ -320,6 +332,7 @@ class ClusterClient(NamespacedClient):
     def exists_component_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular component template exist
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
 
         :arg name: The name of the template
@@ -342,6 +355,7 @@ class ClusterClient(NamespacedClient):
     def delete_voting_config_exclusions(self, params=None, headers=None):
         """
         Clears cluster voting config exclusions.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
 
         :arg wait_for_removal: Specifies whether to wait for all
@@ -359,6 +373,7 @@ class ClusterClient(NamespacedClient):
     def post_voting_config_exclusions(self, params=None, headers=None):
         """
         Updates the cluster voting config exclusions by node ids or node names.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
 
         :arg node_ids: A comma-separated list of the persistent ids of

--- a/elasticsearch/client/cluster.pyi
+++ b/elasticsearch/client/cluster.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class ClusterClient(NamespacedClient):
     def health(
         self,
+        *,
         index: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         level: Optional[Any] = ...,
@@ -42,10 +43,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def pending_tasks(
         self,
+        *,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -57,10 +59,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def state(
         self,
+        *,
         metric: Optional[Any] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -80,10 +83,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stats(
         self,
+        *,
         node_id: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -96,10 +100,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def reroute(
         self,
+        *,
         body: Optional[Any] = ...,
         dry_run: Optional[Any] = ...,
         explain: Optional[Any] = ...,
@@ -116,10 +121,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_settings(
         self,
+        *,
         flat_settings: Optional[Any] = ...,
         include_defaults: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -133,10 +139,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_settings(
         self,
+        *,
         body: Any,
         flat_settings: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -150,10 +157,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def remote_info(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -163,10 +171,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def allocation_explain(
         self,
+        *,
         body: Optional[Any] = ...,
         include_disk_info: Optional[Any] = ...,
         include_yes_decisions: Optional[Any] = ...,
@@ -179,11 +188,12 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_component_template(
         self,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -195,10 +205,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_component_template(
         self,
+        *,
         name: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -211,11 +222,12 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_component_template(
         self,
         name: Any,
+        *,
         body: Any,
         create: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -229,11 +241,12 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def exists_component_template(
         self,
         name: Any,
+        *,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -245,10 +258,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def delete_voting_config_exclusions(
         self,
+        *,
         wait_for_removal: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -259,10 +273,11 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def post_voting_config_exclusions(
         self,
+        *,
         node_ids: Optional[Any] = ...,
         node_names: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -275,5 +290,5 @@ class ClusterClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/dangling_indices.py
+++ b/elasticsearch/client/dangling_indices.py
@@ -23,6 +23,7 @@ class DanglingIndicesClient(NamespacedClient):
     def delete_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Deletes the specified dangling index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
 
         :arg index_uuid: The UUID of the dangling index
@@ -45,6 +46,7 @@ class DanglingIndicesClient(NamespacedClient):
     def import_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Imports the specified dangling index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
 
         :arg index_uuid: The UUID of the dangling index
@@ -64,6 +66,7 @@ class DanglingIndicesClient(NamespacedClient):
     def list_dangling_indices(self, params=None, headers=None):
         """
         Returns all dangling indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/dangling_indices.pyi
+++ b/elasticsearch/client/dangling_indices.pyi
@@ -22,6 +22,7 @@ class DanglingIndicesClient(NamespacedClient):
     def delete_dangling_index(
         self,
         index_uuid: Any,
+        *,
         accept_data_loss: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -34,11 +35,12 @@ class DanglingIndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def import_dangling_index(
         self,
         index_uuid: Any,
+        *,
         accept_data_loss: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -51,10 +53,11 @@ class DanglingIndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def list_dangling_indices(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -64,5 +67,5 @@ class DanglingIndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/enrich.py
+++ b/elasticsearch/client/enrich.py
@@ -23,6 +23,7 @@ class EnrichClient(NamespacedClient):
     def delete_policy(self, name, params=None, headers=None):
         """
         Deletes an existing enrich policy and its enrich index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-enrich-policy-api.html>`_
 
         :arg name: The name of the enrich policy
@@ -41,6 +42,7 @@ class EnrichClient(NamespacedClient):
     def execute_policy(self, name, params=None, headers=None):
         """
         Creates the enrich index for an existing enrich policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
 
         :arg name: The name of the enrich policy
@@ -61,6 +63,7 @@ class EnrichClient(NamespacedClient):
     def get_policy(self, name=None, params=None, headers=None):
         """
         Gets information about an enrich policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-enrich-policy-api.html>`_
 
         :arg name: A comma-separated list of enrich policy names
@@ -73,6 +76,7 @@ class EnrichClient(NamespacedClient):
     def put_policy(self, name, body, params=None, headers=None):
         """
         Creates a new enrich policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-enrich-policy-api.html>`_
 
         :arg name: The name of the enrich policy
@@ -95,6 +99,7 @@ class EnrichClient(NamespacedClient):
         """
         Gets enrich coordinator statistics and information about enrich policies that
         are currently executing.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/enrich.pyi
+++ b/elasticsearch/client/enrich.pyi
@@ -22,6 +22,7 @@ class EnrichClient(NamespacedClient):
     def delete_policy(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def execute_policy(
         self,
         name: Any,
+        *,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -46,10 +48,11 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_policy(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -60,11 +63,12 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_policy(
         self,
         name: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -75,10 +79,11 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stats(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -88,5 +93,5 @@ class EnrichClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/eql.py
+++ b/elasticsearch/client/eql.py
@@ -23,6 +23,7 @@ class EqlClient(NamespacedClient):
     def search(self, index, body, params=None, headers=None):
         """
         Returns results matching a query expressed in Event Query Language (EQL)
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
         :arg index: The name of the index to scope the operation
@@ -53,6 +54,7 @@ class EqlClient(NamespacedClient):
         """
         Deletes an async EQL search by ID. If the search is still running, the search
         request will be cancelled. Otherwise, the saved search results are deleted.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
         :arg id: The async search ID
@@ -69,6 +71,7 @@ class EqlClient(NamespacedClient):
         """
         Returns async results from previously executed Event Query Language (EQL)
         search
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
         :arg id: The async search ID

--- a/elasticsearch/client/eql.pyi
+++ b/elasticsearch/client/eql.pyi
@@ -22,6 +22,7 @@ class EqlClient(NamespacedClient):
     def search(
         self,
         index: Any,
+        *,
         body: Any,
         keep_alive: Optional[Any] = ...,
         keep_on_completion: Optional[Any] = ...,
@@ -35,11 +36,12 @@ class EqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -49,11 +51,12 @@ class EqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get(
         self,
         id: Any,
+        *,
         keep_alive: Optional[Any] = ...,
         wait_for_completion_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -65,5 +68,5 @@ class EqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/graph.py
+++ b/elasticsearch/client/graph.py
@@ -24,6 +24,7 @@ class GraphClient(NamespacedClient):
         """
         Explore extracted and summarized information about the documents and terms in
         an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
 
         :arg index: A comma-separated list of index names to search; use

--- a/elasticsearch/client/graph.pyi
+++ b/elasticsearch/client/graph.pyi
@@ -22,6 +22,7 @@ class GraphClient(NamespacedClient):
     def explore(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         routing: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -34,5 +35,5 @@ class GraphClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/ilm.py
+++ b/elasticsearch/client/ilm.py
@@ -24,6 +24,7 @@ class IlmClient(NamespacedClient):
         """
         Deletes the specified lifecycle policy definition. A currently used policy
         cannot be deleted.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-delete-lifecycle.html>`_
 
         :arg policy: The name of the index lifecycle policy
@@ -43,6 +44,7 @@ class IlmClient(NamespacedClient):
         """
         Retrieves information about the index's current lifecycle state, such as the
         currently executing phase, action, and step.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-explain-lifecycle.html>`_
 
         :arg index: The name of the index to explain
@@ -63,6 +65,7 @@ class IlmClient(NamespacedClient):
         """
         Returns the specified policy definition. Includes the policy version and last
         modified date.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-lifecycle.html>`_
 
         :arg policy: The name of the index lifecycle policy
@@ -75,6 +78,7 @@ class IlmClient(NamespacedClient):
     def get_status(self, params=None, headers=None):
         """
         Retrieves the current index lifecycle management (ILM) status.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
         """
         return self.transport.perform_request(
@@ -85,6 +89,7 @@ class IlmClient(NamespacedClient):
     def move_to_step(self, index, body=None, params=None, headers=None):
         """
         Manually moves an index into the specified step and executes that step.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-move-to-step.html>`_
 
         :arg index: The name of the index whose lifecycle step is to
@@ -106,6 +111,7 @@ class IlmClient(NamespacedClient):
     def put_lifecycle(self, policy, body=None, params=None, headers=None):
         """
         Creates a lifecycle policy
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-put-lifecycle.html>`_
 
         :arg policy: The name of the index lifecycle policy
@@ -126,6 +132,7 @@ class IlmClient(NamespacedClient):
     def remove_policy(self, index, params=None, headers=None):
         """
         Removes the assigned lifecycle policy and stops managing the specified index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-remove-policy.html>`_
 
         :arg index: The name of the index to remove policy on
@@ -141,6 +148,7 @@ class IlmClient(NamespacedClient):
     def retry(self, index, params=None, headers=None):
         """
         Retries executing the policy for an index that is in the ERROR step.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-retry-policy.html>`_
 
         :arg index: The name of the indices (comma-separated) whose
@@ -157,6 +165,7 @@ class IlmClient(NamespacedClient):
     def start(self, params=None, headers=None):
         """
         Start the index lifecycle management (ILM) plugin.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-start.html>`_
         """
         return self.transport.perform_request(
@@ -168,6 +177,7 @@ class IlmClient(NamespacedClient):
         """
         Halts all lifecycle management operations and stops the index lifecycle
         management (ILM) plugin
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-stop.html>`_
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/ilm.pyi
+++ b/elasticsearch/client/ilm.pyi
@@ -22,6 +22,7 @@ class IlmClient(NamespacedClient):
     def delete_lifecycle(
         self,
         policy: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def explain_lifecycle(
         self,
         index: Any,
+        *,
         only_errors: Optional[Any] = ...,
         only_managed: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -47,10 +49,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_lifecycle(
         self,
+        *,
         policy: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -61,10 +64,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -74,11 +78,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def move_to_step(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -89,11 +94,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_lifecycle(
         self,
         policy: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -104,11 +110,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def remove_policy(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -118,11 +125,12 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def retry(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -132,10 +140,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def start(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -145,10 +154,11 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stop(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -158,5 +168,5 @@ class IlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -24,6 +24,7 @@ class IndicesClient(NamespacedClient):
         """
         Performs the analysis process on a text and return the tokens breakdown of the
         text.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html>`_
 
         :arg body: Define analyzer/tokenizer parameters and the text on
@@ -42,6 +43,7 @@ class IndicesClient(NamespacedClient):
     def refresh(self, index=None, params=None, headers=None):
         """
         Performs the refresh operation in one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -69,6 +71,7 @@ class IndicesClient(NamespacedClient):
     def flush(self, index=None, params=None, headers=None):
         """
         Performs the flush operation on one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -99,6 +102,7 @@ class IndicesClient(NamespacedClient):
     def create(self, index, body=None, params=None, headers=None):
         """
         Creates an index with optional settings and mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html>`_
 
         :arg index: The name of the index
@@ -120,6 +124,7 @@ class IndicesClient(NamespacedClient):
     def clone(self, index, target, body=None, params=None, headers=None):
         """
         Clones an index
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html>`_
 
         :arg index: The name of the source index to clone
@@ -155,6 +160,7 @@ class IndicesClient(NamespacedClient):
     def get(self, index, params=None, headers=None):
         """
         Returns information about one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html>`_
 
         :arg index: A comma-separated list of index names
@@ -191,6 +197,7 @@ class IndicesClient(NamespacedClient):
     def open(self, index, params=None, headers=None):
         """
         Opens an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
 
         :arg index: A comma separated list of indices to open
@@ -225,6 +232,7 @@ class IndicesClient(NamespacedClient):
     def close(self, index, params=None, headers=None):
         """
         Closes an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
 
         :arg index: A comma separated list of indices to close
@@ -258,6 +266,7 @@ class IndicesClient(NamespacedClient):
     def delete(self, index, params=None, headers=None):
         """
         Deletes an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html>`_
 
         :arg index: A comma-separated list of indices to delete; use
@@ -290,6 +299,7 @@ class IndicesClient(NamespacedClient):
     def exists(self, index, params=None, headers=None):
         """
         Returns information about whether a particular index exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html>`_
 
         :arg index: A comma-separated list of index names
@@ -319,6 +329,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular document type exists.
         (DEPRECATED)
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` to
@@ -357,6 +368,7 @@ class IndicesClient(NamespacedClient):
     def put_mapping(self, index, body, params=None, headers=None):
         """
         Updates the index mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html>`_
 
         :arg index: A comma-separated list of index names the mapping
@@ -398,6 +410,7 @@ class IndicesClient(NamespacedClient):
     def get_mapping(self, index=None, params=None, headers=None):
         """
         Returns mappings for one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html>`_
 
         :arg index: A comma-separated list of index names
@@ -421,6 +434,7 @@ class IndicesClient(NamespacedClient):
     def put_alias(self, index, name, body=None, params=None, headers=None):
         """
         Creates or updates an alias.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg index: A comma-separated list of index names the alias
@@ -448,6 +462,7 @@ class IndicesClient(NamespacedClient):
     def exists_alias(self, name, index=None, params=None, headers=None):
         """
         Returns information about whether a particular alias exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg name: A comma-separated list of alias names to return
@@ -475,6 +490,7 @@ class IndicesClient(NamespacedClient):
     def get_alias(self, index=None, name=None, params=None, headers=None):
         """
         Returns an alias.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg index: A comma-separated list of index names to filter
@@ -499,6 +515,7 @@ class IndicesClient(NamespacedClient):
     def update_aliases(self, body, params=None, headers=None):
         """
         Updates index aliases.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg body: The definition of `actions` to perform
@@ -516,6 +533,7 @@ class IndicesClient(NamespacedClient):
     def delete_alias(self, index, name, params=None, headers=None):
         """
         Deletes an alias.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
 
         :arg index: A comma-separated list of index names (supports
@@ -537,6 +555,7 @@ class IndicesClient(NamespacedClient):
     def put_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -564,6 +583,7 @@ class IndicesClient(NamespacedClient):
     def exists_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The comma separated names of the index templates
@@ -585,6 +605,7 @@ class IndicesClient(NamespacedClient):
     def get_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The comma separated names of the index templates
@@ -603,6 +624,7 @@ class IndicesClient(NamespacedClient):
     def delete_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -628,6 +650,7 @@ class IndicesClient(NamespacedClient):
     def get_settings(self, index=None, name=None, params=None, headers=None):
         """
         Returns settings for one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -665,6 +688,7 @@ class IndicesClient(NamespacedClient):
     def put_settings(self, body, index=None, params=None, headers=None):
         """
         Updates the index settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html>`_
 
         :arg body: The index settings to be updated
@@ -712,6 +736,7 @@ class IndicesClient(NamespacedClient):
     def stats(self, index=None, metric=None, params=None, headers=None):
         """
         Provides statistics on operations happening in an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -755,6 +780,7 @@ class IndicesClient(NamespacedClient):
     def segments(self, index=None, params=None, headers=None):
         """
         Provides low-level information about segments in a Lucene index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -785,6 +811,7 @@ class IndicesClient(NamespacedClient):
     def clear_cache(self, index=None, params=None, headers=None):
         """
         Clears all or specific caches for one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html>`_
 
         :arg index: A comma-separated list of index name to limit the
@@ -811,6 +838,7 @@ class IndicesClient(NamespacedClient):
     def recovery(self, index=None, params=None, headers=None):
         """
         Returns information about ongoing index shard recoveries.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -834,6 +862,7 @@ class IndicesClient(NamespacedClient):
     def upgrade(self, index=None, params=None, headers=None):
         """
         DEPRECATED Upgrades to the current version of Lucene.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -859,6 +888,7 @@ class IndicesClient(NamespacedClient):
     def get_upgrade(self, index=None, params=None, headers=None):
         """
         DEPRECATED Returns a progress status of current upgrade.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -882,6 +912,7 @@ class IndicesClient(NamespacedClient):
     def shard_stores(self, index=None, params=None, headers=None):
         """
         Provides store information for shard copies of indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -913,6 +944,7 @@ class IndicesClient(NamespacedClient):
     def forcemerge(self, index=None, params=None, headers=None):
         """
         Performs the force merge operation on one or more indices.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html>`_
 
         :arg index: A comma-separated list of index names; use `_all` or
@@ -940,6 +972,7 @@ class IndicesClient(NamespacedClient):
     def shrink(self, index, target, body=None, params=None, headers=None):
         """
         Allow to shrink an existing index into a new index with fewer primary shards.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html>`_
 
         :arg index: The name of the source index to shrink
@@ -968,6 +1001,7 @@ class IndicesClient(NamespacedClient):
         """
         Allows you to split an existing index into a new index with more primary
         shards.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html>`_
 
         :arg index: The name of the source index to split
@@ -996,6 +1030,7 @@ class IndicesClient(NamespacedClient):
         """
         Updates an alias to point to a new index when the existing index is considered
         to be too large or too old.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html>`_
 
         :arg alias: The name of the alias to rollover
@@ -1034,6 +1069,7 @@ class IndicesClient(NamespacedClient):
         """
         Freezes an index. A frozen index has almost no overhead on the cluster (except
         for maintaining its metadata in memory) and is read-only.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/freeze-index-api.html>`_
 
         :arg index: The name of the index to freeze
@@ -1069,6 +1105,7 @@ class IndicesClient(NamespacedClient):
         """
         Unfreezes an index. When a frozen index is unfrozen, the index goes through the
         normal recovery process and becomes writeable again.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/unfreeze-index-api.html>`_
 
         :arg index: The name of the index to unfreeze
@@ -1096,6 +1133,7 @@ class IndicesClient(NamespacedClient):
     def reload_search_analyzers(self, index, params=None, headers=None):
         """
         Reloads an index's search analyzers and their resources.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html>`_
 
         :arg index: A comma-separated list of index names to reload
@@ -1129,6 +1167,7 @@ class IndicesClient(NamespacedClient):
     def get_field_mapping(self, fields, index=None, params=None, headers=None):
         """
         Returns mapping for one or more fields.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
 
         :arg fields: A comma-separated list of fields
@@ -1175,6 +1214,7 @@ class IndicesClient(NamespacedClient):
     ):
         """
         Allows a user to validate a potentially expensive query without executing it.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
 
         :arg body: The query definition specified with the Query DSL
@@ -1220,6 +1260,7 @@ class IndicesClient(NamespacedClient):
     def create_data_stream(self, name, params=None, headers=None):
         """
         Creates a data stream
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: The name of the data stream
@@ -1235,6 +1276,7 @@ class IndicesClient(NamespacedClient):
     def delete_data_stream(self, name, params=None, headers=None):
         """
         Deletes a data stream.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: A comma-separated list of data streams to delete; use
@@ -1251,6 +1293,7 @@ class IndicesClient(NamespacedClient):
     def delete_index_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -1271,6 +1314,7 @@ class IndicesClient(NamespacedClient):
     def get_index_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The comma separated names of the index templates
@@ -1289,6 +1333,7 @@ class IndicesClient(NamespacedClient):
     def put_index_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -1315,6 +1360,7 @@ class IndicesClient(NamespacedClient):
     def exists_index_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the template
@@ -1337,6 +1383,7 @@ class IndicesClient(NamespacedClient):
         """
         Simulate matching the given index name against the index templates in the
         system
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg name: The name of the index (it must be a concrete index
@@ -1365,6 +1412,7 @@ class IndicesClient(NamespacedClient):
     def get_data_stream(self, name=None, params=None, headers=None):
         """
         Returns data streams.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: A comma-separated list of data streams to get; use
@@ -1378,6 +1426,7 @@ class IndicesClient(NamespacedClient):
     def simulate_template(self, body=None, name=None, params=None, headers=None):
         """
         Simulate resolving the given template name or body
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
         :arg body: New index template definition to be simulated, if no
@@ -1402,6 +1451,7 @@ class IndicesClient(NamespacedClient):
     def resolve_index(self, name, params=None, headers=None):
         """
         Returns information about any matching indices, aliases, and data streams
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
 
         :arg name: A comma-separated list of names or wildcard
@@ -1427,6 +1477,7 @@ class IndicesClient(NamespacedClient):
     def add_block(self, index, block, params=None, headers=None):
         """
         Adds a block to an index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html>`_
 
         :arg index: A comma separated list of indices to add a block to
@@ -1455,6 +1506,7 @@ class IndicesClient(NamespacedClient):
     def data_streams_stats(self, name=None, params=None, headers=None):
         """
         Provides statistics on operations happening in a data stream.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
 
         :arg name: A comma-separated list of data stream names; use

--- a/elasticsearch/client/indices.pyi
+++ b/elasticsearch/client/indices.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class IndicesClient(NamespacedClient):
     def analyze(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -32,10 +33,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def refresh(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -49,10 +51,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def flush(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -68,11 +71,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def create(
         self,
         index: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -86,12 +90,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def clone(
         self,
         index: Any,
         target: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -105,11 +110,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
@@ -126,11 +132,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def open(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -146,11 +153,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def close(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -166,11 +174,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -185,11 +194,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def exists(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
@@ -205,12 +215,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def exists_type(
         self,
         index: Any,
         doc_type: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -224,11 +235,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def put_mapping(
         self,
         index: Any,
+        *,
         body: Any,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -245,10 +257,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_mapping(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -264,12 +277,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_alias(
         self,
         index: Any,
         name: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -282,11 +296,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def exists_alias(
         self,
         name: Any,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -301,10 +316,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def get_alias(
         self,
+        *,
         index: Optional[Any] = ...,
         name: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -320,10 +336,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_aliases(
         self,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -336,12 +353,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_alias(
         self,
         index: Any,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -353,11 +371,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_template(
         self,
         name: Any,
+        *,
         body: Any,
         create: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -371,11 +390,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def exists_template(
         self,
         name: Any,
+        *,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -388,10 +408,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def get_template(
         self,
+        *,
         name: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
@@ -405,11 +426,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_template(
         self,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -421,10 +443,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_settings(
         self,
+        *,
         index: Optional[Any] = ...,
         name: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -443,10 +466,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_settings(
         self,
+        *,
         body: Any,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
@@ -465,10 +489,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stats(
         self,
+        *,
         index: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         completion_fields: Optional[Any] = ...,
@@ -490,10 +515,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def segments(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -508,10 +534,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def clear_cache(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -529,10 +556,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def recovery(
         self,
+        *,
         index: Optional[Any] = ...,
         active_only: Optional[Any] = ...,
         detailed: Optional[Any] = ...,
@@ -545,10 +573,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def upgrade(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -564,10 +593,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_upgrade(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -581,10 +611,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def shard_stores(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -599,10 +630,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def forcemerge(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -619,12 +651,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def shrink(
         self,
         index: Any,
         target: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -638,12 +671,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def split(
         self,
         index: Any,
         target: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -657,11 +691,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def rollover(
         self,
         alias: Any,
+        *,
         body: Optional[Any] = ...,
         new_index: Optional[Any] = ...,
         dry_run: Optional[Any] = ...,
@@ -677,11 +712,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def freeze(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -697,11 +733,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def unfreeze(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -717,11 +754,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def reload_search_analyzers(
         self,
         index: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -734,11 +772,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_field_mapping(
         self,
         fields: Any,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -754,10 +793,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def validate_query(
         self,
+        *,
         body: Optional[Any] = ...,
         index: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
@@ -782,11 +822,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def create_data_stream(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -796,11 +837,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_data_stream(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -810,11 +852,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_index_template(
         self,
         name: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -826,10 +869,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_index_template(
         self,
+        *,
         name: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
@@ -843,11 +887,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_index_template(
         self,
         name: Any,
+        *,
         body: Any,
         cause: Optional[Any] = ...,
         create: Optional[Any] = ...,
@@ -861,11 +906,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def exists_index_template(
         self,
         name: Any,
+        *,
         flat_settings: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -878,11 +924,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> bool: ...
     def simulate_index_template(
         self,
         name: Any,
+        *,
         body: Optional[Any] = ...,
         cause: Optional[Any] = ...,
         create: Optional[Any] = ...,
@@ -896,10 +943,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_data_stream(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -910,10 +958,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def simulate_template(
         self,
+        *,
         body: Optional[Any] = ...,
         name: Optional[Any] = ...,
         cause: Optional[Any] = ...,
@@ -928,11 +977,12 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def resolve_index(
         self,
         name: Any,
+        *,
         expand_wildcards: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -943,12 +993,13 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def add_block(
         self,
         index: Any,
         block: Any,
+        *,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -963,10 +1014,11 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def data_streams_stats(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -977,5 +1029,5 @@ class IndicesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/ingest.py
+++ b/elasticsearch/client/ingest.py
@@ -23,6 +23,7 @@ class IngestClient(NamespacedClient):
     def get_pipeline(self, id=None, params=None, headers=None):
         """
         Returns a pipeline.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
 
         :arg id: Comma separated list of pipeline ids. Wildcards
@@ -38,6 +39,7 @@ class IngestClient(NamespacedClient):
     def put_pipeline(self, id, body, params=None, headers=None):
         """
         Creates or updates a pipeline.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html>`_
 
         :arg id: Pipeline ID
@@ -62,6 +64,7 @@ class IngestClient(NamespacedClient):
     def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes a pipeline.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
 
         :arg id: Pipeline ID
@@ -83,6 +86,7 @@ class IngestClient(NamespacedClient):
     def simulate(self, body, id=None, params=None, headers=None):
         """
         Allows to simulate a pipeline with example documents.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
 
         :arg body: The simulate definition
@@ -105,6 +109,7 @@ class IngestClient(NamespacedClient):
     def processor_grok(self, params=None, headers=None):
         """
         Returns a list of the built-in patterns.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get>`_
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/ingest.pyi
+++ b/elasticsearch/client/ingest.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class IngestClient(NamespacedClient):
     def get_pipeline(
         self,
+        *,
         id: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -32,11 +33,12 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_pipeline(
         self,
         id: Any,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -49,11 +51,12 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_pipeline(
         self,
         id: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -65,10 +68,11 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def simulate(
         self,
+        *,
         body: Any,
         id: Optional[Any] = ...,
         verbose: Optional[Any] = ...,
@@ -81,10 +85,11 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def processor_grok(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -94,5 +99,5 @@ class IngestClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/license.py
+++ b/elasticsearch/client/license.py
@@ -23,6 +23,7 @@ class LicenseClient(NamespacedClient):
     def delete(self, params=None, headers=None):
         """
         Deletes licensing information for the cluster
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
         """
         return self.transport.perform_request(
@@ -33,6 +34,7 @@ class LicenseClient(NamespacedClient):
     def get(self, params=None, headers=None):
         """
         Retrieves licensing information for the cluster
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
 
         :arg accept_enterprise: Supported for backwards compatibility
@@ -48,6 +50,7 @@ class LicenseClient(NamespacedClient):
     def get_basic_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the basic license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
         """
         return self.transport.perform_request(
@@ -58,6 +61,7 @@ class LicenseClient(NamespacedClient):
     def get_trial_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the trial license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
         """
         return self.transport.perform_request(
@@ -68,6 +72,7 @@ class LicenseClient(NamespacedClient):
     def post(self, body=None, params=None, headers=None):
         """
         Updates the license for the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html>`_
 
         :arg body: licenses to be installed
@@ -82,6 +87,7 @@ class LicenseClient(NamespacedClient):
     def post_start_basic(self, params=None, headers=None):
         """
         Starts an indefinite basic license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html>`_
 
         :arg acknowledge: whether the user has acknowledged acknowledge
@@ -95,6 +101,7 @@ class LicenseClient(NamespacedClient):
     def post_start_trial(self, params=None, headers=None):
         """
         starts a limited time trial license.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html>`_
 
         :arg acknowledge: whether the user has acknowledged acknowledge

--- a/elasticsearch/client/license.pyi
+++ b/elasticsearch/client/license.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class LicenseClient(NamespacedClient):
     def delete(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,10 +31,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get(
         self,
+        *,
         accept_enterprise: Optional[Any] = ...,
         local: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_basic_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -58,10 +61,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_trial_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -71,10 +75,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def post(
         self,
+        *,
         body: Optional[Any] = ...,
         acknowledge: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -86,10 +91,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def post_start_basic(
         self,
+        *,
         acknowledge: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -100,10 +106,11 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def post_start_trial(
         self,
+        *,
         acknowledge: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -115,5 +122,5 @@ class LicenseClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/migration.py
+++ b/elasticsearch/client/migration.py
@@ -25,6 +25,7 @@ class MigrationClient(NamespacedClient):
         Retrieves information about different cluster, node, and index level settings
         that use deprecated features that will be removed or changed in the next major
         version.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html>`_
 
         :arg index: Index pattern

--- a/elasticsearch/client/migration.pyi
+++ b/elasticsearch/client/migration.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class MigrationClient(NamespacedClient):
     def deprecations(
         self,
+        *,
         index: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -31,5 +32,5 @@ class MigrationClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -24,6 +24,7 @@ class MlClient(NamespacedClient):
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed
         multiple times throughout its lifecycle.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html>`_
 
         :arg job_id: The name of the job to close
@@ -53,6 +54,7 @@ class MlClient(NamespacedClient):
     def delete_calendar(self, calendar_id, params=None, headers=None):
         """
         Deletes a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html>`_
 
         :arg calendar_id: The ID of the calendar to delete
@@ -73,6 +75,7 @@ class MlClient(NamespacedClient):
     def delete_calendar_event(self, calendar_id, event_id, params=None, headers=None):
         """
         Deletes scheduled events from a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -93,6 +96,7 @@ class MlClient(NamespacedClient):
     def delete_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Deletes anomaly detection jobs from a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -113,6 +117,7 @@ class MlClient(NamespacedClient):
     def delete_datafeed(self, datafeed_id, params=None, headers=None):
         """
         Deletes an existing datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to delete
@@ -134,6 +139,7 @@ class MlClient(NamespacedClient):
     def delete_expired_data(self, body=None, job_id=None, params=None, headers=None):
         """
         Deletes expired and unused machine learning data.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-expired-data.html>`_
 
         :arg body: deleting expired data parameters
@@ -156,6 +162,7 @@ class MlClient(NamespacedClient):
     def delete_filter(self, filter_id, params=None, headers=None):
         """
         Deletes a filter.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-filter.html>`_
 
         :arg filter_id: The ID of the filter to delete
@@ -174,6 +181,7 @@ class MlClient(NamespacedClient):
     def delete_forecast(self, job_id, forecast_id=None, params=None, headers=None):
         """
         Deletes forecasts from a machine learning job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-forecast.html>`_
 
         :arg job_id: The ID of the job from which to delete forecasts
@@ -198,6 +206,7 @@ class MlClient(NamespacedClient):
     def delete_job(self, job_id, params=None, headers=None):
         """
         Deletes an existing anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-job.html>`_
 
         :arg job_id: The ID of the job to delete
@@ -219,6 +228,7 @@ class MlClient(NamespacedClient):
     def delete_model_snapshot(self, job_id, snapshot_id, params=None, headers=None):
         """
         Deletes an existing model snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -257,6 +267,7 @@ class MlClient(NamespacedClient):
         """
         Finds the structure of a text file. The text file must contain data that is
         suitable to be ingested into Elasticsearch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-find-file-structure.html>`_
 
         :arg body: The contents of the file to be analyzed
@@ -308,6 +319,7 @@ class MlClient(NamespacedClient):
     def flush_job(self, job_id, body=None, params=None, headers=None):
         """
         Forces any buffered data to be processed by the job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-flush-job.html>`_
 
         :arg job_id: The name of the job to flush
@@ -338,6 +350,7 @@ class MlClient(NamespacedClient):
     def forecast(self, job_id, params=None, headers=None):
         """
         Predicts the future behavior of a time series by using its historical behavior.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-forecast.html>`_
 
         :arg job_id: The ID of the job to forecast for
@@ -371,6 +384,7 @@ class MlClient(NamespacedClient):
     def get_buckets(self, job_id, body=None, timestamp=None, params=None, headers=None):
         """
         Retrieves anomaly detection job results for one or more buckets.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-bucket.html>`_
 
         :arg job_id: ID of the job to get bucket results from
@@ -408,6 +422,7 @@ class MlClient(NamespacedClient):
     def get_calendar_events(self, calendar_id, params=None, headers=None):
         """
         Retrieves information about the scheduled events in calendars.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html>`_
 
         :arg calendar_id: The ID of the calendar containing the events
@@ -438,6 +453,7 @@ class MlClient(NamespacedClient):
     def get_calendars(self, body=None, calendar_id=None, params=None, headers=None):
         """
         Retrieves configuration information for calendars.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html>`_
 
         :arg body: The from and size parameters optionally sent in the
@@ -462,6 +478,7 @@ class MlClient(NamespacedClient):
     def get_datafeed_stats(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves usage information for datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html>`_
 
         :arg datafeed_id: The ID of the datafeeds stats to fetch
@@ -479,10 +496,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match")
+    @query_params("allow_no_datafeeds", "allow_no_match", "exclude_generated")
     def get_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves configuration information for datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeeds to fetch
@@ -492,6 +510,8 @@ class MlClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no datafeeds. (This includes `_all` string or when no datafeeds
             have been specified)
+        :arg exclude_generated: Omits fields that are illegal to set on
+            datafeed PUT
         """
         return self.transport.perform_request(
             "GET",
@@ -504,6 +524,7 @@ class MlClient(NamespacedClient):
     def get_filters(self, filter_id=None, params=None, headers=None):
         """
         Retrieves filters.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-filter.html>`_
 
         :arg filter_id: The ID of the filter to fetch
@@ -534,6 +555,7 @@ class MlClient(NamespacedClient):
     def get_influencers(self, job_id, body=None, params=None, headers=None):
         """
         Retrieves anomaly detection job results for one or more influencers.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-influencer.html>`_
 
         :arg job_id: Identifier for the anomaly detection job
@@ -568,6 +590,7 @@ class MlClient(NamespacedClient):
     def get_job_stats(self, job_id=None, params=None, headers=None):
         """
         Retrieves usage information for anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html>`_
 
         :arg job_id: The ID of the jobs stats to fetch
@@ -585,10 +608,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_jobs", "allow_no_match")
+    @query_params("allow_no_jobs", "allow_no_match", "exclude_generated")
     def get_jobs(self, job_id=None, params=None, headers=None):
         """
         Retrieves configuration information for anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job.html>`_
 
         :arg job_id: The ID of the jobs to fetch
@@ -598,6 +622,8 @@ class MlClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no jobs. (This includes `_all` string or when no jobs have been
             specified)
+        :arg exclude_generated: Omits fields that are illegal to set on
+            job PUT
         """
         return self.transport.perform_request(
             "GET",
@@ -620,6 +646,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves overall bucket results that summarize the bucket results of multiple
         anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-overall-buckets.html>`_
 
         :arg job_id: The job IDs for which to calculate overall bucket
@@ -671,6 +698,7 @@ class MlClient(NamespacedClient):
     def get_records(self, job_id, body=None, params=None, headers=None):
         """
         Retrieves anomaly records for an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-record.html>`_
 
         :arg job_id: The ID of the job
@@ -704,6 +732,7 @@ class MlClient(NamespacedClient):
     def info(self, params=None, headers=None):
         """
         Returns defaults and limits used by machine learning.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
         """
         return self.transport.perform_request(
@@ -714,6 +743,7 @@ class MlClient(NamespacedClient):
     def open_job(self, job_id, params=None, headers=None):
         """
         Opens one or more anomaly detection jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-open-job.html>`_
 
         :arg job_id: The ID of the job to open
@@ -732,6 +762,7 @@ class MlClient(NamespacedClient):
     def post_calendar_events(self, calendar_id, body, params=None, headers=None):
         """
         Posts scheduled events in a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-calendar-event.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -753,6 +784,7 @@ class MlClient(NamespacedClient):
     def post_data(self, job_id, body, params=None, headers=None):
         """
         Sends data to an anomaly detection job for analysis.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-data.html>`_
 
         :arg job_id: The name of the job receiving the data
@@ -779,6 +811,7 @@ class MlClient(NamespacedClient):
     def preview_datafeed(self, datafeed_id, params=None, headers=None):
         """
         Previews a datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-preview-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to preview
@@ -799,6 +832,7 @@ class MlClient(NamespacedClient):
     def put_calendar(self, calendar_id, body=None, params=None, headers=None):
         """
         Instantiates a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar.html>`_
 
         :arg calendar_id: The ID of the calendar to create
@@ -821,6 +855,7 @@ class MlClient(NamespacedClient):
     def put_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Adds an anomaly detection job to a calendar.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar-job.html>`_
 
         :arg calendar_id: The ID of the calendar to modify
@@ -843,6 +878,7 @@ class MlClient(NamespacedClient):
     def put_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
         Instantiates a datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to create
@@ -873,6 +909,7 @@ class MlClient(NamespacedClient):
     def put_filter(self, filter_id, body, params=None, headers=None):
         """
         Instantiates a filter.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-filter.html>`_
 
         :arg filter_id: The ID of the filter to create
@@ -894,6 +931,7 @@ class MlClient(NamespacedClient):
     def put_job(self, job_id, body, params=None, headers=None):
         """
         Instantiates an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html>`_
 
         :arg job_id: The ID of the job to create
@@ -916,6 +954,7 @@ class MlClient(NamespacedClient):
         """
         Sets a cluster wide upgrade_mode setting that prepares machine learning indices
         for an upgrade.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-set-upgrade-mode.html>`_
 
         :arg enabled: Whether to enable upgrade_mode ML setting or not.
@@ -931,6 +970,7 @@ class MlClient(NamespacedClient):
     def start_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Starts one or more datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to start
@@ -958,6 +998,7 @@ class MlClient(NamespacedClient):
     def stop_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Stops one or more datafeeds.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-stop-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to stop
@@ -991,6 +1032,7 @@ class MlClient(NamespacedClient):
     def update_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
         Updates certain properties of a datafeed.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html>`_
 
         :arg datafeed_id: The ID of the datafeed to update
@@ -1021,6 +1063,7 @@ class MlClient(NamespacedClient):
     def update_filter(self, filter_id, body, params=None, headers=None):
         """
         Updates the description of a filter, adds items, or removes items.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-filter.html>`_
 
         :arg filter_id: The ID of the filter to update
@@ -1042,6 +1085,7 @@ class MlClient(NamespacedClient):
     def update_job(self, job_id, body, params=None, headers=None):
         """
         Updates certain properties of an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-job.html>`_
 
         :arg job_id: The ID of the job to create
@@ -1063,6 +1107,7 @@ class MlClient(NamespacedClient):
     def validate(self, body, params=None, headers=None):
         """
         Validates an anomaly detection job.
+
         `<https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html>`_
 
         :arg body: The job config
@@ -1082,6 +1127,7 @@ class MlClient(NamespacedClient):
     def validate_detector(self, body, params=None, headers=None):
         """
         Validates an anomaly detection detector.
+
         `<https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html>`_
 
         :arg body: The detector
@@ -1101,6 +1147,7 @@ class MlClient(NamespacedClient):
     def delete_data_frame_analytics(self, id, params=None, headers=None):
         """
         Deletes an existing data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to delete
@@ -1122,6 +1169,7 @@ class MlClient(NamespacedClient):
     def evaluate_data_frame(self, body, params=None, headers=None):
         """
         Evaluates the data frame analytics for an annotated index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html>`_
 
         :arg body: The evaluation definition
@@ -1137,16 +1185,19 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params("allow_no_match", "exclude_generated", "from_", "size")
     def get_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Retrieves configuration information for data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no data frame analytics. (This includes `_all` string or when no
             data frame analytics have been specified)  Default: True
+        :arg exclude_generated: Omits fields that are illegal to set on
+            data frame analytics PUT
         :arg from\\_: skips a number of analytics
         :arg size: specifies a max number of analytics to get  Default:
             100
@@ -1166,6 +1217,7 @@ class MlClient(NamespacedClient):
     def get_data_frame_analytics_stats(self, id=None, params=None, headers=None):
         """
         Retrieves usage information for data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html>`_
 
         :arg id: The ID of the data frame analytics stats to fetch
@@ -1192,6 +1244,7 @@ class MlClient(NamespacedClient):
     def put_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Instantiates a data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to create
@@ -1213,6 +1266,7 @@ class MlClient(NamespacedClient):
     def start_data_frame_analytics(self, id, body=None, params=None, headers=None):
         """
         Starts a data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to start
@@ -1235,6 +1289,7 @@ class MlClient(NamespacedClient):
     def stop_data_frame_analytics(self, id, body=None, params=None, headers=None):
         """
         Stops one or more data frame analytics jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to stop
@@ -1263,7 +1318,8 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing trained inference model that is currently not referenced by
         an ingest pipeline.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models.html>`_
 
         :arg model_id: The ID of the trained model to delete
         """
@@ -1272,7 +1328,7 @@ class MlClient(NamespacedClient):
 
         return self.transport.perform_request(
             "DELETE",
-            _make_path("_ml", "inference", model_id),
+            _make_path("_ml", "trained_models", model_id),
             params=params,
             headers=headers,
         )
@@ -1280,7 +1336,7 @@ class MlClient(NamespacedClient):
     @query_params(
         "allow_no_match",
         "decompress_definition",
-        "for_export",
+        "exclude_generated",
         "from_",
         "include",
         "include_model_definition",
@@ -1290,7 +1346,8 @@ class MlClient(NamespacedClient):
     def get_trained_models(self, model_id=None, params=None, headers=None):
         """
         Retrieves configuration information for a trained inference model.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models.html>`_
 
         :arg model_id: The ID of the trained models to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
@@ -1299,8 +1356,8 @@ class MlClient(NamespacedClient):
         :arg decompress_definition: Should the model definition be
             decompressed into valid JSON or returned in a custom compressed format.
             Defaults to true.  Default: True
-        :arg for_export: Omits fields that are illegal to set on model
-            PUT
+        :arg exclude_generated: Omits fields that are illegal to set on
+            model PUT
         :arg from\\_: skips a number of trained models
         :arg include: A comma-separate list of fields to optionally
             include. Valid options are 'definition' and 'total_feature_importance'.
@@ -1319,7 +1376,7 @@ class MlClient(NamespacedClient):
 
         return self.transport.perform_request(
             "GET",
-            _make_path("_ml", "inference", model_id),
+            _make_path("_ml", "trained_models", model_id),
             params=params,
             headers=headers,
         )
@@ -1328,7 +1385,8 @@ class MlClient(NamespacedClient):
     def get_trained_models_stats(self, model_id=None, params=None, headers=None):
         """
         Retrieves usage information for trained inference models.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-stats.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html>`_
 
         :arg model_id: The ID of the trained models stats to fetch
         :arg allow_no_match: Whether to ignore if a wildcard expression
@@ -1344,7 +1402,7 @@ class MlClient(NamespacedClient):
 
         return self.transport.perform_request(
             "GET",
-            _make_path("_ml", "inference", model_id, "_stats"),
+            _make_path("_ml", "trained_models", model_id, "_stats"),
             params=params,
             headers=headers,
         )
@@ -1353,7 +1411,8 @@ class MlClient(NamespacedClient):
     def put_trained_model(self, model_id, body, params=None, headers=None):
         """
         Creates an inference trained model.
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference.html>`_
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models.html>`_
 
         :arg model_id: The ID of the trained models to store
         :arg body: The trained model configuration
@@ -1364,7 +1423,7 @@ class MlClient(NamespacedClient):
 
         return self.transport.perform_request(
             "PUT",
-            _make_path("_ml", "inference", model_id),
+            _make_path("_ml", "trained_models", model_id),
             params=params,
             headers=headers,
             body=body,
@@ -1374,6 +1433,7 @@ class MlClient(NamespacedClient):
     def estimate_model_memory(self, body, params=None, headers=None):
         """
         Estimates the model memory
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-apis.html>`_
 
         :arg body: The analysis config, plus cardinality estimates for
@@ -1396,6 +1456,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Explains a data frame analytics config.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html>`_
 
         :arg body: The data frame analytics config to explain
@@ -1415,6 +1476,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Retrieves anomaly detection job results for one or more categories.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-category.html>`_
 
         :arg job_id: The name of the job
@@ -1450,6 +1512,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Retrieves information about model snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -1487,6 +1550,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Reverts to a specific snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-revert-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -1520,6 +1584,7 @@ class MlClient(NamespacedClient):
     ):
         """
         Updates certain properties of a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-snapshot.html>`_
 
         :arg job_id: The ID of the job to fetch
@@ -1549,6 +1614,7 @@ class MlClient(NamespacedClient):
     def update_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Updates certain properties of a data frame analytics job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html>`_
 
         :arg id: The ID of the data frame analytics to update

--- a/elasticsearch/client/ml.pyi
+++ b/elasticsearch/client/ml.pyi
@@ -22,6 +22,7 @@ class MlClient(NamespacedClient):
     def close_job(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -36,11 +37,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_calendar(
         self,
         calendar_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -50,12 +52,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_calendar_event(
         self,
         calendar_id: Any,
         event_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -65,12 +68,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_calendar_job(
         self,
         calendar_id: Any,
         job_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -80,11 +84,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_datafeed(
         self,
         datafeed_id: Any,
+        *,
         force: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -95,10 +100,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_expired_data(
         self,
+        *,
         body: Optional[Any] = ...,
         job_id: Optional[Any] = ...,
         requests_per_second: Optional[Any] = ...,
@@ -112,11 +118,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_filter(
         self,
         filter_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -126,11 +133,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_forecast(
         self,
         job_id: Any,
+        *,
         forecast_id: Optional[Any] = ...,
         allow_no_forecasts: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -143,11 +151,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_job(
         self,
         job_id: Any,
+        *,
         force: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -159,12 +168,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_model_snapshot(
         self,
         job_id: Any,
         snapshot_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -174,10 +184,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def find_file_structure(
         self,
+        *,
         body: Any,
         charset: Optional[Any] = ...,
         column_names: Optional[Any] = ...,
@@ -201,11 +212,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def flush_job(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         advance_time: Optional[Any] = ...,
         calc_interim: Optional[Any] = ...,
@@ -221,11 +233,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def forecast(
         self,
         job_id: Any,
+        *,
         duration: Optional[Any] = ...,
         expires_in: Optional[Any] = ...,
         max_model_memory: Optional[Any] = ...,
@@ -238,11 +251,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_buckets(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         timestamp: Optional[Any] = ...,
         anomaly_score: Optional[Any] = ...,
@@ -263,11 +277,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_calendar_events(
         self,
         calendar_id: Any,
+        *,
         end: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         job_id: Optional[Any] = ...,
@@ -282,10 +297,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_calendars(
         self,
+        *,
         body: Optional[Any] = ...,
         calendar_id: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -299,10 +315,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_datafeed_stats(
         self,
+        *,
         datafeed_id: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -315,13 +332,15 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_datafeeds(
         self,
+        *,
         datafeed_id: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -331,10 +350,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_filters(
         self,
+        *,
         filter_id: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
@@ -347,11 +367,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_influencers(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         desc: Optional[Any] = ...,
         end: Optional[Any] = ...,
@@ -370,10 +391,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_job_stats(
         self,
+        *,
         job_id: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -386,13 +408,15 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_jobs(
         self,
+        *,
         job_id: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -402,11 +426,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_overall_buckets(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_jobs: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -425,11 +450,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_records(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         desc: Optional[Any] = ...,
         end: Optional[Any] = ...,
@@ -448,10 +474,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def info(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -461,11 +488,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def open_job(
         self,
         job_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -475,11 +503,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def post_calendar_events(
         self,
         calendar_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -490,11 +519,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def post_data(
         self,
         job_id: Any,
+        *,
         body: Any,
         reset_end: Optional[Any] = ...,
         reset_start: Optional[Any] = ...,
@@ -507,11 +537,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def preview_datafeed(
         self,
         datafeed_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -521,11 +552,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_calendar(
         self,
         calendar_id: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -536,12 +568,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_calendar_job(
         self,
         calendar_id: Any,
         job_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -551,11 +584,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Any,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -570,11 +604,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_filter(
         self,
         filter_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -585,11 +620,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_job(
         self,
         job_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -600,10 +636,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def set_upgrade_mode(
         self,
+        *,
         enabled: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -615,11 +652,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def start_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Optional[Any] = ...,
         end: Optional[Any] = ...,
         start: Optional[Any] = ...,
@@ -633,11 +671,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stop_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_datafeeds: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
@@ -652,11 +691,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_datafeed(
         self,
         datafeed_id: Any,
+        *,
         body: Any,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -671,11 +711,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_filter(
         self,
         filter_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -686,11 +727,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_job(
         self,
         job_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -701,10 +743,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def validate(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -715,10 +758,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def validate_detector(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -729,11 +773,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_data_frame_analytics(
         self,
         id: Any,
+        *,
         force: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -745,10 +790,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def evaluate_data_frame(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -759,12 +805,14 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_data_frame_analytics(
         self,
+        *,
         id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -776,10 +824,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_data_frame_analytics_stats(
         self,
+        *,
         id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -794,11 +843,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -809,11 +859,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def start_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -825,11 +876,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stop_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         force: Optional[Any] = ...,
@@ -843,11 +895,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_trained_model(
         self,
         model_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -857,14 +910,15 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_trained_models(
         self,
+        *,
         model_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         decompress_definition: Optional[Any] = ...,
-        for_export: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         include: Optional[Any] = ...,
         include_model_definition: Optional[Any] = ...,
@@ -879,10 +933,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_trained_models_stats(
         self,
+        *,
         model_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -896,11 +951,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_trained_model(
         self,
         model_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -911,10 +967,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def estimate_model_memory(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -925,10 +982,11 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def explain_data_frame_analytics(
         self,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -940,11 +998,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_categories(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         category_id: Optional[Any] = ...,
         from_: Optional[Any] = ...,
@@ -959,11 +1018,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_model_snapshots(
         self,
         job_id: Any,
+        *,
         body: Optional[Any] = ...,
         snapshot_id: Optional[Any] = ...,
         desc: Optional[Any] = ...,
@@ -981,12 +1041,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def revert_model_snapshot(
         self,
         job_id: Any,
         snapshot_id: Any,
+        *,
         body: Optional[Any] = ...,
         delete_intervening_results: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -998,12 +1059,13 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_model_snapshot(
         self,
         job_id: Any,
         snapshot_id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -1014,11 +1076,12 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_data_frame_analytics(
         self,
         id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -1029,5 +1092,5 @@ class MlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/monitoring.py
+++ b/elasticsearch/client/monitoring.py
@@ -23,6 +23,7 @@ class MonitoringClient(NamespacedClient):
     def bulk(self, body, doc_type=None, params=None, headers=None):
         """
         Used by the monitoring features to send monitoring data.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
 
         :arg body: The operation definition and data (action-data

--- a/elasticsearch/client/monitoring.pyi
+++ b/elasticsearch/client/monitoring.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class MonitoringClient(NamespacedClient):
     def bulk(
         self,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         interval: Optional[Any] = ...,
@@ -35,5 +36,5 @@ class MonitoringClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/nodes.py
+++ b/elasticsearch/client/nodes.py
@@ -25,6 +25,7 @@ class NodesClient(NamespacedClient):
     ):
         """
         Reloads secure settings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings>`_
 
         :arg body: An object containing the password for the
@@ -46,6 +47,7 @@ class NodesClient(NamespacedClient):
     def info(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns information about nodes in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -69,6 +71,7 @@ class NodesClient(NamespacedClient):
     def hot_threads(self, node_id=None, params=None, headers=None):
         """
         Returns information about hot threads on each node in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -102,6 +105,7 @@ class NodesClient(NamespacedClient):
     def usage(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns low-level information about REST actions usage on nodes.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to
@@ -134,6 +138,7 @@ class NodesClient(NamespacedClient):
     ):
         """
         Returns statistical information about nodes in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
 
         :arg node_id: A comma-separated list of node IDs or names to

--- a/elasticsearch/client/nodes.pyi
+++ b/elasticsearch/client/nodes.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class NodesClient(NamespacedClient):
     def reload_secure_settings(
         self,
+        *,
         body: Optional[Any] = ...,
         node_id: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -33,10 +34,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def info(
         self,
+        *,
         node_id: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         flat_settings: Optional[Any] = ...,
@@ -50,10 +52,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def hot_threads(
         self,
+        *,
         node_id: Optional[Any] = ...,
         doc_type: Optional[Any] = ...,
         ignore_idle_threads: Optional[Any] = ...,
@@ -70,10 +73,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def usage(
         self,
+        *,
         node_id: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -86,10 +90,11 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stats(
         self,
+        *,
         node_id: Optional[Any] = ...,
         metric: Optional[Any] = ...,
         index_metric: Optional[Any] = ...,
@@ -110,5 +115,5 @@ class NodesClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/remote.py
+++ b/elasticsearch/client/remote.py
@@ -22,7 +22,7 @@ class RemoteClient(NamespacedClient):
     @query_params()
     def info(self, params=None, headers=None):
         """
-        `<http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
         """
         return self.transport.perform_request(
             "GET", "/_remote/info", params=params, headers=headers

--- a/elasticsearch/client/remote.pyi
+++ b/elasticsearch/client/remote.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class RemoteClient(NamespacedClient):
     def info(
         self,
+        *,
         timeout: Optional[Any] = None,
         pretty: Optional[bool] = None,
         human: Optional[bool] = None,

--- a/elasticsearch/client/rollup.py
+++ b/elasticsearch/client/rollup.py
@@ -23,6 +23,7 @@ class RollupClient(NamespacedClient):
     def delete_job(self, id, params=None, headers=None):
         """
         Deletes an existing rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html>`_
 
         :arg id: The ID of the job to delete
@@ -38,6 +39,7 @@ class RollupClient(NamespacedClient):
     def get_jobs(self, id=None, params=None, headers=None):
         """
         Retrieves the configuration, stats, and status of rollup jobs.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html>`_
 
         :arg id: The ID of the job(s) to fetch. Accepts glob patterns,
@@ -52,6 +54,7 @@ class RollupClient(NamespacedClient):
         """
         Returns the capabilities of any rollup jobs that have been configured for a
         specific index or index pattern.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html>`_
 
         :arg id: The ID of the index to check rollup capabilities on, or
@@ -66,6 +69,7 @@ class RollupClient(NamespacedClient):
         """
         Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
         index where rollup data is stored).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html>`_
 
         :arg index: The rollup index or index pattern to obtain rollup
@@ -82,6 +86,7 @@ class RollupClient(NamespacedClient):
     def put_job(self, id, body, params=None, headers=None):
         """
         Creates a rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html>`_
 
         :arg id: The ID of the job to create
@@ -103,6 +108,7 @@ class RollupClient(NamespacedClient):
     def rollup_search(self, index, body, doc_type=None, params=None, headers=None):
         """
         Enables searching rolled-up data using the standard query DSL.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html>`_
 
         :arg index: The indices or index-pattern(s) (containing rollup
@@ -130,6 +136,7 @@ class RollupClient(NamespacedClient):
     def start_job(self, id, params=None, headers=None):
         """
         Starts an existing, stopped rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html>`_
 
         :arg id: The ID of the job to start
@@ -148,6 +155,7 @@ class RollupClient(NamespacedClient):
     def stop_job(self, id, params=None, headers=None):
         """
         Stops an existing, started rollup job.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html>`_
 
         :arg id: The ID of the job to stop

--- a/elasticsearch/client/rollup.pyi
+++ b/elasticsearch/client/rollup.pyi
@@ -22,6 +22,7 @@ class RollupClient(NamespacedClient):
     def delete_job(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,10 +32,11 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_jobs(
         self,
+        *,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_rollup_caps(
         self,
+        *,
         id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -59,11 +62,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_rollup_index_caps(
         self,
         index: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -73,11 +77,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_job(
         self,
         id: Any,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -88,11 +93,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def rollup_search(
         self,
         index: Any,
+        *,
         body: Any,
         doc_type: Optional[Any] = ...,
         rest_total_hits_as_int: Optional[Any] = ...,
@@ -106,11 +112,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def start_job(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -120,11 +127,12 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stop_job(
         self,
         id: Any,
+        *,
         timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -136,5 +144,5 @@ class RollupClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/searchable_snapshots.py
+++ b/elasticsearch/client/searchable_snapshots.py
@@ -23,6 +23,7 @@ class SearchableSnapshotsClient(NamespacedClient):
     def clear_cache(self, index=None, params=None, headers=None):
         """
         Clear the cache of searchable snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
 
         :arg index: A comma-separated list of index name to limit the
@@ -47,6 +48,7 @@ class SearchableSnapshotsClient(NamespacedClient):
     def mount(self, repository, snapshot, body, params=None, headers=None):
         """
         Mount a snapshot as a searchable index.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html>`_
 
         :arg repository: The name of the repository containing the
@@ -75,6 +77,7 @@ class SearchableSnapshotsClient(NamespacedClient):
     def stats(self, index=None, params=None, headers=None):
         """
         Retrieve various statistics about searchable snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
 
         :arg index: A comma-separated list of index names

--- a/elasticsearch/client/searchable_snapshots.pyi
+++ b/elasticsearch/client/searchable_snapshots.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SearchableSnapshotsClient(NamespacedClient):
     def clear_cache(
         self,
+        *,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[Any] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -34,12 +35,13 @@ class SearchableSnapshotsClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def mount(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
@@ -52,10 +54,11 @@ class SearchableSnapshotsClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stats(
         self,
+        *,
         index: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -66,5 +69,5 @@ class SearchableSnapshotsClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/security.py
+++ b/elasticsearch/client/security.py
@@ -24,6 +24,7 @@ class SecurityClient(NamespacedClient):
         """
         Enables authentication as a user and retrieve information about the
         authenticated user.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
         """
         return self.transport.perform_request(
@@ -34,6 +35,7 @@ class SecurityClient(NamespacedClient):
     def change_password(self, body, username=None, params=None, headers=None):
         """
         Changes the passwords of users in the native realm and built-in users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-change-password.html>`_
 
         :arg body: the new password for the user
@@ -60,6 +62,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts users from the user cache. Can completely clear the cache or evict
         specific users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-cache.html>`_
 
         :arg realms: Comma-separated list of realms to clear
@@ -80,6 +83,7 @@ class SecurityClient(NamespacedClient):
     def clear_cached_roles(self, name, params=None, headers=None):
         """
         Evicts roles from the native role cache.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-role-cache.html>`_
 
         :arg name: Role name
@@ -98,6 +102,7 @@ class SecurityClient(NamespacedClient):
     def create_api_key(self, body, params=None, headers=None):
         """
         Creates an API key for access without requiring basic authentication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-api-key.html>`_
 
         :arg body: The api key request to create an API key
@@ -117,6 +122,7 @@ class SecurityClient(NamespacedClient):
     def delete_privileges(self, application, name, params=None, headers=None):
         """
         Removes application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-privilege.html>`_
 
         :arg application: Application name
@@ -141,6 +147,7 @@ class SecurityClient(NamespacedClient):
     def delete_role(self, name, params=None, headers=None):
         """
         Removes roles in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role.html>`_
 
         :arg name: Role name
@@ -163,6 +170,7 @@ class SecurityClient(NamespacedClient):
     def delete_role_mapping(self, name, params=None, headers=None):
         """
         Removes role mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role-mapping.html>`_
 
         :arg name: Role-mapping name
@@ -185,6 +193,7 @@ class SecurityClient(NamespacedClient):
     def delete_user(self, username, params=None, headers=None):
         """
         Deletes users from the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-user.html>`_
 
         :arg username: username
@@ -207,6 +216,7 @@ class SecurityClient(NamespacedClient):
     def disable_user(self, username, params=None, headers=None):
         """
         Disables users in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user.html>`_
 
         :arg username: The username of the user to disable
@@ -229,6 +239,7 @@ class SecurityClient(NamespacedClient):
     def enable_user(self, username, params=None, headers=None):
         """
         Enables users in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user.html>`_
 
         :arg username: The username of the user to enable
@@ -251,6 +262,7 @@ class SecurityClient(NamespacedClient):
     def get_api_key(self, params=None, headers=None):
         """
         Retrieves information for one or more API keys.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-api-key.html>`_
 
         :arg id: API key id of the API key to be retrieved
@@ -270,6 +282,7 @@ class SecurityClient(NamespacedClient):
     def get_privileges(self, application=None, name=None, params=None, headers=None):
         """
         Retrieves application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
 
         :arg application: Application name
@@ -286,6 +299,7 @@ class SecurityClient(NamespacedClient):
     def get_role(self, name=None, params=None, headers=None):
         """
         Retrieves roles in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role.html>`_
 
         :arg name: A comma-separated list of role names
@@ -298,6 +312,7 @@ class SecurityClient(NamespacedClient):
     def get_role_mapping(self, name=None, params=None, headers=None):
         """
         Retrieves role mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role-mapping.html>`_
 
         :arg name: A comma-separated list of role-mapping names
@@ -313,6 +328,7 @@ class SecurityClient(NamespacedClient):
     def get_token(self, body, params=None, headers=None):
         """
         Creates a bearer token for access without requiring basic authentication.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html>`_
 
         :arg body: The token request to get
@@ -328,6 +344,7 @@ class SecurityClient(NamespacedClient):
     def get_user(self, username=None, params=None, headers=None):
         """
         Retrieves information about users in the native realm and built-in users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user.html>`_
 
         :arg username: A comma-separated list of usernames
@@ -343,6 +360,7 @@ class SecurityClient(NamespacedClient):
     def get_user_privileges(self, params=None, headers=None):
         """
         Retrieves application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
         """
         return self.transport.perform_request(
@@ -353,6 +371,7 @@ class SecurityClient(NamespacedClient):
     def has_privileges(self, body, user=None, params=None, headers=None):
         """
         Determines whether the specified user has a specified list of privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges.html>`_
 
         :arg body: The privileges to test
@@ -373,6 +392,7 @@ class SecurityClient(NamespacedClient):
     def invalidate_api_key(self, body, params=None, headers=None):
         """
         Invalidates one or more API keys.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-api-key.html>`_
 
         :arg body: The api key request to invalidate API key(s)
@@ -388,6 +408,7 @@ class SecurityClient(NamespacedClient):
     def invalidate_token(self, body, params=None, headers=None):
         """
         Invalidates one or more access tokens or refresh tokens.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-token.html>`_
 
         :arg body: The token to invalidate
@@ -407,6 +428,7 @@ class SecurityClient(NamespacedClient):
     def put_privileges(self, body, params=None, headers=None):
         """
         Adds or updates application privileges.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-privileges.html>`_
 
         :arg body: The privilege(s) to add
@@ -426,6 +448,7 @@ class SecurityClient(NamespacedClient):
     def put_role(self, name, body, params=None, headers=None):
         """
         Adds and updates roles in the native realm.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role.html>`_
 
         :arg name: Role name
@@ -451,6 +474,7 @@ class SecurityClient(NamespacedClient):
     def put_role_mapping(self, name, body, params=None, headers=None):
         """
         Creates and updates role mappings.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role-mapping.html>`_
 
         :arg name: Role-mapping name
@@ -477,6 +501,7 @@ class SecurityClient(NamespacedClient):
         """
         Adds and updates users in the native realm. These users are commonly referred
         to as native users.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-user.html>`_
 
         :arg username: The username of the User
@@ -503,6 +528,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves the list of cluster privileges and index privileges that are
         available in this version of Elasticsearch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
         """
         return self.transport.perform_request(
@@ -513,6 +539,7 @@ class SecurityClient(NamespacedClient):
     def clear_cached_privileges(self, application, params=None, headers=None):
         """
         Evicts application privileges from the native application privileges cache.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-privilege-cache.html>`_
 
         :arg application: A comma-separated list of application names
@@ -527,4 +554,48 @@ class SecurityClient(NamespacedClient):
             _make_path("_security", "privilege", application, "_clear_cache"),
             params=params,
             headers=headers,
+        )
+
+    @query_params()
+    def clear_api_key_cache(self, ids, params=None, headers=None):
+        """
+        Clear a subset or all entries from the API key cache.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-api-key-cache.html>`_
+
+        :arg ids: A comma-separated list of IDs of API keys to clear
+            from the cache
+        """
+        if ids in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'ids'.")
+
+        return self.transport.perform_request(
+            "POST",
+            _make_path("_security", "api_key", ids, "_clear_cache"),
+            params=params,
+            headers=headers,
+        )
+
+    @query_params("refresh")
+    def grant_api_key(self, body, params=None, headers=None):
+        """
+        Creates an API key on behalf of another user.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-grant-api-key.html>`_
+
+        :arg body: The api key request to create an API key
+        :arg refresh: If `true` (the default) then refresh the affected
+            shards to make this operation visible to search, if `wait_for` then wait
+            for a refresh to make this operation visible to search, if `false` then
+            do nothing with refreshes.  Valid choices: true, false, wait_for
+        """
+        if body in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'body'.")
+
+        return self.transport.perform_request(
+            "POST",
+            "/_security/api_key/grant",
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/elasticsearch/client/security.pyi
+++ b/elasticsearch/client/security.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SecurityClient(NamespacedClient):
     def authenticate(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,10 +31,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def change_password(
         self,
+        *,
         body: Any,
         username: Optional[Any] = ...,
         refresh: Optional[Any] = ...,
@@ -46,11 +48,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def clear_cached_realms(
         self,
         realms: Any,
+        *,
         usernames: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -61,11 +64,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def clear_cached_roles(
         self,
         name: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -75,10 +79,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def create_api_key(
         self,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -90,12 +95,13 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_privileges(
         self,
         application: Any,
         name: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -106,11 +112,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_role(
         self,
         name: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -121,11 +128,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_role_mapping(
         self,
         name: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -136,11 +144,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_user(
         self,
         username: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -151,11 +160,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def disable_user(
         self,
         username: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -166,11 +176,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def enable_user(
         self,
         username: Any,
+        *,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -181,10 +192,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_api_key(
         self,
+        *,
         id: Optional[Any] = ...,
         name: Optional[Any] = ...,
         owner: Optional[Any] = ...,
@@ -199,10 +211,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_privileges(
         self,
+        *,
         application: Optional[Any] = ...,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -214,10 +227,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_role(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -228,10 +242,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_role_mapping(
         self,
+        *,
         name: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -242,10 +257,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_token(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -256,10 +272,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_user(
         self,
+        *,
         username: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -270,10 +287,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_user_privileges(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -283,10 +301,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def has_privileges(
         self,
+        *,
         body: Any,
         user: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -298,10 +317,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def invalidate_api_key(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -312,10 +332,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def invalidate_token(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -326,10 +347,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_privileges(
         self,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -341,11 +363,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_role(
         self,
         name: Any,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -357,11 +380,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_role_mapping(
         self,
         name: Any,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -373,11 +397,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_user(
         self,
         username: Any,
+        *,
         body: Any,
         refresh: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -389,10 +414,11 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_builtin_privileges(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -402,11 +428,12 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def clear_cached_privileges(
         self,
         application: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -416,5 +443,36 @@ class SecurityClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
+    ) -> Any: ...
+    def clear_api_key_cache(
+        self,
+        ids: Any,
+        *,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
+    ) -> Any: ...
+    def grant_api_key(
+        self,
+        *,
+        body: Any,
+        refresh: Optional[Any] = ...,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/slm.py
+++ b/elasticsearch/client/slm.py
@@ -23,6 +23,7 @@ class SlmClient(NamespacedClient):
     def delete_lifecycle(self, policy_id, params=None, headers=None):
         """
         Deletes an existing snapshot lifecycle policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-delete-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to
@@ -43,6 +44,7 @@ class SlmClient(NamespacedClient):
         """
         Immediately creates a snapshot according to the lifecycle policy, without
         waiting for the scheduled time.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-lifecycle.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy to be
@@ -63,6 +65,7 @@ class SlmClient(NamespacedClient):
         """
         Deletes any snapshots that are expired according to the policy's retention
         rules.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
         """
         return self.transport.perform_request(
@@ -74,6 +77,7 @@ class SlmClient(NamespacedClient):
         """
         Retrieves one or more snapshot lifecycle policy definitions and information
         about the latest snapshot attempts.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-policy.html>`_
 
         :arg policy_id: Comma-separated list of snapshot lifecycle
@@ -91,6 +95,7 @@ class SlmClient(NamespacedClient):
         """
         Returns global and policy-level statistics about actions taken by snapshot
         lifecycle management.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
         """
         return self.transport.perform_request(
@@ -101,6 +106,7 @@ class SlmClient(NamespacedClient):
     def put_lifecycle(self, policy_id, body=None, params=None, headers=None):
         """
         Creates or updates a snapshot lifecycle policy.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-put-policy.html>`_
 
         :arg policy_id: The id of the snapshot lifecycle policy
@@ -121,6 +127,7 @@ class SlmClient(NamespacedClient):
     def get_status(self, params=None, headers=None):
         """
         Retrieves the status of snapshot lifecycle management (SLM).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
         """
         return self.transport.perform_request(
@@ -131,6 +138,7 @@ class SlmClient(NamespacedClient):
     def start(self, params=None, headers=None):
         """
         Turns on snapshot lifecycle management (SLM).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
         """
         return self.transport.perform_request(
@@ -141,6 +149,7 @@ class SlmClient(NamespacedClient):
     def stop(self, params=None, headers=None):
         """
         Turns off snapshot lifecycle management (SLM).
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/slm.pyi
+++ b/elasticsearch/client/slm.pyi
@@ -22,6 +22,7 @@ class SlmClient(NamespacedClient):
     def delete_lifecycle(
         self,
         policy_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -31,11 +32,12 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def execute_lifecycle(
         self,
         policy_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def execute_retention(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -58,10 +61,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_lifecycle(
         self,
+        *,
         policy_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -72,10 +76,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_stats(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -85,11 +90,12 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_lifecycle(
         self,
         policy_id: Any,
+        *,
         body: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -100,10 +106,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_status(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -113,10 +120,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def start(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -126,10 +134,11 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stop(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -139,5 +148,5 @@ class SlmClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/snapshot.py
+++ b/elasticsearch/client/snapshot.py
@@ -23,6 +23,7 @@ class SnapshotClient(NamespacedClient):
     def create(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Creates a snapshot in a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -49,6 +50,7 @@ class SnapshotClient(NamespacedClient):
     def delete(self, repository, snapshot, params=None, headers=None):
         """
         Deletes one or more snapshots.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -71,6 +73,7 @@ class SnapshotClient(NamespacedClient):
     def get(self, repository, snapshot, params=None, headers=None):
         """
         Returns information about a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -98,6 +101,7 @@ class SnapshotClient(NamespacedClient):
     def delete_repository(self, repository, params=None, headers=None):
         """
         Deletes a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: Name of the snapshot repository to unregister.
@@ -120,6 +124,7 @@ class SnapshotClient(NamespacedClient):
     def get_repository(self, repository=None, params=None, headers=None):
         """
         Returns information about a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A comma-separated list of repository names
@@ -136,6 +141,7 @@ class SnapshotClient(NamespacedClient):
     def create_repository(self, repository, body, params=None, headers=None):
         """
         Creates a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -161,6 +167,7 @@ class SnapshotClient(NamespacedClient):
     def restore(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Restores a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -187,6 +194,7 @@ class SnapshotClient(NamespacedClient):
     def status(self, repository=None, snapshot=None, params=None, headers=None):
         """
         Returns information about the status of a snapshot.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -208,6 +216,7 @@ class SnapshotClient(NamespacedClient):
     def verify_repository(self, repository, params=None, headers=None):
         """
         Verifies a repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
 
         :arg repository: A repository name
@@ -229,6 +238,7 @@ class SnapshotClient(NamespacedClient):
     def cleanup_repository(self, repository, params=None, headers=None):
         """
         Removes stale data from repository.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html>`_
 
         :arg repository: A repository name
@@ -244,4 +254,32 @@ class SnapshotClient(NamespacedClient):
             _make_path("_snapshot", repository, "_cleanup"),
             params=params,
             headers=headers,
+        )
+
+    @query_params("master_timeout")
+    def clone(
+        self, repository, snapshot, target_snapshot, body, params=None, headers=None
+    ):
+        """
+        Clones indices from one snapshot into another snapshot in the same repository.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+
+        :arg repository: A repository name
+        :arg snapshot: The name of the snapshot to clone from
+        :arg target_snapshot: The name of the cloned snapshot to create
+        :arg body: The snapshot clone definition
+        :arg master_timeout: Explicit operation timeout for connection
+            to master node
+        """
+        for param in (repository, snapshot, target_snapshot, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+
+        return self.transport.perform_request(
+            "PUT",
+            _make_path("_snapshot", repository, snapshot, "_clone", target_snapshot),
+            params=params,
+            headers=headers,
+            body=body,
         )

--- a/elasticsearch/client/snapshot.pyi
+++ b/elasticsearch/client/snapshot.pyi
@@ -23,6 +23,7 @@ class SnapshotClient(NamespacedClient):
         self,
         repository: Any,
         snapshot: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
@@ -35,12 +36,13 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -51,12 +53,13 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         ignore_unavailable: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         verbose: Optional[Any] = ...,
@@ -69,11 +72,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_repository(
         self,
         repository: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -85,10 +89,11 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_repository(
         self,
+        *,
         repository: Optional[Any] = ...,
         local: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
@@ -101,11 +106,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def create_repository(
         self,
         repository: Any,
+        *,
         body: Any,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -119,12 +125,13 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def restore(
         self,
         repository: Any,
         snapshot: Any,
+        *,
         body: Optional[Any] = ...,
         master_timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
@@ -137,10 +144,11 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def status(
         self,
+        *,
         repository: Optional[Any] = ...,
         snapshot: Optional[Any] = ...,
         ignore_unavailable: Optional[Any] = ...,
@@ -154,11 +162,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def verify_repository(
         self,
         repository: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -170,11 +179,12 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def cleanup_repository(
         self,
         repository: Any,
+        *,
         master_timeout: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -186,5 +196,24 @@ class SnapshotClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
+    ) -> Any: ...
+    def clone(
+        self,
+        repository: Any,
+        snapshot: Any,
+        target_snapshot: Any,
+        *,
+        body: Any,
+        master_timeout: Optional[Any] = ...,
+        pretty: Optional[bool] = ...,
+        human: Optional[bool] = ...,
+        error_trace: Optional[bool] = ...,
+        format: Optional[str] = ...,
+        filter_path: Optional[Union[str, Collection[str]]] = ...,
+        request_timeout: Optional[Union[int, float]] = ...,
+        ignore: Optional[Union[int, Collection[int]]] = ...,
+        opaque_id: Optional[str] = ...,
+        params: Optional[MutableMapping[str, Any]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/sql.py
+++ b/elasticsearch/client/sql.py
@@ -23,6 +23,7 @@ class SqlClient(NamespacedClient):
     def clear_cursor(self, body, params=None, headers=None):
         """
         Clears the SQL cursor
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-pagination.html>`_
 
         :arg body: Specify the cursor value in the `cursor` element to
@@ -39,6 +40,7 @@ class SqlClient(NamespacedClient):
     def query(self, body, params=None, headers=None):
         """
         Executes a SQL request
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-rest-overview.html>`_
 
         :arg body: Use the `query` element to start a query. Use the
@@ -57,6 +59,7 @@ class SqlClient(NamespacedClient):
     def translate(self, body, params=None, headers=None):
         """
         Translates SQL into Elasticsearch queries
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate.html>`_
 
         :arg body: Specify the query in the `query` element.

--- a/elasticsearch/client/sql.pyi
+++ b/elasticsearch/client/sql.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SqlClient(NamespacedClient):
     def clear_cursor(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -31,10 +32,11 @@ class SqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def query(
         self,
+        *,
         body: Any,
         format: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -45,10 +47,11 @@ class SqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def translate(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -59,5 +62,5 @@ class SqlClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/ssl.py
+++ b/elasticsearch/client/ssl.py
@@ -24,6 +24,7 @@ class SslClient(NamespacedClient):
         """
         Retrieves information about the X.509 certificates used to encrypt
         communications in the cluster.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/ssl.pyi
+++ b/elasticsearch/client/ssl.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class SslClient(NamespacedClient):
     def certificates(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -30,5 +31,5 @@ class SslClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/tasks.py
+++ b/elasticsearch/client/tasks.py
@@ -31,6 +31,7 @@ class TasksClient(NamespacedClient):
     def list(self, params=None, headers=None):
         """
         Returns a list of tasks.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg actions: A comma-separated list of actions that should be
@@ -55,6 +56,7 @@ class TasksClient(NamespacedClient):
     def cancel(self, task_id=None, params=None, headers=None):
         """
         Cancels a task, if it can be cancelled through an API.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg task_id: Cancel the task with specified task id
@@ -81,6 +83,7 @@ class TasksClient(NamespacedClient):
     def get(self, task_id, params=None, headers=None):
         """
         Returns information about a task.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
 
         :arg task_id: Return the task with specified id

--- a/elasticsearch/client/tasks.pyi
+++ b/elasticsearch/client/tasks.pyi
@@ -21,6 +21,7 @@ from .utils import NamespacedClient
 class TasksClient(NamespacedClient):
     def list(
         self,
+        *,
         actions: Optional[Any] = ...,
         detailed: Optional[Any] = ...,
         group_by: Optional[Any] = ...,
@@ -37,10 +38,11 @@ class TasksClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def cancel(
         self,
+        *,
         task_id: Optional[Any] = ...,
         actions: Optional[Any] = ...,
         nodes: Optional[Any] = ...,
@@ -55,11 +57,12 @@ class TasksClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get(
         self,
         task_id: Any,
+        *,
         timeout: Optional[Any] = ...,
         wait_for_completion: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -71,5 +74,5 @@ class TasksClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/transform.py
+++ b/elasticsearch/client/transform.py
@@ -23,6 +23,7 @@ class TransformClient(NamespacedClient):
     def delete_transform(self, transform_id, params=None, headers=None):
         """
         Deletes an existing transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-transform.html>`_
 
         :arg transform_id: The id of the transform to delete
@@ -42,10 +43,11 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params("allow_no_match", "exclude_generated", "from_", "size")
     def get_transform(self, transform_id=None, params=None, headers=None):
         """
         Retrieves configuration information for transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform.html>`_
 
         :arg transform_id: The id or comma delimited list of id
@@ -54,6 +56,8 @@ class TransformClient(NamespacedClient):
         :arg allow_no_match: Whether to ignore if a wildcard expression
             matches no transforms. (This includes `_all` string or when no
             transforms have been specified)
+        :arg exclude_generated: Omits fields that are illegal to set on
+            transform PUT
         :arg from\\_: skips a number of transform configs, defaults to 0
         :arg size: specifies a max number of transforms to get, defaults
             to 100
@@ -73,6 +77,7 @@ class TransformClient(NamespacedClient):
     def get_transform_stats(self, transform_id, params=None, headers=None):
         """
         Retrieves usage information for transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform-stats.html>`_
 
         :arg transform_id: The id of the transform for which to get
@@ -104,6 +109,7 @@ class TransformClient(NamespacedClient):
     def preview_transform(self, body, params=None, headers=None):
         """
         Previews a transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-transform.html>`_
 
         :arg body: The definition for the transform to preview
@@ -119,6 +125,7 @@ class TransformClient(NamespacedClient):
     def put_transform(self, transform_id, body, params=None, headers=None):
         """
         Instantiates a transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-transform.html>`_
 
         :arg transform_id: The id of the new transform.
@@ -142,6 +149,7 @@ class TransformClient(NamespacedClient):
     def start_transform(self, transform_id, params=None, headers=None):
         """
         Starts one or more transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
 
         :arg transform_id: The id of the transform to start
@@ -170,6 +178,7 @@ class TransformClient(NamespacedClient):
     def stop_transform(self, transform_id, params=None, headers=None):
         """
         Stops one or more transforms.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html>`_
 
         :arg transform_id: The id of the transform to stop
@@ -201,6 +210,7 @@ class TransformClient(NamespacedClient):
     def update_transform(self, transform_id, body, params=None, headers=None):
         """
         Updates certain properties of a transform.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html>`_
 
         :arg transform_id: The id of the transform.

--- a/elasticsearch/client/transform.pyi
+++ b/elasticsearch/client/transform.pyi
@@ -22,6 +22,7 @@ class TransformClient(NamespacedClient):
     def delete_transform(
         self,
         transform_id: Any,
+        *,
         force: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -32,12 +33,14 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_transform(
         self,
+        *,
         transform_id: Optional[Any] = ...,
         allow_no_match: Optional[Any] = ...,
+        exclude_generated: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -49,11 +52,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_transform_stats(
         self,
         transform_id: Any,
+        *,
         allow_no_match: Optional[Any] = ...,
         from_: Optional[Any] = ...,
         size: Optional[Any] = ...,
@@ -66,10 +70,11 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def preview_transform(
         self,
+        *,
         body: Any,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -80,11 +85,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_transform(
         self,
         transform_id: Any,
+        *,
         body: Any,
         defer_validation: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -96,11 +102,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def start_transform(
         self,
         transform_id: Any,
+        *,
         timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -111,11 +118,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stop_transform(
         self,
         transform_id: Any,
+        *,
         allow_no_match: Optional[Any] = ...,
         force: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -130,11 +138,12 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def update_transform(
         self,
         transform_id: Any,
+        *,
         body: Any,
         defer_validation: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -146,5 +155,5 @@ class TransformClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/watcher.py
+++ b/elasticsearch/client/watcher.py
@@ -23,6 +23,7 @@ class WatcherClient(NamespacedClient):
     def ack_watch(self, watch_id, action_id=None, params=None, headers=None):
         """
         Acknowledges a watch, manually throttling the execution of the watch's actions.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-ack-watch.html>`_
 
         :arg watch_id: Watch ID
@@ -43,6 +44,7 @@ class WatcherClient(NamespacedClient):
     def activate_watch(self, watch_id, params=None, headers=None):
         """
         Activates a currently inactive watch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-activate-watch.html>`_
 
         :arg watch_id: Watch ID
@@ -61,6 +63,7 @@ class WatcherClient(NamespacedClient):
     def deactivate_watch(self, watch_id, params=None, headers=None):
         """
         Deactivates a currently active watch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-deactivate-watch.html>`_
 
         :arg watch_id: Watch ID
@@ -79,6 +82,7 @@ class WatcherClient(NamespacedClient):
     def delete_watch(self, id, params=None, headers=None):
         """
         Removes a watch from Watcher.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-delete-watch.html>`_
 
         :arg id: Watch ID
@@ -97,6 +101,7 @@ class WatcherClient(NamespacedClient):
     def execute_watch(self, body=None, id=None, params=None, headers=None):
         """
         Forces the execution of a stored watch.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-execute-watch.html>`_
 
         :arg body: Execution control
@@ -116,6 +121,7 @@ class WatcherClient(NamespacedClient):
     def get_watch(self, id, params=None, headers=None):
         """
         Retrieves a watch by its ID.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-watch.html>`_
 
         :arg id: Watch ID
@@ -131,6 +137,7 @@ class WatcherClient(NamespacedClient):
     def put_watch(self, id, body=None, params=None, headers=None):
         """
         Creates a new watch, or updates an existing one.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-put-watch.html>`_
 
         :arg id: Watch ID
@@ -157,6 +164,7 @@ class WatcherClient(NamespacedClient):
     def start(self, params=None, headers=None):
         """
         Starts Watcher if it is not already running.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
         """
         return self.transport.perform_request(
@@ -167,6 +175,7 @@ class WatcherClient(NamespacedClient):
     def stats(self, metric=None, params=None, headers=None):
         """
         Retrieves the current Watcher metrics.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stats.html>`_
 
         :arg metric: Controls what additional stat metrics should be
@@ -186,6 +195,7 @@ class WatcherClient(NamespacedClient):
     def stop(self, params=None, headers=None):
         """
         Stops Watcher if it is running.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
         """
         return self.transport.perform_request(

--- a/elasticsearch/client/watcher.pyi
+++ b/elasticsearch/client/watcher.pyi
@@ -22,6 +22,7 @@ class WatcherClient(NamespacedClient):
     def ack_watch(
         self,
         watch_id: Any,
+        *,
         action_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -32,11 +33,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def activate_watch(
         self,
         watch_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -46,11 +48,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def deactivate_watch(
         self,
         watch_id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -60,11 +63,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def delete_watch(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -74,10 +78,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def execute_watch(
         self,
+        *,
         body: Optional[Any] = ...,
         id: Optional[Any] = ...,
         debug: Optional[Any] = ...,
@@ -90,11 +95,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def get_watch(
         self,
         id: Any,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -104,11 +110,12 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def put_watch(
         self,
         id: Any,
+        *,
         body: Optional[Any] = ...,
         active: Optional[Any] = ...,
         if_primary_term: Optional[Any] = ...,
@@ -123,10 +130,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def start(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -136,10 +144,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stats(
         self,
+        *,
         metric: Optional[Any] = ...,
         emit_stacktraces: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -151,10 +160,11 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def stop(
         self,
+        *,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,
@@ -164,5 +174,5 @@ class WatcherClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/elasticsearch/client/xpack.py
+++ b/elasticsearch/client/xpack.py
@@ -27,6 +27,7 @@ class XPackClient(NamespacedClient):
     def info(self, params=None, headers=None):
         """
         Retrieves information about the installed X-Pack features.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/info-api.html>`_
 
         :arg accept_enterprise: If this param is used it must be set to
@@ -42,6 +43,7 @@ class XPackClient(NamespacedClient):
     def usage(self, params=None, headers=None):
         """
         Retrieves usage information about the installed X-Pack features.
+
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/usage-api.html>`_
 
         :arg master_timeout: Specify timeout for watch write operation

--- a/elasticsearch/client/xpack.pyi
+++ b/elasticsearch/client/xpack.pyi
@@ -24,6 +24,7 @@ class XPackClient(NamespacedClient):
     # AUTO-GENERATED-API-DEFINITIONS #
     def info(
         self,
+        *,
         accept_enterprise: Optional[Any] = ...,
         categories: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
@@ -35,10 +36,11 @@ class XPackClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...
     def usage(
         self,
+        *,
         master_timeout: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -49,5 +51,5 @@ class XPackClient(NamespacedClient):
         ignore: Optional[Union[int, Collection[int]]] = ...,
         opaque_id: Optional[str] = ...,
         params: Optional[MutableMapping[str, Any]] = ...,
-        headers: Optional[MutableMapping[str, str]] = ...,
+        headers: Optional[MutableMapping[str, str]] = ...
     ) -> Any: ...

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,8 @@ def lint(session):
     # Run mypy on the package and then the type examples separately for
     # the two different mypy use-cases, ourselves and our users.
     session.run("mypy", "--strict", "elasticsearch/")
-    session.run("mypy", "--strict", "test_elasticsearch/test_types/")
+    session.run("mypy", "--strict", "test_elasticsearch/test_types/sync_types.py")
+    session.run("mypy", "--strict", "test_elasticsearch/test_types/async_types.py")
 
     # Make sure we don't require aiohttp to be installed for users to
     # receive type hint information from mypy.

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "Issue Tracker": "https://github.com/elastic/elasticsearch-py/issues",
     },
     packages=packages,
-    package_data={"elasticsearch": ["py.typed"]},
+    package_data={"elasticsearch": ["py.typed", "*.pyi"]},
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/test_elasticsearch/test_types/aliased_types.py
+++ b/test_elasticsearch/test_types/aliased_types.py
@@ -1,0 +1,195 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+from typing import Generator, Dict, Any, AsyncGenerator
+from elasticsearch8 import (
+    Elasticsearch,
+    Transport,
+    RequestsHttpConnection,
+    ConnectionPool,
+    AsyncElasticsearch,
+    AsyncTransport,
+    AIOHttpConnection,
+)
+from elasticsearch8.helpers import (
+    scan,
+    streaming_bulk,
+    reindex,
+    bulk,
+    async_scan,
+    async_streaming_bulk,
+    async_reindex,
+    async_bulk,
+)
+
+
+es = Elasticsearch(
+    [{"host": "localhost", "port": 9443}],
+    transport_class=Transport,
+)
+t = Transport(
+    [{}],
+    connection_class=RequestsHttpConnection,
+    connection_pool_class=ConnectionPool,
+    sniff_on_start=True,
+    sniffer_timeout=0.1,
+    sniff_timeout=1,
+    sniff_on_connection_fail=False,
+    max_retries=1,
+    retry_on_status={100, 400, 503},
+    retry_on_timeout=True,
+    send_get_body_as="source",
+)
+
+
+def sync_gen() -> Generator[Dict[Any, Any], None, None]:
+    yield {}
+
+
+def scan_types() -> None:
+    for _ in scan(
+        es,
+        query={"query": {"match_all": {}}},
+        request_timeout=10,
+        clear_scroll=True,
+        scroll_kwargs={"request_timeout": 10},
+    ):
+        pass
+    for _ in scan(
+        es,
+        raise_on_error=False,
+        preserve_order=False,
+        scroll="10m",
+        size=10,
+        request_timeout=10.0,
+    ):
+        pass
+
+
+def streaming_bulk_types() -> None:
+    for _ in streaming_bulk(es, sync_gen()):
+        pass
+    for _ in streaming_bulk(es, sync_gen().__iter__()):
+        pass
+    for _ in streaming_bulk(es, [{}]):
+        pass
+    for _ in streaming_bulk(es, ({},)):
+        pass
+
+
+def bulk_types() -> None:
+    _, _ = bulk(es, sync_gen())
+    _, _ = bulk(es, sync_gen().__iter__())
+    _, _ = bulk(es, [{}])
+    _, _ = bulk(es, ({},))
+
+
+def reindex_types() -> None:
+    _, _ = reindex(
+        es, "src-index", "target-index", query={"query": {"match": {"key": "val"}}}
+    )
+    _, _ = reindex(
+        es, source_index="src-index", target_index="target-index", target_client=es
+    )
+    _, _ = reindex(
+        es,
+        "src-index",
+        "target-index",
+        chunk_size=1,
+        scroll="10m",
+        scan_kwargs={"request_timeout": 10},
+        bulk_kwargs={"request_timeout": 10},
+    )
+
+
+es2 = AsyncElasticsearch(
+    [{"host": "localhost", "port": 9443}],
+    transport_class=AsyncTransport,
+)
+t2 = AsyncTransport(
+    [{}],
+    connection_class=AIOHttpConnection,
+    connection_pool_class=ConnectionPool,
+    sniff_on_start=True,
+    sniffer_timeout=0.1,
+    sniff_timeout=1,
+    sniff_on_connection_fail=False,
+    max_retries=1,
+    retry_on_status={100, 400, 503},
+    retry_on_timeout=True,
+    send_get_body_as="source",
+)
+
+
+async def async_gen() -> AsyncGenerator[Dict[Any, Any], None]:
+    yield {}
+
+
+async def async_scan_types() -> None:
+    async for _ in async_scan(
+        es2,
+        query={"query": {"match_all": {}}},
+        request_timeout=10,
+        clear_scroll=True,
+        scroll_kwargs={"request_timeout": 10},
+    ):
+        pass
+    async for _ in async_scan(
+        es2,
+        raise_on_error=False,
+        preserve_order=False,
+        scroll="10m",
+        size=10,
+        request_timeout=10.0,
+    ):
+        pass
+
+
+async def async_streaming_bulk_types() -> None:
+    async for _ in async_streaming_bulk(es2, async_gen()):
+        pass
+    async for _ in async_streaming_bulk(es2, async_gen().__aiter__()):
+        pass
+    async for _ in async_streaming_bulk(es2, [{}]):
+        pass
+    async for _ in async_streaming_bulk(es2, ({},)):
+        pass
+
+
+async def async_bulk_types() -> None:
+    _, _ = await async_bulk(es2, async_gen())
+    _, _ = await async_bulk(es2, async_gen().__aiter__())
+    _, _ = await async_bulk(es2, [{}])
+    _, _ = await async_bulk(es2, ({},))
+
+
+async def async_reindex_types() -> None:
+    _, _ = await async_reindex(
+        es2, "src-index", "target-index", query={"query": {"match": {"key": "val"}}}
+    )
+    _, _ = await async_reindex(
+        es2, source_index="src-index", target_index="target-index", target_client=es2
+    )
+    _, _ = await async_reindex(
+        es2,
+        "src-index",
+        "target-index",
+        chunk_size=1,
+        scroll="10m",
+        scan_kwargs={"request_timeout": 10},
+        bulk_kwargs={"request_timeout": 10},
+    )

--- a/utils/templates/base
+++ b/utils/templates/base
@@ -6,6 +6,7 @@
         {{ api.description|replace("\n", " ")|wordwrap(wrapstring="\n        ") }}
         {% endif %}
         {% if api.doc_url %}
+
         `<{{ api.doc_url }}>`_
         {% endif %}
         {% if api.params|list|length %}

--- a/utils/templates/func_params_pyi
+++ b/utils/templates/func_params_pyi
@@ -2,6 +2,8 @@
   {% if info.required %}{{ p }}: {{ info.type }}, {% endif %}
 {% endfor %}
 
+*,
+
 {% if api.body %}
   body{% if not api.body.required %}: Optional[Any]=...{% else %}: Any{% endif %},
 {% endif %}


### PR DESCRIPTION
- Adds tests for typing metadata to the `build-dist` script
- Makes all type stubs use keyword-only arguments for non-required (+`body`) parameters to conform to best practices.