### PR TITLE
Handle RecursionError exception in perform_request

### DIFF
--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -300,10 +300,9 @@ class AIOHttpConnection(AsyncConnection):
                     raw_data = await response.text()
                 duration = self.loop.time() - start
 
-        # We want to reraise a cancellation.
-        except asyncio.CancelledError:
+        # We want to reraise a cancellation or recursion error.
+        except (asyncio.CancelledError, RecursionError):
             raise
-
         except Exception as e:
             self.log_request_fail(
                 method,

--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -166,6 +166,8 @@ class RequestsHttpConnection(Connection):
             response = self.session.send(prepared_request, **send_kwargs)
             duration = time.time() - start
             raw_data = response.content.decode("utf-8", "surrogatepass")
+        except RecursionError:
+            raise
         except Exception as e:
             self.log_request_fail(
                 method,

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -253,6 +253,8 @@ class Urllib3HttpConnection(Connection):
             )
             duration = time.time() - start
             raw_data = response.data.decode("utf-8", "surrogatepass")
+        except RecursionError:
+            raise
         except Exception as e:
             self.log_request_fail(
                 method, full_url, url, orig_body, time.time() - start, exception=e


### PR DESCRIPTION
Propagate RecursionError if it happends on lower levels so when used like:
```
import sys
import inspect
import elasticsearch

es_client = elasticsearch.Elasticsearch("http://localhost:9200/")
print(f"Recursion limit: {sys.getrecursionlimit()}")

def rec():
    print(len(inspect.stack()))
    es_client.index(index='testing', body={'test': 'test'}, request_timeout=1)
    rec()

rec()
```
So it doesn't crash python interpreter with core dump and raises as expected RecursionError.

Related issue: #1602