### PR TITLE
Fix broken `elasticsearch-dsl` hyperlink

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -72,20 +72,20 @@ This client was designed as very thin wrapper around Elasticsearch's REST API to
 allow for maximum flexibility. This means that there are no opinions in this
 client; it also means that some of the APIs are a little cumbersome to use from
 Python. We have created some :ref:`helpers` to help with this issue as well as
-a more high level library (`elasticsearch-dsl`_) on top of this one to provide
+a more high level library (`elasticsearch\-dsl`_) on top of this one to provide
 a more convenient way of working with Elasticsearch.
 
-.. _elasticsearch-dsl: https://elasticsearch-dsl.readthedocs.io
+.. _elasticsearch\-dsl: https://elasticsearch-dsl.readthedocs.io
 
 
 Elasticsearch-DSL
 -----------------
 
 For a more high level client library with more limited scope, have a look at
-`elasticsearch-dsl`_ - a more pythonic library sitting on top of
+`elasticsearch\-dsl`_ - a more pythonic library sitting on top of
 ``elasticsearch-py``.
 
-`elasticsearch-dsl`_ provides a more convenient and idiomatic way to write and manipulate
+`elasticsearch\-dsl`_ provides a more convenient and idiomatic way to write and manipulate
 `queries`_ by mirroring the terminology and structure of Elasticsearch JSON DSL
 while exposing the whole range of the DSL from Python
 either directly using defined classes or a queryset-like expressions.
@@ -94,7 +94,7 @@ It also provides an optional `persistence layer`_ for working with documents as
 Python objects in an ORM-like fashion: defining mappings, retrieving and saving
 documents, wrapping the document data in user-defined classes.
 
-.. _elasticsearch-dsl: https://elasticsearch-dsl.readthedocs.io/
+.. _elasticsearch\-dsl: https://elasticsearch-dsl.readthedocs.io/
 .. _queries: https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html
 .. _persistence layer: https://elasticsearch-dsl.readthedocs.io/en/latest/persistence.html#doctype
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -72,20 +72,19 @@ This client was designed as very thin wrapper around Elasticsearch's REST API to
 allow for maximum flexibility. This means that there are no opinions in this
 client; it also means that some of the APIs are a little cumbersome to use from
 Python. We have created some :ref:`helpers` to help with this issue as well as
-a more high level library (`elasticsearch\-dsl`_) on top of this one to provide
+a more high level library (`elasticsearch-dsl`_) on top of this one to provide
 a more convenient way of working with Elasticsearch.
 
-.. _elasticsearch\-dsl: https://elasticsearch-dsl.readthedocs.io
 
 
 Elasticsearch-DSL
 -----------------
 
 For a more high level client library with more limited scope, have a look at
-`elasticsearch\-dsl`_ - a more pythonic library sitting on top of
+`elasticsearch-dsl`_ - a more pythonic library sitting on top of
 ``elasticsearch-py``.
 
-`elasticsearch\-dsl`_ provides a more convenient and idiomatic way to write and manipulate
+`elasticsearch-dsl`_ provides a more convenient and idiomatic way to write and manipulate
 `queries`_ by mirroring the terminology and structure of Elasticsearch JSON DSL
 while exposing the whole range of the DSL from Python
 either directly using defined classes or a queryset-like expressions.
@@ -94,7 +93,7 @@ It also provides an optional `persistence layer`_ for working with documents as
 Python objects in an ORM-like fashion: defining mappings, retrieving and saving
 documents, wrapping the document data in user-defined classes.
 
-.. _elasticsearch\-dsl: https://elasticsearch-dsl.readthedocs.io/
+.. _elasticsearch-dsl: https://elasticsearch-dsl.readthedocs.io/
 .. _queries: https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html
 .. _persistence layer: https://elasticsearch-dsl.readthedocs.io/en/latest/persistence.html#doctype
 


### PR DESCRIPTION
## What

~~I use `\` to escape the `-` character to fix the broken hyperlink,~~


Remove duplication of the hyperlink target `elasticsearch-dsl`.

## Why

~~Currently https://elasticsearch-py.readthedocs.io/en/v8.4.3/#id1 's `elasticsearch-dsl` hyper link is broken due to missing the escape to `-` using `\`~~

Duplication of the hyperlink target breaks elasticsearch-dsl hyper-link.