### PR TITLE
[DOCS] Adds Examples section to Python book

### DIFF
--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -1,13 +1,8 @@
 [[connecting]]
 == Connecting
 
-This page contains the information you need to connect and use the Client with 
-{es}.
+This page contains the information you need to connect the Client with {es}.
 
-**On this page**
-
-* <<authentication>>
-* <<client-usage, Using the client>>
 
 [discrete]
 [[authentication]]
@@ -70,81 +65,4 @@ from elasticsearch import Elasticsearch
 es = Elasticsearch(
     api_key=(“api_key_id”, “api_key_secret”)
 )
-----------------------------
-
-
-[discrete]
-[[client-usage]]
-=== Usage
-
-This section is a brief overview of the client and its syntax.
-
-
-[discrete]
-==== Indexing a document
-  
-To index a document, you need to specify four pieces of information: `index`, 
-`id`, and a `body`:
-
-[source,py]
-----------------------------
-from datetime import datetime
-from elasticsearch import Elasticsearch
-es = Elasticsearch()
-
-doc = {
-    'author': 'author_name',
-    'text': 'Interensting content...',
-    'timestamp': datetime.now(),
-}
-res = es.index(index="test-index", id=1, body=doc)
-print(res['result'])
-----------------------------
-
-
-[discrete]
-==== Getting a document 
-
-To get a document, you need to specify its `index` and `id`:
-
-[source,py]
-----------------------------
-res = es.get(index="test-index", id=1)
-print(res['_source'])
-----------------------------
-
-
-[discrete]
-==== Refreshing an index
-
-You can perform the refresh operation on an index:
-
-[source,py]
-----------------------------
-es.indices.refresh(index="test-index")
-----------------------------
-
-
-[discrete]
-==== Searching for a document
-
-The `search()` method returns results that are matching a query:
-
-[source,py]
-----------------------------
-res = es.search(index="test-index", body={"query": {"match_all": {}}})
-print("Got %d Hits:" % res['hits']['total']['value'])
-for hit in res['hits']['hits']:
-    print("%(timestamp)s %(author)s: %(text)s" % hit["_source"])
-----------------------------
-
-
-[discrete]
-==== Deleting a document
-
-You can delete a document by specifying its `index`, and `id` in the `delete()` 
-method:
-
-----------------------------
-es.delete(index="test-index", id=1)
 ----------------------------

--- a/docs/guide/examples.asciidoc
+++ b/docs/guide/examples.asciidoc
@@ -1,0 +1,106 @@
+[[examples]]
+== Examples
+
+Below you can find examples of how to use the most frequently called APIs with 
+the Python client.
+
+* <<ex-index>>
+* <<ex-get>>
+* <<ex-refresh>>
+* <<ex-search>>
+* <<ex-update>>
+* <<ex-delete>>
+
+[discrete]
+[[ex-index]]
+=== Indexing a document
+  
+To index a document, you need to specify four pieces of information: `index`, 
+`id`, and a `body`:
+
+[source,py]
+----------------------------
+from datetime import datetime
+from elasticsearch import Elasticsearch
+es = Elasticsearch()
+
+doc = {
+    'author': 'author_name',
+    'text': 'Interensting content...',
+    'timestamp': datetime.now(),
+}
+res = es.index(index="test-index", id=1, body=doc)
+print(res['result'])
+----------------------------
+
+
+[discrete]
+[[ex-get]]
+=== Getting a document 
+
+To get a document, you need to specify its `index` and `id`:
+
+[source,py]
+----------------------------
+res = es.get(index="test-index", id=1)
+print(res['_source'])
+----------------------------
+
+
+[discrete]
+[[ex-refresh]]
+=== Refreshing an index
+
+You can perform the refresh operation on an index:
+
+[source,py]
+----------------------------
+es.indices.refresh(index="test-index")
+----------------------------
+
+
+[discrete]
+[[ex-search]]
+=== Searching for a document
+
+The `search()` method returns results that are matching a query:
+
+[source,py]
+----------------------------
+res = es.search(index="test-index", body={"query": {"match_all": {}}})
+print("Got %d Hits:" % res['hits']['total']['value'])
+for hit in res['hits']['hits']:
+    print("%(timestamp)s %(author)s: %(text)s" % hit["_source"])
+----------------------------
+
+
+[discrete]
+[[ex-update]]
+=== Updating a document
+
+[source,py]
+----------------------------
+from datetime import datetime
+from elasticsearch import Elasticsearch
+es = Elasticsearch()
+
+doc = {
+    'author': 'author_name',
+    'text': 'Interensting modified content...',
+    'timestamp': datetime.now(),
+}
+res = es.update(index="test-index", id=1, body=doc)
+print(res['result'])
+----------------------------
+
+
+[discrete]
+[[ex-delete]]
+=== Deleting a document
+
+You can delete a document by specifying its `index`, and `id` in the `delete()` 
+method:
+
+----------------------------
+es.delete(index="test-index", id=1)
+----------------------------

--- a/docs/guide/examples.asciidoc
+++ b/docs/guide/examples.asciidoc
@@ -101,6 +101,7 @@ print(res['result'])
 You can delete a document by specifying its `index`, and `id` in the `delete()` 
 method:
 
+[source,py]
 ----------------------------
 es.delete(index="test-index", id=1)
 ----------------------------

--- a/docs/guide/examples.asciidoc
+++ b/docs/guide/examples.asciidoc
@@ -15,7 +15,7 @@ the Python client.
 [[ex-index]]
 === Indexing a document
   
-To index a document, you need to specify four pieces of information: `index`, 
+To index a document, you need to specify three pieces of information: `index`, 
 `id`, and a `body`:
 
 [source,py]
@@ -77,6 +77,9 @@ for hit in res['hits']['hits']:
 [discrete]
 [[ex-update]]
 === Updating a document
+
+To update a document, you need to specify three pieces of information: `index`, 
+`id`, and a `body`:
 
 [source,py]
 ----------------------------

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -13,3 +13,5 @@ include::connecting.asciidoc[]
 include::configuration.asciidoc[]
 
 include::integrations.asciidoc[]
+
+include::examples.asciidoc[]


### PR DESCRIPTION
## Overview

This PR adds a new section to the Python book called `Examples`. This section contains some basic examples of how to use APIs for CRUD operations. Some of the content is relocated from the `Connecting` section.

This PR is part of the Client docs redesign effort. Related issue: https://github.com/elastic/clients-team/issues/257

### Preview

[Examples](https://elasticsearch-py_1551.docs-preview.app.elstc.co/guide/en/elasticsearch/client/python-api/master/examples.html#ex-index)