### PR TITLE
backport of term-missing on main

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,12 @@ ignore = E203, E266, E501, W503
 
 [tool:pytest]
 junit_family=legacy
+addopts = --cov-report=term-missing --cov=elasticsearch --cov-config=setup.cfg
 
 [tool:isort]
 profile=black
+
+[report]
+show_missing = True
+exclude_lines=
+    raise NotImplementedError*


### PR DESCRIPTION
Manual backport of #1727 

Reference: 
- https://pytest-cov.readthedocs.io/en/latest/config.html
- https://coverage.readthedocs.io/en/coverage-5.5/config.html#report

@sethmlarson Run jenkins once, lets see if it works

