### PR TITLE
Fix Pipelines

### DIFF
--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -365,6 +365,9 @@ class YamlRunner:
             ):
                 expected = re.compile(expected[1:-1], re.VERBOSE | re.MULTILINE)
                 assert expected.search(value), f"{value!r} does not match {expected!r}"
+            elif isinstance(value, list) and isinstance(expected, list):
+                assert len(value) == len(expected)
+                [self._assert_match_equals(a, b) for a, b in zip(value, expected)]
             else:
                 self._assert_match_equals(value, expected)
 

--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -366,7 +366,9 @@ class YamlRunner:
                 expected = re.compile(expected[1:-1], re.VERBOSE | re.MULTILINE)
                 assert expected.search(value), f"{value!r} does not match {expected!r}"
             elif isinstance(value, list) and isinstance(expected, list):
-                assert len(value) == len(expected)
+                assert len(value) == len(
+                    expected
+                ), f"Length between {value!r} and {expected!r} wasn't equal"
                 [self._assert_match_equals(a, b) for a, b in zip(value, expected)]
             else:
                 self._assert_match_equals(value, expected)


### PR DESCRIPTION
This fixes
- test_elasticsearch/test_server/test_rest_api_spec.py::test_rest_api_spec[unsigned_long/50_script_values[1]]
- test_elasticsearch/test_server/test_rest_api_spec.py::test_rest_api_spec[unsigned_long/50_script_values[2]]