### PR TITLE
[Backport 8.5] add codegen code

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -12,7 +12,7 @@ ENV BUILDER_GROUP elastic
 RUN groupadd --system -g ${BUILDER_GID} ${BUILDER_GROUP} \
     && useradd --system --shell /bin/bash -u ${BUILDER_UID} -g ${BUILDER_GROUP} -d /var/lib/elastic -m elastic 1>/dev/null 2>/dev/null \
     && mkdir -p /code/elasticsearch-py && mkdir /code/elasticsearch-py/build \
-    && chown -R ${BUILDER_USER}:${BUILDER_GROUP} /code/elasticsearch-py
+    && chown -R ${BUILDER_USER}:${BUILDER_GROUP} /code/
 COPY --chown=$BUILDER_USER:$BUILDER_GROUP . .
 WORKDIR /code/elasticsearch-py
 USER ${BUILDER_USER}:${BUILDER_GROUP}

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -161,7 +161,15 @@ if [[ "$CMD" == "bump" ]]; then
 fi
 
 if [[ "$CMD" == "codegen" ]]; then
-    echo "TODO"
+  docker run \
+     --rm -v $repo:/code/elasticsearch-py \
+     $product \
+     /bin/bash -c "cd /code && python -m pip install nox && \
+     git clone https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-python.git && \
+     cd /code/elastic-client-generator-python && GIT_BRANCH=$VERSION python -m nox -s generate-es && \
+     cd /code/elasticsearch-py && python -m nox -s format"
+
+  exit 0
 fi
 
 if [[ "$CMD" == "docsgen" ]]; then


### PR DESCRIPTION
Missed one backport when trying to fix `8.5` (15b6394a62f8f5301879313e1f0fee2d23454629). Hopefully this fixes the 8.5 codegen.