### PR TITLE
Bumping version to 7.16.3

### DIFF
--- a/elasticsearch/_version.py
+++ b/elasticsearch/_version.py
@@ -15,4 +15,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__versionstr__ = "7.16.2"
+__versionstr__ = "7.16.3"


### PR DESCRIPTION
set version string to 7.16.next. Building `7.16.3` artefacts successfully:

```
===============================
a elasticsearch-7.16.3-py2.py3-none-any.whl
a elasticsearch-7.16.3.tar.gz
a elasticsearch7-7.16.3-py2.py3-none-any.whl
a elasticsearch7-7.16.3.tar.gz
/Users/pkrauss/github.com/elasticsearch-py
TARGET: successfully assembled client v7.16.3
```