### PR TITLE
Skip `$body` key when fetching response attributes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,6 +15,7 @@ isort
 black
 twine
 build
+nox
 
 # No wheels for Python 3.10 yet!
 numpy; python_version<"3.10"

--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -467,9 +467,11 @@ class YamlRunner:
         for step in path.split("."):
             if not step:
                 continue
+            # We check body again to handle E.g. '$body.$backing_index.data_stream'
+            if step.startswith("$body"):
+                continue
             step = step.replace("\1", ".")
             step = self._resolve(step)
-
             if (
                 isinstance(step, string_types)
                 and step.isdigit()


### PR DESCRIPTION
This PR fixes one REST API Test which is causing pipeline to fail

URL: https://clients-ci.elastic.co/job/elastic+elasticsearch-py+main/338/PYTHON_CONNECTION_CLASS=urllib3,PYTHON_VERSION=3.9,STACK_VERSION=8.1.0-SNAPSHOT,TEST_SUITE=platinum,label=linux/consoleFull

The following expression isn't resolved `$body.$backing_index.data_stream`.

```
_________________ test_rest_api_spec[data_stream/150_tsdb[0]] __________________
05:59:36 
05:59:36 test_spec = {}
05:59:36 sync_runner = <test_elasticsearch.test_server.test_rest_api_spec.YamlRunner object at 0x7f7dcecfb1f0>
05:59:36 
05:59:36     @pytest.mark.parametrize("test_spec", YAML_TEST_SPECS)
05:59:36     def test_rest_api_spec(test_spec, sync_runner):
05:59:36         if test_spec.get("skip", False):
05:59:36             pytest.skip("Manually skipped in 'SKIP_TESTS'")
05:59:36         sync_runner.use_spec(test_spec)
05:59:36 >       sync_runner.run()
05:59:36 
05:59:36 test_elasticsearch/test_server/test_rest_api_spec.py:649: 
05:59:36 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:59:36 test_elasticsearch/test_server/test_rest_api_spec.py:196: in run
05:59:36     self.run_code(self._run_code)
05:59:36 test_elasticsearch/test_server/test_rest_api_spec.py:211: in run_code
05:59:36     getattr(self, "run_" + action_type)(action)
05:59:36 test_elasticsearch/test_server/test_rest_api_spec.py:390: in run_match
05:59:36     value = self._lookup(path)
05:59:36 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:59:36 
05:59:36 self = <test_elasticsearch.test_server.test_rest_api_spec.YamlRunner object at 0x7f7dcecfb1f0>
05:59:36 path = '$body.$backing_index.data_stream'
05:59:36 
05:59:36     def _lookup(self, path):
05:59:36         # fetch the possibly nested value from last_response
05:59:36         value = self.last_response
05:59:36         if path == "$body":
05:59:36             return value
05:59:36         path = path.replace(r"\.", "\1")
05:59:36         for step in path.split("."):
05:59:36             if not step:
05:59:36                 continue
05:59:36             step = step.replace("\1", ".")
05:59:36             step = self._resolve(step)
05:59:36     
05:59:36             if (
05:59:36                 isinstance(step, string_types)
05:59:36                 and step.isdigit()
05:59:36                 and isinstance(value, list)
05:59:36             ):
05:59:36                 step = int(step)
05:59:36                 assert isinstance(value, list)
05:59:36                 assert len(value) > step
05:59:36             elif step == "_arbitrary_key_":
05:59:36                 return list(value.keys())[0]
05:59:36             else:
05:59:36 >               assert step in value
05:59:36 E               AssertionError: assert '$body' in {'.ds-k8s-2022.01.14-000001': {'aliases': {}, 'data_stream': 'k8s', 'mappings': {'_data_stream_timestamp': {'enabled':...: '1642119345529', 'creation_date_string': '2022-01-14T00:15:45.529Z', 'hidden': 'true', 'mode': 'time_series', ...}}}}
05:59:36 
05:59:36 test_elasticsearch/test_server/test_rest_api_spec.py:484: AssertionError
```