### PR TITLE
Rename 'master' branch to 'main'

### DIFF
--- a/.ci/jobs/elastic+elasticsearch-py+main.yml
+++ b/.ci/jobs/elastic+elasticsearch-py+main.yml
@@ -1,12 +1,12 @@
 ---
 - job:
-    name: elastic+elasticsearch-py+master
-    display-name: 'elastic / elasticsearch-py # master'
-    description: Testing the elasticsearch-py master branch.
+    name: elastic+elasticsearch-py+main
+    display-name: 'elastic / elasticsearch-py # main'
+    description: Testing the elasticsearch-py main branch.
     junit_results: "*-junit.xml"
     parameters:
     - string:
         name: branch_specifier
-        default: refs/heads/master
+        default: refs/heads/main
         description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
           &lt;commitId&gt;, etc.)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@
     below, and delete the other block.
 
 3.  For issues with API definition please note that the API is [auto
-    generated](https://github.com/elastic/elasticsearch-py/blob/master/CONTRIBUTING.md#api-code-generation)
+    generated](https://github.com/elastic/elasticsearch-py/blob/main/CONTRIBUTING.md#api-code-generation)
     so any problems should be checked and reported against [the Elasticsearch
     repo](https://github.com/elastic/elasticsearch) instead.
 

--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -9,7 +9,6 @@ on:
       - 'README.md'
     branches:
       - main
-      - master
       - '[0-9]+.[0-9]+'
       - '[0-9]+.x'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,23 +32,10 @@ you don't have Elasticsearch running locally the integration tests will be skipp
 All the API methods (any method in `elasticsearch.client` classes decorated
 with `@query_params`) are actually auto-generated from the
 [rest-api-spec](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api)
-found in the `Elasticsearch` repository. Any changes to those methods should be
-done either by submitting a PR to Elasticsearch itself (in case of adding or
-modifying any of the API methods) or to the [Generate
-Script](https://github.com/elastic/elasticsearch-py/blob/master/utils/generate-api.py).
-
-To run the code generation make sure you have pre-requisites installed:
-
-* by running `python -m pip install -e '.[develop]'`
-* having the [elasticsearch](https://github.com/elastic/elasticsearch) repo
-  cloned on the same level as `elasticsearch-py` and switched to appropriate
-  version
-
-Then you should be able to run the code generation by invoking:
-
-```
-$ python utils/generate-api.py 8.0.0-SNAPSHOT
-```
+found in the `Elasticsearch` or the [Elasticsearch specification](https://github.com/elastic/elasticsearch-specification)
+repositories. Any changes to those methods should be done either by submitting a PR to one of these repositories
+instead of directly to the Python client otherwise your change will be overwritten the
+next time the APIs are generated.
 
 ## Contributing Code Changes
 
@@ -76,7 +63,7 @@ The process for contributing to any of the Elasticsearch repositories is similar
 
 3. Rebase your changes.
    Update your local repository with the most recent code from the main
-   elasticsearch-py repository, and rebase your branch on top of the latest master
+   elasticsearch-py repository, and rebase your branch on top of the latest `main`
    branch. We prefer your changes to be squashed into a single commit for easier
    backporting.
 

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ Elasticsearch Python Client
 .. image:: https://pepy.tech/badge/elasticsearch
    :target: https://pepy.tech/project/elasticsearch?versions=*
 
-.. image:: https://clients-ci.elastic.co/job/elastic+elasticsearch-py+master/badge/icon
-   :target: https://clients-ci.elastic.co/job/elastic+elasticsearch-py+master
+.. image:: https://clients-ci.elastic.co/job/elastic+elasticsearch-py+main/badge/icon
+   :target: https://clients-ci.elastic.co/job/elastic+elasticsearch-py+main
 
 .. image:: https://readthedocs.org/projects/elasticsearch-py/badge/?version=latest&style=flat
    :target: https://elasticsearch-py.readthedocs.io
@@ -52,7 +52,7 @@ the ``async`` extra::
 
     $ python -m pip install elasticsearch[async]
 
-Read more about `how to use asyncio with this project <https://elasticsearch-py.readthedocs.io/en/master/async.html>`_.
+Read more about `how to use asyncio with this project <https://elasticsearch-py.readthedocs.io/en/latest/async.html>`_.
 
 
 Compatibility

--- a/docs/sphinx/helpers.rst
+++ b/docs/sphinx/helpers.rst
@@ -86,7 +86,7 @@ document is like ``{"word": "<myword>"}``.
 
 
 For a more complete and complex example please take a look at
-https://github.com/elastic/elasticsearch-py/blob/master/examples/bulk-ingest
+https://github.com/elastic/elasticsearch-py/blob/main/examples/bulk-ingest
 
 The :meth:`~elasticsearch.Elasticsearch.parallel_bulk` api is a wrapper around the :meth:`~elasticsearch.Elasticsearch.bulk` api to provide threading. :meth:`~elasticsearch.Elasticsearch.parallel_bulk` returns a generator which must be consumed to produce results.
 

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -166,7 +166,7 @@ class AsyncElasticsearch(object):
         )
 
     By default, `JSONSerializer
-    <https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/serializer.py#L24>`_
+    <https://github.com/elastic/elasticsearch-py/blob/main/elasticsearch/serializer.py>`_
     is used to encode all outgoing requests.
     However, you can implement your own custom serializer::
 

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -166,7 +166,7 @@ class Elasticsearch(object):
         )
 
     By default, `JSONSerializer
-    <https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/serializer.py#L24>`_
+    <https://github.com/elastic/elasticsearch-py/blob/main/elasticsearch/serializer.py>`_
     is used to encode all outgoing requests.
     However, you can implement your own custom serializer::
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch-py/issues/1693