### PR TITLE
Require an non-beta elastic-transport~=8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ packages = [
     if package == package_name or package.startswith(package_name + ".")
 ]
 
-install_requires = ["elastic-transport>=8.0.0b1,<9"]
+install_requires = ["elastic-transport>=8,<9"]
 async_requires = ["aiohttp>=3,<4"]
 
 setup(


### PR DESCRIPTION
Now that a stable release of elastic-transport 8.0.0 is available we can require a non-prerelease version.