### PR TITLE
Typo fix - change 'res' to 'resp' in doc example

### DIFF
--- a/docs/guide/examples.asciidoc
+++ b/docs/guide/examples.asciidoc
@@ -68,8 +68,8 @@ The `search()` method returns results that are matching a query:
 [source,py]
 ----------------------------
 resp = es.search(index="test-index", query={"match_all": {}})
-print("Got %d Hits:" % res['hits']['total']['value'])
-for hit in res['hits']['hits']:
+print("Got %d Hits:" % resp['hits']['total']['value'])
+for hit in resp['hits']['hits']:
     print("%(timestamp)s %(author)s: %(text)s" % hit["_source"])
 ----------------------------
 


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/client/python-api/master/examples.html has the following sample code:

![Screenshot_2022-01-06_18-18-21](https://user-images.githubusercontent.com/79528/148385632-b7cebe81-a400-462e-908d-be8de3a39e31.png)

The variable is named `resp` and not `res` (without `p` at the end). This PR fixes this doc example problem.

