### PR TITLE
Forward transport keyword arguments to all APIs in scan helper

### DIFF
--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -334,6 +334,20 @@ async def async_scan(
         query = query.copy() if query else {}
         query["sort"] = "_doc"
 
+    # Grab options that should be propagated to every
+    # API call within this helper instead of just 'search()'
+    transport_kwargs = {}
+    for key in ("headers", "api_key", "http_auth"):
+        if key in kwargs:
+            transport_kwargs[key] = kwargs[key]
+
+    # If the user is using 'scroll_kwargs' we want
+    # to propagate there too, but to not break backwards
+    # compatibility we'll not override anything already given.
+    if scroll_kwargs is not None and transport_kwargs:
+        for key, val in transport_kwargs.items():
+            scroll_kwargs.setdefault(key, val)
+
     # initial search
     resp = await client.search(
         body=query, scroll=scroll, size=size, request_timeout=request_timeout, **kwargs
@@ -378,6 +392,7 @@ async def async_scan(
         if scroll_id and clear_scroll:
             await client.clear_scroll(
                 body={"scroll_id": [scroll_id]},
+                **transport_kwargs,
                 ignore=(404,),
                 params={"__elastic_client_meta": (("h", "s"),)},
             )

--- a/test_elasticsearch/test_server/test_helpers.py
+++ b/test_elasticsearch/test_server/test_helpers.py
@@ -470,6 +470,69 @@ class TestScan(ElasticsearchTestCase):
             client_mock.scroll.assert_not_called()
             client_mock.clear_scroll.assert_not_called()
 
+    def test_scan_auth_kwargs_forwarded(self):
+        for key, val in {
+            "api_key": ("name", "value"),
+            "http_auth": ("username", "password"),
+            "headers": {"custom": "header"},
+        }.items():
+            with patch.object(self, "client") as client_mock:
+                client_mock.search.return_value = {
+                    "_scroll_id": "scroll_id",
+                    "_shards": {"successful": 5, "total": 5, "skipped": 0},
+                    "hits": {"hits": [{"search_data": 1}]},
+                }
+                client_mock.scroll.return_value = {
+                    "_scroll_id": "scroll_id",
+                    "_shards": {"successful": 5, "total": 5, "skipped": 0},
+                    "hits": {"hits": []},
+                }
+                client_mock.clear_scroll.return_value = {}
+
+                data = list(helpers.scan(self.client, index="test_index", **{key: val}))
+
+                self.assertEqual(data, [{"search_data": 1}])
+
+                # Assert that 'search', 'scroll' and 'clear_scroll' all
+                # received the extra kwarg related to authentication.
+                for api_mock in (
+                    client_mock.search,
+                    client_mock.scroll,
+                    client_mock.clear_scroll,
+                ):
+                    self.assertEqual(api_mock.call_args[1][key], val)
+
+    def test_scan_auth_kwargs_favor_scroll_kwargs_option(self):
+        with patch.object(self, "client") as client_mock:
+            client_mock.search.return_value = {
+                "_scroll_id": "scroll_id",
+                "_shards": {"successful": 5, "total": 5, "skipped": 0},
+                "hits": {"hits": [{"search_data": 1}]},
+            }
+            client_mock.scroll.return_value = {
+                "_scroll_id": "scroll_id",
+                "_shards": {"successful": 5, "total": 5, "skipped": 0},
+                "hits": {"hits": []},
+            }
+            client_mock.clear_scroll.return_value = {}
+
+            data = list(
+                helpers.scan(
+                    self.client,
+                    index="test_index",
+                    scroll_kwargs={"headers": {"scroll": "kwargs"}, "sort": "asc"},
+                    headers={"not scroll": "kwargs"},
+                )
+            )
+
+            self.assertEqual(data, [{"search_data": 1}])
+
+            # Assert that we see 'scroll_kwargs' options used instead of 'kwargs'
+            self.assertEqual(
+                client_mock.scroll.call_args[1]["headers"], {"scroll": "kwargs"}
+            )
+            self.assertEqual(client_mock.scroll.call_args[1]["sort"], "asc")
+
     @patch("elasticsearch.helpers.actions.logger")
     def test_logger(self, logger_mock):
         bulk = []


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/pull/1592
Closes https://github.com/elastic/elasticsearch-py/pull/1368