### PR TITLE
Tolerate RecursionError not being defined in Python<3.5

### DIFF
--- a/elasticsearch/_async/http_aiohttp.py
+++ b/elasticsearch/_async/http_aiohttp.py
@@ -22,7 +22,7 @@ import warnings
 
 import urllib3  # type: ignore
 
-from ..compat import urlencode
+from ..compat import reraise_exceptions, urlencode
 from ..connection.base import Connection
 from ..exceptions import (
     ConnectionError,
@@ -304,7 +304,7 @@ class AIOHttpConnection(AsyncConnection):
                 duration = self.loop.time() - start
 
         # We want to reraise a cancellation or recursion error.
-        except (asyncio.CancelledError, RecursionError):
+        except reraise_exceptions:
             raise
         except Exception as e:
             self.log_request_fail(

--- a/elasticsearch/compat.py
+++ b/elasticsearch/compat.py
@@ -58,8 +58,22 @@ except ImportError:
     from collections import Mapping
 
 
+try:
+    reraise_exceptions = (RecursionError,)
+except NameError:
+    reraise_exceptions = ()
+
+try:
+    import asyncio
+
+    reraise_exceptions += (asyncio.CancelledError,)
+except (ImportError, AttributeError):
+    pass
+
+
 __all__ = [
     "string_types",
+    "reraise_exceptions",
     "quote_plus",
     "quote",
     "urlencode",

--- a/elasticsearch/compat.pyi
+++ b/elasticsearch/compat.pyi
@@ -16,13 +16,14 @@
 #  under the License.
 
 import sys
-from typing import Callable, Tuple, Union
+from typing import Callable, Tuple, Type, Union
 
 PY2: bool
 string_types: Tuple[type, ...]
 
 to_str: Callable[[Union[str, bytes]], str]
 to_bytes: Callable[[Union[str, bytes]], bytes]
+reraise_exceptions: Tuple[Type[Exception], ...]
 
 if sys.version_info[0] == 2:
     from itertools import imap as map

--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -18,7 +18,7 @@
 import time
 import warnings
 
-from ..compat import string_types, urlencode
+from ..compat import reraise_exceptions, string_types, urlencode
 from ..exceptions import (
     ConnectionError,
     ConnectionTimeout,
@@ -166,7 +166,7 @@ class RequestsHttpConnection(Connection):
             response = self.session.send(prepared_request, **send_kwargs)
             duration = time.time() - start
             raw_data = response.content.decode("utf-8", "surrogatepass")
-        except RecursionError:
+        except reraise_exceptions:
             raise
         except Exception as e:
             self.log_request_fail(

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -24,7 +24,7 @@ from urllib3.exceptions import ReadTimeoutError
 from urllib3.exceptions import SSLError as UrllibSSLError  # type: ignore
 from urllib3.util.retry import Retry  # type: ignore
 
-from ..compat import urlencode
+from ..compat import reraise_exceptions, urlencode
 from ..exceptions import (
     ConnectionError,
     ConnectionTimeout,
@@ -253,7 +253,7 @@ class Urllib3HttpConnection(Connection):
             )
             duration = time.time() - start
             raw_data = response.data.decode("utf-8", "surrogatepass")
-        except RecursionError:
+        except reraise_exceptions:
             raise
         except Exception as e:
             self.log_request_fail(


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/issues/1619