### PR TITLE
[DOCS] Add escape characters for docs build error

### DIFF
--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -44,7 +44,7 @@ When you start Elasticsearch for the first time you'll see a distinct block like
 
 [source,sh]
 ----
-----------------------------------------------------------------------
+\----------------------------------------------------------------------
 -> Elasticsearch security features have been automatically configured!
 -> Authentication is enabled and cluster connections are encrypted.
 
@@ -54,7 +54,7 @@ When you start Elasticsearch for the first time you'll see a distinct block like
 ->  HTTP CA certificate SHA-256 fingerprint:
   a52dd93511e8c6045e21f16654b77c9ee0f34aea26d9f40320b531c474676228
 ...
-----------------------------------------------------------------------
+\----------------------------------------------------------------------
 ----
 
 Note down the `elastic` user password and HTTP CA fingerprint for the next sections. In the examples below they will be stored in the variables `ELASTIC_PASSWORD` and `CERT_FINGERPRINT` respectively.


### PR DESCRIPTION
This PR adds a fix for the following documentation build failure:

> 17:07:52 INFO:build_docs:Building docs
17:07:57 INFO:build_docs: -                            Python Client: Building master...
17:07:58 INFO:build_docs:
17:07:58 INFO:build_docs:ERROR building Python Client version master
17:07:58 INFO:build_docs:
17:07:58 INFO:build_docs:Recent commits in elasticsearch-py/Python Client:main:docs/guide
17:07:58 INFO:build_docs:----------------------------------------------------------------
17:07:58 INFO:build_docs:15726cd3 - (HEAD -> main) Change 'Connecting' section to make connecting to SOBD clusters easier (61 minutes ago) <Seth Michael Larson>
17:07:58 INFO:build_docs:
17:07:58 INFO:build_docs:
17:07:58 INFO:build_docs:asciidoctor: WARNING: connecting.asciidoc: line 47: MIGRATION: code block end doesn't match start
17:07:58 INFO:build_docs:asciidoctor: WARNING: connecting.asciidoc: line 58: MIGRATION: code block end doesn't match start
17:07:58 INFO:build_docs:
17:07:58 INFO:build_docs:Child exited with 255 at lib/ES/Util.pm line 666.

... which seems to be related to [Connecting](https://www.elastic.co/guide/en/elasticsearch/client/python-api/master/connecting.html) and https://github.com/elastic/elasticsearch-py/pull/1932

The problem seems to be resolved by adding a backslash escape character within the problematic code block, however the backslash then appears in the output. Another alternative that might work is to entirely omit those dashed lines from the codeblock, since they don't seem necessary.