### PR TITLE
[DOCS] Adds Integrations section to Python book

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -11,3 +11,5 @@ include::installation.asciidoc[]
 include::connecting.asciidoc[]
 
 include::configuration.asciidoc[]
+
+include::integrations.asciidoc[]

--- a/docs/guide/integrations.asciidoc
+++ b/docs/guide/integrations.asciidoc
@@ -1,0 +1,27 @@
+[[integrations]]
+== Integrations
+
+You can find integration options and information on this page.
+
+
+[discrete]
+[[transport]]
+=== Transport
+
+The `Transport` class is a subclass of the 
+https://elasticsearch-py.readthedocs.io/en/latest/connection.html[Connection Layer API]
+that contains all the classes that are responsible for handling the connection 
+to the {es} cluster. 
+
+The `Transport` class is an encapsulation of the transport-related logic of the 
+Python client. For the exhaustive list of parameters, refer to the 
+https://elasticsearch-py.readthedocs.io/en/latest/connection.html#transport[documentation].
+
+
+[discrete]
+[[transport-classes]]
+==== Transport classes
+
+The `Transform` classes can be used to maintain connection with an {es} cluster. 
+For the reference information of these classes, refer to the 
+https://elasticsearch-py.readthedocs.io/en/latest/transports.html[documentation].

--- a/docs/guide/integrations.asciidoc
+++ b/docs/guide/integrations.asciidoc
@@ -22,6 +22,6 @@ https://elasticsearch-py.readthedocs.io/en/latest/connection.html#transport[docu
 [[transport-classes]]
 ==== Transport classes
 
-The `Transform` classes can be used to maintain connection with an {es} cluster. 
+The `Transport` classes can be used to maintain connection with an {es} cluster. 
 For the reference information of these classes, refer to the 
 https://elasticsearch-py.readthedocs.io/en/latest/transports.html[documentation].


### PR DESCRIPTION
## Overview

This PR adds a new section to the Python book called `Integrations`. This section contains light-weight information about the Transport class and its subclasses, and links to the documentation page.

This PR is part of the Client docs redesign effort. Related issue: https://github.com/elastic/clients-team/issues/257

### Preview

[Integrations](https://elasticsearch-py_1545.docs-preview.app.elstc.co/guide/en/elasticsearch/client/python-api/master/integrations.html)