### PR TITLE
Fix typo: collections.abs -> collections.abc

### DIFF
--- a/elasticsearch/compat.py
+++ b/elasticsearch/compat.py
@@ -33,7 +33,7 @@ else:
     from queue import Queue
 
 try:
-    from collections.abs import Mapping
+    from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
 


### PR DESCRIPTION
`collections.abs` does not exist, and surely `collections.abc` was meant instead. (Introduced in #1387.)

This causes a warning in recent versions of Python 3.