### PR TITLE
Fix API doc reference to Cluster GET Settings page

### DIFF
--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -192,7 +192,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns cluster settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html>`_
 
         :arg flat_settings: Return settings in flat format (default:
             false)

--- a/elasticsearch/client/cluster.py
+++ b/elasticsearch/client/cluster.py
@@ -192,7 +192,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns cluster settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html>`_
 
         :arg flat_settings: Return settings in flat format (default:
             false)


### PR DESCRIPTION
Hi, was using the API doc and noticed this one link was out-of-place