### PR TITLE
Fixing `rest_api_spec` failures

### DIFF
--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -400,7 +400,7 @@ class YamlRunner:
                         and isinstance(value, string_types)
                         and key_replace in value
                     ):
-                        value = value.replace(key_replace, v)
+                        value = value.replace(key_replace, str(v))
                         break
 
         if isinstance(value, string_types):


### PR DESCRIPTION
There are 9 failures
- Fixes `rest-api-spec/test/platinum/api_key/20_query.yml`