### PR TITLE
docs: fix simple typo, decribing -> describing

### DIFF
--- a/test_elasticsearch/test_async/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_async/test_server/test_rest_api_spec.py
@@ -16,7 +16,7 @@
 #  under the License.
 
 """
-Dynamically generated set of TestCases based on set of yaml files decribing
+Dynamically generated set of TestCases based on set of yaml files describing
 some integration tests. These files are shared among all official Elasticsearch
 clients.
 """


### PR DESCRIPTION
There is a small typo in test_elasticsearch/test_async/test_server/test_rest_api_spec.py.

Should read `describing` rather than `decribing`.