### PR TITLE
Deprecate the 'http_auth' parameter

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -168,6 +168,7 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
         sniffer_timeout=DEFAULT,
         sniff_on_connection_fail=DEFAULT,
+        http_auth=DEFAULT,
         # Internal use only
         _transport: Optional[AsyncTransport] = None,
     ) -> None:
@@ -346,6 +347,7 @@ class AsyncElasticsearch(BaseClient):
             self._headers["x-opaque-id"] = opaque_id
         self._headers = resolve_auth_headers(
             self._headers,
+            http_auth=http_auth,
             api_key=api_key,
             basic_auth=basic_auth,
             bearer_auth=bearer_auth,

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -168,6 +168,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         sniffer_timeout=DEFAULT,
         sniff_on_connection_fail=DEFAULT,
+        http_auth=DEFAULT,
         # Internal use only
         _transport: Optional[Transport] = None,
     ) -> None:
@@ -346,6 +347,7 @@ class Elasticsearch(BaseClient):
             self._headers["x-opaque-id"] = opaque_id
         self._headers = resolve_auth_headers(
             self._headers,
+            http_auth=http_auth,
             api_key=api_key,
             basic_auth=basic_auth,
             bearer_auth=bearer_auth,


### PR DESCRIPTION
This parameter is deprecated in favor of `basic_auth`.