### PR TITLE
Reduce Pipeline time by running specific python version

### DIFF
--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -42,4 +42,4 @@ docker run \
   --name elasticsearch-py \
   --rm \
   elastic/elasticsearch-py \
-  nox -s test
+  nox -s test-${PYTHON_VERSION}


### PR DESCRIPTION
Currently Pipelines for 3.6, 3.7. 3.8 are running their specific python version tests and running 3.9 by default. 

This causes running tests twice. 

Hence run specific tests only. So, all the test suites should get finished in 23 - 27 minutes. Right now, it is 55 minutes.

Reference: https://clients-ci.elastic.co/job/elastic+elasticsearch-py+pull-request/249/PYTHON_CONNECTION_CLASS=Urllib3HttpConnection,PYTHON_VERSION=3.6,STACK_VERSION=8.0.0-SNAPSHOT,TEST_SUITE=platinum,label=linux/consoleFull