### PR TITLE
bulk operation should support of "master_timeout"

### DIFF
--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -407,6 +407,7 @@ class Elasticsearch(object):
         "routing",
         "timeout",
         "wait_for_active_shards",
+        "master_timeout",
     )
     def bulk(self, body, index=None, doc_type=None, params=None, headers=None):
         """


### PR DESCRIPTION
bulk operation should support also "master_timeout" as a query parameter according to the formal API documentation:
https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html