### PR TITLE
Add clearer TypeError when using positional arguments in API methods

### DIFF
--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -292,6 +292,13 @@ def _rewrite_parameters(
         def wrapped(*args: Any, **kwargs: Any) -> Any:
             nonlocal api, body_name, body_fields
 
+            # Let's give a nicer error message when users pass positional arguments.
+            if len(args) >= 2:
+                raise TypeError(
+                    "Positional arguments can't be used with Elasticsearch API methods. "
+                    "Instead only use keyword arguments."
+                )
+
             # We merge 'params' first as transport options can be specified using params.
             if "params" in kwargs and (
                 not ignore_deprecated_options

--- a/test_elasticsearch/test_client/test_rewrite_parameters.py
+++ b/test_elasticsearch/test_client/test_rewrite_parameters.py
@@ -19,6 +19,7 @@ import warnings
 
 import pytest
 
+from elasticsearch import AsyncElasticsearch, Elasticsearch
 from elasticsearch._sync.client.utils import _rewrite_parameters
 
 
@@ -212,3 +213,21 @@ class TestRewriteParameters:
 
         self.wrapped_func_aliases(source=["key3"])
         assert self.calls[-1] == ((), {"source": ["key3"]})
+
+    @pytest.mark.parametrize("client_cls", [Elasticsearch, AsyncElasticsearch])
+    def test_positional_argument_error(self, client_cls):
+        client = client_cls("https://localhost:9200")
+
+        with pytest.raises(TypeError) as e:
+            client.search("index")
+        assert str(e.value) == (
+            "Positional arguments can't be used with Elasticsearch API methods. "
+            "Instead only use keyword arguments."
+        )
+
+        with pytest.raises(TypeError) as e:
+            client.indices.exists("index")
+        assert str(e.value) == (
+            "Positional arguments can't be used with Elasticsearch API methods. "
+            "Instead only use keyword arguments."
+        )


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/issues/1846