### PR TITLE
Fix compatibility mode by only sending 'Content-Type' when necessary

### DIFF
--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -33,7 +33,7 @@ echo -e "\033[1m>>>>> Run [elastic/elasticsearch-py container] >>>>>>>>>>>>>>>>>
 
 if [[ "$STACK_VERSION" == "8.0.0-SNAPSHOT" ]]; then
   export STACK_VERSION="7.x-SNAPSHOT"
-  export ELASTIC_CLIENT_APIVERSIONING="1"
+  export ELASTIC_CLIENT_APIVERSIONING="true"
 fi
 
 mkdir -p junit

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -32,7 +32,8 @@ docker build \
 echo -e "\033[1m>>>>> Run [elastic/elasticsearch-py container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 
 if [[ "$STACK_VERSION" == "8.0.0-SNAPSHOT" ]]; then
-  ELASTIC_CLIENT_APIVERSIONING="1"
+  export STACK_VERSION="7.x-SNAPSHOT"
+  export ELASTIC_CLIENT_APIVERSIONING="1"
 fi
 
 mkdir -p junit

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -979,6 +979,7 @@ class AsyncElasticsearch(object):
         "fields",
         "ignore_unavailable",
         "include_unmapped",
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     async def field_caps(self, body=None, index=None, params=None, headers=None):
@@ -2319,6 +2320,7 @@ class AsyncElasticsearch(object):
         )
 
     @query_params(
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     async def close_point_in_time(self, body=None, params=None, headers=None):

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -267,7 +267,9 @@ class AsyncElasticsearch(object):
         await self.transport.close()
 
     # AUTO-GENERATED-API-DEFINITIONS #
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def ping(self, params=None, headers=None):
         """
         Returns whether the cluster is running.
@@ -281,7 +283,9 @@ class AsyncElasticsearch(object):
         except TransportError:
             return False
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def info(self, params=None, headers=None):
         """
         Returns basic information about the cluster.
@@ -300,6 +304,8 @@ class AsyncElasticsearch(object):
         "version",
         "version_type",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_name="document",
     )
     async def create(self, index, id, body, doc_type=None, params=None, headers=None):
