### PR TITLE
[DOCS] Includes source_branch in docs index and changes URLs.

### DIFF
--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -301,8 +301,8 @@ es = Elasticsearch(
 
 HTTP Bearer authentication uses the `bearer_auth` parameter by passing the token
 as a string. This authentication method is used by 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html[Service Account Tokens]
-and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html[Bearer Tokens].
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-service-token.html[Service Account Tokens]
+and https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-token.html[Bearer Tokens].
 
 [source,python]
 ----

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -2,6 +2,8 @@
 
 :doctype:           book
 
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -2,7 +2,7 @@
 
 :doctype:           book
 
-include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/clients-team/issues/532.
This PR includes `source_branch` in the docs index file and changes URLs in `connecting.asciidoc` so they will use {branch} instead of `master`.

### Notes

The changes of this PR need to be backported to:
* 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0.