### PR TITLE
[8.0][DOCS] Includes source_branch in docs index and changes URLs

### DIFF
--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -301,8 +301,8 @@ es = Elasticsearch(
 
 HTTP Bearer authentication uses the `bearer_auth` parameter by passing the token
 as a string. This authentication method is used by 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html[Service Account Tokens]
-and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html[Bearer Tokens].
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-service-token.html[Service Account Tokens]
+and https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-token.html[Bearer Tokens].
 
 [source,python]
 ----

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -2,6 +2,8 @@
 
 :doctype:           book
 
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]


### PR DESCRIPTION
## Overview

This PR backports the following changes to the 8.0 branch:
https://github.com/elastic/elasticsearch-py/pull/2166