### PR TITLE
Bug fix typo #1642

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ with `@query_params`) are actually auto-generated from the
 found in the `Elasticsearch` repository. Any changes to those methods should be
 done either by submitting a PR to Elasticsearch itself (in case of adding or
 modifying any of the API methods) or to the [Generate
-Script](https://github.com/elastic/elasticsearch-py/blob/master/utils/generate_api.py).
+Script](https://github.com/elastic/elasticsearch-py/blob/master/utils/generate-api.py).
 
 To run the code generation make sure you have pre-requisites installed:
 


### PR DESCRIPTION
Bug fix https://github.com/elastic/elasticsearch-py/issues/1642

Updated link from https://github.com/elastic/elasticsearch-py/blob/master/utils/generate_api.py to https://github.com/elastic/elasticsearch-py/blob/master/utils/generate-api.py