### PR TITLE
Add release notes for 8.5.3

### DIFF
--- a/docs/guide/release-notes.asciidoc
+++ b/docs/guide/release-notes.asciidoc
@@ -1,6 +1,8 @@
 [[release-notes]]
 == Release notes
 
+* <<rn-8-5-3>>
+* <<rn-8-5-2>>
 * <<rn-8-5-1>>
 * <<rn-8-5-0>>
 * <<rn-8-4-3>>
@@ -19,6 +21,18 @@
 * <<rn-8-1-1>>
 * <<rn-8-1-0>>
 * <<rn-8-0-0>>
+
+[discrete]
+[[rn-8-5-3]]
+=== 8.5.3 (2022-12-08)
+
+* Client is compatible with Elasticsearch 8.5.3
+
+[discrete]
+[[rn-8-5-2]]
+=== 8.5.2 (2022-11-23)
+
+* Client is compatible with Elasticsearch 8.5.2
 
 [discrete]
 [[rn-8-5-1]]


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch-py/pull/2123