### PR TITLE
Test Against Python 3.11

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -10,6 +10,7 @@ PYTHON_VERSION:
   - "3.8"
   - "3.9"
   - "3.10"
+  - "3.11"
 
 PYTHON_CONNECTION_CLASS:
   - urllib3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         experimental: [false]
         nox-session: [""]
         include:
-          - python-version: 3.10-dev
+          - python-version: 3.11.0-beta.3
             experimental: true
-            nox-session: test-3.10
+            nox-session: test-3.11
 
     runs-on: ubuntu-latest
     name: test-${{ matrix.python-version }}
@@ -65,3 +65,10 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           NOX_SESSION: ${{ matrix.nox-session }}
+          # TEMPORARY for 3.11
+          # https://github.com/aio-libs/aiohttp/issues/6600
+          AIOHTTP_NO_EXTENSIONS: 1
+          # https://github.com/aio-libs/frozenlist/issues/285
+          FROZENLIST_NO_EXTENSIONS: 1
+          # https://github.com/aio-libs/yarl/issues/680
+          YARL_NO_EXTENSIONS: 1

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ SOURCE_FILES = (
 )
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 def test(session):
     session.install(".")
     session.install("-r", "dev-requirements.txt")


### PR DESCRIPTION
This PR adds Python 3.11 to the test suite.

closes https://github.com/elastic/elasticsearch-py/issues/1985