### PR TITLE
Update unified release to use envvars

### DIFF
--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -16,13 +16,10 @@ jobs:
   assemble:
     name: Assemble
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        stack_version: ['8.2.0-SNAPSHOT']
-
+    env:
+      STACK_VERSION: 8.2.0-SNAPSHOT
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - run: "./.ci/make.sh assemble ${{ matrix.stack_version }}"
-        name: Assemble ${{ matrix.stack_version }}
+      - name: "Assemble ${{ env.STACK_VERSION }}"
+        run: "./.ci/make.sh assemble ${{ env.STACK_VERSION }}"


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch-py/pull/1960 without the setting of stack-version.