### PR TITLE
[7.x] Fix sniffer_timeout typo in AsyncTransport

### DIFF
--- a/elasticsearch/_async/transport.py
+++ b/elasticsearch/_async/transport.py
@@ -132,7 +132,7 @@ class AsyncTransport(Transport):
             await self._async_init()
 
         if self.sniffer_timeout:
-            if self.loop.time() >= self.last_sniff + self.sniff_timeout:
+            if self.loop.time() >= self.last_sniff + self.sniffer_timeout:
                 self.create_sniff_task()
 
     async def _get_node_info(self, conn, initial):


### PR DESCRIPTION
Backported from c5de86d6c98b105456ff6822e6705daaf36be2d4

Co-authored-by: Igor Nehoroshev <HarrySky@users.noreply.github.com>