### PR TITLE
Add arbitrary_key to test_rest_api_spec

### DIFF
--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -51,6 +51,7 @@ IMPLEMENTED_FEATURES = {
     "warnings",
     "allowed_warnings",
     "contains",
+    "arbitrary_key",
 }
 
 # broken YAML tests on some releases
@@ -313,6 +314,8 @@ class YamlRunner:
                 step = int(step)
                 assert isinstance(value, list)
                 assert len(value) > step
+            elif step == "_arbitrary_key_":
+                return list(value.keys())[0]
             else:
                 assert step in value
             value = value[step]


### PR DESCRIPTION
Another feature in #1265 .

@sethmlarson Please review this.

Ask jenkins to test this, because, my local is too slow for running all tests. I have only checked the tests w.r.t this change.