### PR TITLE
Replace unsafe API method for temporary file creation

### DIFF
--- a/utils/generate-examples.py
+++ b/utils/generate-examples.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import black
 from click.testing import CliRunner
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, NamedTemporaryFile
 
 code_root = Path(__file__).absolute().parent.parent
 asciidocs_dir = code_root / "docs/examples"
@@ -154,7 +154,7 @@ def main():
                 )
             )
 
-        tmp_path = Path(tempfile.mktemp())
+        tmp_path = Path(tempfile.NamedTemporaryFile().name)
         with tmp_path.open(mode="w") as f:
             f.write(t.render(parsed_sources=parsed_sources))
 


### PR DESCRIPTION
In file: generate-examples.py, there is a method that creates a temporary file using an unsafe API mktemp. The use of this is discouraged in the Python documentation (https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). We suggested that a temporary file should be created using NamedTemporaryFile(https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) which is a safe API.