### PR TITLE
Use 'ubuntu-20.04' to test Python 3.6 and earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         experimental: [false]
+        runs-on: ["ubuntu-latest"]
         include:
-          - python-version: 3.10-dev
-            experimental: true
+          - python-version: 2.7
+            experimental: false
+            runs-on: "ubuntu-20.04"
+          - python-version: 3.5
+            experimental: false
+            runs-on: "ubuntu-20.04"
+          - python-version: 3.6
+            experimental: false
+            runs-on: "ubuntu-20.04"
 
-    runs-on: ubuntu-latest
+          - python-version: 3.11
+            experimental: true
+            runs-on: "ubuntu-20.04"
+
+    runs-on: ${{ matrix.runs-on }}
     name: test-${{ matrix.python-version }}
     continue-on-error: ${{ matrix.experimental }}
     steps:


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-py/pull/2128 to 7.17