### PR TITLE
[7.x] Fix typo (collections.abs -> collections.abc) to restore Python 3.9 support

### DIFF
--- a/elasticsearch/compat.py
+++ b/elasticsearch/compat.py
@@ -33,7 +33,7 @@ else:
     from queue import Queue
 
 try:
-    from collections.abs import Mapping
+    from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
 


### PR DESCRIPTION
Backported from fc5b6e87705421d7076f75c4ac36dc2cd826bf0f