### PR TITLE
[7.17] Rewrite the 'from' parameter from kwargs/query into 'from_'

### DIFF
--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -357,8 +357,16 @@ async def async_scan(
 
     # initial search
     search_kwargs = kwargs.copy()
+
+    # Setting query={"from": ...} would make 'from' be used
+    # as a keyword argument instead of 'from_'. We handle that here.
+    if "from" in search_kwargs:
+        search_kwargs["from_"] = search_kwargs.pop("from")
     if query:
         search_kwargs.update(query)
+    if "from" in search_kwargs:
+        search_kwargs["from_"] = search_kwargs.pop("from")
+
     search_kwargs["scroll"] = scroll
     search_kwargs["size"] = size
     search_kwargs["request_timeout"] = request_timeout

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -567,8 +567,16 @@ def scan(
 
     # initial search
     search_kwargs = kwargs.copy()
+
+    # Setting query={"from": ...} would make 'from' be used
+    # as a keyword argument instead of 'from_'. We handle that here.
+    if "from" in search_kwargs:
+        search_kwargs["from_"] = search_kwargs.pop("from")
     if query:
         search_kwargs.update(query)
+    if "from" in search_kwargs:
+        search_kwargs["from_"] = search_kwargs.pop("from")
+
     search_kwargs["scroll"] = scroll
     search_kwargs["size"] = size
     search_kwargs["request_timeout"] = request_timeout

--- a/test_elasticsearch/test_server/test_helpers.py
+++ b/test_elasticsearch/test_server/test_helpers.py
@@ -899,3 +899,29 @@ class TestDataStreamReindex(object):
                 query={"query": {"bool": {"filter": {"term": {"type": "answers"}}}}},
                 op_type="_index",
             )
+
+
+@pytest.mark.parametrize(
+    "scan_kwargs",
+    [
+        {"from": 1},
+        {"from_": 1},
+        {"query": {"from": 1}},
+        {"query": {"from_": 1}},
+        {"query": {"query": {"match_all": {}}}, "from": 1},
+        {"query": {"query": {"match_all": {}}}, "from_": 1},
+    ],
+)
+def test_scan_from_keyword_is_aliased(sync_client, scan_kwargs):
+    with patch.object(
+        sync_client,
+        "search",
+        return_value={
+            "_scroll_id": "dummy_id",
+            "_shards": {"successful": 5, "total": 5},
+            "hits": {"hits": []},
+        },
+    ) as search_mock, patch.object(sync_client, "clear_scroll"):
+        list(helpers.scan(sync_client, index="test_index", **scan_kwargs))
+        assert search_mock.call_args[1]["from_"] == 1
+        assert "from" not in search_mock.call_args[1]


### PR DESCRIPTION
Backport of #1897 