### PR TITLE
Rank Eval templates 

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -2980,6 +2980,7 @@ class AsyncElasticsearch(BaseClient):
         metric: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         search_type: t.Optional[str] = None,
+        templates: t.Optional[t.List[t.Mapping[str, t.Any]]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to evaluate the quality of ranked search results over a set of typical
@@ -3004,6 +3005,7 @@ class AsyncElasticsearch(BaseClient):
             in the response.
         :param metric: Definition of the evaluation metric to calculate.
         :param search_type: Search operation type
+        :param templates: A set of template definitions that can be referenced
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3035,6 +3037,8 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         if search_type is not None:
             __query["search_type"] = search_type
+        if templates is not None:
+            __body["templates"] = templates
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -2978,6 +2978,7 @@ class Elasticsearch(BaseClient):
         metric: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         search_type: t.Optional[str] = None,
+        templates: t.Optional[t.List[t.Mapping[str, t.Any]]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to evaluate the quality of ranked search results over a set of typical
@@ -3002,6 +3003,7 @@ class Elasticsearch(BaseClient):
             in the response.
         :param metric: Definition of the evaluation metric to calculate.
         :param search_type: Search operation type
+        :param templates: A set of template definitions that can be referenced
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3033,6 +3035,8 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if search_type is not None:
             __query["search_type"] = search_type
+        if templates is not None:
+            __body["templates"] = templates
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body


### PR DESCRIPTION
Allows for templates to be used in rank_eval as by the documentation (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_template_based_ranking_evaluation). 

Example:

```
import elasticsearch

es = elasticsearch.Elasticsearch("http://localhost:9200")

templates = [
    {
        "id": "match_one_field_query",
        "template": {
            "inline": {"query": {"match": {"{{field}}": {"query": "{{query_string}}"}}}}
        },
    }
]

requests = [
    {
        "id": "amsterdam_query",
        "ratings": [
            {"_index": "my-index-000001", "_id": "doc1", "rating": 0},
            {"_index": "my-index-000001", "_id": "doc2", "rating": 3},
            {"_index": "my-index-000001", "_id": "doc3", "rating": 1},
        ],
        "template_id": "match_one_field_query",
        "params": {"query_string": "amsterdam", "field": "text"},
    }
]

metric = {"mean_reciprocal_rank": {"k": 20, "relevant_rating_threshold": 1}}

result = es.rank_eval(
    requests=requests, metric=metric, index="my-index-000001", templates=templates
)

```