### PR TITLE
Don't raise DeprecationWarnings per API

### DIFF
--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -275,9 +275,8 @@ def _rewrite_parameters(
                             "Instead of using 'params' use individual API parameters"
                         )
                     warnings.warn(
-                        f"The 'params' parameter is deprecated for the '{api.__name__!s}' API and "
-                        "will be removed in a future version. Instead use individual "
-                        "parameters.",
+                        "The 'params' parameter is deprecated and will be removed "
+                        "in a future version. Instead use individual parameters.",
                         category=DeprecationWarning,
                         stacklevel=warn_stacklevel(),
                     )
@@ -335,8 +334,8 @@ def _rewrite_parameters(
                             )
 
                         warnings.warn(
-                            f"The 'body' parameter is deprecated for the '{api.__name__!s}' API and "
-                            f"will be removed in a future version. Instead use the '{body_name}' parameter. "
+                            "The 'body' parameter is deprecated and will be removed "
+                            f"in a future version. Instead use the '{body_name}' parameter. "
                             "See https://github.com/elastic/elasticsearch-py/issues/1698 "
                             "for more information",
                             category=DeprecationWarning,
@@ -351,9 +350,8 @@ def _rewrite_parameters(
                                 "Instead of using 'body' use individual API parameters"
                             )
                         warnings.warn(
-                            f"The 'body' parameter is deprecated for the '{api.__name__!s}' API and "
-                            "will be removed in a future version. Instead use individual "
-                            "parameters.",
+                            "The 'body' parameter is deprecated and will be removed "
+                            "in a future version. Instead use individual parameters.",
                             category=DeprecationWarning,
                             stacklevel=warn_stacklevel(),
                         )

--- a/test_elasticsearch/test_client/test_rewrite_parameters.py
+++ b/test_elasticsearch/test_client/test_rewrite_parameters.py
@@ -67,7 +67,7 @@ class TestRewriteParameters:
         assert w[0].category == DeprecationWarning
         assert (
             str(w[0].message)
-            == "The 'params' parameter is deprecated for the 'wrapped_func_default' API and will be removed in a future version. Instead use individual parameters."
+            == "The 'params' parameter is deprecated and will be removed in a future version. Instead use individual parameters."
         )
         assert w[1].category == DeprecationWarning
         assert (
@@ -94,7 +94,7 @@ class TestRewriteParameters:
         )
         assert w[1].category == DeprecationWarning
         assert str(w[1].message) == (
-            "The 'body' parameter is deprecated for the 'wrapped_func_body_name' API and will be removed in a "
+            "The 'body' parameter is deprecated and will be removed in a "
             "future version. Instead use the 'document' parameter. See https://github.com/elastic/elasticsearch-py/issues/1698 "
             "for more information"
         )
@@ -146,7 +146,7 @@ class TestRewriteParameters:
         )
         assert w[1].category == DeprecationWarning
         assert str(w[1].message) == (
-            "The 'body' parameter is deprecated for the 'wrapped_func_body_fields' API and will be removed in a future version. Instead use individual parameters."
+            "The 'body' parameter is deprecated and will be removed in a future version. Instead use individual parameters."
         )
 
         assert self.calls == [


### PR DESCRIPTION
Because the message is per-API in some places we end up being chattier than we need to be. Instead raise it once per problem so we're not bogging down people's consoles.