### PR TITLE
Added a CSVSerializer to DEFAULT_SERIALIZERS  for supporting text/csv .

### DIFF
--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -134,9 +134,22 @@ class JSONSerializer(Serializer):
             raise SerializationError(data, e)
 
 
+class CSVSerializer(object):
+    mimetype = "text/csv"
+
+    def loads(self, s):
+        return s
+
+    def dumps(self, data):
+        if isinstance(data, string_types):
+            return data
+        raise SerializationError("Cannot serialize %r into csv." % data)
+
+
 DEFAULT_SERIALIZERS = {
     JSONSerializer.mimetype: JSONSerializer(),
     TextSerializer.mimetype: TextSerializer(),
+    CSVSerializer.mimetype: CSVSerializer(),
 }
 
 


### PR DESCRIPTION

Extend the serializer of elasticsearch-py by adding a CSVSerializer class to support CSV when using es.sql.query(body,format='csv'') .