@@ -355,6 +361,8 @@ class AsyncElasticsearch(object):
         "version",
         "version_type",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_name="document",
     )
     async def index(
@@ -422,6 +430,8 @@ class AsyncElasticsearch(object):
         "routing",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     async def bulk(self, body, index=None, doc_type=None, params=None, headers=None):
         """
@@ -469,7 +479,11 @@ class AsyncElasticsearch(object):
             body=body,
         )
 
-    @query_params(body_params=["scroll_id"])
+    @query_params(
+        request_mimetypes=["application/json", "text/plain"],
+        response_mimetypes=["application/json"],
+        body_params=["scroll_id"],
+    )
     async def clear_scroll(self, body=None, scroll_id=None, params=None, headers=None):
         """
         Explicitly clears the search context for a scroll.
@@ -506,6 +520,8 @@ class AsyncElasticsearch(object):
         "q",
         "routing",
         "terminate_after",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def count(
         self, body=None, index=None, doc_type=None, params=None, headers=None
@@ -566,6 +582,7 @@ class AsyncElasticsearch(object):
         "version",
         "version_type",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     async def delete(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -642,6 +659,8 @@ class AsyncElasticsearch(object):
         "version",
         "wait_for_active_shards",
         "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def delete_by_query(
         self, index, body, doc_type=None, params=None, headers=None
@@ -739,7 +758,10 @@ class AsyncElasticsearch(object):
             body=body,
         )
 
-    @query_params("requests_per_second")
+    @query_params(
+        "requests_per_second",
+        response_mimetypes=["application/json"],
+    )
     async def delete_by_query_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Delete By Query
@@ -761,7 +783,11 @@ class AsyncElasticsearch(object):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_script(self, id, params=None, headers=None):
         """
         Deletes a script.
@@ -790,6 +816,7 @@ class AsyncElasticsearch(object):
         "stored_fields",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     async def exists(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -841,6 +868,7 @@ class AsyncElasticsearch(object):
         "routing",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     async def exists_source(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -895,6 +923,8 @@ class AsyncElasticsearch(object):
         "q",
         "routing",
         "stored_fields",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def explain(
         self, index, id, body=None, doc_type=None, params=None, headers=None
@@ -949,6 +979,7 @@ class AsyncElasticsearch(object):
         "fields",
         "ignore_unavailable",
         "include_unmapped",
+        response_mimetypes=["application/json"],
     )
     async def field_caps(self, body=None, index=None, params=None, headers=None):
         """
@@ -991,6 +1022,7 @@ class AsyncElasticsearch(object):
         "stored_fields",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     async def get(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -1035,7 +1067,10 @@ class AsyncElasticsearch(object):
             "GET", _make_path(index, doc_type, id), params=params, headers=headers
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_script(self, id, params=None, headers=None):
         """
         Returns a script.
@@ -1062,6 +1097,7 @@ class AsyncElasticsearch(object):
         "routing",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     async def get_source(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -1112,6 +1148,8 @@ class AsyncElasticsearch(object):
         "refresh",
         "routing",
         "stored_fields",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def mget(self, body, index=None, doc_type=None, params=None, headers=None):
         """
@@ -1159,6 +1197,8 @@ class AsyncElasticsearch(object):
         "rest_total_hits_as_int",
         "search_type",
         "typed_keys",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     async def msearch(self, body, index=None, doc_type=None, params=None, headers=None):
         """
@@ -1213,6 +1253,8 @@ class AsyncElasticsearch(object):
         "rest_total_hits_as_int",
         "search_type",
         "typed_keys",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     async def msearch_template(
         self, body, index=None, doc_type=None, params=None, headers=None
@@ -1265,6 +1307,8 @@ class AsyncElasticsearch(object):
         "term_statistics",
         "version",
         "version_type",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def mtermvectors(
         self, body=None, index=None, doc_type=None, params=None, headers=None
@@ -1320,7 +1364,12 @@ class AsyncElasticsearch(object):
             "POST", path, params=params, headers=headers, body=body
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_script(self, id, body, context=None, params=None, headers=None):
         """
         Creates or updates a script.
@@ -1346,7 +1395,12 @@ class AsyncElasticsearch(object):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "search_type"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "search_type",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def rank_eval(self, body, index=None, params=None, headers=None):
         """
@@ -1395,6 +1449,8 @@ class AsyncElasticsearch(object):
         "timeout",
         "wait_for_active_shards",
         "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def reindex(self, body, params=None, headers=None):
         """
@@ -1433,7 +1489,10 @@ class AsyncElasticsearch(object):
             "POST", "/_reindex", params=params, headers=headers, body=body
         )
 
-    @query_params("requests_per_second")
+    @query_params(
+        "requests_per_second",
+        response_mimetypes=["application/json"],
+    )
     async def reindex_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Reindex operation.
@@ -1454,7 +1513,10 @@ class AsyncElasticsearch(object):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def render_search_template(
         self, body=None, id=None, params=None, headers=None
     ):
@@ -1474,7 +1536,10 @@ class AsyncElasticsearch(object):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def scripts_painless_execute(self, body=None, params=None, headers=None):
         """
         Allows an arbitrary script to be executed and a result to be returned
@@ -1500,6 +1565,8 @@ class AsyncElasticsearch(object):
         "rest_total_hits_as_int",
         "scroll",
         "scroll_id",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=["scroll", "scroll_id"],
     )
     async def scroll(self, body=None, scroll_id=None, params=None, headers=None):
@@ -1571,6 +1638,8 @@ class AsyncElasticsearch(object):
         "track_total_hits",
         "typed_keys",
         "version",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=[
             "_source",
             "aggregations",
@@ -1789,6 +1858,7 @@ class AsyncElasticsearch(object):
         "local",
         "preference",
         "routing",
+        response_mimetypes=["application/json"],
     )
     async def search_shards(self, index=None, params=None, headers=None):
         """
@@ -1831,6 +1901,8 @@ class AsyncElasticsearch(object):
         "scroll",
         "search_type",
         "typed_keys",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def search_template(
         self, body, index=None, doc_type=None, params=None, headers=None
@@ -1896,6 +1968,8 @@ class AsyncElasticsearch(object):
         "term_statistics",
         "version",
         "version_type",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def termvectors(
         self, index, body=None, doc_type=None, id=None, params=None, headers=None
@@ -1958,6 +2032,8 @@ class AsyncElasticsearch(object):
         "routing",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=[
             "_source",
             "detect_noop",
@@ -2078,6 +2154,8 @@ class AsyncElasticsearch(object):
         "version_type",
         "wait_for_active_shards",
         "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def update_by_query(
         self, index, body=None, doc_type=None, params=None, headers=None
@@ -2179,7 +2257,10 @@ class AsyncElasticsearch(object):
             body=body,
         )
 
-    @query_params("requests_per_second")
+    @query_params(
+        "requests_per_second",
+        response_mimetypes=["application/json"],
+    )
     async def update_by_query_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Update By Query
@@ -2201,7 +2282,9 @@ class AsyncElasticsearch(object):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_script_context(self, params=None, headers=None):
         """
         Returns all script contexts.
@@ -2217,7 +2300,9 @@ class AsyncElasticsearch(object):
             "GET", "/_script_context", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_script_languages(self, params=None, headers=None):
         """
         Returns available script types, languages and contexts
@@ -2233,7 +2318,9 @@ class AsyncElasticsearch(object):
             "GET", "/_script_language", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def close_point_in_time(self, body=None, params=None, headers=None):
         """
         Close a point in time
@@ -2247,9 +2334,14 @@ class AsyncElasticsearch(object):
         )
 
     @query_params(
-        "expand_wildcards", "ignore_unavailable", "keep_alive", "preference", "routing"
+        "expand_wildcards",
+        "ignore_unavailable",
+        "keep_alive",
+        "preference",
+        "routing",
+        response_mimetypes=["application/json"],
     )
-    async def open_point_in_time(self, index=None, params=None, headers=None):
+    async def open_point_in_time(self, index, params=None, headers=None):
         """
         Open a point in time that can be used in subsequent searches
 
@@ -2268,11 +2360,17 @@ class AsyncElasticsearch(object):
             be performed on (default: random)
         :arg routing: Specific routing value
         """
+        if index in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'index'.")
+
         return await self.transport.perform_request(
             "POST", _make_path(index, "_pit"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def terms_enum(self, index, body=None, params=None, headers=None):
         """
         The terms enum API  can be used to discover terms in the index that begin with
@@ -2308,6 +2406,8 @@ class AsyncElasticsearch(object):
         "grid_precision",
         "grid_type",
         "size",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/vnd.mapbox-vector-tile"],
         body_params=[
             "aggs",
             "exact_bounds",

--- a/elasticsearch/_async/client/__init__.pyi
+++ b/elasticsearch/_async/client/__init__.pyi
@@ -504,7 +504,7 @@ class AsyncElasticsearch(object):
     async def field_caps(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[bool] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -1172,7 +1172,7 @@ class AsyncElasticsearch(object):
     async def close_point_in_time(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,

--- a/elasticsearch/_async/client/__init__.pyi
+++ b/elasticsearch/_async/client/__init__.pyi
@@ -1189,7 +1189,7 @@ class AsyncElasticsearch(object):
     async def open_point_in_time(
         self,
         *,
-        index: Optional[Any] = ...,
+        index: Any,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[bool] = ...,
         keep_alive: Optional[Any] = ...,

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class AsyncSearchClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete(self, id, params=None, headers=None):
         """
         Deletes an async search by ID. If the search is still running, the search
@@ -36,7 +38,12 @@ class AsyncSearchClient(NamespacedClient):
             "DELETE", _make_path("_async_search", id), params=params, headers=headers
         )
 
-    @query_params("keep_alive", "typed_keys", "wait_for_completion_timeout")
+    @query_params(
+        "keep_alive",
+        "typed_keys",
+        "wait_for_completion_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get(self, id, params=None, headers=None):
         """
         Retrieves the results of a previously submitted async search request given its
@@ -101,6 +108,8 @@ class AsyncSearchClient(NamespacedClient):
         "typed_keys",
         "version",
         "wait_for_completion_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def submit(self, body=None, index=None, params=None, headers=None):
         """
@@ -205,7 +214,9 @@ class AsyncSearchClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def status(self, id, params=None, headers=None):
         """
         Retrieves the status of a previously submitted async search request given its

--- a/elasticsearch/_async/client/autoscaling.py
+++ b/elasticsearch/_async/client/autoscaling.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class AutoscalingClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_autoscaling_policy(self, name, params=None, headers=None):
         """
         Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
@@ -39,7 +41,9 @@ class AutoscalingClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_autoscaling_policy(self, name, params=None, headers=None):
         """
         Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
@@ -59,7 +63,10 @@ class AutoscalingClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_autoscaling_policy(self, name, body, params=None, headers=None):
         """
         Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
@@ -82,7 +89,9 @@ class AutoscalingClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_autoscaling_capacity(self, params=None, headers=None):
         """
         Gets the current autoscaling capacity based on the configured autoscaling

--- a/elasticsearch/_async/client/cat.py
+++ b/elasticsearch/_async/client/cat.py
@@ -19,7 +19,16 @@ from .utils import NamespacedClient, _make_path, query_params
 
 
 class CatClient(NamespacedClient):
-    @query_params("expand_wildcards", "format", "h", "help", "local", "s", "v")
+    @query_params(
+        "expand_wildcards",
+        "format",
+        "h",
+        "help",
+        "local",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def aliases(self, name=None, params=None, headers=None):
         """
         Shows information about currently configured aliases to indices including
@@ -45,7 +54,17 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "aliases", name), params=params, headers=headers
         )
 
-    @query_params("bytes", "format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def allocation(self, node_id=None, params=None, headers=None):
         """
         Provides a snapshot of how many shards are allocated to each data node and how
@@ -76,7 +95,14 @@ class CatClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("format", "h", "help", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def count(self, index=None, params=None, headers=None):
         """
         Provides quick access to the document count of the entire cluster, or
@@ -98,7 +124,16 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "count", index), params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "s", "time", "ts", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "ts",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def health(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster health.
@@ -120,7 +155,11 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/health", params=params, headers=headers
         )
 
-    @query_params("help", "s")
+    @query_params(
+        "help",
+        "s",
+        response_mimetypes=["text/plain"],
+    )
     async def help(self, params=None, headers=None):
         """
         Returns help for the Cat APIs.
@@ -149,6 +188,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def indices(self, index=None, params=None, headers=None):
         """
@@ -189,7 +229,16 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "indices", index), params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def master(self, params=None, headers=None):
         """
         Returns information about the master node.
@@ -224,6 +273,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def nodes(self, params=None, headers=None):
         """
@@ -257,7 +307,16 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "active_only", "bytes", "detailed", "format", "h", "help", "s", "time", "v"
+        "active_only",
+        "bytes",
+        "detailed",
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def recovery(self, index=None, params=None, headers=None):
         """
@@ -288,7 +347,16 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "bytes", "format", "h", "help", "local", "master_timeout", "s", "time", "v"
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def shards(self, index=None, params=None, headers=None):
         """
@@ -318,7 +386,15 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "shards", index), params=params, headers=headers
         )
 
-    @query_params("bytes", "format", "h", "help", "s", "v")
+    @query_params(
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def segments(self, index=None, params=None, headers=None):
         """
         Provides low-level information about the segments in the shards of an index.
@@ -341,7 +417,17 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "segments", index), params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "time", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def pending_tasks(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster pending tasks.
@@ -366,7 +452,17 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/pending_tasks", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "size", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "size",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def thread_pool(self, thread_pool_patterns=None, params=None, headers=None):
         """
         Returns cluster-wide thread pool statistics per node. By default the active,
@@ -397,7 +493,15 @@ class CatClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("bytes", "format", "h", "help", "s", "v")
+    @query_params(
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def fielddata(self, fields=None, params=None, headers=None):
         """
         Shows how much heap memory is currently being used by fielddata on every data
@@ -425,7 +529,15 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "format", "h", "help", "include_bootstrap", "local", "master_timeout", "s", "v"
+        "format",
+        "h",
+        "help",
+        "include_bootstrap",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def plugins(self, params=None, headers=None):
         """
@@ -451,7 +563,16 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/plugins", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def nodeattrs(self, params=None, headers=None):
         """
         Returns information about custom node attributes.
@@ -474,7 +595,16 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/nodeattrs", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def repositories(self, params=None, headers=None):
         """
         Returns information about snapshot repositories registered in the cluster.
@@ -498,7 +628,15 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "format", "h", "help", "ignore_unavailable", "master_timeout", "s", "time", "v"
+        "format",
+        "h",
+        "help",
+        "ignore_unavailable",
+        "master_timeout",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def snapshots(self, repository=None, params=None, headers=None):
         """
@@ -540,6 +678,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def tasks(self, params=None, headers=None):
         """
@@ -570,7 +709,16 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/tasks", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def templates(self, name=None, params=None, headers=None):
         """
         Returns information about existing templates.
@@ -594,7 +742,17 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "templates", name), params=params, headers=headers
         )
 
-    @query_params("allow_no_match", "bytes", "format", "h", "help", "s", "time", "v")
+    @query_params(
+        "allow_no_match",
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     async def ml_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Gets configuration and usage information about data frame analytics jobs.
@@ -625,7 +783,15 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_datafeeds", "allow_no_match", "format", "h", "help", "s", "time", "v"
+        "allow_no_datafeeds",
+        "allow_no_match",
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def ml_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
@@ -667,6 +833,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def ml_jobs(self, job_id=None, params=None, headers=None):
         """
@@ -711,6 +878,7 @@ class CatClient(NamespacedClient):
         "size",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def ml_trained_models(self, model_id=None, params=None, headers=None):
         """
@@ -748,7 +916,16 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_match", "format", "from_", "h", "help", "s", "size", "time", "v"
+        "allow_no_match",
+        "format",
+        "from_",
+        "h",
+        "help",
+        "s",
+        "size",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     async def transforms(self, transform_id=None, params=None, headers=None):
         """

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class CcrClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Deletes auto-follow patterns.
@@ -38,7 +40,11 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("wait_for_active_shards")
+    @query_params(
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def follow(self, index, body, params=None, headers=None):
         """
         Creates a new follower index configured to follow the referenced leader index.
@@ -66,7 +72,9 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def follow_info(self, index, params=None, headers=None):
         """
         Retrieves information about all follower indices, including parameters and
@@ -84,7 +92,9 @@ class CcrClient(NamespacedClient):
             "GET", _make_path(index, "_ccr", "info"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def follow_stats(self, index, params=None, headers=None):
         """
         Retrieves follower stats. return shard-level stats about the following tasks
@@ -102,7 +112,10 @@ class CcrClient(NamespacedClient):
             "GET", _make_path(index, "_ccr", "stats"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def forget_follower(self, index, body, params=None, headers=None):
         """
         Removes the follower retention leases from the leader.
@@ -128,7 +141,9 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_auto_follow_pattern(self, name=None, params=None, headers=None):
         """
         Gets configured auto-follow patterns. Returns the specified auto-follow pattern
@@ -145,7 +160,9 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def pause_follow(self, index, params=None, headers=None):
         """
         Pauses a follower index. The follower index will not fetch any additional
@@ -166,7 +183,10 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_auto_follow_pattern(self, name, body, params=None, headers=None):
         """
         Creates a new named collection of auto-follow patterns against a specified
@@ -190,7 +210,10 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def resume_follow(self, index, body=None, params=None, headers=None):
         """
         Resumes a follower index that has been paused
@@ -212,7 +235,9 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def stats(self, params=None, headers=None):
         """
         Gets all stats related to cross-cluster replication.
@@ -223,7 +248,9 @@ class CcrClient(NamespacedClient):
             "GET", "/_ccr/stats", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def unfollow(self, index, params=None, headers=None):
         """
         Stops the following task associated with a follower index and removes index
@@ -244,7 +271,9 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def pause_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Pauses an auto-follow pattern
@@ -264,7 +293,9 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def resume_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Resumes an auto-follow pattern that has been paused

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -31,6 +31,7 @@ class ClusterClient(NamespacedClient):
         "wait_for_no_relocating_shards",
         "wait_for_nodes",
         "wait_for_status",
+        response_mimetypes=["application/json"],
     )
     async def health(self, index=None, params=None, headers=None):
         """
@@ -70,7 +71,11 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def pending_tasks(self, params=None, headers=None):
         """
         Returns a list of any cluster-level changes (e.g. create index, update mapping,
@@ -95,6 +100,7 @@ class ClusterClient(NamespacedClient):
         "master_timeout",
         "wait_for_metadata_version",
         "wait_for_timeout",
+        response_mimetypes=["application/json"],
     )
     async def state(self, metric=None, index=None, params=None, headers=None):
         """
@@ -135,7 +141,11 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("flat_settings", "timeout")
+    @query_params(
+        "flat_settings",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def stats(self, node_id=None, params=None, headers=None):
         """
         Returns high-level overview of cluster statistics.
@@ -160,7 +170,14 @@ class ClusterClient(NamespacedClient):
         )
 
     @query_params(
-        "dry_run", "explain", "master_timeout", "metric", "retry_failed", "timeout"
+        "dry_run",
+        "explain",
+        "master_timeout",
+        "metric",
+        "retry_failed",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def reroute(self, body=None, params=None, headers=None):
         """
@@ -187,7 +204,13 @@ class ClusterClient(NamespacedClient):
             "POST", "/_cluster/reroute", params=params, headers=headers, body=body
         )
 
-    @query_params("flat_settings", "include_defaults", "master_timeout", "timeout")
+    @query_params(
+        "flat_settings",
+        "include_defaults",
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_settings(self, params=None, headers=None):
         """
         Returns cluster settings.
@@ -206,7 +229,13 @@ class ClusterClient(NamespacedClient):
             "GET", "/_cluster/settings", params=params, headers=headers
         )
 
-    @query_params("flat_settings", "master_timeout", "timeout")
+    @query_params(
+        "flat_settings",
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_settings(self, body, params=None, headers=None):
         """
         Updates the cluster settings.
@@ -228,7 +257,9 @@ class ClusterClient(NamespacedClient):
             "PUT", "/_cluster/settings", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def remote_info(self, params=None, headers=None):
         """
         Returns the information about configured remote clusters.
@@ -239,7 +270,12 @@ class ClusterClient(NamespacedClient):
             "GET", "/_remote/info", params=params, headers=headers
         )
 
-    @query_params("include_disk_info", "include_yes_decisions")
+    @query_params(
+        "include_disk_info",
+        "include_yes_decisions",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def allocation_explain(self, body=None, params=None, headers=None):
         """
         Provides explanations for shard allocations in the cluster.
@@ -261,7 +297,11 @@ class ClusterClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_component_template(self, name, params=None, headers=None):
         """
         Deletes a component template
@@ -282,7 +322,11 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_component_template(self, name=None, params=None, headers=None):
         """
         Returns one or more component templates
@@ -302,7 +346,13 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("create", "master_timeout", "timeout")
+    @query_params(
+        "create",
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_component_template(self, name, body, params=None, headers=None):
         """
         Creates or updates a component template
@@ -328,7 +378,11 @@ class ClusterClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def exists_component_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular component template exist
@@ -351,7 +405,10 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("wait_for_removal")
+    @query_params(
+        "wait_for_removal",
+        response_mimetypes=["application/json"],
+    )
     async def delete_voting_config_exclusions(self, params=None, headers=None):
         """
         Clears cluster voting config exclusions.
@@ -369,7 +426,12 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("node_ids", "node_names", "timeout")
+    @query_params(
+        "node_ids",
+        "node_names",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def post_voting_config_exclusions(self, params=None, headers=None):
         """
         Updates the cluster voting config exclusions by node ids or node names.

--- a/elasticsearch/_async/client/dangling_indices.py
+++ b/elasticsearch/_async/client/dangling_indices.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class DanglingIndicesClient(NamespacedClient):
-    @query_params("accept_data_loss", "master_timeout", "timeout")
+    @query_params(
+        "accept_data_loss",
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Deletes the specified dangling index
@@ -42,7 +47,12 @@ class DanglingIndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("accept_data_loss", "master_timeout", "timeout")
+    @query_params(
+        "accept_data_loss",
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def import_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Imports the specified dangling index
@@ -62,7 +72,9 @@ class DanglingIndicesClient(NamespacedClient):
             "POST", _make_path("_dangling", index_uuid), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def list_dangling_indices(self, params=None, headers=None):
         """
         Returns all dangling indices.

--- a/elasticsearch/_async/client/enrich.py
+++ b/elasticsearch/_async/client/enrich.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class EnrichClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_policy(self, name, params=None, headers=None):
         """
         Deletes an existing enrich policy and its enrich index.
@@ -38,7 +40,10 @@ class EnrichClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("wait_for_completion")
+    @query_params(
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     async def execute_policy(self, name, params=None, headers=None):
         """
         Creates the enrich index for an existing enrich policy.
@@ -59,7 +64,9 @@ class EnrichClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_policy(self, name=None, params=None, headers=None):
         """
         Gets information about an enrich policy.
@@ -72,7 +79,10 @@ class EnrichClient(NamespacedClient):
             "GET", _make_path("_enrich", "policy", name), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_policy(self, name, body, params=None, headers=None):
         """
         Creates a new enrich policy.
@@ -94,7 +104,9 @@ class EnrichClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def stats(self, params=None, headers=None):
         """
         Gets enrich coordinator statistics and information about enrich policies that

--- a/elasticsearch/_async/client/eql.py
+++ b/elasticsearch/_async/client/eql.py
@@ -19,7 +19,13 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class EqlClient(NamespacedClient):
-    @query_params("keep_alive", "keep_on_completion", "wait_for_completion_timeout")
+    @query_params(
+        "keep_alive",
+        "keep_on_completion",
+        "wait_for_completion_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def search(self, index, body, params=None, headers=None):
         """
         Returns results matching a query expressed in Event Query Language (EQL)
@@ -49,7 +55,9 @@ class EqlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete(self, id, params=None, headers=None):
         """
         Deletes an async EQL search by ID. If the search is still running, the search
@@ -66,7 +74,11 @@ class EqlClient(NamespacedClient):
             "DELETE", _make_path("_eql", "search", id), params=params, headers=headers
         )
 
-    @query_params("keep_alive", "wait_for_completion_timeout")
+    @query_params(
+        "keep_alive",
+        "wait_for_completion_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get(self, id, params=None, headers=None):
         """
         Returns async results from previously executed Event Query Language (EQL)
@@ -87,7 +99,9 @@ class EqlClient(NamespacedClient):
             "GET", _make_path("_eql", "search", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_status(self, id, params=None, headers=None):
         """
         Returns the status of a previously submitted async or stored Event Query

--- a/elasticsearch/_async/client/features.py
+++ b/elasticsearch/_async/client/features.py
@@ -19,7 +19,10 @@ from .utils import NamespacedClient, query_params
 
 
 class FeaturesClient(NamespacedClient):
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_features(self, params=None, headers=None):
         """
         Gets a list of features which can be included in snapshots using the
@@ -34,7 +37,9 @@ class FeaturesClient(NamespacedClient):
             "GET", "/_features", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def reset_features(self, params=None, headers=None):
         """
         Resets the internal state of features, usually by deleting system indices

--- a/elasticsearch/_async/client/fleet.py
+++ b/elasticsearch/_async/client/fleet.py
@@ -19,7 +19,14 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class FleetClient(NamespacedClient):
-    @query_params("checkpoints", "timeout", "wait_for_advance", "wait_for_index")
+    @query_params(
+        "checkpoints",
+        "timeout",
+        "wait_for_advance",
+        "wait_for_index",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def global_checkpoints(self, index, params=None, headers=None):
         """
         Returns the current global checkpoints for an index. This API is design for

--- a/elasticsearch/_async/client/graph.py
+++ b/elasticsearch/_async/client/graph.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class GraphClient(NamespacedClient):
-    @query_params("routing", "timeout")
+    @query_params(
+        "routing",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def explore(self, index, body=None, doc_type=None, params=None, headers=None):
         """
         Explore extracted and summarized information about the documents and terms in

--- a/elasticsearch/_async/client/ilm.py
+++ b/elasticsearch/_async/client/ilm.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IlmClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_lifecycle(self, policy, params=None, headers=None):
         """
         Deletes the specified lifecycle policy definition. A currently used policy
@@ -39,7 +41,11 @@ class IlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("only_errors", "only_managed")
+    @query_params(
+        "only_errors",
+        "only_managed",
+        response_mimetypes=["application/json"],
+    )
     async def explain_lifecycle(self, index, params=None, headers=None):
         """
         Retrieves information about the index's current lifecycle state, such as the
@@ -60,7 +66,9 @@ class IlmClient(NamespacedClient):
             "GET", _make_path(index, "_ilm", "explain"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_lifecycle(self, policy=None, params=None, headers=None):
         """
         Returns the specified policy definition. Includes the policy version and last
@@ -74,7 +82,9 @@ class IlmClient(NamespacedClient):
             "GET", _make_path("_ilm", "policy", policy), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_status(self, params=None, headers=None):
         """
         Retrieves the current index lifecycle management (ILM) status.
@@ -85,7 +95,10 @@ class IlmClient(NamespacedClient):
             "GET", "/_ilm/status", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def move_to_step(self, index, body=None, params=None, headers=None):
         """
         Manually moves an index into the specified step and executes that step.
@@ -107,7 +120,10 @@ class IlmClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_lifecycle(self, policy, body=None, params=None, headers=None):
         """
         Creates a lifecycle policy
@@ -128,7 +144,9 @@ class IlmClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def remove_policy(self, index, params=None, headers=None):
         """
         Removes the assigned lifecycle policy and stops managing the specified index
@@ -144,7 +162,9 @@ class IlmClient(NamespacedClient):
             "POST", _make_path(index, "_ilm", "remove"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def retry(self, index, params=None, headers=None):
         """
         Retries executing the policy for an index that is in the ERROR step.
@@ -161,7 +181,9 @@ class IlmClient(NamespacedClient):
             "POST", _make_path(index, "_ilm", "retry"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def start(self, params=None, headers=None):
         """
         Start the index lifecycle management (ILM) plugin.
@@ -172,7 +194,9 @@ class IlmClient(NamespacedClient):
             "POST", "/_ilm/start", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def stop(self, params=None, headers=None):
         """
         Halts all lifecycle management operations and stops the index lifecycle
@@ -184,7 +208,11 @@ class IlmClient(NamespacedClient):
             "POST", "/_ilm/stop", params=params, headers=headers
         )
 
-    @query_params("dry_run")
+    @query_params(
+        "dry_run",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def migrate_to_data_tiers(self, body=None, params=None, headers=None):
         """
         Migrates the indices and ILM policies away from custom node attribute

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IndicesClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def analyze(self, body=None, index=None, params=None, headers=None):
         """
         Performs the analysis process on a text and return the tokens breakdown of the
@@ -39,7 +42,12 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     async def refresh(self, index=None, params=None, headers=None):
         """
         Performs the refresh operation in one or more indices.
@@ -67,6 +75,7 @@ class IndicesClient(NamespacedClient):
         "force",
         "ignore_unavailable",
         "wait_if_ongoing",
+        response_mimetypes=["application/json"],
     )
     async def flush(self, index=None, params=None, headers=None):
         """
@@ -103,6 +112,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=["aliases", "mappings", "settings"],
     )
     async def create(self, index, body=None, params=None, headers=None):
@@ -135,7 +146,13 @@ class IndicesClient(NamespacedClient):
             "PUT", _make_path(index), params=params, headers=headers, body=body
         )
 
-    @query_params("master_timeout", "timeout", "wait_for_active_shards")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def clone(self, index, target, body=None, params=None, headers=None):
         """
         Clones an index
@@ -172,6 +189,7 @@ class IndicesClient(NamespacedClient):
         "include_type_name",
         "local",
         "master_timeout",
+        response_mimetypes=["application/json"],
     )
     async def get(self, index, params=None, headers=None):
         """
@@ -217,6 +235,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     async def open(self, index, params=None, headers=None):
         """
@@ -252,6 +271,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     async def close(self, index, params=None, headers=None):
         """
@@ -288,6 +308,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "master_timeout",
         "timeout",
+        response_mimetypes=["application/json"],
     )
     async def delete(self, index, params=None, headers=None):
         """
@@ -301,7 +322,7 @@ class IndicesClient(NamespacedClient):
             to no concrete indices (default: false)
         :arg expand_wildcards: Whether wildcard expressions should get
             expanded to open or closed indices (default: open)  Valid choices: open,
-            closed, hidden, none, all  Default: open
+            closed, hidden, none, all  Default: open,closed
         :arg ignore_unavailable: Ignore unavailable indexes (default:
             false)
         :arg master_timeout: Specify timeout for connection to master
@@ -321,6 +342,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "include_defaults",
         "local",
+        response_mimetypes=["application/json"],
     )
     async def exists(self, index, params=None, headers=None):
         """
@@ -350,7 +372,13 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path(index), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable", "local")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     async def exists_type(self, index, doc_type, params=None, headers=None):
         """
         Returns information about whether a particular document type exists.
@@ -391,6 +419,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "write_index_only",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def put_mapping(
         self, body, index=None, doc_type=None, params=None, headers=None
@@ -441,6 +471,7 @@ class IndicesClient(NamespacedClient):
         "include_type_name",
         "local",
         "master_timeout",
+        response_mimetypes=["application/json"],
     )
     async def get_mapping(self, index=None, doc_type=None, params=None, headers=None):
         """
@@ -478,6 +509,7 @@ class IndicesClient(NamespacedClient):
         "include_defaults",
         "include_type_name",
         "local",
+        response_mimetypes=["application/json"],
     )
     async def get_field_mapping(
         self, fields, index=None, doc_type=None, params=None, headers=None
@@ -515,7 +547,12 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_alias(self, index, name, body=None, params=None, headers=None):
         """
         Creates or updates an alias.
@@ -543,7 +580,13 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable", "local")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     async def exists_alias(self, name, index=None, params=None, headers=None):
         """
         Returns information about whether a particular alias exists.
@@ -571,7 +614,13 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path(index, "_alias", name), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable", "local")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     async def get_alias(self, index=None, name=None, params=None, headers=None):
         """
         Returns an alias.
@@ -596,7 +645,12 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path(index, "_alias", name), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def update_aliases(self, body, params=None, headers=None):
         """
         Updates index aliases.
@@ -614,7 +668,11 @@ class IndicesClient(NamespacedClient):
             "POST", "/_aliases", params=params, headers=headers, body=body
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_alias(self, index, name, params=None, headers=None):
         """
         Deletes an alias.
@@ -639,7 +697,14 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("create", "include_type_name", "master_timeout", "order")
+    @query_params(
+        "create",
+        "include_type_name",
+        "master_timeout",
+        "order",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
@@ -669,7 +734,12 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("flat_settings", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def exists_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
@@ -691,7 +761,13 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path("_template", name), params=params, headers=headers
         )
 
-    @query_params("flat_settings", "include_type_name", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "include_type_name",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
@@ -712,7 +788,11 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path("_template", name), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
@@ -738,6 +818,7 @@ class IndicesClient(NamespacedClient):
         "include_defaults",
         "local",
         "master_timeout",
+        response_mimetypes=["application/json"],
     )
     async def get_settings(self, index=None, name=None, params=None, headers=None):
         """
@@ -776,6 +857,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "preserve_existing",
         "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def put_settings(self, body, index=None, params=None, headers=None):
         """
@@ -824,6 +907,7 @@ class IndicesClient(NamespacedClient):
         "include_unloaded_segments",
         "level",
         "types",
+        response_mimetypes=["application/json"],
     )
     async def stats(self, index=None, metric=None, params=None, headers=None):
         """
@@ -865,7 +949,11 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "verbose"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "verbose",
+        response_mimetypes=["application/json"],
     )
     async def segments(self, index=None, params=None, headers=None):
         """
@@ -902,6 +990,8 @@ class IndicesClient(NamespacedClient):
         "lenient",
         "q",
         "rewrite",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def validate_query(
         self, body=None, index=None, doc_type=None, params=None, headers=None
@@ -958,6 +1048,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "query",
         "request",
+        response_mimetypes=["application/json"],
     )
     async def clear_cache(self, index=None, params=None, headers=None):
         """
@@ -985,7 +1076,11 @@ class IndicesClient(NamespacedClient):
             "POST", _make_path(index, "_cache", "clear"), params=params, headers=headers
         )
 
-    @query_params("active_only", "detailed")
+    @query_params(
+        "active_only",
+        "detailed",
+        response_mimetypes=["application/json"],
+    )
     async def recovery(self, index=None, params=None, headers=None):
         """
         Returns information about ongoing index shard recoveries.
@@ -1009,6 +1104,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "only_ancient_segments",
         "wait_for_completion",
+        response_mimetypes=["application/json"],
     )
     async def upgrade(self, index=None, params=None, headers=None):
         """
@@ -1035,7 +1131,12 @@ class IndicesClient(NamespacedClient):
             "POST", _make_path(index, "_upgrade"), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     async def get_upgrade(self, index=None, params=None, headers=None):
         """
         DEPRECATED Returns a progress status of current upgrade.
@@ -1057,7 +1158,12 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path(index, "_upgrade"), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     async def flush_synced(self, index=None, params=None, headers=None):
         """
         Performs a synced flush operation on one or more indices. Synced flush is
@@ -1084,7 +1190,11 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "status"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "status",
+        response_mimetypes=["application/json"],
     )
     async def shard_stores(self, index=None, params=None, headers=None):
         """
@@ -1117,6 +1227,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "max_num_segments",
         "only_expunge_deletes",
+        response_mimetypes=["application/json"],
     )
     async def forcemerge(self, index=None, params=None, headers=None):
         """
@@ -1146,7 +1257,12 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "copy_settings", "master_timeout", "timeout", "wait_for_active_shards"
+        "copy_settings",
+        "master_timeout",
+        "timeout",
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def shrink(self, index, target, body=None, params=None, headers=None):
         """
@@ -1178,7 +1294,12 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "copy_settings", "master_timeout", "timeout", "wait_for_active_shards"
+        "copy_settings",
+        "master_timeout",
+        "timeout",
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def split(self, index, target, body=None, params=None, headers=None):
         """
@@ -1216,6 +1337,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def rollover(
         self, alias, body=None, new_index=None, params=None, headers=None
@@ -1259,6 +1382,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     async def freeze(self, index, params=None, headers=None):
         """
@@ -1295,6 +1419,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     async def unfreeze(self, index, params=None, headers=None):
         """
@@ -1324,7 +1449,12 @@ class IndicesClient(NamespacedClient):
             "POST", _make_path(index, "_unfreeze"), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     async def reload_search_analyzers(self, index, params=None, headers=None):
         """
         Reloads an index's search analyzers and their resources.
@@ -1352,7 +1482,9 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def create_data_stream(self, name, params=None, headers=None):
         """
         Creates a data stream
@@ -1368,7 +1500,10 @@ class IndicesClient(NamespacedClient):
             "PUT", _make_path("_data_stream", name), params=params, headers=headers
         )
 
-    @query_params("expand_wildcards")
+    @query_params(
+        "expand_wildcards",
+        response_mimetypes=["application/json"],
+    )
     async def delete_data_stream(self, name, params=None, headers=None):
         """
         Deletes a data stream.
@@ -1388,7 +1523,11 @@ class IndicesClient(NamespacedClient):
             "DELETE", _make_path("_data_stream", name), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_index_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
@@ -1409,7 +1548,12 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("flat_settings", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def exists_index_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
@@ -1431,7 +1575,12 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path("_index_template", name), params=params, headers=headers
         )
 
-    @query_params("flat_settings", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_index_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
@@ -1450,7 +1599,13 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path("_index_template", name), params=params, headers=headers
         )
 
-    @query_params("cause", "create", "master_timeout")
+    @query_params(
+        "cause",
+        "create",
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_index_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
@@ -1477,7 +1632,13 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("cause", "create", "master_timeout")
+    @query_params(
+        "cause",
+        "create",
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def simulate_index_template(self, name, body=None, params=None, headers=None):
         """
         Simulate matching the given index name against the index templates in the
@@ -1507,7 +1668,10 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("expand_wildcards")
+    @query_params(
+        "expand_wildcards",
+        response_mimetypes=["application/json"],
+    )
     async def get_data_stream(self, name=None, params=None, headers=None):
         """
         Returns data streams.
@@ -1524,7 +1688,13 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path("_data_stream", name), params=params, headers=headers
         )
 
-    @query_params("cause", "create", "master_timeout")
+    @query_params(
+        "cause",
+        "create",
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def simulate_template(self, body=None, name=None, params=None, headers=None):
         """
         Simulate resolving the given template name or body
@@ -1549,7 +1719,10 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("expand_wildcards")
+    @query_params(
+        "expand_wildcards",
+        response_mimetypes=["application/json"],
+    )
     async def resolve_index(self, name, params=None, headers=None):
         """
         Returns information about any matching indices, aliases, and data streams
@@ -1580,6 +1753,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "master_timeout",
         "timeout",
+        response_mimetypes=["application/json"],
     )
     async def add_block(self, index, block, params=None, headers=None):
         """
@@ -1609,7 +1783,9 @@ class IndicesClient(NamespacedClient):
             "PUT", _make_path(index, "_block", block), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def data_streams_stats(self, name=None, params=None, headers=None):
         """
         Provides statistics on operations happening in a data stream.
@@ -1626,7 +1802,9 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def promote_data_stream(self, name, params=None, headers=None):
         """
         Promotes a data stream from a replicated data stream managed by CCR to a
@@ -1646,7 +1824,9 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def migrate_to_data_stream(self, name, params=None, headers=None):
         """
         Migrates an alias to a data stream
@@ -1671,6 +1851,7 @@ class IndicesClient(NamespacedClient):
         "flush",
         "ignore_unavailable",
         "run_expensive_tasks",
+        response_mimetypes=["application/json"],
     )
     async def disk_usage(self, index, params=None, headers=None):
         """
@@ -1706,7 +1887,11 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "fields", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "fields",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
     )
     async def field_usage_stats(self, index, params=None, headers=None):
         """

--- a/elasticsearch/_async/client/ingest.py
+++ b/elasticsearch/_async/client/ingest.py
@@ -19,7 +19,11 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IngestClient(NamespacedClient):
-    @query_params("master_timeout", "summary")
+    @query_params(
+        "master_timeout",
+        "summary",
+        response_mimetypes=["application/json"],
+    )
     async def get_pipeline(self, id=None, params=None, headers=None):
         """
         Returns a pipeline.
@@ -37,7 +41,12 @@ class IngestClient(NamespacedClient):
             "GET", _make_path("_ingest", "pipeline", id), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_pipeline(self, id, body, params=None, headers=None):
         """
         Creates or updates a pipeline.
@@ -62,7 +71,11 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes a pipeline.
@@ -84,7 +97,11 @@ class IngestClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("verbose")
+    @query_params(
+        "verbose",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def simulate(self, body, id=None, params=None, headers=None):
         """
         Allows to simulate a pipeline with example documents.
@@ -107,7 +124,9 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def processor_grok(self, params=None, headers=None):
         """
         Returns a list of the built-in patterns.
@@ -118,7 +137,9 @@ class IngestClient(NamespacedClient):
             "GET", "/_ingest/processor/grok", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def geo_ip_stats(self, params=None, headers=None):
         """
         Returns statistical information about geoip databases

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -19,7 +19,9 @@ from .utils import NamespacedClient, query_params
 
 
 class LicenseClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete(self, params=None, headers=None):
         """
         Deletes licensing information for the cluster
@@ -30,7 +32,11 @@ class LicenseClient(NamespacedClient):
             "DELETE", "/_license", params=params, headers=headers
         )
 
-    @query_params("accept_enterprise", "local")
+    @query_params(
+        "accept_enterprise",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     async def get(self, params=None, headers=None):
         """
         Retrieves licensing information for the cluster
@@ -46,7 +52,9 @@ class LicenseClient(NamespacedClient):
             "GET", "/_license", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_basic_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the basic license.
@@ -57,7 +65,9 @@ class LicenseClient(NamespacedClient):
             "GET", "/_license/basic_status", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_trial_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the trial license.
@@ -68,7 +78,11 @@ class LicenseClient(NamespacedClient):
             "GET", "/_license/trial_status", params=params, headers=headers
         )
 
-    @query_params("acknowledge")
+    @query_params(
+        "acknowledge",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def post(self, body=None, params=None, headers=None):
         """
         Updates the license for the cluster.
@@ -83,7 +97,10 @@ class LicenseClient(NamespacedClient):
             "PUT", "/_license", params=params, headers=headers, body=body
         )
 
-    @query_params("acknowledge")
+    @query_params(
+        "acknowledge",
+        response_mimetypes=["application/json"],
+    )
     async def post_start_basic(self, params=None, headers=None):
         """
         Starts an indefinite basic license.
@@ -97,7 +114,11 @@ class LicenseClient(NamespacedClient):
             "POST", "/_license/start_basic", params=params, headers=headers
         )
 
-    @query_params("acknowledge", "type")
+    @query_params(
+        "acknowledge",
+        "type",
+        response_mimetypes=["application/json"],
+    )
     async def post_start_trial(self, params=None, headers=None):
         """
         starts a limited time trial license.

--- a/elasticsearch/_async/client/logstash.py
+++ b/elasticsearch/_async/client/logstash.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class LogstashClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes Logstash Pipelines used by Central Management
@@ -38,7 +40,9 @@ class LogstashClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_pipeline(self, id, params=None, headers=None):
         """
         Retrieves Logstash Pipelines used by Central Management
@@ -57,7 +61,10 @@ class LogstashClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_pipeline(self, id, body, params=None, headers=None):
         """
         Adds and updates Logstash Pipelines used for Central Management

--- a/elasticsearch/_async/client/migration.py
+++ b/elasticsearch/_async/client/migration.py
@@ -19,7 +19,9 @@ from .utils import NamespacedClient, _make_path, query_params
 
 
 class MigrationClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def deprecations(self, index=None, params=None, headers=None):
         """
         Retrieves information about different cluster, node, and index level settings

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -19,7 +19,14 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _bulk_body, _make_path, query
 
 
 class MlClient(NamespacedClient):
-    @query_params("allow_no_jobs", "allow_no_match", "force", "timeout")
+    @query_params(
+        "allow_no_jobs",
+        "allow_no_match",
+        "force",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def close_job(self, job_id, body=None, params=None, headers=None):
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed
@@ -50,7 +57,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_calendar(self, calendar_id, params=None, headers=None):
         """
         Deletes a calendar.
@@ -71,7 +80,9 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_calendar_event(
         self, calendar_id, event_id, params=None, headers=None
     ):
@@ -94,7 +105,9 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Deletes anomaly detection jobs from a calendar.
@@ -115,7 +128,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("force")
+    @query_params(
+        "force",
+        response_mimetypes=["application/json"],
+    )
     async def delete_datafeed(self, datafeed_id, params=None, headers=None):
         """
         Deletes an existing datafeed.
@@ -137,7 +153,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("requests_per_second", "timeout")
+    @query_params(
+        "requests_per_second",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_expired_data(
         self, body=None, job_id=None, params=None, headers=None
     ):
@@ -162,7 +182,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_filter(self, filter_id, params=None, headers=None):
         """
         Deletes a filter.
@@ -181,7 +203,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_forecasts", "timeout")
+    @query_params(
+        "allow_no_forecasts",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_forecast(
         self, job_id, forecast_id=None, params=None, headers=None
     ):
@@ -208,7 +234,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("force", "wait_for_completion")
+    @query_params(
+        "force",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     async def delete_job(self, job_id, params=None, headers=None):
         """
         Deletes an existing anomaly detection job.
@@ -230,7 +260,9 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_model_snapshot(
         self, job_id, snapshot_id, params=None, headers=None
     ):
@@ -255,7 +287,15 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("advance_time", "calc_interim", "end", "skip_time", "start")
+    @query_params(
+        "advance_time",
+        "calc_interim",
+        "end",
+        "skip_time",
+        "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def flush_job(self, job_id, body=None, params=None, headers=None):
         """
         Forces any buffered data to be processed by the job.
@@ -286,7 +326,12 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("duration", "expires_in", "max_model_memory")
+    @query_params(
+        "duration",
+        "expires_in",
+        "max_model_memory",
+        response_mimetypes=["application/json"],
+    )
     async def forecast(self, job_id, params=None, headers=None):
         """
         Predicts the future behavior of a time series by using its historical behavior.
@@ -320,6 +365,8 @@ class MlClient(NamespacedClient):
         "size",
         "sort",
         "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def get_buckets(
         self, job_id, body=None, timestamp=None, params=None, headers=None
@@ -359,7 +406,14 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("end", "from_", "job_id", "size", "start")
+    @query_params(
+        "end",
+        "from_",
+        "job_id",
+        "size",
+        "start",
+        response_mimetypes=["application/json"],
+    )
     async def get_calendar_events(self, calendar_id, params=None, headers=None):
         """
         Retrieves information about the scheduled events in calendars.
@@ -389,7 +443,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("from_", "size")
+    @query_params(
+        "from_",
+        "size",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def get_calendars(
         self, body=None, calendar_id=None, params=None, headers=None
     ):
@@ -415,7 +474,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("from_", "partition_field_value", "size")
+    @query_params(
+        "from_",
+        "partition_field_value",
+        "size",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def get_categories(
         self, job_id, body=None, category_id=None, params=None, headers=None
     ):
@@ -450,7 +515,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match")
+    @query_params(
+        "allow_no_datafeeds",
+        "allow_no_match",
+        response_mimetypes=["application/json"],
+    )
     async def get_datafeed_stats(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves usage information for datafeeds.
@@ -472,7 +541,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match", "exclude_generated")
+    @query_params(
+        "allow_no_datafeeds",
+        "allow_no_match",
+        "exclude_generated",
+        response_mimetypes=["application/json"],
+    )
     async def get_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves configuration information for datafeeds.
@@ -496,7 +570,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("from_", "size")
+    @query_params(
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     async def get_filters(self, filter_id=None, params=None, headers=None):
         """
         Retrieves filters.
@@ -526,6 +604,8 @@ class MlClient(NamespacedClient):
         "size",
         "sort",
         "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def get_influencers(self, job_id, body=None, params=None, headers=None):
         """
@@ -560,7 +640,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_jobs", "allow_no_match")
+    @query_params(
+        "allow_no_jobs",
+        "allow_no_match",
+        response_mimetypes=["application/json"],
+    )
     async def get_job_stats(self, job_id=None, params=None, headers=None):
         """
         Retrieves usage information for anomaly detection jobs.
@@ -582,7 +666,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_jobs", "allow_no_match", "exclude_generated")
+    @query_params(
+        "allow_no_jobs",
+        "allow_no_match",
+        "exclude_generated",
+        response_mimetypes=["application/json"],
+    )
     async def get_jobs(self, job_id=None, params=None, headers=None):
         """
         Retrieves configuration information for anomaly detection jobs.
@@ -606,7 +695,16 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("desc", "end", "from_", "size", "sort", "start")
+    @query_params(
+        "desc",
+        "end",
+        "from_",
+        "size",
+        "sort",
+        "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def get_model_snapshots(
         self, job_id, body=None, snapshot_id=None, params=None, headers=None
     ):
@@ -652,6 +750,8 @@ class MlClient(NamespacedClient):
         "overall_score",
         "start",
         "top_n",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def get_overall_buckets(self, job_id, body=None, params=None, headers=None):
         """
@@ -705,6 +805,8 @@ class MlClient(NamespacedClient):
         "size",
         "sort",
         "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def get_records(self, job_id, body=None, params=None, headers=None):
         """
@@ -738,7 +840,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def info(self, params=None, headers=None):
         """
         Returns defaults and limits used by machine learning.
@@ -749,7 +853,9 @@ class MlClient(NamespacedClient):
             "GET", "/_ml/info", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def open_job(self, job_id, params=None, headers=None):
         """
         Opens one or more anomaly detection jobs.
@@ -768,7 +874,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def post_calendar_events(self, calendar_id, body, params=None, headers=None):
         """
         Posts scheduled events in a calendar.
@@ -790,7 +899,12 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("reset_end", "reset_start")
+    @query_params(
+        "reset_end",
+        "reset_start",
+        request_mimetypes=["application/x-ndjson", "application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def post_data(self, job_id, body, params=None, headers=None):
         """
         Sends data to an anomaly detection job for analysis.
@@ -817,7 +931,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def preview_datafeed(
         self, body=None, datafeed_id=None, params=None, headers=None
     ):
@@ -838,7 +954,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_calendar(self, calendar_id, body=None, params=None, headers=None):
         """
         Instantiates a calendar.
@@ -861,7 +980,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def put_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Adds an anomaly detection job to a calendar.
@@ -883,7 +1004,12 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_throttled", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_throttled",
+        "ignore_unavailable",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def put_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
@@ -915,7 +1041,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_filter(self, filter_id, body, params=None, headers=None):
         """
         Instantiates a filter.
@@ -938,7 +1067,12 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_throttled", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_throttled",
+        "ignore_unavailable",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def put_job(self, job_id, body, params=None, headers=None):
         """
@@ -972,7 +1106,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("delete_intervening_results")
+    @query_params(
+        "delete_intervening_results",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def revert_model_snapshot(
         self, job_id, snapshot_id, body=None, params=None, headers=None
     ):
@@ -1006,7 +1144,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("enabled", "timeout")
+    @query_params(
+        "enabled",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def set_upgrade_mode(self, params=None, headers=None):
         """
         Sets a cluster wide upgrade_mode setting that prepares machine learning indices
@@ -1023,7 +1165,13 @@ class MlClient(NamespacedClient):
             "POST", "/_ml/set_upgrade_mode", params=params, headers=headers
         )
 
-    @query_params("end", "start", "timeout")
+    @query_params(
+        "end",
+        "start",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def start_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Starts one or more datafeeds.
@@ -1051,7 +1199,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match", "force", "timeout")
+    @query_params(
+        "allow_no_datafeeds",
+        "allow_no_match",
+        "force",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def stop_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Stops one or more datafeeds.
@@ -1084,7 +1238,12 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_throttled", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_throttled",
+        "ignore_unavailable",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     async def update_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
@@ -1116,7 +1275,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def update_filter(self, filter_id, body, params=None, headers=None):
         """
         Updates the description of a filter, adds items, or removes items.
@@ -1138,7 +1300,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def update_job(self, job_id, body, params=None, headers=None):
         """
         Updates certain properties of an anomaly detection job.
@@ -1160,7 +1325,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def update_model_snapshot(
         self, job_id, snapshot_id, body, params=None, headers=None
     ):
@@ -1192,7 +1360,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def validate(self, body, params=None, headers=None):
         """
         Validates an anomaly detection job.
@@ -1212,7 +1383,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def validate_detector(self, body, params=None, headers=None):
         """
         Validates an anomaly detection detector.
@@ -1232,7 +1406,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("force", "timeout")
+    @query_params(
+        "force",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_data_frame_analytics(self, id, params=None, headers=None):
         """
         Deletes an existing data frame analytics job.
@@ -1254,7 +1432,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def evaluate_data_frame(self, body, params=None, headers=None):
         """
         Evaluates the data frame analytics for an annotated index.
@@ -1274,7 +1455,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_match", "exclude_generated", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "exclude_generated",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     async def get_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Retrieves configuration information for data frame analytics jobs.
@@ -1301,7 +1488,13 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size", "verbose")
+    @query_params(
+        "allow_no_match",
+        "from_",
+        "size",
+        "verbose",
+        response_mimetypes=["application/json"],
+    )
     async def get_data_frame_analytics_stats(self, id=None, params=None, headers=None):
         """
         Retrieves usage information for data frame analytics jobs.
@@ -1327,7 +1520,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Instantiates a data frame analytics job.
@@ -1349,7 +1545,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def start_data_frame_analytics(
         self, id, body=None, params=None, headers=None
     ):
@@ -1374,7 +1574,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_match", "force", "timeout")
+    @query_params(
+        "allow_no_match",
+        "force",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def stop_data_frame_analytics(self, id, body=None, params=None, headers=None):
         """
         Stops one or more data frame analytics jobs.
@@ -1402,7 +1608,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_trained_model(self, model_id, params=None, headers=None):
         """
         Deletes an existing trained inference model that is currently not referenced by
@@ -1422,7 +1630,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def explain_data_frame_analytics(
         self, body=None, id=None, params=None, headers=None
     ):
@@ -1451,6 +1662,7 @@ class MlClient(NamespacedClient):
         "include_model_definition",
         "size",
         "tags",
+        response_mimetypes=["application/json"],
     )
     async def get_trained_models(self, model_id=None, params=None, headers=None):
         """
@@ -1489,7 +1701,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     async def get_trained_models_stats(self, model_id=None, params=None, headers=None):
         """
         Retrieves usage information for trained inference models.
@@ -1514,7 +1731,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("defer_definition_decompression")
+    @query_params(
+        "defer_definition_decompression",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_trained_model(self, model_id, body, params=None, headers=None):
         """
         Creates an inference trained model.
@@ -1539,7 +1760,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def estimate_model_memory(self, body, params=None, headers=None):
         """
         Estimates the model memory
@@ -1560,7 +1784,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def update_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Updates certain properties of a data frame analytics job.
@@ -1582,7 +1809,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("timeout", "wait_for_completion")
+    @query_params(
+        "timeout",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     async def upgrade_job_snapshot(
         self, job_id, snapshot_id, params=None, headers=None
     ):
@@ -1616,7 +1847,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def delete_trained_model_alias(
         self, model_id, model_alias, params=None, headers=None
     ):
@@ -1640,7 +1874,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def preview_data_frame_analytics(
         self, body=None, id=None, params=None, headers=None
     ):
@@ -1660,7 +1897,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("reassign")
+    @query_params(
+        "reassign",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_trained_model_alias(
         self, model_id, model_alias, params=None, headers=None
     ):
@@ -1702,6 +1943,8 @@ class MlClient(NamespacedClient):
         "timeout",
         "timestamp_field",
         "timestamp_format",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     async def find_file_structure(self, body, params=None, headers=None):
         """
@@ -1760,7 +2003,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("wait_for_completion")
+    @query_params(
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     async def reset_job(self, job_id, params=None, headers=None):
         """
         Resets an existing anomaly detection job.

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -156,6 +156,7 @@ class MlClient(NamespacedClient):
     @query_params(
         "requests_per_second",
         "timeout",
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     async def delete_expired_data(
@@ -932,6 +933,7 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     async def preview_datafeed(
@@ -1204,6 +1206,7 @@ class MlClient(NamespacedClient):
         "allow_no_match",
         "force",
         "timeout",
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     async def stop_datafeed(self, datafeed_id, body=None, params=None, headers=None):

--- a/elasticsearch/_async/client/ml.pyi
+++ b/elasticsearch/_async/client/ml.pyi
@@ -126,7 +126,7 @@ class MlClient(NamespacedClient):
     async def delete_expired_data(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         job_id: Optional[Any] = ...,
         requests_per_second: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -626,7 +626,7 @@ class MlClient(NamespacedClient):
     async def preview_datafeed(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         datafeed_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -802,7 +802,7 @@ class MlClient(NamespacedClient):
         self,
         *,
         datafeed_id: Any,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         allow_no_datafeeds: Optional[bool] = ...,
         allow_no_match: Optional[bool] = ...,
         force: Optional[bool] = ...,

--- a/elasticsearch/_async/client/monitoring.py
+++ b/elasticsearch/_async/client/monitoring.py
@@ -19,7 +19,13 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _bulk_body, _make_path, query
 
 
 class MonitoringClient(NamespacedClient):
-    @query_params("interval", "system_api_version", "system_id")
+    @query_params(
+        "interval",
+        "system_api_version",
+        "system_id",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
+    )
     async def bulk(self, body, doc_type=None, params=None, headers=None):
         """
         Used by the monitoring features to send monitoring data.

--- a/elasticsearch/_async/client/nodes.py
+++ b/elasticsearch/_async/client/nodes.py
@@ -19,7 +19,11 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class NodesClient(NamespacedClient):
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def reload_secure_settings(
         self, body=None, node_id=None, params=None, headers=None
     ):
@@ -43,7 +47,11 @@ class NodesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("flat_settings", "timeout")
+    @query_params(
+        "flat_settings",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def info(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns information about nodes in the cluster.
@@ -75,6 +83,7 @@ class NodesClient(NamespacedClient):
         "level",
         "timeout",
         "types",
+        response_mimetypes=["application/json"],
     )
     async def stats(
         self, node_id=None, metric=None, index_metric=None, params=None, headers=None
@@ -124,7 +133,13 @@ class NodesClient(NamespacedClient):
         )
 
     @query_params(
-        "ignore_idle_threads", "interval", "snapshots", "threads", "timeout", "type"
+        "ignore_idle_threads",
+        "interval",
+        "snapshots",
+        "threads",
+        "timeout",
+        "type",
+        response_mimetypes=["text/plain"],
     )
     async def hot_threads(self, node_id=None, params=None, headers=None):
         """
@@ -155,7 +170,10 @@ class NodesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def usage(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns low-level information about REST actions usage on nodes.
@@ -177,7 +195,9 @@ class NodesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def clear_repositories_metering_archive(
         self, node_id, max_archive_version, params=None, headers=None
     ):
@@ -209,7 +229,9 @@ class NodesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_repositories_metering_info(self, node_id, params=None, headers=None):
         """
         Returns cluster repositories metering information.

--- a/elasticsearch/_async/client/rollup.py
+++ b/elasticsearch/_async/client/rollup.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class RollupClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_job(self, id, params=None, headers=None):
         """
         Deletes an existing rollup job.
@@ -40,7 +42,9 @@ class RollupClient(NamespacedClient):
             "DELETE", _make_path("_rollup", "job", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_jobs(self, id=None, params=None, headers=None):
         """
         Retrieves the configuration, stats, and status of rollup jobs.
@@ -59,7 +63,9 @@ class RollupClient(NamespacedClient):
             "GET", _make_path("_rollup", "job", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_rollup_caps(self, id=None, params=None, headers=None):
         """
         Returns the capabilities of any rollup jobs that have been configured for a
@@ -79,7 +85,9 @@ class RollupClient(NamespacedClient):
             "GET", _make_path("_rollup", "data", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_rollup_index_caps(self, index, params=None, headers=None):
         """
         Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
@@ -102,7 +110,10 @@ class RollupClient(NamespacedClient):
             "GET", _make_path(index, "_rollup", "data"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_job(self, id, body, params=None, headers=None):
         """
         Creates a rollup job.
@@ -129,7 +140,12 @@ class RollupClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("rest_total_hits_as_int", "typed_keys")
+    @query_params(
+        "rest_total_hits_as_int",
+        "typed_keys",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def rollup_search(
         self, index, body, doc_type=None, params=None, headers=None
     ):
@@ -164,7 +180,9 @@ class RollupClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def start_job(self, id, params=None, headers=None):
         """
         Starts an existing, stopped rollup job.
@@ -188,7 +206,11 @@ class RollupClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("timeout", "wait_for_completion")
+    @query_params(
+        "timeout",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     async def stop_job(self, id, params=None, headers=None):
         """
         Stops an existing, started rollup job.
@@ -217,7 +239,10 @@ class RollupClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def rollup(self, index, rollup_index, body, params=None, headers=None):
         """
         Rollup an index

--- a/elasticsearch/_async/client/searchable_snapshots.py
+++ b/elasticsearch/_async/client/searchable_snapshots.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SearchableSnapshotsClient(NamespacedClient):
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     async def clear_cache(self, index=None, params=None, headers=None):
         """
         Clear the cache of searchable snapshots.
@@ -48,7 +53,13 @@ class SearchableSnapshotsClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "storage", "wait_for_completion")
+    @query_params(
+        "master_timeout",
+        "storage",
+        "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def mount(self, repository, snapshot, body, params=None, headers=None):
         """
         Mount a snapshot as a searchable index.
@@ -84,7 +95,9 @@ class SearchableSnapshotsClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def repository_stats(self, repository, params=None, headers=None):
         """
         DEPRECATED: This API is replaced by the Repositories Metering API.
@@ -108,7 +121,10 @@ class SearchableSnapshotsClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("level")
+    @query_params(
+        "level",
+        response_mimetypes=["application/json"],
+    )
     async def stats(self, index=None, params=None, headers=None):
         """
         Retrieve shard-level statistics about searchable snapshots.
@@ -131,7 +147,9 @@ class SearchableSnapshotsClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def cache_stats(self, node_id=None, params=None, headers=None):
         """
         Retrieve node-level cache statistics about searchable snapshots.

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SecurityClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def authenticate(self, params=None, headers=None):
         """
         Enables authentication as a user and retrieve information about the
@@ -31,7 +33,11 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/_authenticate", params=params, headers=headers
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def change_password(self, body, username=None, params=None, headers=None):
         """
         Changes the passwords of users in the native realm and built-in users.
@@ -57,7 +63,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("usernames")
+    @query_params(
+        "usernames",
+        response_mimetypes=["application/json"],
+    )
     async def clear_cached_realms(self, realms, params=None, headers=None):
         """
         Evicts users from the user cache. Can completely clear the cache or evict
@@ -79,7 +88,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def clear_cached_roles(self, name, params=None, headers=None):
         """
         Evicts roles from the native role cache.
@@ -98,7 +109,11 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def create_api_key(self, body, params=None, headers=None):
         """
         Creates an API key for access without requiring basic authentication.
@@ -118,7 +133,10 @@ class SecurityClient(NamespacedClient):
             "PUT", "/_security/api_key", params=params, headers=headers, body=body
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def delete_privileges(self, application, name, params=None, headers=None):
         """
         Removes application privileges.
@@ -143,7 +161,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def delete_role(self, name, params=None, headers=None):
         """
         Removes roles in the native realm.
@@ -166,7 +187,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def delete_role_mapping(self, name, params=None, headers=None):
         """
         Removes role mappings.
@@ -189,7 +213,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def delete_user(self, username, params=None, headers=None):
         """
         Deletes users from the native realm.
@@ -212,7 +239,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def disable_user(self, username, params=None, headers=None):
         """
         Disables users in the native realm.
@@ -235,7 +265,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def enable_user(self, username, params=None, headers=None):
         """
         Enables users in the native realm.
@@ -258,7 +291,14 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("id", "name", "owner", "realm_name", "username")
+    @query_params(
+        "id",
+        "name",
+        "owner",
+        "realm_name",
+        "username",
+        response_mimetypes=["application/json"],
+    )
     async def get_api_key(self, params=None, headers=None):
         """
         Retrieves information for one or more API keys.
@@ -278,7 +318,9 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/api_key", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_privileges(
         self, application=None, name=None, params=None, headers=None
     ):
@@ -297,7 +339,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_role(self, name=None, params=None, headers=None):
         """
         Retrieves roles in the native realm.
@@ -310,7 +354,9 @@ class SecurityClient(NamespacedClient):
             "GET", _make_path("_security", "role", name), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_role_mapping(self, name=None, params=None, headers=None):
         """
         Retrieves role mappings.
@@ -326,7 +372,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def get_token(self, body, params=None, headers=None):
         """
         Creates a bearer token for access without requiring basic authentication.
@@ -342,7 +391,9 @@ class SecurityClient(NamespacedClient):
             "POST", "/_security/oauth2/token", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_user(self, username=None, params=None, headers=None):
         """
         Retrieves information about users in the native realm and built-in users.
@@ -358,7 +409,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_user_privileges(self, params=None, headers=None):
         """
         Retrieves security privileges for the logged in user.
@@ -369,7 +422,10 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/user/_privileges", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def has_privileges(self, body, user=None, params=None, headers=None):
         """
         Determines whether the specified user has a specified list of privileges.
@@ -390,7 +446,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def invalidate_api_key(self, body, params=None, headers=None):
         """
         Invalidates one or more API keys.
@@ -406,7 +465,10 @@ class SecurityClient(NamespacedClient):
             "DELETE", "/_security/api_key", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def invalidate_token(self, body, params=None, headers=None):
         """
         Invalidates one or more access tokens or refresh tokens.
@@ -426,7 +488,11 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_privileges(self, body, params=None, headers=None):
         """
         Adds or updates application privileges.
@@ -446,7 +512,11 @@ class SecurityClient(NamespacedClient):
             "PUT", "/_security/privilege/", params=params, headers=headers, body=body
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_role(self, name, body, params=None, headers=None):
         """
         Adds and updates roles in the native realm.
@@ -472,7 +542,11 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_role_mapping(self, name, body, params=None, headers=None):
         """
         Creates and updates role mappings.
@@ -498,7 +572,11 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_user(self, username, body, params=None, headers=None):
         """
         Adds and updates users in the native realm. These users are commonly referred
@@ -525,7 +603,9 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_builtin_privileges(self, params=None, headers=None):
         """
         Retrieves the list of cluster privileges and index privileges that are
@@ -537,7 +617,9 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/privilege/_builtin", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def clear_cached_privileges(self, application, params=None, headers=None):
         """
         Evicts application privileges from the native application privileges cache.
@@ -558,7 +640,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def clear_api_key_cache(self, ids, params=None, headers=None):
         """
         Clear a subset or all entries from the API key cache.
@@ -578,7 +662,11 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def grant_api_key(self, body, params=None, headers=None):
         """
         Creates an API key on behalf of another user.
@@ -602,7 +690,9 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def clear_cached_service_tokens(
         self, namespace, service, name, params=None, headers=None
     ):
@@ -640,7 +730,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def create_service_token(
         self, namespace, service, name=None, params=None, headers=None
     ):
@@ -676,7 +769,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     async def delete_service_token(
         self, namespace, service, name, params=None, headers=None
     ):
@@ -711,7 +807,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_service_accounts(
         self, namespace=None, service=None, params=None, headers=None
     ):
@@ -735,7 +833,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_service_credentials(
         self, namespace, service, params=None, headers=None
     ):
@@ -763,7 +863,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def saml_complete_logout(self, body, params=None, headers=None):
         """
         Verifies the logout response sent from the SAML IdP
@@ -783,7 +886,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def saml_authenticate(self, body, params=None, headers=None):
         """
         Exchanges a SAML Response message for an Elasticsearch access token and refresh
@@ -804,7 +910,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def saml_invalidate(self, body, params=None, headers=None):
         """
         Consumes a SAML LogoutRequest
@@ -824,7 +933,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def saml_logout(self, body, params=None, headers=None):
         """
         Invalidates an access token and a refresh token that were generated via the
@@ -841,7 +953,10 @@ class SecurityClient(NamespacedClient):
             "POST", "/_security/saml/logout", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def saml_prepare_authentication(self, body, params=None, headers=None):
         """
         Creates a SAML authentication request
@@ -858,7 +973,10 @@ class SecurityClient(NamespacedClient):
             "POST", "/_security/saml/prepare", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def saml_service_provider_metadata(
         self, realm_name, params=None, headers=None
     ):
@@ -880,7 +998,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def query_api_keys(self, body=None, params=None, headers=None):
         """
         Retrieves information for API keys using a subset of query DSL

--- a/elasticsearch/_async/client/shutdown.py
+++ b/elasticsearch/_async/client/shutdown.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class ShutdownClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def delete_node(self, node_id, params=None, headers=None):
         """
         Removes a node from the shutdown list
@@ -44,7 +47,10 @@ class ShutdownClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def get_node(self, node_id=None, params=None, headers=None):
         """
         Retrieve status of a node or nodes that are currently marked as shutting down
@@ -66,7 +72,10 @@ class ShutdownClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_node(self, node_id, body, params=None, headers=None):
         """
         Adds a node to be shut down

--- a/elasticsearch/_async/client/slm.py
+++ b/elasticsearch/_async/client/slm.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SlmClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_lifecycle(self, policy_id, params=None, headers=None):
         """
         Deletes an existing snapshot lifecycle policy.
@@ -39,7 +41,9 @@ class SlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def execute_lifecycle(self, policy_id, params=None, headers=None):
         """
         Immediately creates a snapshot according to the lifecycle policy, without
@@ -60,7 +64,9 @@ class SlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def execute_retention(self, params=None, headers=None):
         """
         Deletes any snapshots that are expired according to the policy's retention
@@ -72,7 +78,9 @@ class SlmClient(NamespacedClient):
             "POST", "/_slm/_execute_retention", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_lifecycle(self, policy_id=None, params=None, headers=None):
         """
         Retrieves one or more snapshot lifecycle policy definitions and information
@@ -90,7 +98,9 @@ class SlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_stats(self, params=None, headers=None):
         """
         Returns global and policy-level statistics about actions taken by snapshot
@@ -102,7 +112,10 @@ class SlmClient(NamespacedClient):
             "GET", "/_slm/stats", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_lifecycle(self, policy_id, body=None, params=None, headers=None):
         """
         Creates or updates a snapshot lifecycle policy.
@@ -123,7 +136,9 @@ class SlmClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_status(self, params=None, headers=None):
         """
         Retrieves the status of snapshot lifecycle management (SLM).
@@ -134,7 +149,9 @@ class SlmClient(NamespacedClient):
             "GET", "/_slm/status", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def start(self, params=None, headers=None):
         """
         Turns on snapshot lifecycle management (SLM).
@@ -145,7 +162,9 @@ class SlmClient(NamespacedClient):
             "POST", "/_slm/start", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def stop(self, params=None, headers=None):
         """
         Turns off snapshot lifecycle management (SLM).

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SnapshotClient(NamespacedClient):
-    @query_params("master_timeout", "wait_for_completion")
+    @query_params(
+        "master_timeout",
+        "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def create(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Creates a snapshot in a repository.
@@ -46,7 +51,10 @@ class SnapshotClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete(self, repository, snapshot, params=None, headers=None):
         """
         Deletes a snapshot.
@@ -75,6 +83,7 @@ class SnapshotClient(NamespacedClient):
         "index_details",
         "master_timeout",
         "verbose",
+        response_mimetypes=["application/json"],
     )
     async def get(self, repository, snapshot, params=None, headers=None):
         """
@@ -107,7 +116,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def delete_repository(self, repository, params=None, headers=None):
         """
         Deletes a repository.
@@ -130,7 +143,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_repository(self, repository=None, params=None, headers=None):
         """
         Returns information about a repository.
@@ -147,7 +164,13 @@ class SnapshotClient(NamespacedClient):
             "GET", _make_path("_snapshot", repository), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout", "verify")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        "verify",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def create_repository(self, repository, body, params=None, headers=None):
         """
         Creates a repository.
@@ -173,7 +196,12 @@ class SnapshotClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "wait_for_completion")
+    @query_params(
+        "master_timeout",
+        "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def restore(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Restores a snapshot.
@@ -200,7 +228,11 @@ class SnapshotClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("ignore_unavailable", "master_timeout")
+    @query_params(
+        "ignore_unavailable",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def status(self, repository=None, snapshot=None, params=None, headers=None):
         """
         Returns information about the status of a snapshot.
@@ -222,7 +254,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def verify_repository(self, repository, params=None, headers=None):
         """
         Verifies a repository.
@@ -244,7 +280,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def cleanup_repository(self, repository, params=None, headers=None):
         """
         Removes stale data from repository.
@@ -266,7 +306,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def clone(
         self, repository, snapshot, target_snapshot, body, params=None, headers=None
     ):
@@ -306,6 +350,7 @@ class SnapshotClient(NamespacedClient):
         "read_node_count",
         "seed",
         "timeout",
+        response_mimetypes=["application/json"],
     )
     async def repository_analyze(self, repository, params=None, headers=None):
         """

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SqlClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def clear_cursor(self, body, params=None, headers=None):
         """
         Clears the SQL cursor
@@ -36,7 +39,11 @@ class SqlClient(NamespacedClient):
             "POST", "/_sql/close", params=params, headers=headers, body=body
         )
 
-    @query_params("format")
+    @query_params(
+        "format",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def query(self, body, params=None, headers=None):
         """
         Executes a SQL request
@@ -55,7 +62,10 @@ class SqlClient(NamespacedClient):
             "POST", "/_sql", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def translate(self, body, params=None, headers=None):
         """
         Translates SQL into Elasticsearch queries
@@ -71,7 +81,9 @@ class SqlClient(NamespacedClient):
             "POST", "/_sql/translate", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_async(self, id, params=None, headers=None):
         """
         Deletes an async SQL search or a stored synchronous SQL search. If the search
@@ -91,7 +103,13 @@ class SqlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("delimiter", "format", "keep_alive", "wait_for_completion_timeout")
+    @query_params(
+        "delimiter",
+        "format",
+        "keep_alive",
+        "wait_for_completion_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def get_async(self, id, params=None, headers=None):
         """
         Returns the current status and available results for an async SQL search or
@@ -114,7 +132,9 @@ class SqlClient(NamespacedClient):
             "GET", _make_path("_sql", "async", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_async_status(self, id, params=None, headers=None):
         """
         Returns the current status of an async SQL search or a stored synchronous SQL

--- a/elasticsearch/_async/client/ssl.py
+++ b/elasticsearch/_async/client/ssl.py
@@ -19,7 +19,9 @@ from .utils import NamespacedClient, query_params
 
 
 class SslClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def certificates(self, params=None, headers=None):
         """
         Retrieves information about the X.509 certificates used to encrypt

--- a/elasticsearch/_async/client/tasks.py
+++ b/elasticsearch/_async/client/tasks.py
@@ -29,6 +29,7 @@ class TasksClient(NamespacedClient):
         "parent_task_id",
         "timeout",
         "wait_for_completion",
+        response_mimetypes=["application/json"],
     )
     async def list(self, params=None, headers=None):
         """
@@ -59,7 +60,13 @@ class TasksClient(NamespacedClient):
             "GET", "/_tasks", params=params, headers=headers
         )
 
-    @query_params("actions", "nodes", "parent_task_id", "wait_for_completion")
+    @query_params(
+        "actions",
+        "nodes",
+        "parent_task_id",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     async def cancel(self, task_id=None, params=None, headers=None):
         """
         Cancels a task, if it can be cancelled through an API.
@@ -91,7 +98,11 @@ class TasksClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("timeout", "wait_for_completion")
+    @query_params(
+        "timeout",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     async def get(self, task_id=None, params=None, headers=None):
         """
         Returns information about a task.

--- a/elasticsearch/_async/client/text_structure.py
+++ b/elasticsearch/_async/client/text_structure.py
@@ -34,6 +34,8 @@ class TextStructureClient(NamespacedClient):
         "timeout",
         "timestamp_field",
         "timestamp_format",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     async def find_structure(self, body, params=None, headers=None):
         """

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class TransformClient(NamespacedClient):
-    @query_params("force")
+    @query_params(
+        "force",
+        response_mimetypes=["application/json"],
+    )
     async def delete_transform(self, transform_id, params=None, headers=None):
         """
         Deletes an existing transform.
@@ -43,7 +46,13 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "exclude_generated", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "exclude_generated",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     async def get_transform(self, transform_id=None, params=None, headers=None):
         """
         Retrieves configuration information for transforms.
@@ -72,7 +81,12 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     async def get_transform_stats(self, transform_id, params=None, headers=None):
         """
         Retrieves usage information for transforms.
@@ -103,7 +117,10 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def preview_transform(
         self, body=None, transform_id=None, params=None, headers=None
     ):
@@ -123,7 +140,11 @@ class TransformClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("defer_validation")
+    @query_params(
+        "defer_validation",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_transform(self, transform_id, body, params=None, headers=None):
         """
         Instantiates a transform.
@@ -147,7 +168,10 @@ class TransformClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     async def start_transform(self, transform_id, params=None, headers=None):
         """
         Starts one or more transforms.
@@ -176,6 +200,7 @@ class TransformClient(NamespacedClient):
         "timeout",
         "wait_for_checkpoint",
         "wait_for_completion",
+        response_mimetypes=["application/json"],
     )
     async def stop_transform(self, transform_id, params=None, headers=None):
         """
@@ -208,7 +233,11 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("defer_validation")
+    @query_params(
+        "defer_validation",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def update_transform(self, transform_id, body, params=None, headers=None):
         """
         Updates certain properties of a transform.

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class WatcherClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def ack_watch(self, watch_id, action_id=None, params=None, headers=None):
         """
         Acknowledges a watch, manually throttling the execution of the watch's actions.
@@ -40,7 +42,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def activate_watch(self, watch_id, params=None, headers=None):
         """
         Activates a currently inactive watch.
@@ -59,7 +63,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def deactivate_watch(self, watch_id, params=None, headers=None):
         """
         Deactivates a currently active watch.
@@ -78,7 +84,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def delete_watch(self, id, params=None, headers=None):
         """
         Removes a watch from Watcher.
@@ -97,7 +105,11 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("debug")
+    @query_params(
+        "debug",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def execute_watch(self, body=None, id=None, params=None, headers=None):
         """
         Forces the execution of a stored watch.
@@ -117,7 +129,9 @@ class WatcherClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def get_watch(self, id, params=None, headers=None):
         """
         Retrieves a watch by its ID.
@@ -133,7 +147,14 @@ class WatcherClient(NamespacedClient):
             "GET", _make_path("_watcher", "watch", id), params=params, headers=headers
         )
 
-    @query_params("active", "if_primary_term", "if_seq_no", "version")
+    @query_params(
+        "active",
+        "if_primary_term",
+        "if_seq_no",
+        "version",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def put_watch(self, id, body=None, params=None, headers=None):
         """
         Creates a new watch, or updates an existing one.
@@ -160,7 +181,9 @@ class WatcherClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def start(self, params=None, headers=None):
         """
         Starts Watcher if it is not already running.
@@ -171,7 +194,10 @@ class WatcherClient(NamespacedClient):
             "POST", "/_watcher/_start", params=params, headers=headers
         )
 
-    @query_params("emit_stacktraces")
+    @query_params(
+        "emit_stacktraces",
+        response_mimetypes=["application/json"],
+    )
     async def stats(self, metric=None, params=None, headers=None):
         """
         Retrieves the current Watcher metrics.
@@ -191,7 +217,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     async def stop(self, params=None, headers=None):
         """
         Stops Watcher if it is running.
@@ -202,7 +230,10 @@ class WatcherClient(NamespacedClient):
             "POST", "/_watcher/_stop", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     async def query_watches(self, body=None, params=None, headers=None):
         """
         Retrieves stored watches.

--- a/elasticsearch/_async/client/xpack.py
+++ b/elasticsearch/_async/client/xpack.py
@@ -23,7 +23,11 @@ class XPackClient(NamespacedClient):
         return getattr(self.client, attr_name)
 
     # AUTO-GENERATED-API-DEFINITIONS #
-    @query_params("accept_enterprise", "categories")
+    @query_params(
+        "accept_enterprise",
+        "categories",
+        response_mimetypes=["application/json"],
+    )
     async def info(self, params=None, headers=None):
         """
         Retrieves information about the installed X-Pack features.
@@ -39,7 +43,10 @@ class XPackClient(NamespacedClient):
             "GET", "/_xpack", params=params, headers=headers
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     async def usage(self, params=None, headers=None):
         """
         Retrieves usage information about the installed X-Pack features.

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -267,7 +267,9 @@ class Elasticsearch(object):
         self.transport.close()
 
     # AUTO-GENERATED-API-DEFINITIONS #
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def ping(self, params=None, headers=None):
         """
         Returns whether the cluster is running.
@@ -281,7 +283,9 @@ class Elasticsearch(object):
         except TransportError:
             return False
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def info(self, params=None, headers=None):
         """
         Returns basic information about the cluster.
@@ -300,6 +304,8 @@ class Elasticsearch(object):
         "version",
         "version_type",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_name="document",
     )
     def create(self, index, id, body, doc_type=None, params=None, headers=None):
@@ -355,6 +361,8 @@ class Elasticsearch(object):
         "version",
         "version_type",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_name="document",
     )
     def index(self, index, body, doc_type=None, id=None, params=None, headers=None):
@@ -420,6 +428,8 @@ class Elasticsearch(object):
         "routing",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     def bulk(self, body, index=None, doc_type=None, params=None, headers=None):
         """
@@ -467,7 +477,11 @@ class Elasticsearch(object):
             body=body,
         )
 
-    @query_params(body_params=["scroll_id"])
+    @query_params(
+        request_mimetypes=["application/json", "text/plain"],
+        response_mimetypes=["application/json"],
+        body_params=["scroll_id"],
+    )
     def clear_scroll(self, body=None, scroll_id=None, params=None, headers=None):
         """
         Explicitly clears the search context for a scroll.
@@ -504,6 +518,8 @@ class Elasticsearch(object):
         "q",
         "routing",
         "terminate_after",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def count(self, body=None, index=None, doc_type=None, params=None, headers=None):
         """
@@ -562,6 +578,7 @@ class Elasticsearch(object):
         "version",
         "version_type",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     def delete(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -638,6 +655,8 @@ class Elasticsearch(object):
         "version",
         "wait_for_active_shards",
         "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def delete_by_query(self, index, body, doc_type=None, params=None, headers=None):
         """
@@ -733,7 +752,10 @@ class Elasticsearch(object):
             body=body,
         )
 
-    @query_params("requests_per_second")
+    @query_params(
+        "requests_per_second",
+        response_mimetypes=["application/json"],
+    )
     def delete_by_query_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Delete By Query
@@ -755,7 +777,11 @@ class Elasticsearch(object):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_script(self, id, params=None, headers=None):
         """
         Deletes a script.
@@ -784,6 +810,7 @@ class Elasticsearch(object):
         "stored_fields",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     def exists(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -835,6 +862,7 @@ class Elasticsearch(object):
         "routing",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     def exists_source(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -889,6 +917,8 @@ class Elasticsearch(object):
         "q",
         "routing",
         "stored_fields",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def explain(self, index, id, body=None, doc_type=None, params=None, headers=None):
         """
@@ -941,6 +971,7 @@ class Elasticsearch(object):
         "fields",
         "ignore_unavailable",
         "include_unmapped",
+        response_mimetypes=["application/json"],
     )
     def field_caps(self, body=None, index=None, params=None, headers=None):
         """
@@ -983,6 +1014,7 @@ class Elasticsearch(object):
         "stored_fields",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     def get(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -1027,7 +1059,10 @@ class Elasticsearch(object):
             "GET", _make_path(index, doc_type, id), params=params, headers=headers
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_script(self, id, params=None, headers=None):
         """
         Returns a script.
@@ -1054,6 +1089,7 @@ class Elasticsearch(object):
         "routing",
         "version",
         "version_type",
+        response_mimetypes=["application/json"],
     )
     def get_source(self, index, id, doc_type=None, params=None, headers=None):
         """
@@ -1104,6 +1140,8 @@ class Elasticsearch(object):
         "refresh",
         "routing",
         "stored_fields",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def mget(self, body, index=None, doc_type=None, params=None, headers=None):
         """
@@ -1151,6 +1189,8 @@ class Elasticsearch(object):
         "rest_total_hits_as_int",
         "search_type",
         "typed_keys",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     def msearch(self, body, index=None, doc_type=None, params=None, headers=None):
         """
@@ -1205,6 +1245,8 @@ class Elasticsearch(object):
         "rest_total_hits_as_int",
         "search_type",
         "typed_keys",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     def msearch_template(
         self, body, index=None, doc_type=None, params=None, headers=None
@@ -1257,6 +1299,8 @@ class Elasticsearch(object):
         "term_statistics",
         "version",
         "version_type",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def mtermvectors(
         self, body=None, index=None, doc_type=None, params=None, headers=None
@@ -1312,7 +1356,12 @@ class Elasticsearch(object):
             "POST", path, params=params, headers=headers, body=body
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_script(self, id, body, context=None, params=None, headers=None):
         """
         Creates or updates a script.
@@ -1338,7 +1387,12 @@ class Elasticsearch(object):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "search_type"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "search_type",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def rank_eval(self, body, index=None, params=None, headers=None):
         """
@@ -1387,6 +1441,8 @@ class Elasticsearch(object):
         "timeout",
         "wait_for_active_shards",
         "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def reindex(self, body, params=None, headers=None):
         """
@@ -1425,7 +1481,10 @@ class Elasticsearch(object):
             "POST", "/_reindex", params=params, headers=headers, body=body
         )
 
-    @query_params("requests_per_second")
+    @query_params(
+        "requests_per_second",
+        response_mimetypes=["application/json"],
+    )
     def reindex_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Reindex operation.
@@ -1446,7 +1505,10 @@ class Elasticsearch(object):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def render_search_template(self, body=None, id=None, params=None, headers=None):
         """
         Allows to use the Mustache language to pre-render a search definition.
@@ -1464,7 +1526,10 @@ class Elasticsearch(object):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def scripts_painless_execute(self, body=None, params=None, headers=None):
         """
         Allows an arbitrary script to be executed and a result to be returned
@@ -1490,6 +1555,8 @@ class Elasticsearch(object):
         "rest_total_hits_as_int",
         "scroll",
         "scroll_id",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=["scroll", "scroll_id"],
     )
     def scroll(self, body=None, scroll_id=None, params=None, headers=None):
@@ -1561,6 +1628,8 @@ class Elasticsearch(object):
         "track_total_hits",
         "typed_keys",
         "version",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=[
             "_source",
             "aggregations",
@@ -1777,6 +1846,7 @@ class Elasticsearch(object):
         "local",
         "preference",
         "routing",
+        response_mimetypes=["application/json"],
     )
     def search_shards(self, index=None, params=None, headers=None):
         """
@@ -1819,6 +1889,8 @@ class Elasticsearch(object):
         "scroll",
         "search_type",
         "typed_keys",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def search_template(
         self, body, index=None, doc_type=None, params=None, headers=None
@@ -1884,6 +1956,8 @@ class Elasticsearch(object):
         "term_statistics",
         "version",
         "version_type",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def termvectors(
         self, index, body=None, doc_type=None, id=None, params=None, headers=None
@@ -1946,6 +2020,8 @@ class Elasticsearch(object):
         "routing",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=[
             "_source",
             "detect_noop",
@@ -2066,6 +2142,8 @@ class Elasticsearch(object):
         "version_type",
         "wait_for_active_shards",
         "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def update_by_query(
         self, index, body=None, doc_type=None, params=None, headers=None
@@ -2167,7 +2245,10 @@ class Elasticsearch(object):
             body=body,
         )
 
-    @query_params("requests_per_second")
+    @query_params(
+        "requests_per_second",
+        response_mimetypes=["application/json"],
+    )
     def update_by_query_rethrottle(self, task_id, params=None, headers=None):
         """
         Changes the number of requests per second for a particular Update By Query
@@ -2189,7 +2270,9 @@ class Elasticsearch(object):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_script_context(self, params=None, headers=None):
         """
         Returns all script contexts.
@@ -2205,7 +2288,9 @@ class Elasticsearch(object):
             "GET", "/_script_context", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_script_languages(self, params=None, headers=None):
         """
         Returns available script types, languages and contexts
@@ -2221,7 +2306,9 @@ class Elasticsearch(object):
             "GET", "/_script_language", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def close_point_in_time(self, body=None, params=None, headers=None):
         """
         Close a point in time
@@ -2235,9 +2322,14 @@ class Elasticsearch(object):
         )
 
     @query_params(
-        "expand_wildcards", "ignore_unavailable", "keep_alive", "preference", "routing"
+        "expand_wildcards",
+        "ignore_unavailable",
+        "keep_alive",
+        "preference",
+        "routing",
+        response_mimetypes=["application/json"],
     )
-    def open_point_in_time(self, index=None, params=None, headers=None):
+    def open_point_in_time(self, index, params=None, headers=None):
         """
         Open a point in time that can be used in subsequent searches
 
@@ -2256,11 +2348,17 @@ class Elasticsearch(object):
             be performed on (default: random)
         :arg routing: Specific routing value
         """
+        if index in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for a required argument 'index'.")
+
         return self.transport.perform_request(
             "POST", _make_path(index, "_pit"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def terms_enum(self, index, body=None, params=None, headers=None):
         """
         The terms enum API  can be used to discover terms in the index that begin with
@@ -2296,6 +2394,8 @@ class Elasticsearch(object):
         "grid_precision",
         "grid_type",
         "size",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/vnd.mapbox-vector-tile"],
         body_params=[
             "aggs",
             "exact_bounds",

--- a/elasticsearch/client/__init__.py
+++ b/elasticsearch/client/__init__.py
@@ -971,6 +971,7 @@ class Elasticsearch(object):
         "fields",
         "ignore_unavailable",
         "include_unmapped",
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     def field_caps(self, body=None, index=None, params=None, headers=None):
@@ -2307,6 +2308,7 @@ class Elasticsearch(object):
         )
 
     @query_params(
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     def close_point_in_time(self, body=None, params=None, headers=None):

--- a/elasticsearch/client/__init__.pyi
+++ b/elasticsearch/client/__init__.pyi
@@ -1189,7 +1189,7 @@ class Elasticsearch(object):
     def open_point_in_time(
         self,
         *,
-        index: Optional[Any] = ...,
+        index: Any,
         expand_wildcards: Optional[Any] = ...,
         ignore_unavailable: Optional[bool] = ...,
         keep_alive: Optional[Any] = ...,

--- a/elasticsearch/client/__init__.pyi
+++ b/elasticsearch/client/__init__.pyi
@@ -504,7 +504,7 @@ class Elasticsearch(object):
     def field_caps(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         index: Optional[Any] = ...,
         allow_no_indices: Optional[bool] = ...,
         expand_wildcards: Optional[Any] = ...,
@@ -1172,7 +1172,7 @@ class Elasticsearch(object):
     def close_point_in_time(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
         error_trace: Optional[bool] = ...,

--- a/elasticsearch/client/async_search.py
+++ b/elasticsearch/client/async_search.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class AsyncSearchClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete(self, id, params=None, headers=None):
         """
         Deletes an async search by ID. If the search is still running, the search
@@ -36,7 +38,12 @@ class AsyncSearchClient(NamespacedClient):
             "DELETE", _make_path("_async_search", id), params=params, headers=headers
         )
 
-    @query_params("keep_alive", "typed_keys", "wait_for_completion_timeout")
+    @query_params(
+        "keep_alive",
+        "typed_keys",
+        "wait_for_completion_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get(self, id, params=None, headers=None):
         """
         Retrieves the results of a previously submitted async search request given its
@@ -101,6 +108,8 @@ class AsyncSearchClient(NamespacedClient):
         "typed_keys",
         "version",
         "wait_for_completion_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def submit(self, body=None, index=None, params=None, headers=None):
         """
@@ -205,7 +214,9 @@ class AsyncSearchClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def status(self, id, params=None, headers=None):
         """
         Retrieves the status of a previously submitted async search request given its

--- a/elasticsearch/client/autoscaling.py
+++ b/elasticsearch/client/autoscaling.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class AutoscalingClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_autoscaling_policy(self, name, params=None, headers=None):
         """
         Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
@@ -39,7 +41,9 @@ class AutoscalingClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_autoscaling_policy(self, name, params=None, headers=None):
         """
         Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
@@ -59,7 +63,10 @@ class AutoscalingClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_autoscaling_policy(self, name, body, params=None, headers=None):
         """
         Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
@@ -82,7 +89,9 @@ class AutoscalingClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_autoscaling_capacity(self, params=None, headers=None):
         """
         Gets the current autoscaling capacity based on the configured autoscaling

--- a/elasticsearch/client/cat.py
+++ b/elasticsearch/client/cat.py
@@ -19,7 +19,16 @@ from .utils import NamespacedClient, _make_path, query_params
 
 
 class CatClient(NamespacedClient):
-    @query_params("expand_wildcards", "format", "h", "help", "local", "s", "v")
+    @query_params(
+        "expand_wildcards",
+        "format",
+        "h",
+        "help",
+        "local",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def aliases(self, name=None, params=None, headers=None):
         """
         Shows information about currently configured aliases to indices including
@@ -45,7 +54,17 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "aliases", name), params=params, headers=headers
         )
 
-    @query_params("bytes", "format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def allocation(self, node_id=None, params=None, headers=None):
         """
         Provides a snapshot of how many shards are allocated to each data node and how
@@ -76,7 +95,14 @@ class CatClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("format", "h", "help", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def count(self, index=None, params=None, headers=None):
         """
         Provides quick access to the document count of the entire cluster, or
@@ -98,7 +124,16 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "count", index), params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "s", "time", "ts", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "ts",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def health(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster health.
@@ -120,7 +155,11 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/health", params=params, headers=headers
         )
 
-    @query_params("help", "s")
+    @query_params(
+        "help",
+        "s",
+        response_mimetypes=["text/plain"],
+    )
     def help(self, params=None, headers=None):
         """
         Returns help for the Cat APIs.
@@ -149,6 +188,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def indices(self, index=None, params=None, headers=None):
         """
@@ -189,7 +229,16 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "indices", index), params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def master(self, params=None, headers=None):
         """
         Returns information about the master node.
@@ -224,6 +273,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def nodes(self, params=None, headers=None):
         """
@@ -257,7 +307,16 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "active_only", "bytes", "detailed", "format", "h", "help", "s", "time", "v"
+        "active_only",
+        "bytes",
+        "detailed",
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def recovery(self, index=None, params=None, headers=None):
         """
@@ -288,7 +347,16 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "bytes", "format", "h", "help", "local", "master_timeout", "s", "time", "v"
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def shards(self, index=None, params=None, headers=None):
         """
@@ -318,7 +386,15 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "shards", index), params=params, headers=headers
         )
 
-    @query_params("bytes", "format", "h", "help", "s", "v")
+    @query_params(
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def segments(self, index=None, params=None, headers=None):
         """
         Provides low-level information about the segments in the shards of an index.
@@ -341,7 +417,17 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "segments", index), params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "time", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def pending_tasks(self, params=None, headers=None):
         """
         Returns a concise representation of the cluster pending tasks.
@@ -366,7 +452,17 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/pending_tasks", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "size", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "size",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def thread_pool(self, thread_pool_patterns=None, params=None, headers=None):
         """
         Returns cluster-wide thread pool statistics per node. By default the active,
@@ -397,7 +493,15 @@ class CatClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("bytes", "format", "h", "help", "s", "v")
+    @query_params(
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def fielddata(self, fields=None, params=None, headers=None):
         """
         Shows how much heap memory is currently being used by fielddata on every data
@@ -425,7 +529,15 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "format", "h", "help", "include_bootstrap", "local", "master_timeout", "s", "v"
+        "format",
+        "h",
+        "help",
+        "include_bootstrap",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def plugins(self, params=None, headers=None):
         """
@@ -451,7 +563,16 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/plugins", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def nodeattrs(self, params=None, headers=None):
         """
         Returns information about custom node attributes.
@@ -474,7 +595,16 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/nodeattrs", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def repositories(self, params=None, headers=None):
         """
         Returns information about snapshot repositories registered in the cluster.
@@ -498,7 +628,15 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "format", "h", "help", "ignore_unavailable", "master_timeout", "s", "time", "v"
+        "format",
+        "h",
+        "help",
+        "ignore_unavailable",
+        "master_timeout",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def snapshots(self, repository=None, params=None, headers=None):
         """
@@ -540,6 +678,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def tasks(self, params=None, headers=None):
         """
@@ -570,7 +709,16 @@ class CatClient(NamespacedClient):
             "GET", "/_cat/tasks", params=params, headers=headers
         )
 
-    @query_params("format", "h", "help", "local", "master_timeout", "s", "v")
+    @query_params(
+        "format",
+        "h",
+        "help",
+        "local",
+        "master_timeout",
+        "s",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def templates(self, name=None, params=None, headers=None):
         """
         Returns information about existing templates.
@@ -594,7 +742,17 @@ class CatClient(NamespacedClient):
             "GET", _make_path("_cat", "templates", name), params=params, headers=headers
         )
 
-    @query_params("allow_no_match", "bytes", "format", "h", "help", "s", "time", "v")
+    @query_params(
+        "allow_no_match",
+        "bytes",
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
+    )
     def ml_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Gets configuration and usage information about data frame analytics jobs.
@@ -625,7 +783,15 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_datafeeds", "allow_no_match", "format", "h", "help", "s", "time", "v"
+        "allow_no_datafeeds",
+        "allow_no_match",
+        "format",
+        "h",
+        "help",
+        "s",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def ml_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
@@ -667,6 +833,7 @@ class CatClient(NamespacedClient):
         "s",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def ml_jobs(self, job_id=None, params=None, headers=None):
         """
@@ -711,6 +878,7 @@ class CatClient(NamespacedClient):
         "size",
         "time",
         "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def ml_trained_models(self, model_id=None, params=None, headers=None):
         """
@@ -748,7 +916,16 @@ class CatClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_match", "format", "from_", "h", "help", "s", "size", "time", "v"
+        "allow_no_match",
+        "format",
+        "from_",
+        "h",
+        "help",
+        "s",
+        "size",
+        "time",
+        "v",
+        response_mimetypes=["text/plain", "application/json"],
     )
     def transforms(self, transform_id=None, params=None, headers=None):
         """

--- a/elasticsearch/client/ccr.py
+++ b/elasticsearch/client/ccr.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class CcrClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Deletes auto-follow patterns.
@@ -38,7 +40,11 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("wait_for_active_shards")
+    @query_params(
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def follow(self, index, body, params=None, headers=None):
         """
         Creates a new follower index configured to follow the referenced leader index.
@@ -66,7 +72,9 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def follow_info(self, index, params=None, headers=None):
         """
         Retrieves information about all follower indices, including parameters and
@@ -84,7 +92,9 @@ class CcrClient(NamespacedClient):
             "GET", _make_path(index, "_ccr", "info"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def follow_stats(self, index, params=None, headers=None):
         """
         Retrieves follower stats. return shard-level stats about the following tasks
@@ -102,7 +112,10 @@ class CcrClient(NamespacedClient):
             "GET", _make_path(index, "_ccr", "stats"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def forget_follower(self, index, body, params=None, headers=None):
         """
         Removes the follower retention leases from the leader.
@@ -128,7 +141,9 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_auto_follow_pattern(self, name=None, params=None, headers=None):
         """
         Gets configured auto-follow patterns. Returns the specified auto-follow pattern
@@ -145,7 +160,9 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def pause_follow(self, index, params=None, headers=None):
         """
         Pauses a follower index. The follower index will not fetch any additional
@@ -166,7 +183,10 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_auto_follow_pattern(self, name, body, params=None, headers=None):
         """
         Creates a new named collection of auto-follow patterns against a specified
@@ -190,7 +210,10 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def resume_follow(self, index, body=None, params=None, headers=None):
         """
         Resumes a follower index that has been paused
@@ -212,7 +235,9 @@ class CcrClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def stats(self, params=None, headers=None):
         """
         Gets all stats related to cross-cluster replication.
@@ -223,7 +248,9 @@ class CcrClient(NamespacedClient):
             "GET", "/_ccr/stats", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def unfollow(self, index, params=None, headers=None):
         """
         Stops the following task associated with a follower index and removes index
@@ -244,7 +271,9 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def pause_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Pauses an auto-follow pattern
@@ -264,7 +293,9 @@ class CcrClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def resume_auto_follow_pattern(self, name, params=None, headers=None):
         """
         Resumes an auto-follow pattern that has been paused

--- a/elasticsearch/client/cluster.py
+++ b/elasticsearch/client/cluster.py
@@ -31,6 +31,7 @@ class ClusterClient(NamespacedClient):
         "wait_for_no_relocating_shards",
         "wait_for_nodes",
         "wait_for_status",
+        response_mimetypes=["application/json"],
     )
     def health(self, index=None, params=None, headers=None):
         """
@@ -70,7 +71,11 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def pending_tasks(self, params=None, headers=None):
         """
         Returns a list of any cluster-level changes (e.g. create index, update mapping,
@@ -95,6 +100,7 @@ class ClusterClient(NamespacedClient):
         "master_timeout",
         "wait_for_metadata_version",
         "wait_for_timeout",
+        response_mimetypes=["application/json"],
     )
     def state(self, metric=None, index=None, params=None, headers=None):
         """
@@ -135,7 +141,11 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("flat_settings", "timeout")
+    @query_params(
+        "flat_settings",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def stats(self, node_id=None, params=None, headers=None):
         """
         Returns high-level overview of cluster statistics.
@@ -160,7 +170,14 @@ class ClusterClient(NamespacedClient):
         )
 
     @query_params(
-        "dry_run", "explain", "master_timeout", "metric", "retry_failed", "timeout"
+        "dry_run",
+        "explain",
+        "master_timeout",
+        "metric",
+        "retry_failed",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def reroute(self, body=None, params=None, headers=None):
         """
@@ -187,7 +204,13 @@ class ClusterClient(NamespacedClient):
             "POST", "/_cluster/reroute", params=params, headers=headers, body=body
         )
 
-    @query_params("flat_settings", "include_defaults", "master_timeout", "timeout")
+    @query_params(
+        "flat_settings",
+        "include_defaults",
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_settings(self, params=None, headers=None):
         """
         Returns cluster settings.
@@ -206,7 +229,13 @@ class ClusterClient(NamespacedClient):
             "GET", "/_cluster/settings", params=params, headers=headers
         )
 
-    @query_params("flat_settings", "master_timeout", "timeout")
+    @query_params(
+        "flat_settings",
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_settings(self, body, params=None, headers=None):
         """
         Updates the cluster settings.
@@ -228,7 +257,9 @@ class ClusterClient(NamespacedClient):
             "PUT", "/_cluster/settings", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def remote_info(self, params=None, headers=None):
         """
         Returns the information about configured remote clusters.
@@ -239,7 +270,12 @@ class ClusterClient(NamespacedClient):
             "GET", "/_remote/info", params=params, headers=headers
         )
 
-    @query_params("include_disk_info", "include_yes_decisions")
+    @query_params(
+        "include_disk_info",
+        "include_yes_decisions",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def allocation_explain(self, body=None, params=None, headers=None):
         """
         Provides explanations for shard allocations in the cluster.
@@ -261,7 +297,11 @@ class ClusterClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_component_template(self, name, params=None, headers=None):
         """
         Deletes a component template
@@ -282,7 +322,11 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_component_template(self, name=None, params=None, headers=None):
         """
         Returns one or more component templates
@@ -302,7 +346,13 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("create", "master_timeout", "timeout")
+    @query_params(
+        "create",
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_component_template(self, name, body, params=None, headers=None):
         """
         Creates or updates a component template
@@ -328,7 +378,11 @@ class ClusterClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def exists_component_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular component template exist
@@ -351,7 +405,10 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("wait_for_removal")
+    @query_params(
+        "wait_for_removal",
+        response_mimetypes=["application/json"],
+    )
     def delete_voting_config_exclusions(self, params=None, headers=None):
         """
         Clears cluster voting config exclusions.
@@ -369,7 +426,12 @@ class ClusterClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("node_ids", "node_names", "timeout")
+    @query_params(
+        "node_ids",
+        "node_names",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def post_voting_config_exclusions(self, params=None, headers=None):
         """
         Updates the cluster voting config exclusions by node ids or node names.

--- a/elasticsearch/client/dangling_indices.py
+++ b/elasticsearch/client/dangling_indices.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class DanglingIndicesClient(NamespacedClient):
-    @query_params("accept_data_loss", "master_timeout", "timeout")
+    @query_params(
+        "accept_data_loss",
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Deletes the specified dangling index
@@ -42,7 +47,12 @@ class DanglingIndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("accept_data_loss", "master_timeout", "timeout")
+    @query_params(
+        "accept_data_loss",
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def import_dangling_index(self, index_uuid, params=None, headers=None):
         """
         Imports the specified dangling index
@@ -62,7 +72,9 @@ class DanglingIndicesClient(NamespacedClient):
             "POST", _make_path("_dangling", index_uuid), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def list_dangling_indices(self, params=None, headers=None):
         """
         Returns all dangling indices.

--- a/elasticsearch/client/enrich.py
+++ b/elasticsearch/client/enrich.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class EnrichClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_policy(self, name, params=None, headers=None):
         """
         Deletes an existing enrich policy and its enrich index.
@@ -38,7 +40,10 @@ class EnrichClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("wait_for_completion")
+    @query_params(
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     def execute_policy(self, name, params=None, headers=None):
         """
         Creates the enrich index for an existing enrich policy.
@@ -59,7 +64,9 @@ class EnrichClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_policy(self, name=None, params=None, headers=None):
         """
         Gets information about an enrich policy.
@@ -72,7 +79,10 @@ class EnrichClient(NamespacedClient):
             "GET", _make_path("_enrich", "policy", name), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_policy(self, name, body, params=None, headers=None):
         """
         Creates a new enrich policy.
@@ -94,7 +104,9 @@ class EnrichClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def stats(self, params=None, headers=None):
         """
         Gets enrich coordinator statistics and information about enrich policies that

--- a/elasticsearch/client/eql.py
+++ b/elasticsearch/client/eql.py
@@ -19,7 +19,13 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class EqlClient(NamespacedClient):
-    @query_params("keep_alive", "keep_on_completion", "wait_for_completion_timeout")
+    @query_params(
+        "keep_alive",
+        "keep_on_completion",
+        "wait_for_completion_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def search(self, index, body, params=None, headers=None):
         """
         Returns results matching a query expressed in Event Query Language (EQL)
@@ -49,7 +55,9 @@ class EqlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete(self, id, params=None, headers=None):
         """
         Deletes an async EQL search by ID. If the search is still running, the search
@@ -66,7 +74,11 @@ class EqlClient(NamespacedClient):
             "DELETE", _make_path("_eql", "search", id), params=params, headers=headers
         )
 
-    @query_params("keep_alive", "wait_for_completion_timeout")
+    @query_params(
+        "keep_alive",
+        "wait_for_completion_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get(self, id, params=None, headers=None):
         """
         Returns async results from previously executed Event Query Language (EQL)
@@ -87,7 +99,9 @@ class EqlClient(NamespacedClient):
             "GET", _make_path("_eql", "search", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_status(self, id, params=None, headers=None):
         """
         Returns the status of a previously submitted async or stored Event Query

--- a/elasticsearch/client/features.py
+++ b/elasticsearch/client/features.py
@@ -19,7 +19,10 @@ from .utils import NamespacedClient, query_params
 
 
 class FeaturesClient(NamespacedClient):
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_features(self, params=None, headers=None):
         """
         Gets a list of features which can be included in snapshots using the
@@ -34,7 +37,9 @@ class FeaturesClient(NamespacedClient):
             "GET", "/_features", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def reset_features(self, params=None, headers=None):
         """
         Resets the internal state of features, usually by deleting system indices

--- a/elasticsearch/client/fleet.py
+++ b/elasticsearch/client/fleet.py
@@ -19,7 +19,14 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class FleetClient(NamespacedClient):
-    @query_params("checkpoints", "timeout", "wait_for_advance", "wait_for_index")
+    @query_params(
+        "checkpoints",
+        "timeout",
+        "wait_for_advance",
+        "wait_for_index",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def global_checkpoints(self, index, params=None, headers=None):
         """
         Returns the current global checkpoints for an index. This API is design for

--- a/elasticsearch/client/graph.py
+++ b/elasticsearch/client/graph.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class GraphClient(NamespacedClient):
-    @query_params("routing", "timeout")
+    @query_params(
+        "routing",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def explore(self, index, body=None, doc_type=None, params=None, headers=None):
         """
         Explore extracted and summarized information about the documents and terms in

--- a/elasticsearch/client/ilm.py
+++ b/elasticsearch/client/ilm.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IlmClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_lifecycle(self, policy, params=None, headers=None):
         """
         Deletes the specified lifecycle policy definition. A currently used policy
@@ -39,7 +41,11 @@ class IlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("only_errors", "only_managed")
+    @query_params(
+        "only_errors",
+        "only_managed",
+        response_mimetypes=["application/json"],
+    )
     def explain_lifecycle(self, index, params=None, headers=None):
         """
         Retrieves information about the index's current lifecycle state, such as the
@@ -60,7 +66,9 @@ class IlmClient(NamespacedClient):
             "GET", _make_path(index, "_ilm", "explain"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_lifecycle(self, policy=None, params=None, headers=None):
         """
         Returns the specified policy definition. Includes the policy version and last
@@ -74,7 +82,9 @@ class IlmClient(NamespacedClient):
             "GET", _make_path("_ilm", "policy", policy), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_status(self, params=None, headers=None):
         """
         Retrieves the current index lifecycle management (ILM) status.
@@ -85,7 +95,10 @@ class IlmClient(NamespacedClient):
             "GET", "/_ilm/status", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def move_to_step(self, index, body=None, params=None, headers=None):
         """
         Manually moves an index into the specified step and executes that step.
@@ -107,7 +120,10 @@ class IlmClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_lifecycle(self, policy, body=None, params=None, headers=None):
         """
         Creates a lifecycle policy
@@ -128,7 +144,9 @@ class IlmClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def remove_policy(self, index, params=None, headers=None):
         """
         Removes the assigned lifecycle policy and stops managing the specified index
@@ -144,7 +162,9 @@ class IlmClient(NamespacedClient):
             "POST", _make_path(index, "_ilm", "remove"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def retry(self, index, params=None, headers=None):
         """
         Retries executing the policy for an index that is in the ERROR step.
@@ -161,7 +181,9 @@ class IlmClient(NamespacedClient):
             "POST", _make_path(index, "_ilm", "retry"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def start(self, params=None, headers=None):
         """
         Start the index lifecycle management (ILM) plugin.
@@ -172,7 +194,9 @@ class IlmClient(NamespacedClient):
             "POST", "/_ilm/start", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def stop(self, params=None, headers=None):
         """
         Halts all lifecycle management operations and stops the index lifecycle
@@ -184,7 +208,11 @@ class IlmClient(NamespacedClient):
             "POST", "/_ilm/stop", params=params, headers=headers
         )
 
-    @query_params("dry_run")
+    @query_params(
+        "dry_run",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def migrate_to_data_tiers(self, body=None, params=None, headers=None):
         """
         Migrates the indices and ILM policies away from custom node attribute

--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IndicesClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def analyze(self, body=None, index=None, params=None, headers=None):
         """
         Performs the analysis process on a text and return the tokens breakdown of the
@@ -39,7 +42,12 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     def refresh(self, index=None, params=None, headers=None):
         """
         Performs the refresh operation in one or more indices.
@@ -67,6 +75,7 @@ class IndicesClient(NamespacedClient):
         "force",
         "ignore_unavailable",
         "wait_if_ongoing",
+        response_mimetypes=["application/json"],
     )
     def flush(self, index=None, params=None, headers=None):
         """
@@ -103,6 +112,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
         body_params=["aliases", "mappings", "settings"],
     )
     def create(self, index, body=None, params=None, headers=None):
@@ -135,7 +146,13 @@ class IndicesClient(NamespacedClient):
             "PUT", _make_path(index), params=params, headers=headers, body=body
         )
 
-    @query_params("master_timeout", "timeout", "wait_for_active_shards")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def clone(self, index, target, body=None, params=None, headers=None):
         """
         Clones an index
@@ -172,6 +189,7 @@ class IndicesClient(NamespacedClient):
         "include_type_name",
         "local",
         "master_timeout",
+        response_mimetypes=["application/json"],
     )
     def get(self, index, params=None, headers=None):
         """
@@ -217,6 +235,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     def open(self, index, params=None, headers=None):
         """
@@ -252,6 +271,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     def close(self, index, params=None, headers=None):
         """
@@ -288,6 +308,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "master_timeout",
         "timeout",
+        response_mimetypes=["application/json"],
     )
     def delete(self, index, params=None, headers=None):
         """
@@ -301,7 +322,7 @@ class IndicesClient(NamespacedClient):
             to no concrete indices (default: false)
         :arg expand_wildcards: Whether wildcard expressions should get
             expanded to open or closed indices (default: open)  Valid choices: open,
-            closed, hidden, none, all  Default: open
+            closed, hidden, none, all  Default: open,closed
         :arg ignore_unavailable: Ignore unavailable indexes (default:
             false)
         :arg master_timeout: Specify timeout for connection to master
@@ -321,6 +342,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "include_defaults",
         "local",
+        response_mimetypes=["application/json"],
     )
     def exists(self, index, params=None, headers=None):
         """
@@ -350,7 +372,13 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path(index), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable", "local")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     def exists_type(self, index, doc_type, params=None, headers=None):
         """
         Returns information about whether a particular document type exists.
@@ -391,6 +419,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "write_index_only",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def put_mapping(self, body, index=None, doc_type=None, params=None, headers=None):
         """
@@ -439,6 +469,7 @@ class IndicesClient(NamespacedClient):
         "include_type_name",
         "local",
         "master_timeout",
+        response_mimetypes=["application/json"],
     )
     def get_mapping(self, index=None, doc_type=None, params=None, headers=None):
         """
@@ -476,6 +507,7 @@ class IndicesClient(NamespacedClient):
         "include_defaults",
         "include_type_name",
         "local",
+        response_mimetypes=["application/json"],
     )
     def get_field_mapping(
         self, fields, index=None, doc_type=None, params=None, headers=None
@@ -513,7 +545,12 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_alias(self, index, name, body=None, params=None, headers=None):
         """
         Creates or updates an alias.
@@ -541,7 +578,13 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable", "local")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     def exists_alias(self, name, index=None, params=None, headers=None):
         """
         Returns information about whether a particular alias exists.
@@ -569,7 +612,13 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path(index, "_alias", name), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable", "local")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     def get_alias(self, index=None, name=None, params=None, headers=None):
         """
         Returns an alias.
@@ -594,7 +643,12 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path(index, "_alias", name), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def update_aliases(self, body, params=None, headers=None):
         """
         Updates index aliases.
@@ -612,7 +666,11 @@ class IndicesClient(NamespacedClient):
             "POST", "/_aliases", params=params, headers=headers, body=body
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_alias(self, index, name, params=None, headers=None):
         """
         Deletes an alias.
@@ -637,7 +695,14 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("create", "include_type_name", "master_timeout", "order")
+    @query_params(
+        "create",
+        "include_type_name",
+        "master_timeout",
+        "order",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
@@ -667,7 +732,12 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("flat_settings", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def exists_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
@@ -689,7 +759,13 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path("_template", name), params=params, headers=headers
         )
 
-    @query_params("flat_settings", "include_type_name", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "include_type_name",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
@@ -710,7 +786,11 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path("_template", name), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
@@ -736,6 +816,7 @@ class IndicesClient(NamespacedClient):
         "include_defaults",
         "local",
         "master_timeout",
+        response_mimetypes=["application/json"],
     )
     def get_settings(self, index=None, name=None, params=None, headers=None):
         """
@@ -774,6 +855,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "preserve_existing",
         "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def put_settings(self, body, index=None, params=None, headers=None):
         """
@@ -822,6 +905,7 @@ class IndicesClient(NamespacedClient):
         "include_unloaded_segments",
         "level",
         "types",
+        response_mimetypes=["application/json"],
     )
     def stats(self, index=None, metric=None, params=None, headers=None):
         """
@@ -863,7 +947,11 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "verbose"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "verbose",
+        response_mimetypes=["application/json"],
     )
     def segments(self, index=None, params=None, headers=None):
         """
@@ -900,6 +988,8 @@ class IndicesClient(NamespacedClient):
         "lenient",
         "q",
         "rewrite",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def validate_query(
         self, body=None, index=None, doc_type=None, params=None, headers=None
@@ -956,6 +1046,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "query",
         "request",
+        response_mimetypes=["application/json"],
     )
     def clear_cache(self, index=None, params=None, headers=None):
         """
@@ -983,7 +1074,11 @@ class IndicesClient(NamespacedClient):
             "POST", _make_path(index, "_cache", "clear"), params=params, headers=headers
         )
 
-    @query_params("active_only", "detailed")
+    @query_params(
+        "active_only",
+        "detailed",
+        response_mimetypes=["application/json"],
+    )
     def recovery(self, index=None, params=None, headers=None):
         """
         Returns information about ongoing index shard recoveries.
@@ -1007,6 +1102,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "only_ancient_segments",
         "wait_for_completion",
+        response_mimetypes=["application/json"],
     )
     def upgrade(self, index=None, params=None, headers=None):
         """
@@ -1033,7 +1129,12 @@ class IndicesClient(NamespacedClient):
             "POST", _make_path(index, "_upgrade"), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     def get_upgrade(self, index=None, params=None, headers=None):
         """
         DEPRECATED Returns a progress status of current upgrade.
@@ -1055,7 +1156,12 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path(index, "_upgrade"), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     def flush_synced(self, index=None, params=None, headers=None):
         """
         Performs a synced flush operation on one or more indices. Synced flush is
@@ -1082,7 +1188,11 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_unavailable", "status"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "status",
+        response_mimetypes=["application/json"],
     )
     def shard_stores(self, index=None, params=None, headers=None):
         """
@@ -1115,6 +1225,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "max_num_segments",
         "only_expunge_deletes",
+        response_mimetypes=["application/json"],
     )
     def forcemerge(self, index=None, params=None, headers=None):
         """
@@ -1144,7 +1255,12 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "copy_settings", "master_timeout", "timeout", "wait_for_active_shards"
+        "copy_settings",
+        "master_timeout",
+        "timeout",
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def shrink(self, index, target, body=None, params=None, headers=None):
         """
@@ -1176,7 +1292,12 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "copy_settings", "master_timeout", "timeout", "wait_for_active_shards"
+        "copy_settings",
+        "master_timeout",
+        "timeout",
+        "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def split(self, index, target, body=None, params=None, headers=None):
         """
@@ -1214,6 +1335,8 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def rollover(self, alias, body=None, new_index=None, params=None, headers=None):
         """
@@ -1255,6 +1378,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     def freeze(self, index, params=None, headers=None):
         """
@@ -1291,6 +1415,7 @@ class IndicesClient(NamespacedClient):
         "master_timeout",
         "timeout",
         "wait_for_active_shards",
+        response_mimetypes=["application/json"],
     )
     def unfreeze(self, index, params=None, headers=None):
         """
@@ -1320,7 +1445,12 @@ class IndicesClient(NamespacedClient):
             "POST", _make_path(index, "_unfreeze"), params=params, headers=headers
         )
 
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     def reload_search_analyzers(self, index, params=None, headers=None):
         """
         Reloads an index's search analyzers and their resources.
@@ -1348,7 +1478,9 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def create_data_stream(self, name, params=None, headers=None):
         """
         Creates a data stream
@@ -1364,7 +1496,10 @@ class IndicesClient(NamespacedClient):
             "PUT", _make_path("_data_stream", name), params=params, headers=headers
         )
 
-    @query_params("expand_wildcards")
+    @query_params(
+        "expand_wildcards",
+        response_mimetypes=["application/json"],
+    )
     def delete_data_stream(self, name, params=None, headers=None):
         """
         Deletes a data stream.
@@ -1384,7 +1519,11 @@ class IndicesClient(NamespacedClient):
             "DELETE", _make_path("_data_stream", name), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_index_template(self, name, params=None, headers=None):
         """
         Deletes an index template.
@@ -1405,7 +1544,12 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("flat_settings", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def exists_index_template(self, name, params=None, headers=None):
         """
         Returns information about whether a particular index template exists.
@@ -1427,7 +1571,12 @@ class IndicesClient(NamespacedClient):
             "HEAD", _make_path("_index_template", name), params=params, headers=headers
         )
 
-    @query_params("flat_settings", "local", "master_timeout")
+    @query_params(
+        "flat_settings",
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_index_template(self, name=None, params=None, headers=None):
         """
         Returns an index template.
@@ -1446,7 +1595,13 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path("_index_template", name), params=params, headers=headers
         )
 
-    @query_params("cause", "create", "master_timeout")
+    @query_params(
+        "cause",
+        "create",
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_index_template(self, name, body, params=None, headers=None):
         """
         Creates or updates an index template.
@@ -1473,7 +1628,13 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("cause", "create", "master_timeout")
+    @query_params(
+        "cause",
+        "create",
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def simulate_index_template(self, name, body=None, params=None, headers=None):
         """
         Simulate matching the given index name against the index templates in the
@@ -1503,7 +1664,10 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("expand_wildcards")
+    @query_params(
+        "expand_wildcards",
+        response_mimetypes=["application/json"],
+    )
     def get_data_stream(self, name=None, params=None, headers=None):
         """
         Returns data streams.
@@ -1520,7 +1684,13 @@ class IndicesClient(NamespacedClient):
             "GET", _make_path("_data_stream", name), params=params, headers=headers
         )
 
-    @query_params("cause", "create", "master_timeout")
+    @query_params(
+        "cause",
+        "create",
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def simulate_template(self, body=None, name=None, params=None, headers=None):
         """
         Simulate resolving the given template name or body
@@ -1545,7 +1715,10 @@ class IndicesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("expand_wildcards")
+    @query_params(
+        "expand_wildcards",
+        response_mimetypes=["application/json"],
+    )
     def resolve_index(self, name, params=None, headers=None):
         """
         Returns information about any matching indices, aliases, and data streams
@@ -1576,6 +1749,7 @@ class IndicesClient(NamespacedClient):
         "ignore_unavailable",
         "master_timeout",
         "timeout",
+        response_mimetypes=["application/json"],
     )
     def add_block(self, index, block, params=None, headers=None):
         """
@@ -1605,7 +1779,9 @@ class IndicesClient(NamespacedClient):
             "PUT", _make_path(index, "_block", block), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def data_streams_stats(self, name=None, params=None, headers=None):
         """
         Provides statistics on operations happening in a data stream.
@@ -1622,7 +1798,9 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def promote_data_stream(self, name, params=None, headers=None):
         """
         Promotes a data stream from a replicated data stream managed by CCR to a
@@ -1642,7 +1820,9 @@ class IndicesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def migrate_to_data_stream(self, name, params=None, headers=None):
         """
         Migrates an alias to a data stream
@@ -1667,6 +1847,7 @@ class IndicesClient(NamespacedClient):
         "flush",
         "ignore_unavailable",
         "run_expensive_tasks",
+        response_mimetypes=["application/json"],
     )
     def disk_usage(self, index, params=None, headers=None):
         """
@@ -1702,7 +1883,11 @@ class IndicesClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "fields", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "fields",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
     )
     def field_usage_stats(self, index, params=None, headers=None):
         """

--- a/elasticsearch/client/ingest.py
+++ b/elasticsearch/client/ingest.py
@@ -19,7 +19,11 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class IngestClient(NamespacedClient):
-    @query_params("master_timeout", "summary")
+    @query_params(
+        "master_timeout",
+        "summary",
+        response_mimetypes=["application/json"],
+    )
     def get_pipeline(self, id=None, params=None, headers=None):
         """
         Returns a pipeline.
@@ -37,7 +41,12 @@ class IngestClient(NamespacedClient):
             "GET", _make_path("_ingest", "pipeline", id), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_pipeline(self, id, body, params=None, headers=None):
         """
         Creates or updates a pipeline.
@@ -62,7 +71,11 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes a pipeline.
@@ -84,7 +97,11 @@ class IngestClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("verbose")
+    @query_params(
+        "verbose",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def simulate(self, body, id=None, params=None, headers=None):
         """
         Allows to simulate a pipeline with example documents.
@@ -107,7 +124,9 @@ class IngestClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def processor_grok(self, params=None, headers=None):
         """
         Returns a list of the built-in patterns.
@@ -118,7 +137,9 @@ class IngestClient(NamespacedClient):
             "GET", "/_ingest/processor/grok", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def geo_ip_stats(self, params=None, headers=None):
         """
         Returns statistical information about geoip databases

--- a/elasticsearch/client/license.py
+++ b/elasticsearch/client/license.py
@@ -19,7 +19,9 @@ from .utils import NamespacedClient, query_params
 
 
 class LicenseClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete(self, params=None, headers=None):
         """
         Deletes licensing information for the cluster
@@ -30,7 +32,11 @@ class LicenseClient(NamespacedClient):
             "DELETE", "/_license", params=params, headers=headers
         )
 
-    @query_params("accept_enterprise", "local")
+    @query_params(
+        "accept_enterprise",
+        "local",
+        response_mimetypes=["application/json"],
+    )
     def get(self, params=None, headers=None):
         """
         Retrieves licensing information for the cluster
@@ -46,7 +52,9 @@ class LicenseClient(NamespacedClient):
             "GET", "/_license", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_basic_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the basic license.
@@ -57,7 +65,9 @@ class LicenseClient(NamespacedClient):
             "GET", "/_license/basic_status", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_trial_status(self, params=None, headers=None):
         """
         Retrieves information about the status of the trial license.
@@ -68,7 +78,11 @@ class LicenseClient(NamespacedClient):
             "GET", "/_license/trial_status", params=params, headers=headers
         )
 
-    @query_params("acknowledge")
+    @query_params(
+        "acknowledge",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def post(self, body=None, params=None, headers=None):
         """
         Updates the license for the cluster.
@@ -83,7 +97,10 @@ class LicenseClient(NamespacedClient):
             "PUT", "/_license", params=params, headers=headers, body=body
         )
 
-    @query_params("acknowledge")
+    @query_params(
+        "acknowledge",
+        response_mimetypes=["application/json"],
+    )
     def post_start_basic(self, params=None, headers=None):
         """
         Starts an indefinite basic license.
@@ -97,7 +114,11 @@ class LicenseClient(NamespacedClient):
             "POST", "/_license/start_basic", params=params, headers=headers
         )
 
-    @query_params("acknowledge", "type")
+    @query_params(
+        "acknowledge",
+        "type",
+        response_mimetypes=["application/json"],
+    )
     def post_start_trial(self, params=None, headers=None):
         """
         starts a limited time trial license.

--- a/elasticsearch/client/logstash.py
+++ b/elasticsearch/client/logstash.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class LogstashClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_pipeline(self, id, params=None, headers=None):
         """
         Deletes Logstash Pipelines used by Central Management
@@ -38,7 +40,9 @@ class LogstashClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_pipeline(self, id, params=None, headers=None):
         """
         Retrieves Logstash Pipelines used by Central Management
@@ -57,7 +61,10 @@ class LogstashClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_pipeline(self, id, body, params=None, headers=None):
         """
         Adds and updates Logstash Pipelines used for Central Management

--- a/elasticsearch/client/migration.py
+++ b/elasticsearch/client/migration.py
@@ -19,7 +19,9 @@ from .utils import NamespacedClient, _make_path, query_params
 
 
 class MigrationClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def deprecations(self, index=None, params=None, headers=None):
         """
         Retrieves information about different cluster, node, and index level settings

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -19,7 +19,14 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _bulk_body, _make_path, query
 
 
 class MlClient(NamespacedClient):
-    @query_params("allow_no_jobs", "allow_no_match", "force", "timeout")
+    @query_params(
+        "allow_no_jobs",
+        "allow_no_match",
+        "force",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def close_job(self, job_id, body=None, params=None, headers=None):
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed
@@ -50,7 +57,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_calendar(self, calendar_id, params=None, headers=None):
         """
         Deletes a calendar.
@@ -71,7 +80,9 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_calendar_event(self, calendar_id, event_id, params=None, headers=None):
         """
         Deletes scheduled events from a calendar.
@@ -92,7 +103,9 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Deletes anomaly detection jobs from a calendar.
@@ -113,7 +126,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("force")
+    @query_params(
+        "force",
+        response_mimetypes=["application/json"],
+    )
     def delete_datafeed(self, datafeed_id, params=None, headers=None):
         """
         Deletes an existing datafeed.
@@ -135,7 +151,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("requests_per_second", "timeout")
+    @query_params(
+        "requests_per_second",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_expired_data(self, body=None, job_id=None, params=None, headers=None):
         """
         Deletes expired and unused machine learning data.
@@ -158,7 +178,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_filter(self, filter_id, params=None, headers=None):
         """
         Deletes a filter.
@@ -177,7 +199,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_forecasts", "timeout")
+    @query_params(
+        "allow_no_forecasts",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_forecast(self, job_id, forecast_id=None, params=None, headers=None):
         """
         Deletes forecasts from a machine learning job.
@@ -202,7 +228,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("force", "wait_for_completion")
+    @query_params(
+        "force",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     def delete_job(self, job_id, params=None, headers=None):
         """
         Deletes an existing anomaly detection job.
@@ -224,7 +254,9 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_model_snapshot(self, job_id, snapshot_id, params=None, headers=None):
         """
         Deletes an existing model snapshot.
@@ -247,7 +279,15 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("advance_time", "calc_interim", "end", "skip_time", "start")
+    @query_params(
+        "advance_time",
+        "calc_interim",
+        "end",
+        "skip_time",
+        "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def flush_job(self, job_id, body=None, params=None, headers=None):
         """
         Forces any buffered data to be processed by the job.
@@ -278,7 +318,12 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("duration", "expires_in", "max_model_memory")
+    @query_params(
+        "duration",
+        "expires_in",
+        "max_model_memory",
+        response_mimetypes=["application/json"],
+    )
     def forecast(self, job_id, params=None, headers=None):
         """
         Predicts the future behavior of a time series by using its historical behavior.
@@ -312,6 +357,8 @@ class MlClient(NamespacedClient):
         "size",
         "sort",
         "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def get_buckets(self, job_id, body=None, timestamp=None, params=None, headers=None):
         """
@@ -349,7 +396,14 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("end", "from_", "job_id", "size", "start")
+    @query_params(
+        "end",
+        "from_",
+        "job_id",
+        "size",
+        "start",
+        response_mimetypes=["application/json"],
+    )
     def get_calendar_events(self, calendar_id, params=None, headers=None):
         """
         Retrieves information about the scheduled events in calendars.
@@ -379,7 +433,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("from_", "size")
+    @query_params(
+        "from_",
+        "size",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def get_calendars(self, body=None, calendar_id=None, params=None, headers=None):
         """
         Retrieves configuration information for calendars.
@@ -403,7 +462,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("from_", "partition_field_value", "size")
+    @query_params(
+        "from_",
+        "partition_field_value",
+        "size",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def get_categories(
         self, job_id, body=None, category_id=None, params=None, headers=None
     ):
@@ -438,7 +503,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match")
+    @query_params(
+        "allow_no_datafeeds",
+        "allow_no_match",
+        response_mimetypes=["application/json"],
+    )
     def get_datafeed_stats(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves usage information for datafeeds.
@@ -460,7 +529,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match", "exclude_generated")
+    @query_params(
+        "allow_no_datafeeds",
+        "allow_no_match",
+        "exclude_generated",
+        response_mimetypes=["application/json"],
+    )
     def get_datafeeds(self, datafeed_id=None, params=None, headers=None):
         """
         Retrieves configuration information for datafeeds.
@@ -484,7 +558,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("from_", "size")
+    @query_params(
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     def get_filters(self, filter_id=None, params=None, headers=None):
         """
         Retrieves filters.
@@ -514,6 +592,8 @@ class MlClient(NamespacedClient):
         "size",
         "sort",
         "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def get_influencers(self, job_id, body=None, params=None, headers=None):
         """
@@ -548,7 +628,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_jobs", "allow_no_match")
+    @query_params(
+        "allow_no_jobs",
+        "allow_no_match",
+        response_mimetypes=["application/json"],
+    )
     def get_job_stats(self, job_id=None, params=None, headers=None):
         """
         Retrieves usage information for anomaly detection jobs.
@@ -570,7 +654,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_jobs", "allow_no_match", "exclude_generated")
+    @query_params(
+        "allow_no_jobs",
+        "allow_no_match",
+        "exclude_generated",
+        response_mimetypes=["application/json"],
+    )
     def get_jobs(self, job_id=None, params=None, headers=None):
         """
         Retrieves configuration information for anomaly detection jobs.
@@ -594,7 +683,16 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("desc", "end", "from_", "size", "sort", "start")
+    @query_params(
+        "desc",
+        "end",
+        "from_",
+        "size",
+        "sort",
+        "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def get_model_snapshots(
         self, job_id, body=None, snapshot_id=None, params=None, headers=None
     ):
@@ -640,6 +738,8 @@ class MlClient(NamespacedClient):
         "overall_score",
         "start",
         "top_n",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def get_overall_buckets(self, job_id, body=None, params=None, headers=None):
         """
@@ -693,6 +793,8 @@ class MlClient(NamespacedClient):
         "size",
         "sort",
         "start",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def get_records(self, job_id, body=None, params=None, headers=None):
         """
@@ -726,7 +828,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def info(self, params=None, headers=None):
         """
         Returns defaults and limits used by machine learning.
@@ -737,7 +841,9 @@ class MlClient(NamespacedClient):
             "GET", "/_ml/info", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def open_job(self, job_id, params=None, headers=None):
         """
         Opens one or more anomaly detection jobs.
@@ -756,7 +862,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def post_calendar_events(self, calendar_id, body, params=None, headers=None):
         """
         Posts scheduled events in a calendar.
@@ -778,7 +887,12 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("reset_end", "reset_start")
+    @query_params(
+        "reset_end",
+        "reset_start",
+        request_mimetypes=["application/x-ndjson", "application/json"],
+        response_mimetypes=["application/json"],
+    )
     def post_data(self, job_id, body, params=None, headers=None):
         """
         Sends data to an anomaly detection job for analysis.
@@ -805,7 +919,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def preview_datafeed(self, body=None, datafeed_id=None, params=None, headers=None):
         """
         Previews a datafeed.
@@ -824,7 +940,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_calendar(self, calendar_id, body=None, params=None, headers=None):
         """
         Instantiates a calendar.
@@ -847,7 +966,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def put_calendar_job(self, calendar_id, job_id, params=None, headers=None):
         """
         Adds an anomaly detection job to a calendar.
@@ -869,7 +990,12 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_throttled", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_throttled",
+        "ignore_unavailable",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def put_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
@@ -901,7 +1027,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_filter(self, filter_id, body, params=None, headers=None):
         """
         Instantiates a filter.
@@ -924,7 +1053,12 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_throttled", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_throttled",
+        "ignore_unavailable",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def put_job(self, job_id, body, params=None, headers=None):
         """
@@ -958,7 +1092,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("delete_intervening_results")
+    @query_params(
+        "delete_intervening_results",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def revert_model_snapshot(
         self, job_id, snapshot_id, body=None, params=None, headers=None
     ):
@@ -992,7 +1130,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("enabled", "timeout")
+    @query_params(
+        "enabled",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def set_upgrade_mode(self, params=None, headers=None):
         """
         Sets a cluster wide upgrade_mode setting that prepares machine learning indices
@@ -1009,7 +1151,13 @@ class MlClient(NamespacedClient):
             "POST", "/_ml/set_upgrade_mode", params=params, headers=headers
         )
 
-    @query_params("end", "start", "timeout")
+    @query_params(
+        "end",
+        "start",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def start_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Starts one or more datafeeds.
@@ -1037,7 +1185,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_datafeeds", "allow_no_match", "force", "timeout")
+    @query_params(
+        "allow_no_datafeeds",
+        "allow_no_match",
+        "force",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def stop_datafeed(self, datafeed_id, body=None, params=None, headers=None):
         """
         Stops one or more datafeeds.
@@ -1070,7 +1224,12 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
-        "allow_no_indices", "expand_wildcards", "ignore_throttled", "ignore_unavailable"
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_throttled",
+        "ignore_unavailable",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
     )
     def update_datafeed(self, datafeed_id, body, params=None, headers=None):
         """
@@ -1102,7 +1261,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def update_filter(self, filter_id, body, params=None, headers=None):
         """
         Updates the description of a filter, adds items, or removes items.
@@ -1124,7 +1286,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def update_job(self, job_id, body, params=None, headers=None):
         """
         Updates certain properties of an anomaly detection job.
@@ -1146,7 +1311,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def update_model_snapshot(
         self, job_id, snapshot_id, body, params=None, headers=None
     ):
@@ -1178,7 +1346,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def validate(self, body, params=None, headers=None):
         """
         Validates an anomaly detection job.
@@ -1198,7 +1369,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def validate_detector(self, body, params=None, headers=None):
         """
         Validates an anomaly detection detector.
@@ -1218,7 +1392,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("force", "timeout")
+    @query_params(
+        "force",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_data_frame_analytics(self, id, params=None, headers=None):
         """
         Deletes an existing data frame analytics job.
@@ -1240,7 +1418,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def evaluate_data_frame(self, body, params=None, headers=None):
         """
         Evaluates the data frame analytics for an annotated index.
@@ -1260,7 +1441,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_match", "exclude_generated", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "exclude_generated",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     def get_data_frame_analytics(self, id=None, params=None, headers=None):
         """
         Retrieves configuration information for data frame analytics jobs.
@@ -1287,7 +1474,13 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size", "verbose")
+    @query_params(
+        "allow_no_match",
+        "from_",
+        "size",
+        "verbose",
+        response_mimetypes=["application/json"],
+    )
     def get_data_frame_analytics_stats(self, id=None, params=None, headers=None):
         """
         Retrieves usage information for data frame analytics jobs.
@@ -1313,7 +1506,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Instantiates a data frame analytics job.
@@ -1335,7 +1531,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def start_data_frame_analytics(self, id, body=None, params=None, headers=None):
         """
         Starts a data frame analytics job.
@@ -1358,7 +1558,13 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("allow_no_match", "force", "timeout")
+    @query_params(
+        "allow_no_match",
+        "force",
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def stop_data_frame_analytics(self, id, body=None, params=None, headers=None):
         """
         Stops one or more data frame analytics jobs.
@@ -1386,7 +1592,9 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_trained_model(self, model_id, params=None, headers=None):
         """
         Deletes an existing trained inference model that is currently not referenced by
@@ -1406,7 +1614,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def explain_data_frame_analytics(
         self, body=None, id=None, params=None, headers=None
     ):
@@ -1435,6 +1646,7 @@ class MlClient(NamespacedClient):
         "include_model_definition",
         "size",
         "tags",
+        response_mimetypes=["application/json"],
     )
     def get_trained_models(self, model_id=None, params=None, headers=None):
         """
@@ -1473,7 +1685,12 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     def get_trained_models_stats(self, model_id=None, params=None, headers=None):
         """
         Retrieves usage information for trained inference models.
@@ -1498,7 +1715,11 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("defer_definition_decompression")
+    @query_params(
+        "defer_definition_decompression",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_trained_model(self, model_id, body, params=None, headers=None):
         """
         Creates an inference trained model.
@@ -1523,7 +1744,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def estimate_model_memory(self, body, params=None, headers=None):
         """
         Estimates the model memory
@@ -1544,7 +1768,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def update_data_frame_analytics(self, id, body, params=None, headers=None):
         """
         Updates certain properties of a data frame analytics job.
@@ -1566,7 +1793,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("timeout", "wait_for_completion")
+    @query_params(
+        "timeout",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     def upgrade_job_snapshot(self, job_id, snapshot_id, params=None, headers=None):
         """
         Upgrades a given job snapshot to the current major version.
@@ -1598,7 +1829,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def delete_trained_model_alias(
         self, model_id, model_alias, params=None, headers=None
     ):
@@ -1622,7 +1856,10 @@ class MlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def preview_data_frame_analytics(
         self, body=None, id=None, params=None, headers=None
     ):
@@ -1642,7 +1879,11 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("reassign")
+    @query_params(
+        "reassign",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_trained_model_alias(self, model_id, model_alias, params=None, headers=None):
         """
         Creates a new model alias (or reassigns an existing one) to refer to the
@@ -1682,6 +1923,8 @@ class MlClient(NamespacedClient):
         "timeout",
         "timestamp_field",
         "timestamp_format",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     def find_file_structure(self, body, params=None, headers=None):
         """
@@ -1740,7 +1983,10 @@ class MlClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("wait_for_completion")
+    @query_params(
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     def reset_job(self, job_id, params=None, headers=None):
         """
         Resets an existing anomaly detection job.

--- a/elasticsearch/client/ml.py
+++ b/elasticsearch/client/ml.py
@@ -154,6 +154,7 @@ class MlClient(NamespacedClient):
     @query_params(
         "requests_per_second",
         "timeout",
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     def delete_expired_data(self, body=None, job_id=None, params=None, headers=None):
@@ -920,6 +921,7 @@ class MlClient(NamespacedClient):
         )
 
     @query_params(
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     def preview_datafeed(self, body=None, datafeed_id=None, params=None, headers=None):
@@ -1190,6 +1192,7 @@ class MlClient(NamespacedClient):
         "allow_no_match",
         "force",
         "timeout",
+        request_mimetypes=["application/json"],
         response_mimetypes=["application/json"],
     )
     def stop_datafeed(self, datafeed_id, body=None, params=None, headers=None):

--- a/elasticsearch/client/ml.pyi
+++ b/elasticsearch/client/ml.pyi
@@ -126,7 +126,7 @@ class MlClient(NamespacedClient):
     def delete_expired_data(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         job_id: Optional[Any] = ...,
         requests_per_second: Optional[Any] = ...,
         timeout: Optional[Any] = ...,
@@ -626,7 +626,7 @@ class MlClient(NamespacedClient):
     def preview_datafeed(
         self,
         *,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         datafeed_id: Optional[Any] = ...,
         pretty: Optional[bool] = ...,
         human: Optional[bool] = ...,
@@ -802,7 +802,7 @@ class MlClient(NamespacedClient):
         self,
         *,
         datafeed_id: Any,
-        body: Optional[Any] = ...,
+        body: Optional[Mapping[str, Any]] = ...,
         allow_no_datafeeds: Optional[bool] = ...,
         allow_no_match: Optional[bool] = ...,
         force: Optional[bool] = ...,

--- a/elasticsearch/client/monitoring.py
+++ b/elasticsearch/client/monitoring.py
@@ -19,7 +19,13 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _bulk_body, _make_path, query
 
 
 class MonitoringClient(NamespacedClient):
-    @query_params("interval", "system_api_version", "system_id")
+    @query_params(
+        "interval",
+        "system_api_version",
+        "system_id",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
+    )
     def bulk(self, body, doc_type=None, params=None, headers=None):
         """
         Used by the monitoring features to send monitoring data.

--- a/elasticsearch/client/nodes.py
+++ b/elasticsearch/client/nodes.py
@@ -19,7 +19,11 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class NodesClient(NamespacedClient):
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def reload_secure_settings(
         self, body=None, node_id=None, params=None, headers=None
     ):
@@ -43,7 +47,11 @@ class NodesClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("flat_settings", "timeout")
+    @query_params(
+        "flat_settings",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def info(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns information about nodes in the cluster.
@@ -75,6 +83,7 @@ class NodesClient(NamespacedClient):
         "level",
         "timeout",
         "types",
+        response_mimetypes=["application/json"],
     )
     def stats(
         self, node_id=None, metric=None, index_metric=None, params=None, headers=None
@@ -124,7 +133,13 @@ class NodesClient(NamespacedClient):
         )
 
     @query_params(
-        "ignore_idle_threads", "interval", "snapshots", "threads", "timeout", "type"
+        "ignore_idle_threads",
+        "interval",
+        "snapshots",
+        "threads",
+        "timeout",
+        "type",
+        response_mimetypes=["text/plain"],
     )
     def hot_threads(self, node_id=None, params=None, headers=None):
         """
@@ -155,7 +170,10 @@ class NodesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def usage(self, node_id=None, metric=None, params=None, headers=None):
         """
         Returns low-level information about REST actions usage on nodes.
@@ -177,7 +195,9 @@ class NodesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def clear_repositories_metering_archive(
         self, node_id, max_archive_version, params=None, headers=None
     ):
@@ -209,7 +229,9 @@ class NodesClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_repositories_metering_info(self, node_id, params=None, headers=None):
         """
         Returns cluster repositories metering information.

--- a/elasticsearch/client/rollup.py
+++ b/elasticsearch/client/rollup.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class RollupClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_job(self, id, params=None, headers=None):
         """
         Deletes an existing rollup job.
@@ -40,7 +42,9 @@ class RollupClient(NamespacedClient):
             "DELETE", _make_path("_rollup", "job", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_jobs(self, id=None, params=None, headers=None):
         """
         Retrieves the configuration, stats, and status of rollup jobs.
@@ -59,7 +63,9 @@ class RollupClient(NamespacedClient):
             "GET", _make_path("_rollup", "job", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_rollup_caps(self, id=None, params=None, headers=None):
         """
         Returns the capabilities of any rollup jobs that have been configured for a
@@ -79,7 +85,9 @@ class RollupClient(NamespacedClient):
             "GET", _make_path("_rollup", "data", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_rollup_index_caps(self, index, params=None, headers=None):
         """
         Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
@@ -102,7 +110,10 @@ class RollupClient(NamespacedClient):
             "GET", _make_path(index, "_rollup", "data"), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_job(self, id, body, params=None, headers=None):
         """
         Creates a rollup job.
@@ -129,7 +140,12 @@ class RollupClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("rest_total_hits_as_int", "typed_keys")
+    @query_params(
+        "rest_total_hits_as_int",
+        "typed_keys",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def rollup_search(self, index, body, doc_type=None, params=None, headers=None):
         """
         Enables searching rolled-up data using the standard query DSL.
@@ -162,7 +178,9 @@ class RollupClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def start_job(self, id, params=None, headers=None):
         """
         Starts an existing, stopped rollup job.
@@ -186,7 +204,11 @@ class RollupClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("timeout", "wait_for_completion")
+    @query_params(
+        "timeout",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     def stop_job(self, id, params=None, headers=None):
         """
         Stops an existing, started rollup job.
@@ -215,7 +237,10 @@ class RollupClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def rollup(self, index, rollup_index, body, params=None, headers=None):
         """
         Rollup an index

--- a/elasticsearch/client/searchable_snapshots.py
+++ b/elasticsearch/client/searchable_snapshots.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SearchableSnapshotsClient(NamespacedClient):
-    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable")
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        response_mimetypes=["application/json"],
+    )
     def clear_cache(self, index=None, params=None, headers=None):
         """
         Clear the cache of searchable snapshots.
@@ -48,7 +53,13 @@ class SearchableSnapshotsClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "storage", "wait_for_completion")
+    @query_params(
+        "master_timeout",
+        "storage",
+        "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def mount(self, repository, snapshot, body, params=None, headers=None):
         """
         Mount a snapshot as a searchable index.
@@ -84,7 +95,9 @@ class SearchableSnapshotsClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def repository_stats(self, repository, params=None, headers=None):
         """
         DEPRECATED: This API is replaced by the Repositories Metering API.
@@ -108,7 +121,10 @@ class SearchableSnapshotsClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("level")
+    @query_params(
+        "level",
+        response_mimetypes=["application/json"],
+    )
     def stats(self, index=None, params=None, headers=None):
         """
         Retrieve shard-level statistics about searchable snapshots.
@@ -131,7 +147,9 @@ class SearchableSnapshotsClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def cache_stats(self, node_id=None, params=None, headers=None):
         """
         Retrieve node-level cache statistics about searchable snapshots.

--- a/elasticsearch/client/security.py
+++ b/elasticsearch/client/security.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SecurityClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def authenticate(self, params=None, headers=None):
         """
         Enables authentication as a user and retrieve information about the
@@ -31,7 +33,11 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/_authenticate", params=params, headers=headers
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def change_password(self, body, username=None, params=None, headers=None):
         """
         Changes the passwords of users in the native realm and built-in users.
@@ -57,7 +63,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("usernames")
+    @query_params(
+        "usernames",
+        response_mimetypes=["application/json"],
+    )
     def clear_cached_realms(self, realms, params=None, headers=None):
         """
         Evicts users from the user cache. Can completely clear the cache or evict
@@ -79,7 +88,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def clear_cached_roles(self, name, params=None, headers=None):
         """
         Evicts roles from the native role cache.
@@ -98,7 +109,11 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def create_api_key(self, body, params=None, headers=None):
         """
         Creates an API key for access without requiring basic authentication.
@@ -118,7 +133,10 @@ class SecurityClient(NamespacedClient):
             "PUT", "/_security/api_key", params=params, headers=headers, body=body
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def delete_privileges(self, application, name, params=None, headers=None):
         """
         Removes application privileges.
@@ -143,7 +161,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def delete_role(self, name, params=None, headers=None):
         """
         Removes roles in the native realm.
@@ -166,7 +187,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def delete_role_mapping(self, name, params=None, headers=None):
         """
         Removes role mappings.
@@ -189,7 +213,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def delete_user(self, username, params=None, headers=None):
         """
         Deletes users from the native realm.
@@ -212,7 +239,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def disable_user(self, username, params=None, headers=None):
         """
         Disables users in the native realm.
@@ -235,7 +265,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def enable_user(self, username, params=None, headers=None):
         """
         Enables users in the native realm.
@@ -258,7 +291,14 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("id", "name", "owner", "realm_name", "username")
+    @query_params(
+        "id",
+        "name",
+        "owner",
+        "realm_name",
+        "username",
+        response_mimetypes=["application/json"],
+    )
     def get_api_key(self, params=None, headers=None):
         """
         Retrieves information for one or more API keys.
@@ -278,7 +318,9 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/api_key", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_privileges(self, application=None, name=None, params=None, headers=None):
         """
         Retrieves application privileges.
@@ -295,7 +337,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_role(self, name=None, params=None, headers=None):
         """
         Retrieves roles in the native realm.
@@ -308,7 +352,9 @@ class SecurityClient(NamespacedClient):
             "GET", _make_path("_security", "role", name), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_role_mapping(self, name=None, params=None, headers=None):
         """
         Retrieves role mappings.
@@ -324,7 +370,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def get_token(self, body, params=None, headers=None):
         """
         Creates a bearer token for access without requiring basic authentication.
@@ -340,7 +389,9 @@ class SecurityClient(NamespacedClient):
             "POST", "/_security/oauth2/token", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_user(self, username=None, params=None, headers=None):
         """
         Retrieves information about users in the native realm and built-in users.
@@ -356,7 +407,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_user_privileges(self, params=None, headers=None):
         """
         Retrieves security privileges for the logged in user.
@@ -367,7 +420,10 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/user/_privileges", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def has_privileges(self, body, user=None, params=None, headers=None):
         """
         Determines whether the specified user has a specified list of privileges.
@@ -388,7 +444,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def invalidate_api_key(self, body, params=None, headers=None):
         """
         Invalidates one or more API keys.
@@ -404,7 +463,10 @@ class SecurityClient(NamespacedClient):
             "DELETE", "/_security/api_key", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def invalidate_token(self, body, params=None, headers=None):
         """
         Invalidates one or more access tokens or refresh tokens.
@@ -424,7 +486,11 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_privileges(self, body, params=None, headers=None):
         """
         Adds or updates application privileges.
@@ -444,7 +510,11 @@ class SecurityClient(NamespacedClient):
             "PUT", "/_security/privilege/", params=params, headers=headers, body=body
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_role(self, name, body, params=None, headers=None):
         """
         Adds and updates roles in the native realm.
@@ -470,7 +540,11 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_role_mapping(self, name, body, params=None, headers=None):
         """
         Creates and updates role mappings.
@@ -496,7 +570,11 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_user(self, username, body, params=None, headers=None):
         """
         Adds and updates users in the native realm. These users are commonly referred
@@ -523,7 +601,9 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_builtin_privileges(self, params=None, headers=None):
         """
         Retrieves the list of cluster privileges and index privileges that are
@@ -535,7 +615,9 @@ class SecurityClient(NamespacedClient):
             "GET", "/_security/privilege/_builtin", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def clear_cached_privileges(self, application, params=None, headers=None):
         """
         Evicts application privileges from the native application privileges cache.
@@ -556,7 +638,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def clear_api_key_cache(self, ids, params=None, headers=None):
         """
         Clear a subset or all entries from the API key cache.
@@ -576,7 +660,11 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def grant_api_key(self, body, params=None, headers=None):
         """
         Creates an API key on behalf of another user.
@@ -600,7 +688,9 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def clear_cached_service_tokens(
         self, namespace, service, name, params=None, headers=None
     ):
@@ -638,7 +728,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def create_service_token(
         self, namespace, service, name=None, params=None, headers=None
     ):
@@ -674,7 +767,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("refresh")
+    @query_params(
+        "refresh",
+        response_mimetypes=["application/json"],
+    )
     def delete_service_token(self, namespace, service, name, params=None, headers=None):
         """
         Deletes a service account token.
@@ -707,7 +803,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_service_accounts(
         self, namespace=None, service=None, params=None, headers=None
     ):
@@ -731,7 +829,9 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_service_credentials(self, namespace, service, params=None, headers=None):
         """
         Retrieves information of all service credentials for a service account.
@@ -757,7 +857,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def saml_complete_logout(self, body, params=None, headers=None):
         """
         Verifies the logout response sent from the SAML IdP
@@ -777,7 +880,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def saml_authenticate(self, body, params=None, headers=None):
         """
         Exchanges a SAML Response message for an Elasticsearch access token and refresh
@@ -798,7 +904,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def saml_invalidate(self, body, params=None, headers=None):
         """
         Consumes a SAML LogoutRequest
@@ -818,7 +927,10 @@ class SecurityClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def saml_logout(self, body, params=None, headers=None):
         """
         Invalidates an access token and a refresh token that were generated via the
@@ -835,7 +947,10 @@ class SecurityClient(NamespacedClient):
             "POST", "/_security/saml/logout", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def saml_prepare_authentication(self, body, params=None, headers=None):
         """
         Creates a SAML authentication request
@@ -852,7 +967,10 @@ class SecurityClient(NamespacedClient):
             "POST", "/_security/saml/prepare", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def saml_service_provider_metadata(self, realm_name, params=None, headers=None):
         """
         Generates SAML metadata for the Elastic stack SAML 2.0 Service Provider
@@ -872,7 +990,10 @@ class SecurityClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def query_api_keys(self, body=None, params=None, headers=None):
         """
         Retrieves information for API keys using a subset of query DSL

--- a/elasticsearch/client/shutdown.py
+++ b/elasticsearch/client/shutdown.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class ShutdownClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def delete_node(self, node_id, params=None, headers=None):
         """
         Removes a node from the shutdown list
@@ -44,7 +47,10 @@ class ShutdownClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def get_node(self, node_id=None, params=None, headers=None):
         """
         Retrieve status of a node or nodes that are currently marked as shutting down
@@ -66,7 +72,10 @@ class ShutdownClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_node(self, node_id, body, params=None, headers=None):
         """
         Adds a node to be shut down

--- a/elasticsearch/client/slm.py
+++ b/elasticsearch/client/slm.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SlmClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_lifecycle(self, policy_id, params=None, headers=None):
         """
         Deletes an existing snapshot lifecycle policy.
@@ -39,7 +41,9 @@ class SlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def execute_lifecycle(self, policy_id, params=None, headers=None):
         """
         Immediately creates a snapshot according to the lifecycle policy, without
@@ -60,7 +64,9 @@ class SlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def execute_retention(self, params=None, headers=None):
         """
         Deletes any snapshots that are expired according to the policy's retention
@@ -72,7 +78,9 @@ class SlmClient(NamespacedClient):
             "POST", "/_slm/_execute_retention", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_lifecycle(self, policy_id=None, params=None, headers=None):
         """
         Retrieves one or more snapshot lifecycle policy definitions and information
@@ -90,7 +98,9 @@ class SlmClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_stats(self, params=None, headers=None):
         """
         Returns global and policy-level statistics about actions taken by snapshot
@@ -102,7 +112,10 @@ class SlmClient(NamespacedClient):
             "GET", "/_slm/stats", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_lifecycle(self, policy_id, body=None, params=None, headers=None):
         """
         Creates or updates a snapshot lifecycle policy.
@@ -123,7 +136,9 @@ class SlmClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_status(self, params=None, headers=None):
         """
         Retrieves the status of snapshot lifecycle management (SLM).
@@ -134,7 +149,9 @@ class SlmClient(NamespacedClient):
             "GET", "/_slm/status", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def start(self, params=None, headers=None):
         """
         Turns on snapshot lifecycle management (SLM).
@@ -145,7 +162,9 @@ class SlmClient(NamespacedClient):
             "POST", "/_slm/start", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def stop(self, params=None, headers=None):
         """
         Turns off snapshot lifecycle management (SLM).

--- a/elasticsearch/client/snapshot.py
+++ b/elasticsearch/client/snapshot.py
@@ -19,7 +19,12 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SnapshotClient(NamespacedClient):
-    @query_params("master_timeout", "wait_for_completion")
+    @query_params(
+        "master_timeout",
+        "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def create(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Creates a snapshot in a repository.
@@ -46,7 +51,10 @@ class SnapshotClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete(self, repository, snapshot, params=None, headers=None):
         """
         Deletes a snapshot.
@@ -75,6 +83,7 @@ class SnapshotClient(NamespacedClient):
         "index_details",
         "master_timeout",
         "verbose",
+        response_mimetypes=["application/json"],
     )
     def get(self, repository, snapshot, params=None, headers=None):
         """
@@ -107,7 +116,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def delete_repository(self, repository, params=None, headers=None):
         """
         Deletes a repository.
@@ -130,7 +143,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("local", "master_timeout")
+    @query_params(
+        "local",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_repository(self, repository=None, params=None, headers=None):
         """
         Returns information about a repository.
@@ -147,7 +164,13 @@ class SnapshotClient(NamespacedClient):
             "GET", _make_path("_snapshot", repository), params=params, headers=headers
         )
 
-    @query_params("master_timeout", "timeout", "verify")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        "verify",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def create_repository(self, repository, body, params=None, headers=None):
         """
         Creates a repository.
@@ -173,7 +196,12 @@ class SnapshotClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("master_timeout", "wait_for_completion")
+    @query_params(
+        "master_timeout",
+        "wait_for_completion",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def restore(self, repository, snapshot, body=None, params=None, headers=None):
         """
         Restores a snapshot.
@@ -200,7 +228,11 @@ class SnapshotClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("ignore_unavailable", "master_timeout")
+    @query_params(
+        "ignore_unavailable",
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def status(self, repository=None, snapshot=None, params=None, headers=None):
         """
         Returns information about the status of a snapshot.
@@ -222,7 +254,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def verify_repository(self, repository, params=None, headers=None):
         """
         Verifies a repository.
@@ -244,7 +280,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout", "timeout")
+    @query_params(
+        "master_timeout",
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def cleanup_repository(self, repository, params=None, headers=None):
         """
         Removes stale data from repository.
@@ -266,7 +306,11 @@ class SnapshotClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def clone(
         self, repository, snapshot, target_snapshot, body, params=None, headers=None
     ):
@@ -306,6 +350,7 @@ class SnapshotClient(NamespacedClient):
         "read_node_count",
         "seed",
         "timeout",
+        response_mimetypes=["application/json"],
     )
     def repository_analyze(self, repository, params=None, headers=None):
         """

--- a/elasticsearch/client/sql.py
+++ b/elasticsearch/client/sql.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class SqlClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def clear_cursor(self, body, params=None, headers=None):
         """
         Clears the SQL cursor
@@ -36,7 +39,11 @@ class SqlClient(NamespacedClient):
             "POST", "/_sql/close", params=params, headers=headers, body=body
         )
 
-    @query_params("format")
+    @query_params(
+        "format",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def query(self, body, params=None, headers=None):
         """
         Executes a SQL request
@@ -55,7 +62,10 @@ class SqlClient(NamespacedClient):
             "POST", "/_sql", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def translate(self, body, params=None, headers=None):
         """
         Translates SQL into Elasticsearch queries
@@ -71,7 +81,9 @@ class SqlClient(NamespacedClient):
             "POST", "/_sql/translate", params=params, headers=headers, body=body
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_async(self, id, params=None, headers=None):
         """
         Deletes an async SQL search or a stored synchronous SQL search. If the search
@@ -91,7 +103,13 @@ class SqlClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("delimiter", "format", "keep_alive", "wait_for_completion_timeout")
+    @query_params(
+        "delimiter",
+        "format",
+        "keep_alive",
+        "wait_for_completion_timeout",
+        response_mimetypes=["application/json"],
+    )
     def get_async(self, id, params=None, headers=None):
         """
         Returns the current status and available results for an async SQL search or
@@ -114,7 +132,9 @@ class SqlClient(NamespacedClient):
             "GET", _make_path("_sql", "async", id), params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_async_status(self, id, params=None, headers=None):
         """
         Returns the current status of an async SQL search or a stored synchronous SQL

--- a/elasticsearch/client/ssl.py
+++ b/elasticsearch/client/ssl.py
@@ -19,7 +19,9 @@ from .utils import NamespacedClient, query_params
 
 
 class SslClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def certificates(self, params=None, headers=None):
         """
         Retrieves information about the X.509 certificates used to encrypt

--- a/elasticsearch/client/tasks.py
+++ b/elasticsearch/client/tasks.py
@@ -29,6 +29,7 @@ class TasksClient(NamespacedClient):
         "parent_task_id",
         "timeout",
         "wait_for_completion",
+        response_mimetypes=["application/json"],
     )
     def list(self, params=None, headers=None):
         """
@@ -59,7 +60,13 @@ class TasksClient(NamespacedClient):
             "GET", "/_tasks", params=params, headers=headers
         )
 
-    @query_params("actions", "nodes", "parent_task_id", "wait_for_completion")
+    @query_params(
+        "actions",
+        "nodes",
+        "parent_task_id",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     def cancel(self, task_id=None, params=None, headers=None):
         """
         Cancels a task, if it can be cancelled through an API.
@@ -91,7 +98,11 @@ class TasksClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("timeout", "wait_for_completion")
+    @query_params(
+        "timeout",
+        "wait_for_completion",
+        response_mimetypes=["application/json"],
+    )
     def get(self, task_id=None, params=None, headers=None):
         """
         Returns information about a task.

--- a/elasticsearch/client/text_structure.py
+++ b/elasticsearch/client/text_structure.py
@@ -34,6 +34,8 @@ class TextStructureClient(NamespacedClient):
         "timeout",
         "timestamp_field",
         "timestamp_format",
+        request_mimetypes=["application/x-ndjson"],
+        response_mimetypes=["application/json"],
     )
     def find_structure(self, body, params=None, headers=None):
         """

--- a/elasticsearch/client/transform.py
+++ b/elasticsearch/client/transform.py
@@ -19,7 +19,10 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class TransformClient(NamespacedClient):
-    @query_params("force")
+    @query_params(
+        "force",
+        response_mimetypes=["application/json"],
+    )
     def delete_transform(self, transform_id, params=None, headers=None):
         """
         Deletes an existing transform.
@@ -43,7 +46,13 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "exclude_generated", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "exclude_generated",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     def get_transform(self, transform_id=None, params=None, headers=None):
         """
         Retrieves configuration information for transforms.
@@ -72,7 +81,12 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("allow_no_match", "from_", "size")
+    @query_params(
+        "allow_no_match",
+        "from_",
+        "size",
+        response_mimetypes=["application/json"],
+    )
     def get_transform_stats(self, transform_id, params=None, headers=None):
         """
         Retrieves usage information for transforms.
@@ -103,7 +117,10 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def preview_transform(
         self, body=None, transform_id=None, params=None, headers=None
     ):
@@ -123,7 +140,11 @@ class TransformClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("defer_validation")
+    @query_params(
+        "defer_validation",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_transform(self, transform_id, body, params=None, headers=None):
         """
         Instantiates a transform.
@@ -147,7 +168,10 @@ class TransformClient(NamespacedClient):
             body=body,
         )
 
-    @query_params("timeout")
+    @query_params(
+        "timeout",
+        response_mimetypes=["application/json"],
+    )
     def start_transform(self, transform_id, params=None, headers=None):
         """
         Starts one or more transforms.
@@ -176,6 +200,7 @@ class TransformClient(NamespacedClient):
         "timeout",
         "wait_for_checkpoint",
         "wait_for_completion",
+        response_mimetypes=["application/json"],
     )
     def stop_transform(self, transform_id, params=None, headers=None):
         """
@@ -208,7 +233,11 @@ class TransformClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("defer_validation")
+    @query_params(
+        "defer_validation",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def update_transform(self, transform_id, body, params=None, headers=None):
         """
         Updates certain properties of a transform.

--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -188,17 +188,17 @@ def query_params(*es_query_params, **kwargs):
             try:
                 if os.environ["ELASTIC_CLIENT_APIVERSIONING"] not in ("true", "1"):
                     raise KeyError  # Unset is the same as env var not being 'true' or '1'
-                if compat_accept:
-                    headers.setdefault("accept", compat_accept)
-                if compat_content_type:
-                    headers.setdefault("content-type", compat_content_type)
+                accept = compat_accept
+                content_type = compat_content_type
             except KeyError:
-                if default_accept:
-                    headers.setdefault("accept", default_accept)
-                if default_content_type:
-                    headers.setdefault("content-type", default_content_type)
+                accept = default_accept
+                content_type = default_content_type
 
-            print(headers)
+            # Set the mimetype headers for the request
+            if accept:
+                headers.setdefault("accept", accept)
+            if content_type:
+                headers.setdefault("content-type", content_type)
 
             http_auth = kwargs.pop("http_auth", None)
             api_key = kwargs.pop("api_key", None)

--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -30,7 +30,7 @@ from ..compat import PY2, quote, string_types, to_bytes, to_str, unquote, urlpar
 # parts of URL to be omitted
 SKIP_IN_PATH = (None, "", b"", [], ())
 
-# Switch this value with 'application/json' if 'ELASTIC_CLIENT_APIVERSIONING=1/true'
+# Switch to this mimetype if 'ELASTIC_CLIENT_APIVERSIONING=1/true'
 _COMPATIBILITY_MIMETYPE = "application/vnd.elasticsearch+json;compatible-with=%s" % (
     __versionstr__.partition(".")[0]
 )
@@ -139,8 +139,6 @@ def query_params(*es_query_params, **kwargs):
 
     def compat_mimetype(mimetypes):
         if os.environ.get("ELASTIC_CLIENT_APIVERSIONING", "") in ("1", "true"):
-            # Need to replace both 'application/json' and 'application/x-ndjson'
-            # with the compatibility header.
             return [
                 _COMPATIBILITY_MIMETYPE
                 if mimetype

--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -143,7 +143,12 @@ def query_params(*es_query_params, **kwargs):
             # with the compatibility header.
             return [
                 _COMPATIBILITY_MIMETYPE
-                if mimetype in ("application/json", "application/x-ndjson")
+                if mimetype
+                in (
+                    "application/json",
+                    "application/x-ndjson",
+                    "application/vnd.mapbox-vector-tile",
+                )
                 else mimetype
                 for mimetype in mimetypes
             ]

--- a/elasticsearch/client/utils.py
+++ b/elasticsearch/client/utils.py
@@ -139,8 +139,12 @@ def query_params(*es_query_params, **kwargs):
 
     def compat_mimetype(mimetypes):
         if os.environ.get("ELASTIC_CLIENT_APIVERSIONING", "") in ("1", "true"):
+            # Need to replace both 'application/json' and 'application/x-ndjson'
+            # with the compatibility header.
             return [
-                _COMPATIBILITY_MIMETYPE if mimetype == "application/json" else mimetype
+                _COMPATIBILITY_MIMETYPE
+                if mimetype in ("application/json", "application/x-ndjson")
+                else mimetype
                 for mimetype in mimetypes
             ]
         return mimetypes

--- a/elasticsearch/client/utils.pyi
+++ b/elasticsearch/client/utils.pyi
@@ -48,6 +48,8 @@ GLOBAL_PARAMS: Tuple[str, ...]
 
 def query_params(
     *es_query_params: str,
+    request_mimetypes: Optional[List[str]] = ...,
+    response_mimetypes: Optional[List[str]] = ...,
     body_params: Optional[List[str]] = ...,
     body_name: Optional[str] = ...,
     body_required: Optional[bool] = ...

--- a/elasticsearch/client/watcher.py
+++ b/elasticsearch/client/watcher.py
@@ -19,7 +19,9 @@ from .utils import SKIP_IN_PATH, NamespacedClient, _make_path, query_params
 
 
 class WatcherClient(NamespacedClient):
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def ack_watch(self, watch_id, action_id=None, params=None, headers=None):
         """
         Acknowledges a watch, manually throttling the execution of the watch's actions.
@@ -40,7 +42,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def activate_watch(self, watch_id, params=None, headers=None):
         """
         Activates a currently inactive watch.
@@ -59,7 +63,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def deactivate_watch(self, watch_id, params=None, headers=None):
         """
         Deactivates a currently active watch.
@@ -78,7 +84,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def delete_watch(self, id, params=None, headers=None):
         """
         Removes a watch from Watcher.
@@ -97,7 +105,11 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params("debug")
+    @query_params(
+        "debug",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def execute_watch(self, body=None, id=None, params=None, headers=None):
         """
         Forces the execution of a stored watch.
@@ -117,7 +129,9 @@ class WatcherClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def get_watch(self, id, params=None, headers=None):
         """
         Retrieves a watch by its ID.
@@ -133,7 +147,14 @@ class WatcherClient(NamespacedClient):
             "GET", _make_path("_watcher", "watch", id), params=params, headers=headers
         )
 
-    @query_params("active", "if_primary_term", "if_seq_no", "version")
+    @query_params(
+        "active",
+        "if_primary_term",
+        "if_seq_no",
+        "version",
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def put_watch(self, id, body=None, params=None, headers=None):
         """
         Creates a new watch, or updates an existing one.
@@ -160,7 +181,9 @@ class WatcherClient(NamespacedClient):
             body=body,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def start(self, params=None, headers=None):
         """
         Starts Watcher if it is not already running.
@@ -171,7 +194,10 @@ class WatcherClient(NamespacedClient):
             "POST", "/_watcher/_start", params=params, headers=headers
         )
 
-    @query_params("emit_stacktraces")
+    @query_params(
+        "emit_stacktraces",
+        response_mimetypes=["application/json"],
+    )
     def stats(self, metric=None, params=None, headers=None):
         """
         Retrieves the current Watcher metrics.
@@ -191,7 +217,9 @@ class WatcherClient(NamespacedClient):
             headers=headers,
         )
 
-    @query_params()
+    @query_params(
+        response_mimetypes=["application/json"],
+    )
     def stop(self, params=None, headers=None):
         """
         Stops Watcher if it is running.
@@ -202,7 +230,10 @@ class WatcherClient(NamespacedClient):
             "POST", "/_watcher/_stop", params=params, headers=headers
         )
 
-    @query_params()
+    @query_params(
+        request_mimetypes=["application/json"],
+        response_mimetypes=["application/json"],
+    )
     def query_watches(self, body=None, params=None, headers=None):
         """
         Retrieves stored watches.

--- a/elasticsearch/client/xpack.py
+++ b/elasticsearch/client/xpack.py
@@ -23,7 +23,11 @@ class XPackClient(NamespacedClient):
         return getattr(self.client, attr_name)
 
     # AUTO-GENERATED-API-DEFINITIONS #
-    @query_params("accept_enterprise", "categories")
+    @query_params(
+        "accept_enterprise",
+        "categories",
+        response_mimetypes=["application/json"],
+    )
     def info(self, params=None, headers=None):
         """
         Retrieves information about the installed X-Pack features.
@@ -39,7 +43,10 @@ class XPackClient(NamespacedClient):
             "GET", "/_xpack", params=params, headers=headers
         )
 
-    @query_params("master_timeout")
+    @query_params(
+        "master_timeout",
+        response_mimetypes=["application/json"],
+    )
     def usage(self, params=None, headers=None):
         """
         Retrieves usage information about the installed X-Pack features.

--- a/elasticsearch/connection/base.py
+++ b/elasticsearch/connection/base.py
@@ -19,7 +19,6 @@ import binascii
 import gzip
 import io
 import logging
-import os
 import re
 import warnings
 from platform import python_version
@@ -29,7 +28,7 @@ try:
 except ImportError:
     import json
 
-from .. import __version__, __versionstr__
+from .. import __versionstr__
 from ..compat import PY2
 from ..exceptions import (
     HTTP_EXCEPTIONS,
@@ -123,14 +122,6 @@ class Connection(object):
         if opaque_id:
             self.headers["x-opaque-id"] = opaque_id
 
-        if os.getenv("ELASTIC_CLIENT_APIVERSIONING") == "1":
-            self.headers.setdefault(
-                "accept",
-                "application/vnd.elasticsearch+json;compatible-with=%s"
-                % (str(__version__[0]),),
-            )
-
-        self.headers.setdefault("content-type", "application/json")
         self.headers.setdefault("user-agent", self._get_default_user_agent())
 
         if api_key is not None:

--- a/test_elasticsearch/test_async/test_connection.py
+++ b/test_elasticsearch/test_async/test_connection.py
@@ -220,7 +220,6 @@ class TestAIOHttpConnection:
         con = AIOHttpConnection()
         assert {
             "connection": "keep-alive",
-            "content-type": "application/json",
             "user-agent": con._get_default_user_agent(),
         } == con.headers
 
@@ -229,7 +228,6 @@ class TestAIOHttpConnection:
         assert {
             "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
             "connection": "keep-alive",
-            "content-type": "application/json",
             "user-agent": con._get_default_user_agent(),
         } == con.headers
 
@@ -237,7 +235,6 @@ class TestAIOHttpConnection:
         con = AIOHttpConnection(http_auth=("username", "secret"))
         assert {
             "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
-            "content-type": "application/json",
             "connection": "keep-alive",
             "user-agent": con._get_default_user_agent(),
         } == con.headers
@@ -246,7 +243,6 @@ class TestAIOHttpConnection:
         con = AIOHttpConnection(http_auth=["username", "secret"])
         assert {
             "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
-            "content-type": "application/json",
             "connection": "keep-alive",
             "user-agent": con._get_default_user_agent(),
         } == con.headers
@@ -358,7 +354,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["method"] == "GET"
         assert data["headers"] == {
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -371,7 +366,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["method"] == "GET"
         assert data["headers"] == {
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -384,7 +378,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -403,7 +396,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "Header1": "override!",
             "Header2": "value2",

--- a/test_elasticsearch/test_async/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_async/test_server/test_rest_api_spec.py
@@ -31,6 +31,7 @@ from elasticsearch.helpers.test import _get_version
 from ...test_server.test_rest_api_spec import (
     APIS_USING_TYPE_INSTEAD_OF_DOC_TYPE,
     APIS_WITH_BODY_FIELDS,
+    COMPATIBILITY_MODE_ENABLED,
     IMPLEMENTED_FEATURES,
     PARAMS_RENAMES,
     RUN_ASYNC_REST_API_TESTS,
@@ -127,6 +128,15 @@ class AsyncYamlRunner(YamlRunner):
             == "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA=="
         ):
             headers.pop("Authorization")
+
+        if (
+            headers
+            and headers.get("Content-Type") == "application/json"
+            and COMPATIBILITY_MODE_ENABLED
+        ):
+            headers[
+                "Content-Type"
+            ] = "application/vnd.elasticsearch+json;compatible-with=7"
 
         method, args = list(action.items())[0]
         args["headers"] = headers

--- a/test_elasticsearch/test_async/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_async/test_server/test_rest_api_spec.py
@@ -31,6 +31,7 @@ from elasticsearch.helpers.test import _get_version
 from ...test_server.test_rest_api_spec import (
     APIS_USING_TYPE_INSTEAD_OF_DOC_TYPE,
     APIS_WITH_BODY_FIELDS,
+    COMPATIBILITY_MIMETYPE,
     COMPATIBILITY_MODE_ENABLED,
     IMPLEMENTED_FEATURES,
     PARAMS_RENAMES,
@@ -129,14 +130,8 @@ class AsyncYamlRunner(YamlRunner):
         ):
             headers.pop("Authorization")
 
-        if (
-            headers
-            and headers.get("Content-Type") == "application/json"
-            and COMPATIBILITY_MODE_ENABLED
-        ):
-            headers[
-                "Content-Type"
-            ] = "application/vnd.elasticsearch+json;compatible-with=7"
+        if headers and "Content-Type" in headers and COMPATIBILITY_MODE_ENABLED:
+            headers["Content-Type"] = COMPATIBILITY_MIMETYPE
 
         method, args = list(action.items())[0]
         args["headers"] = headers

--- a/test_elasticsearch/test_client/test_overrides.py
+++ b/test_elasticsearch/test_client/test_overrides.py
@@ -190,7 +190,7 @@ class TestOverriddenUrlTargets(ElasticsearchTestCase):
             ("POST", "/_search/scroll"): [
                 (
                     {"rest_total_hits_as_int": b"true"},
-                    {},
+                    {"accept": "application/json", "content-type": "application/json"},
                     {"scroll": "5m", "scroll_id": "scroll-id"},
                 )
             ]
@@ -200,7 +200,13 @@ class TestOverriddenUrlTargets(ElasticsearchTestCase):
         self.client.clear_scroll(scroll_id="scroll-id")
         calls = self.client.transport.calls
         assert calls == {
-            ("DELETE", "/_search/scroll"): [({}, {}, {"scroll_id": "scroll-id"})]
+            ("DELETE", "/_search/scroll"): [
+                (
+                    {},
+                    {"accept": "application/json", "content-type": "application/json"},
+                    {"scroll_id": "scroll-id"},
+                )
+            ]
         }
 
     def test_doc_type_works_for_apis_with_type(self):
@@ -210,7 +216,9 @@ class TestOverriddenUrlTargets(ElasticsearchTestCase):
         assert w == []
         calls = self.client.transport.calls
         assert calls == {
-            ("POST", "/_license/start_trial"): [({"type": b"trial"}, {}, None)]
+            ("POST", "/_license/start_trial"): [
+                ({"type": b"trial"}, {"accept": "application/json"}, None)
+            ]
         }
         self.client.transport.calls.pop(("POST", "/_license/start_trial"))
 
@@ -220,7 +228,9 @@ class TestOverriddenUrlTargets(ElasticsearchTestCase):
         assert w == []
         calls = self.client.transport.calls
         assert calls == {
-            ("POST", "/_license/start_trial"): [({"type": "trial"}, {}, None)]
+            ("POST", "/_license/start_trial"): [
+                ({"type": "trial"}, {"accept": "application/json"}, None)
+            ]
         }
         self.client.transport.calls.pop(("POST", "/_license/start_trial"))
 
@@ -235,7 +245,9 @@ class TestOverriddenUrlTargets(ElasticsearchTestCase):
         )
         calls = self.client.transport.calls
         assert calls == {
-            ("POST", "/_license/start_trial"): [({"type": b"trial"}, {}, None)]
+            ("POST", "/_license/start_trial"): [
+                ({"type": b"trial"}, {"accept": "application/json"}, None)
+            ]
         }
         self.client.transport.calls.pop(("POST", "/_license/start_trial"))
 
@@ -248,5 +260,7 @@ class TestOverriddenUrlTargets(ElasticsearchTestCase):
         )
         calls = self.client.transport.calls
         assert calls == {
-            ("POST", "/_license/start_trial"): [({"type": "trial"}, {}, None)]
+            ("POST", "/_license/start_trial"): [
+                ({"type": "trial"}, {"accept": "application/json"}, None)
+            ]
         }

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -371,7 +371,6 @@ class TestUrllib3Connection(TestCase):
             {
                 "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
                 "connection": "keep-alive",
-                "content-type": "application/json",
                 "user-agent": con._get_default_user_agent(),
             },
             con.headers,
@@ -382,7 +381,6 @@ class TestUrllib3Connection(TestCase):
         self.assertEqual(
             {
                 "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
-                "content-type": "application/json",
                 "connection": "keep-alive",
                 "user-agent": con._get_default_user_agent(),
             },
@@ -394,7 +392,6 @@ class TestUrllib3Connection(TestCase):
         self.assertEqual(
             {
                 "authorization": "Basic dXNlcm5hbWU6c2VjcmV0",
-                "content-type": "application/json",
                 "connection": "keep-alive",
                 "user-agent": con._get_default_user_agent(),
             },

--- a/test_elasticsearch/test_connection.py
+++ b/test_elasticsearch/test_connection.py
@@ -19,7 +19,6 @@
 import gzip
 import io
 import json
-import os
 import re
 import ssl
 import warnings
@@ -174,26 +173,6 @@ class TestBaseConnection(TestCase):
         with pytest.raises(TypeError) as e:
             Connection(meta_header=1)
         assert str(e.value) == "meta_header must be of type bool"
-
-    def test_compatibility_accept_header(self):
-        try:
-            conn = Connection()
-            assert "accept" not in conn.headers
-
-            os.environ["ELASTIC_CLIENT_APIVERSIONING"] = "0"
-
-            conn = Connection()
-            assert "accept" not in conn.headers
-
-            os.environ["ELASTIC_CLIENT_APIVERSIONING"] = "1"
-
-            conn = Connection()
-            assert (
-                conn.headers["accept"]
-                == "application/vnd.elasticsearch+json;compatible-with=7"
-            )
-        finally:
-            os.environ.pop("ELASTIC_CLIENT_APIVERSIONING")
 
 
 class TestUrllib3Connection(TestCase):
@@ -359,7 +338,6 @@ class TestUrllib3Connection(TestCase):
         self.assertEqual(
             {
                 "connection": "keep-alive",
-                "content-type": "application/json",
                 "user-agent": con._get_default_user_agent(),
             },
             con.headers,
@@ -698,8 +676,7 @@ class TestRequestsConnection(TestCase):
     def test_default_headers(self):
         con = self._get_mock_connection()
         req = self._get_request(con, "GET", "/")
-        self.assertEqual(req.headers["content-type"], "application/json")
-        self.assertEqual(req.headers["user-agent"], con._get_default_user_agent())
+        self.assertEqual(req.headers, {"user-agent": con._get_default_user_agent()})
 
     def test_custom_headers(self):
         con = self._get_mock_connection()
@@ -945,7 +922,6 @@ class TestConnectionHttpbin:
         assert data["method"] == "GET"
         assert data["headers"] == {
             "Accept-Encoding": "identity",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -959,7 +935,6 @@ class TestConnectionHttpbin:
         assert data["method"] == "GET"
         assert data["headers"] == {
             "Accept-Encoding": "identity",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -972,7 +947,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -991,7 +965,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "Header1": "override!",
             "Header2": "value2",
@@ -1012,7 +985,6 @@ class TestConnectionHttpbin:
         assert data["method"] == "GET"
         assert data["headers"] == {
             "Accept-Encoding": "identity",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -1026,7 +998,6 @@ class TestConnectionHttpbin:
         assert data["method"] == "GET"
         assert data["headers"] == {
             "Accept-Encoding": "identity",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -1039,7 +1010,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "User-Agent": user_agent,
         }
@@ -1058,7 +1028,6 @@ class TestConnectionHttpbin:
         assert status == 200
         assert data["headers"] == {
             "Accept-Encoding": "gzip,deflate",
-            "Content-Type": "application/json",
             "Host": "httpbin.org",
             "Header1": "override!",
             "Header2": "value2",

--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -538,9 +538,8 @@ try:
     # test suite so we use the overridden 'STACK_VERSION' in run-repository.sh instead.
     if os.environ.get("STACK_VERSION") and COMPATIBILITY_MODE_ENABLED:
         version_number = os.environ["STACK_VERSION"]
-        build_hash = (
-            ""  # Setting this to empty means we'll always get the latest build.
-        )
+        # Setting 'build_hash' to empty means we'll always get the latest build.
+        build_hash = ""
     else:
         # Make a request to Elasticsearch for the build hash, we'll be looking for
         # an artifact with this same hash to download test specs for.


### PR DESCRIPTION
The interesting places to look in this PR are:
- `.ci/run-repository.sh`
- `elasticsearch/client/utils.py`
- `elasticsearch/test_elasticsearch/test_rest_api_spec.py`

The generated specs aren't as interesting, pulls the request and response mimetypes into the API definition.