### PR TITLE
Set a default User-Agent header

### DIFF
--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -37,10 +37,17 @@ from typing import (
     Union,
 )
 
-from elastic_transport import AsyncTransport, NodeConfig, SniffOptions, Transport
+from elastic_transport import (
+    AsyncTransport,
+    HttpHeaders,
+    NodeConfig,
+    SniffOptions,
+    Transport,
+)
 from elastic_transport.client_utils import (
     DEFAULT,
     client_meta_version,
+    create_user_agent,
     parse_cloud_id,
     percent_encode,
     url_to_node_config,
@@ -57,6 +64,9 @@ SKIP_IN_PATH: Collection[Any] = (None, "", b"", [], ())
 
 # To be passed to 'client_meta_service' on the Transport
 CLIENT_META_SERVICE = ("es", client_meta_version(__versionstr__))
+
+# Default User-Agent used by the client
+USER_AGENT = create_user_agent("elasticsearch-py", __versionstr__)
 
 _TYPE_HOSTS = Union[str, List[Union[str, Mapping[str, Union[str, int]], NodeConfig]]]
 
@@ -92,6 +102,12 @@ def client_node_configs(
 
     # Remove all values which are 'DEFAULT' to avoid overwriting actual defaults.
     node_options = {k: v for k, v in kwargs.items() if v is not DEFAULT}
+
+    # Set the 'User-Agent' default header.
+    headers = HttpHeaders(node_options.pop("headers", ()))
+    headers.setdefault("user-agent", USER_AGENT)
+    node_options["headers"] = headers
+
     return [node_config.replace(**node_options) for node_config in node_configs]
 
 

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -25,7 +25,7 @@ import pytest
 from elastic_transport import ApiResponseMeta, BaseNode, HttpHeaders, NodeConfig
 from elastic_transport.client_utils import DEFAULT
 
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, __versionstr__
 from elasticsearch.exceptions import (
     ApiError,
     ConnectionError,
@@ -203,6 +203,14 @@ class TestTransport:
         assert 2 == len(calls)
         assert calls[1][0] == ("GET", "/")
         assert calls[1][1]["headers"]["x-opaque-id"] == "request-2"
+
+    def test_custom_user_agent_on_initialization(self):
+        client = Elasticsearch(
+            "http://localhost:9200", headers={"user-agent": "custom/1.2.3"}
+        )
+        headers = [node.config for node in client.transport.node_pool.all()][0].headers
+        assert list(headers.keys()) == ["user-agent"]
+        assert headers["user-agent"].startswith(f"elasticsearch-py/{__versionstr__} (")
 
     def test_request_with_custom_user_agent_header(self):
         client = Elasticsearch(


### PR DESCRIPTION
This got left out of the migration to elastic-transport. Restore setting a default `User-Agent` header.