### PR TITLE
Fixing deprecated param in index.rst example

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -51,7 +51,7 @@ Example Usage
         'text': 'Elasticsearch: cool. bonsai cool.',
         'timestamp': datetime.now(),
     }
-    res = es.index(index="test-index", id=1, body=doc)
+    res = es.index(index="test-index", id=1, document=doc)
     print(res['result'])
 
     res = es.get(index="test-index", id=1)


### PR DESCRIPTION
Changing `Example Usage` example to use the `document` parameter rather than the `body` parameter in the index API (which is deprecated and displays a warning saying it will be removed in `8.0.0`)

Closes #1748 