### PR TITLE
[DOCS] Adds Configuration section to Python book

### DIFF
--- a/docs/guide/configuration.asciidoc
+++ b/docs/guide/configuration.asciidoc
@@ -1,0 +1,12 @@
+[[config]]
+== Configuration
+
+This page contains information about the most important configuration options of 
+the Python {es} client.
+
+* <<connection-pool>>
+* <<connection-selector>>
+
+
+include::connection-pool.asciidoc[]
+include::connection-selector.asciidoc[]

--- a/docs/guide/connection-pool.asciidoc
+++ b/docs/guide/connection-pool.asciidoc
@@ -1,0 +1,18 @@
+[[connection-pool]]
+=== Connection pool
+
+Connection pool is a container that holds the `Connection` instances, manages 
+the selection process (via a `ConnectionSelector`) and dead connections.
+
+Initially connections are stored in the class as a list and – along with the 
+connection options – get passed to the `ConnectionSelector` instance for future 
+reference.
+
+Upon each request, the `Transport` asks for a `Connection` via the 
+`get_connection` method. If the connection fails, it is marked as dead (via 
+`mark_dead`) and put on a timeout. When the timeout is over the connection is 
+resurrected and returned to the live pool. A connection that has been previously 
+marked as dead and then succeeds is marked as live (its fail count is deleted).
+
+For reference information, refer to the 
+https://elasticsearch-py.readthedocs.io/en/latest/connection.html#connection-pool[full {es} Python documentation].

--- a/docs/guide/connection-selector.asciidoc
+++ b/docs/guide/connection-selector.asciidoc
@@ -1,0 +1,20 @@
+[[connection-selector]]
+=== Connection selector
+
+Connection selector is a simple class used to select a connection from a list of 
+currently live connection instances. Initially, it is passed a dictionary 
+containing all the connections options which it can then use during the 
+selection process. When the _select_ method is called it is given a list of 
+currently live connections to choose from.
+
+The options dictionary is passed to `Transport` as the hosts parameter and the 
+same is used to construct the connection object itself. When the connection was 
+created based on information retrieved from the cluster via the sniffing 
+process, it is the dictionary returned by the `host_info_callback`.
+
+Example of where this might be useful is a zone-aware selector that would only 
+select connections from its own zones and only fall back to other connections 
+where there would be none in its zones.
+
+For reference information, refer to the 
+https://elasticsearch-py.readthedocs.io/en/latest/connection.html#connection-selector[full {es} Python documentation].

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -9,3 +9,5 @@ include::overview.asciidoc[]
 include::installation.asciidoc[]
 
 include::connecting.asciidoc[]
+
+include::configuration.asciidoc[]


### PR DESCRIPTION
## Overview

This PR adds a new section to the Python book called `Configuration`. Currently, it has two sub-sections: Connection pool, and Connection selector.

The PR is a part of the Client docs redesign effort. Related issue: https://github.com/elastic/clients-team/issues/257

### Review

[Py TOC](https://elasticsearch-py_1520.docs-preview.app.elstc.co/guide/en/elasticsearch/client/python-api/master/index.html)