### PR TITLE
Add term-missing to pytest

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -38,8 +38,7 @@ def test(session):
     junit_xml = os.path.join(SOURCE_DIR, "junit", "elasticsearch-py-junit.xml")
     pytest_argv = [
         "pytest",
-        "--cov-report",
-        "term-missing",
+        "--cov-report=term-missing",
         "--cov=elasticsearch",
         "--cov-config=setup.cfg",
         f"--junitxml={junit_xml}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,10 @@ def test(session):
     junit_xml = os.path.join(SOURCE_DIR, "junit", "elasticsearch-py-junit.xml")
     pytest_argv = [
         "pytest",
+        "--cov-report",
+        "term-missing",
         "--cov=elasticsearch",
+        "--cov-config=setup.cfg",
         f"--junitxml={junit_xml}",
         "--log-level=DEBUG",
         "--cache-clear",

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,8 @@ junit_family=legacy
 
 [tool:isort]
 profile=black
+
+[report]
+exclude_lines=
+    raise NotImplementedError
+    raise NotImplementedError()

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,4 @@ profile=black
 
 [report]
 exclude_lines=
-    raise NotImplementedError
-    raise NotImplementedError()
+    raise NotImplementedError*


### PR DESCRIPTION
This PR adds term-missing parameter to `pytest-cov` to find out what lines we are missing coverage.

Also excludes some lines which probably don't need tests.

@sethmlarson Take a look and once run Jenkins
