### PR TITLE
Deprecate the broken 'send_get_body_as' parameter

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -133,6 +133,14 @@ class Transport(object):
         if not isinstance(meta_header, bool):
             raise TypeError("meta_header must be of type bool")
 
+        if send_get_body_as != "GET":
+            warnings.warn(
+                "The 'send_get_body_as' parameter is no longer necessary "
+                "and will be removed in 8.0",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         # serialization config
         _serializers = DEFAULT_SERIALIZERS.copy()
         # if a serializer has been specified, use it for deserialization as well

--- a/test_elasticsearch/test_async/test_transport.py
+++ b/test_elasticsearch/test_async/test_transport.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 import asyncio
 import json
 import re
+import warnings
 
 import pytest
 from mock import patch
@@ -181,8 +182,13 @@ class TestTransport:
         } == t.get_connection().calls[0][1]
 
     async def test_send_get_body_as_source(self):
-        t = AsyncTransport(
-            [{}], send_get_body_as="source", connection_class=DummyConnection
+        with warnings.catch_warnings(record=True) as w:
+            t = AsyncTransport(
+                [{}], send_get_body_as="source", connection_class=DummyConnection
+            )
+        assert len(w) == 1
+        assert str(w[0].message) == (
+            "The 'send_get_body_as' parameter is no longer necessary and will be removed in 8.0"
         )
         t._verified_elasticsearch = True
 
@@ -191,8 +197,13 @@ class TestTransport:
         assert ("GET", "/", {"source": "{}"}, None) == t.get_connection().calls[0][0]
 
     async def test_send_get_body_as_post(self):
-        t = AsyncTransport(
-            [{}], send_get_body_as="POST", connection_class=DummyConnection
+        with warnings.catch_warnings(record=True) as w:
+            t = AsyncTransport(
+                [{}], send_get_body_as="POST", connection_class=DummyConnection
+            )
+        assert len(w) == 1
+        assert str(w[0].message) == (
+            "The 'send_get_body_as' parameter is no longer necessary and will be removed in 8.0"
         )
         t._verified_elasticsearch = True
 

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 import json
 import time
+import warnings
 
 import pytest
 from mock import patch
@@ -187,7 +188,14 @@ class TestTransport(TestCase):
         )
 
     def test_send_get_body_as_source(self):
-        t = Transport([{}], send_get_body_as="source", connection_class=DummyConnection)
+        with warnings.catch_warnings(record=True) as w:
+            t = Transport(
+                [{}], send_get_body_as="source", connection_class=DummyConnection
+            )
+        assert len(w) == 1
+        assert str(w[0].message) == (
+            "The 'send_get_body_as' parameter is no longer necessary and will be removed in 8.0"
+        )
         t._verified_elasticsearch = True
 
         t.perform_request("GET", "/", body={})
@@ -197,7 +205,14 @@ class TestTransport(TestCase):
         )
 
     def test_send_get_body_as_post(self):
-        t = Transport([{}], send_get_body_as="POST", connection_class=DummyConnection)
+        with warnings.catch_warnings(record=True) as w:
+            t = Transport(
+                [{}], send_get_body_as="POST", connection_class=DummyConnection
+            )
+        assert len(w) == 1
+        assert str(w[0].message) == (
+            "The 'send_get_body_as' parameter is no longer necessary and will be removed in 8.0"
+        )
         t._verified_elasticsearch = True
 
         t.perform_request("GET", "/", body={})


### PR DESCRIPTION
This parameter is no longer needed as we automatically use the correct HTTP method for each API given whether it accepts a body or not. The parameter is broken in multiple ways like APIs that have a body but only accept `GET` like `ml.get_calendar_events` or encoding large bodies into the request target which can cause errors about the URI being too long.

We're removing this in 8.0 as it's no longer helpful and can only cause problems.