### PR TITLE
Fixed wrong line of documentation in bulk update example

### DIFF
--- a/docs/sphinx/helpers.rst
+++ b/docs/sphinx/helpers.rst
@@ -61,7 +61,7 @@ action (``_op_type`` defaults to ``index``):
         '_op_type': 'update',
         '_index': 'index-name',
         '_id': 42,
-        'doc': {'question': 'The life, universe and everything.'}
+        '_source': {'doc': {'question': 'The life, universe and everything.'},
     }
 
 


### PR DESCRIPTION
Spent an hour figuring this out. The way that was provided did not work, nor did close variations. This seems like the correct way of doing this!