### PR TITLE
[7.x] [DOCS] Retitle Elasticsearch Python Client doc book

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -1,4 +1,4 @@
-= elasticsearch-py
+= Elasticsearch Python Client
 
 :doctype:           book
 


### PR DESCRIPTION
7.x backport of https://github.com/elastic/elasticsearch-py/pull/1755