### PR TITLE
Disallow unicode headers for urllib3

### DIFF
--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -24,7 +24,7 @@ from urllib3.exceptions import ReadTimeoutError
 from urllib3.exceptions import SSLError as UrllibSSLError  # type: ignore
 from urllib3.util.retry import Retry  # type: ignore
 
-from ..compat import reraise_exceptions, urlencode
+from ..compat import reraise_exceptions, to_str, urlencode
 from ..exceptions import (
     ConnectionError,
     ConnectionTimeout,
@@ -243,6 +243,10 @@ class Urllib3HttpConnection(Connection):
 
             request_headers = self.headers.copy()
             request_headers.update(headers or ())
+            request_headers = {
+                to_str(header, "latin-1"): to_str(value, "latin-1")
+                for header, value in request_headers.items()
+            }
 
             if self.http_compress and body:
                 body = self._gzip_compress(body)


### PR DESCRIPTION
Fixes a bug where unicode in HTTP headers would cause issues with Python 2 when using urllib3. This bug was introduced in https://github.com/elastic/elasticsearch-py/commit/8aee058f80cf14b6f523a1996dee932ec925eacc where `Content-Type` and `Accept` headers were being passed to every request.

This bug only exists on the 7.16 branch.