### PR TITLE
Handle RecursionError exception in perform_request (issue 1602)

### DIFF
--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -303,7 +303,8 @@ class AIOHttpConnection(AsyncConnection):
         # We want to reraise a cancellation.
         except asyncio.CancelledError:
             raise
-
+        except RecursionError:
+            raise
         except Exception as e:
             self.log_request_fail(
                 method,
@@ -319,8 +320,6 @@ class AIOHttpConnection(AsyncConnection):
                 e, (asyncio.TimeoutError, aiohttp_exceptions.ServerTimeoutError)
             ):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
-            if isinstance(e, RecursionError):
-                raise RecursionError("RECURSION", str(e), e)
             raise ConnectionError("N/A", str(e), e)
 
         # raise warnings if any from the 'Warnings' header.

--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -319,6 +319,8 @@ class AIOHttpConnection(AsyncConnection):
                 e, (asyncio.TimeoutError, aiohttp_exceptions.ServerTimeoutError)
             ):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
+            if isinstance(e, RecursionError):
+                raise RecursionError("RECURSION", str(e), e)
             raise ConnectionError("N/A", str(e), e)
 
         # raise warnings if any from the 'Warnings' header.

--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -300,10 +300,8 @@ class AIOHttpConnection(AsyncConnection):
                     raw_data = await response.text()
                 duration = self.loop.time() - start
 
-        # We want to reraise a cancellation.
-        except asyncio.CancelledError:
-            raise
-        except RecursionError:
+        # We want to reraise a cancellation or recursion error.
+        except (asyncio.CancelledError, RecursionError):
             raise
         except Exception as e:
             self.log_request_fail(

--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -300,7 +300,7 @@ class AIOHttpConnection(AsyncConnection):
                     raw_data = await response.text()
                 duration = self.loop.time() - start
 
-        # We want to reraise a cancellation or recursion error.
+        # We want to reraise a cancellation or recursion error
         except (asyncio.CancelledError, RecursionError):
             raise
         except Exception as e:

--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -179,6 +179,8 @@ class RequestsHttpConnection(Connection):
                 raise SSLError("N/A", str(e), e)
             if isinstance(e, requests.Timeout):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
+            if isinstance(e, RecursionError):
+                raise RecursionError("RECURSION", str(e), e)
             raise ConnectionError("N/A", str(e), e)
 
         # raise warnings if any from the 'Warnings' header.

--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -166,6 +166,8 @@ class RequestsHttpConnection(Connection):
             response = self.session.send(prepared_request, **send_kwargs)
             duration = time.time() - start
             raw_data = response.content.decode("utf-8", "surrogatepass")
+        except RecursionError:
+            raise
         except Exception as e:
             self.log_request_fail(
                 method,
@@ -179,8 +181,6 @@ class RequestsHttpConnection(Connection):
                 raise SSLError("N/A", str(e), e)
             if isinstance(e, requests.Timeout):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
-            if isinstance(e, RecursionError):
-                raise RecursionError("RECURSION", str(e), e)
             raise ConnectionError("N/A", str(e), e)
 
         # raise warnings if any from the 'Warnings' header.

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -253,6 +253,8 @@ class Urllib3HttpConnection(Connection):
             )
             duration = time.time() - start
             raw_data = response.data.decode("utf-8", "surrogatepass")
+        except RecursionError:
+            raise
         except Exception as e:
             self.log_request_fail(
                 method, full_url, url, orig_body, time.time() - start, exception=e
@@ -261,8 +263,6 @@ class Urllib3HttpConnection(Connection):
                 raise SSLError("N/A", str(e), e)
             if isinstance(e, ReadTimeoutError):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
-            if isinstance(e, RecursionError):
-                raise RecursionError("RECURSION", str(e), e)
             raise ConnectionError("N/A", str(e), e)
 
         # raise warnings if any from the 'Warnings' header.

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -261,6 +261,8 @@ class Urllib3HttpConnection(Connection):
                 raise SSLError("N/A", str(e), e)
             if isinstance(e, ReadTimeoutError):
                 raise ConnectionTimeout("TIMEOUT", str(e), e)
+            if isinstance(e, RecursionError):
+                raise RecursionError("RECURSION", str(e), e)
             raise ConnectionError("N/A", str(e), e)
 
         # raise warnings if any from the 'Warnings' header.


### PR DESCRIPTION
Propagate RecursionError if it happends on lower levels so when used like:
```
import sys
import inspect
import elasticsearch

es_client = elasticsearch.Elasticsearch("http://localhost:9200/")
print(f"Recursion limit: {sys.getrecursionlimit()}")

def rec():
    print(len(inspect.stack()))
    es_client.index(index='testing', body={'test': 'test'}, request_timeout=1)
    rec()

rec()
```
doesn't crash python interpreter with core dump.

Personal opinion is that this is really needed when we you web servers like uwsgi, gunicorn as
then the whole web server dies and doesn't return http 500 status code.

Related issue: https://github.com/elastic/elasticsearch-py/issues/1602