### PR TITLE
[8.0] Serialize 'sort' parameter into query when using shorthand format

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -604,7 +604,7 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -925,7 +925,7 @@ class AsyncElasticsearch(BaseClient):
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -1011,7 +1011,7 @@ class AsyncElasticsearch(BaseClient):
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -1136,7 +1136,7 @@ class AsyncElasticsearch(BaseClient):
         timeout: t.Optional[t.Union[int, str]] = None,
         version: t.Optional[bool] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
@@ -1205,6 +1205,17 @@ class AsyncElasticsearch(BaseClient):
         __path = f"/{_quote(index)}/_delete_by_query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if analyze_wildcard is not None:
@@ -2127,7 +2138,7 @@ class AsyncElasticsearch(BaseClient):
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -2981,7 +2992,7 @@ class AsyncElasticsearch(BaseClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
@@ -3540,6 +3551,17 @@ class AsyncElasticsearch(BaseClient):
             __path = "/_search"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggregations is not None:
             __body["aggregations"] = aggregations
         if aggs is not None:
@@ -3785,6 +3807,17 @@ class AsyncElasticsearch(BaseClient):
         __path = f"/{_quote(index)}/_mvt/{_quote(field)}/{_quote(zoom)}/{_quote(x)}/{_quote(y)}"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggs is not None:
             __body["aggs"] = aggs
         if error_trace is not None:
@@ -4289,7 +4322,7 @@ class AsyncElasticsearch(BaseClient):
         timeout: t.Optional[t.Union[int, str]] = None,
         upsert: t.Optional[t.Mapping[str, t.Any]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -4454,7 +4487,7 @@ class AsyncElasticsearch(BaseClient):
         version: t.Optional[bool] = None,
         version_type: t.Optional[bool] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
@@ -4528,6 +4561,17 @@ class AsyncElasticsearch(BaseClient):
         __path = f"/{_quote(index)}/_update_by_query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if analyze_wildcard is not None:

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -427,6 +427,17 @@ class AsyncSearchClient(NamespacedClient):
             __path = "/_async_search"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggregations is not None:
             __body["aggregations"] = aggregations
         if aggs is not None:

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -86,7 +86,7 @@ class CcrClient(NamespacedClient):
         read_poll_timeout: t.Optional[t.Union[int, str]] = None,
         remote_cluster: t.Optional[str] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -360,7 +360,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_events: t.Optional[
             t.Union[

--- a/elasticsearch/_async/client/fleet.py
+++ b/elasticsearch/_async/client/fleet.py
@@ -489,6 +489,17 @@ class FleetClient(NamespacedClient):
         __path = f"/{_quote(index)}/_fleet/_fleet_search"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggregations is not None:
             __body["aggregations"] = aggregations
         if aggs is not None:

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -304,7 +304,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -389,7 +389,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -458,7 +458,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -794,20 +794,28 @@ class IndicesClient(NamespacedClient):
     async def delete_index_template(
         self,
         *,
-        name: str,
+        name: t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
         human: t.Optional[bool] = None,
+        master_timeout: t.Optional[t.Union[int, str]] = None,
         pretty: t.Optional[bool] = None,
+        timeout: t.Optional[t.Union[int, str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Deletes an index template.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
-        :param name: The name of the template
+        :param name: Comma-separated list of index template names used to limit the request.
+            Wildcard (*) expressions are supported.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -819,8 +827,12 @@ class IndicesClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers
@@ -1236,7 +1248,7 @@ class IndicesClient(NamespacedClient):
     async def field_usage_stats(
         self,
         *,
-        index: t.Optional[t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]] = None,
+        index: t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]],
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
@@ -1269,7 +1281,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -1301,6 +1313,8 @@ class IndicesClient(NamespacedClient):
             before proceeding with the operation. Set to all or any positive integer
             up to the total number of shards in the index (`number_of_replicas+1`).
         """
+        if index in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_field_usage_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2171,7 +2185,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3024,7 +3038,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3268,7 +3282,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3490,7 +3504,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -166,7 +166,7 @@ class MlClient(NamespacedClient):
         self,
         *,
         calendar_id: str,
-        job_id: str,
+        job_id: t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -1464,7 +1464,9 @@ class MlClient(NamespacedClient):
     async def get_filters(
         self,
         *,
-        filter_id: t.Optional[str] = None,
+        filter_id: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -1848,6 +1848,17 @@ class SecurityClient(NamespacedClient):
         __path = "/_security/_query/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -199,11 +199,12 @@ class SqlClient(NamespacedClient):
 
     @_rewrite_parameters(
         body_fields=True,
-        ignore_deprecated_options={"request_timeout"},
+        ignore_deprecated_options={"params", "request_timeout"},
     )
     async def query(
         self,
         *,
+        catalog: t.Optional[str] = None,
         columnar: t.Optional[bool] = None,
         cursor: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -215,17 +216,36 @@ class SqlClient(NamespacedClient):
         ] = None,
         format: t.Optional[str] = None,
         human: t.Optional[bool] = None,
+        index_using_frozen: t.Optional[bool] = None,
+        keep_alive: t.Optional[t.Union[int, str]] = None,
+        keep_on_completion: t.Optional[bool] = None,
         page_timeout: t.Optional[t.Union[int, str]] = None,
+        params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         query: t.Optional[str] = None,
         request_timeout: t.Optional[t.Union[int, str]] = None,
+        runtime_mappings: t.Optional[
+            t.Mapping[
+                str,
+                t.Union[
+                    t.Mapping[str, t.Any],
+                    t.Union[
+                        t.List[t.Mapping[str, t.Any]],
+                        t.Tuple[t.Mapping[str, t.Any], ...],
+                    ],
+                ],
+            ]
+        ] = None,
         time_zone: t.Optional[str] = None,
+        wait_for_completion_timeout: t.Optional[t.Union[int, str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a SQL request
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-search-api.html>`_
 
+        :param catalog: Default catalog (cluster) for queries. If unspecified, the queries
+            execute on the data in the local cluster only.
         :param columnar:
         :param cursor:
         :param fetch_size: The maximum number of rows (or entries) to return in one response
@@ -235,15 +255,29 @@ class SqlClient(NamespacedClient):
             in natural ascending order).
         :param filter: Optional Elasticsearch query DSL for additional filtering.
         :param format: a short version of the Accept header, e.g. json, yaml
+        :param index_using_frozen: If true, the search can run on frozen indices. Defaults
+            to false.
+        :param keep_alive: Retention period for an async or saved synchronous search.
+        :param keep_on_completion: If true, Elasticsearch stores synchronous searches
+            if you also specify the wait_for_completion_timeout parameter. If false,
+            Elasticsearch only stores async searches that don’t finish before the wait_for_completion_timeout.
         :param page_timeout: The timeout before a pagination request fails.
+        :param params: Values for parameters in the query.
         :param query: SQL query to execute
         :param request_timeout: The timeout before the request fails.
+        :param runtime_mappings: Defines one or more runtime fields in the search request.
+            These fields take precedence over mapped fields with the same name.
         :param time_zone: Time-zone in ISO 8601 used for executing the query on the server.
             More information available here.
+        :param wait_for_completion_timeout: Period to wait for complete results. Defaults
+            to no timeout, meaning the request waits for complete search results. If
+            the search doesn’t finish within this period, the search becomes async.
         """
         __path = "/_sql"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        if catalog is not None:
+            __body["catalog"] = catalog
         if columnar is not None:
             __body["columnar"] = columnar
         if cursor is not None:
@@ -262,16 +296,28 @@ class SqlClient(NamespacedClient):
             __query["format"] = format
         if human is not None:
             __query["human"] = human
+        if index_using_frozen is not None:
+            __body["index_using_frozen"] = index_using_frozen
+        if keep_alive is not None:
+            __body["keep_alive"] = keep_alive
+        if keep_on_completion is not None:
+            __body["keep_on_completion"] = keep_on_completion
         if page_timeout is not None:
             __body["page_timeout"] = page_timeout
+        if params is not None:
+            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
         if query is not None:
             __body["query"] = query
         if request_timeout is not None:
             __body["request_timeout"] = request_timeout
+        if runtime_mappings is not None:
+            __body["runtime_mappings"] = runtime_mappings
         if time_zone is not None:
             __body["time_zone"] = time_zone
+        if wait_for_completion_timeout is not None:
+            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -77,7 +77,9 @@ class TransformClient(NamespacedClient):
     async def get_transform(
         self,
         *,
-        transform_id: t.Optional[str] = None,
+        transform_id: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
         allow_no_match: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         exclude_generated: t.Optional[bool] = None,

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -443,6 +443,17 @@ class WatcherClient(NamespacedClient):
         __path = "/_watcher/_query/watches"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -602,7 +602,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -923,7 +923,7 @@ class Elasticsearch(BaseClient):
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -1009,7 +1009,7 @@ class Elasticsearch(BaseClient):
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -1134,7 +1134,7 @@ class Elasticsearch(BaseClient):
         timeout: t.Optional[t.Union[int, str]] = None,
         version: t.Optional[bool] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
@@ -1203,6 +1203,17 @@ class Elasticsearch(BaseClient):
         __path = f"/{_quote(index)}/_delete_by_query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if analyze_wildcard is not None:
@@ -2125,7 +2136,7 @@ class Elasticsearch(BaseClient):
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -2979,7 +2990,7 @@ class Elasticsearch(BaseClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
@@ -3538,6 +3549,17 @@ class Elasticsearch(BaseClient):
             __path = "/_search"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggregations is not None:
             __body["aggregations"] = aggregations
         if aggs is not None:
@@ -3783,6 +3805,17 @@ class Elasticsearch(BaseClient):
         __path = f"/{_quote(index)}/_mvt/{_quote(field)}/{_quote(zoom)}/{_quote(x)}/{_quote(y)}"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggs is not None:
             __body["aggs"] = aggs
         if error_trace is not None:
@@ -4287,7 +4320,7 @@ class Elasticsearch(BaseClient):
         timeout: t.Optional[t.Union[int, str]] = None,
         upsert: t.Optional[t.Mapping[str, t.Any]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -4452,7 +4485,7 @@ class Elasticsearch(BaseClient):
         version: t.Optional[bool] = None,
         version_type: t.Optional[bool] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
@@ -4526,6 +4559,17 @@ class Elasticsearch(BaseClient):
         __path = f"/{_quote(index)}/_update_by_query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if analyze_wildcard is not None:

--- a/elasticsearch/_sync/client/async_search.py
+++ b/elasticsearch/_sync/client/async_search.py
@@ -427,6 +427,17 @@ class AsyncSearchClient(NamespacedClient):
             __path = "/_async_search"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggregations is not None:
             __body["aggregations"] = aggregations
         if aggs is not None:

--- a/elasticsearch/_sync/client/ccr.py
+++ b/elasticsearch/_sync/client/ccr.py
@@ -86,7 +86,7 @@ class CcrClient(NamespacedClient):
         read_poll_timeout: t.Optional[t.Union[int, str]] = None,
         remote_cluster: t.Optional[str] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """

--- a/elasticsearch/_sync/client/cluster.py
+++ b/elasticsearch/_sync/client/cluster.py
@@ -360,7 +360,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_events: t.Optional[
             t.Union[

--- a/elasticsearch/_sync/client/fleet.py
+++ b/elasticsearch/_sync/client/fleet.py
@@ -489,6 +489,17 @@ class FleetClient(NamespacedClient):
         __path = f"/{_quote(index)}/_fleet/_fleet_search"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if aggregations is not None:
             __body["aggregations"] = aggregations
         if aggs is not None:

--- a/elasticsearch/_sync/client/indices.py
+++ b/elasticsearch/_sync/client/indices.py
@@ -304,7 +304,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -389,7 +389,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -458,7 +458,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -794,20 +794,28 @@ class IndicesClient(NamespacedClient):
     def delete_index_template(
         self,
         *,
-        name: str,
+        name: t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
         human: t.Optional[bool] = None,
+        master_timeout: t.Optional[t.Union[int, str]] = None,
         pretty: t.Optional[bool] = None,
+        timeout: t.Optional[t.Union[int, str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Deletes an index template.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
 
-        :param name: The name of the template
+        :param name: Comma-separated list of index template names used to limit the request.
+            Wildcard (*) expressions are supported.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -819,8 +827,12 @@ class IndicesClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers
@@ -1236,7 +1248,7 @@ class IndicesClient(NamespacedClient):
     def field_usage_stats(
         self,
         *,
-        index: t.Optional[t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]] = None,
+        index: t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]],
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
@@ -1269,7 +1281,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -1301,6 +1313,8 @@ class IndicesClient(NamespacedClient):
             before proceeding with the operation. Set to all or any positive integer
             up to the total number of shards in the index (`number_of_replicas+1`).
         """
+        if index in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_field_usage_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2171,7 +2185,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3024,7 +3038,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3268,7 +3282,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3490,7 +3504,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union[int, str]] = None,
         wait_for_active_shards: t.Optional[
-            t.Union[int, t.Union["t.Literal['all']", str]]
+            t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -166,7 +166,7 @@ class MlClient(NamespacedClient):
         self,
         *,
         calendar_id: str,
-        job_id: str,
+        job_id: t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -1464,7 +1464,9 @@ class MlClient(NamespacedClient):
     def get_filters(
         self,
         *,
-        filter_id: t.Optional[str] = None,
+        filter_id: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]

--- a/elasticsearch/_sync/client/security.py
+++ b/elasticsearch/_sync/client/security.py
@@ -1848,6 +1848,17 @@ class SecurityClient(NamespacedClient):
         __path = "/_security/_query/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:

--- a/elasticsearch/_sync/client/sql.py
+++ b/elasticsearch/_sync/client/sql.py
@@ -199,11 +199,12 @@ class SqlClient(NamespacedClient):
 
     @_rewrite_parameters(
         body_fields=True,
-        ignore_deprecated_options={"request_timeout"},
+        ignore_deprecated_options={"params", "request_timeout"},
     )
     def query(
         self,
         *,
+        catalog: t.Optional[str] = None,
         columnar: t.Optional[bool] = None,
         cursor: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -215,17 +216,36 @@ class SqlClient(NamespacedClient):
         ] = None,
         format: t.Optional[str] = None,
         human: t.Optional[bool] = None,
+        index_using_frozen: t.Optional[bool] = None,
+        keep_alive: t.Optional[t.Union[int, str]] = None,
+        keep_on_completion: t.Optional[bool] = None,
         page_timeout: t.Optional[t.Union[int, str]] = None,
+        params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         query: t.Optional[str] = None,
         request_timeout: t.Optional[t.Union[int, str]] = None,
+        runtime_mappings: t.Optional[
+            t.Mapping[
+                str,
+                t.Union[
+                    t.Mapping[str, t.Any],
+                    t.Union[
+                        t.List[t.Mapping[str, t.Any]],
+                        t.Tuple[t.Mapping[str, t.Any], ...],
+                    ],
+                ],
+            ]
+        ] = None,
         time_zone: t.Optional[str] = None,
+        wait_for_completion_timeout: t.Optional[t.Union[int, str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a SQL request
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-search-api.html>`_
 
+        :param catalog: Default catalog (cluster) for queries. If unspecified, the queries
+            execute on the data in the local cluster only.
         :param columnar:
         :param cursor:
         :param fetch_size: The maximum number of rows (or entries) to return in one response
@@ -235,15 +255,29 @@ class SqlClient(NamespacedClient):
             in natural ascending order).
         :param filter: Optional Elasticsearch query DSL for additional filtering.
         :param format: a short version of the Accept header, e.g. json, yaml
+        :param index_using_frozen: If true, the search can run on frozen indices. Defaults
+            to false.
+        :param keep_alive: Retention period for an async or saved synchronous search.
+        :param keep_on_completion: If true, Elasticsearch stores synchronous searches
+            if you also specify the wait_for_completion_timeout parameter. If false,
+            Elasticsearch only stores async searches that don’t finish before the wait_for_completion_timeout.
         :param page_timeout: The timeout before a pagination request fails.
+        :param params: Values for parameters in the query.
         :param query: SQL query to execute
         :param request_timeout: The timeout before the request fails.
+        :param runtime_mappings: Defines one or more runtime fields in the search request.
+            These fields take precedence over mapped fields with the same name.
         :param time_zone: Time-zone in ISO 8601 used for executing the query on the server.
             More information available here.
+        :param wait_for_completion_timeout: Period to wait for complete results. Defaults
+            to no timeout, meaning the request waits for complete search results. If
+            the search doesn’t finish within this period, the search becomes async.
         """
         __path = "/_sql"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        if catalog is not None:
+            __body["catalog"] = catalog
         if columnar is not None:
             __body["columnar"] = columnar
         if cursor is not None:
@@ -262,16 +296,28 @@ class SqlClient(NamespacedClient):
             __query["format"] = format
         if human is not None:
             __query["human"] = human
+        if index_using_frozen is not None:
+            __body["index_using_frozen"] = index_using_frozen
+        if keep_alive is not None:
+            __body["keep_alive"] = keep_alive
+        if keep_on_completion is not None:
+            __body["keep_on_completion"] = keep_on_completion
         if page_timeout is not None:
             __body["page_timeout"] = page_timeout
+        if params is not None:
+            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
         if query is not None:
             __body["query"] = query
         if request_timeout is not None:
             __body["request_timeout"] = request_timeout
+        if runtime_mappings is not None:
+            __body["runtime_mappings"] = runtime_mappings
         if time_zone is not None:
             __body["time_zone"] = time_zone
+        if wait_for_completion_timeout is not None:
+            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -77,7 +77,9 @@ class TransformClient(NamespacedClient):
     def get_transform(
         self,
         *,
-        transform_id: t.Optional[str] = None,
+        transform_id: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
         allow_no_match: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         exclude_generated: t.Optional[bool] = None,

--- a/elasticsearch/_sync/client/watcher.py
+++ b/elasticsearch/_sync/client/watcher.py
@@ -443,6 +443,17 @@ class WatcherClient(NamespacedClient):
         __path = "/_watcher/_query/watches"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = {}
+        # The 'sort' parameter with a colon can't be encoded to the body.
+        if sort is not None and (
+            (isinstance(sort, str) and ":" in sort)
+            or (
+                isinstance(sort, (list, tuple))
+                and all(isinstance(_x, str) for _x in sort)
+                and any(":" in _x for _x in sort)
+            )
+        ):
+            __query["sort"] = sort
+            sort = None
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch-py/pull/1922