### PR TITLE
Fix typo in collections.abc import path

### DIFF
--- a/elasticsearch/compat.py
+++ b/elasticsearch/compat.py
@@ -33,7 +33,7 @@ else:
     from queue import Queue
 
 try:
-    from collections.abs import Mapping
+    from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
 


### PR DESCRIPTION
The module to import from it called "collections.abc", not "collections.abs".

This has worked due to the fallback of importing from "collections" instead, in
case the import from "collections.abs" failed. The fallback on importing from
"collections" will however stop working with Python 3.9 which then makes this a
breaking bug.