### PR TITLE
Removed Unnecessary python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=install_requires,
     test_suite="test_elasticsearch.run_tests.run_all",
     tests_require=tests_require,


### PR DESCRIPTION
Removed required python version condition for Python version 4 as there is no such python version available and will not be available anytime soon.