### PR TITLE
Implement run_contains for REST API Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,9 @@ cython_debug/
 # Pycharm project settings
 .idea
 
+# VSCode project settings
+/.vscode
+
 # elasticsearch files
 test_elasticsearch/cover
 test_elasticsearch/local.py

--- a/.gitignore
+++ b/.gitignore
@@ -140,9 +140,6 @@ cython_debug/
 # Pycharm project settings
 .idea
 
-# VSCode project settings
-/.vscode
-
 # elasticsearch files
 test_elasticsearch/cover
 test_elasticsearch/local.py

--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -282,7 +282,7 @@ class YamlRunner:
             expected = self._resolve(expected)  # dict[str, str]
 
             if expected not in value:
-                raise AssertionError(f"{expected} does not match {value}")
+                raise AssertionError("%s is not contained by %s" % (expected, value))
 
     def _resolve(self, value):
         # resolve variables

--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -50,6 +50,7 @@ IMPLEMENTED_FEATURES = {
     "default_shards",
     "warnings",
     "allowed_warnings",
+    "contains",
 }
 
 # broken YAML tests on some releases
@@ -274,6 +275,14 @@ class YamlRunner:
                 )
             else:
                 assert expected == value, "%r does not match %r" % (value, expected)
+
+    def run_contains(self, action):
+        for path, expected in action.items():
+            value = self._lookup(path)  # list[dict[str,str]] is returned
+            expected = self._resolve(expected)  # dict[str, str]
+
+            if expected not in value:
+                raise AssertionError(f"{expected} does not match {value}")
 
     def _resolve(self, value):
         # resolve variables


### PR DESCRIPTION
Partially does #1265 

- Implemented `run_contains` method.
- There is only one example of `yml` file `elasticsearch\rest-api-spec\src\main\resources\rest-api-spec\test\cluster.voting_config_exclusions\10_basic.yml`
- Also added `.vscode` folder to `.gitignore`. If that is not required. I'll remove it.
@sethmlarson Please review this. Let me know if any changes are required. :)