### PR TITLE
Disable Python 3.10 integration tests, fix Python 2.7 test suite

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -12,7 +12,6 @@ PYTHON_VERSION:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10"
 
 PYTHON_CONNECTION_CLASS:
   - Urllib3HttpConnection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
         experimental: [false]
         include:
-          - python-version: 3.10.0-beta.2
+          - python-version: 3.10-dev
             experimental: true
 
     runs-on: ubuntu-latest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ mock
 sphinx<1.7
 sphinx_rtd_theme
 jinja2
+python-dateutil
 
 # No wheels for Python 3.10 yet!
 numpy; python_version<"3.10"


### PR DESCRIPTION
Currently there isn't a Python 3.10 official Docker image, thought there might be one with release candidates but unfortunately not yet so disable those for now.

Also looks like a recent PR broke the Python 2.7 integration tests so fixing that here.