### PR TITLE
Added missing 8.7 endpoints

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -2154,6 +2154,58 @@ class AsyncElasticsearch(BaseClient):
             "GET", __path, params=__query, headers=__headers
         )
 
+    @_rewrite_parameters()
+    async def health_report(
+        self,
+        *,
+        feature: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        size: t.Optional[int] = None,
+        timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        verbose: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Returns the health of the cluster.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/health-api.html>`_
+
+        :param feature: A feature of the cluster, as returned by the top-level health
+            report API.
+        :param size: Limit the number of affected resources the health report API returns.
+        :param timeout: Explicit operation timeout.
+        :param verbose: Opt-in for more information about the health of the system.
+        """
+        if feature not in SKIP_IN_PATH:
+            __path = f"/_health_report/{_quote(feature)}"
+        else:
+            __path = "/_health_report"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if size is not None:
+            __query["size"] = size
+        if timeout is not None:
+            __query["timeout"] = timeout
+        if verbose is not None:
+            __query["verbose"] = verbose
+        __headers = {"accept": "application/json"}
+        return await self.perform_request(  # type: ignore[return-value]
+            "GET", __path, params=__query, headers=__headers
+        )
+
     @_rewrite_parameters(
         body_name="document",
     )

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -579,6 +579,7 @@ class SnapshotClient(NamespacedClient):
         repository: str,
         snapshot: str,
         error_trace: t.Optional[bool] = None,
+        feature_states: t.Optional[t.Union[t.List[str], t.Tuple[str, ...]]] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
@@ -609,6 +610,7 @@ class SnapshotClient(NamespacedClient):
 
         :param repository: A repository name
         :param snapshot: A snapshot name
+        :param feature_states:
         :param ignore_index_settings:
         :param ignore_unavailable:
         :param include_aliases:
@@ -631,6 +633,8 @@ class SnapshotClient(NamespacedClient):
         __body: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
+        if feature_states is not None:
+            __body["feature_states"] = feature_states
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -443,7 +443,7 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters()
-    async def start_transform(
+    async def schedule_now_transform(
         self,
         *,
         transform_id: str,
@@ -456,11 +456,57 @@ class TransformClient(NamespacedClient):
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
+        Schedules now a transform.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/schedule-now-transform.html>`_
+
+        :param transform_id: Identifier for the transform.
+        :param timeout: Controls the time to wait for the scheduling to take place
+        """
+        if transform_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'transform_id'")
+        __path = f"/_transform/{_quote(transform_id)}/_schedule_now"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
+        __headers = {"accept": "application/json"}
+        return await self.perform_request(  # type: ignore[return-value]
+            "POST", __path, params=__query, headers=__headers
+        )
+
+    @_rewrite_parameters(
+        parameter_aliases={"from": "from_"},
+    )
+    async def start_transform(
+        self,
+        *,
+        transform_id: str,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        from_: t.Optional[str] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
         Starts one or more transforms.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
 
         :param transform_id: Identifier for the transform.
+        :param from_: Restricts the set of transformed entities to those changed after
+            this time. Relative times like now-30d are supported. Only applicable for
+            continuous transforms.
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
@@ -472,6 +518,8 @@ class TransformClient(NamespacedClient):
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
+        if from_ is not None:
+            __query["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -2152,6 +2152,58 @@ class Elasticsearch(BaseClient):
             "GET", __path, params=__query, headers=__headers
         )
 
+    @_rewrite_parameters()
+    def health_report(
+        self,
+        *,
+        feature: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        size: t.Optional[int] = None,
+        timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        verbose: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Returns the health of the cluster.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/health-api.html>`_
+
+        :param feature: A feature of the cluster, as returned by the top-level health
+            report API.
+        :param size: Limit the number of affected resources the health report API returns.
+        :param timeout: Explicit operation timeout.
+        :param verbose: Opt-in for more information about the health of the system.
+        """
+        if feature not in SKIP_IN_PATH:
+            __path = f"/_health_report/{_quote(feature)}"
+        else:
+            __path = "/_health_report"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if size is not None:
+            __query["size"] = size
+        if timeout is not None:
+            __query["timeout"] = timeout
+        if verbose is not None:
+            __query["verbose"] = verbose
+        __headers = {"accept": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
+            "GET", __path, params=__query, headers=__headers
+        )
+
     @_rewrite_parameters(
         body_name="document",
     )

--- a/elasticsearch/_sync/client/snapshot.py
+++ b/elasticsearch/_sync/client/snapshot.py
@@ -579,6 +579,7 @@ class SnapshotClient(NamespacedClient):
         repository: str,
         snapshot: str,
         error_trace: t.Optional[bool] = None,
+        feature_states: t.Optional[t.Union[t.List[str], t.Tuple[str, ...]]] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
@@ -609,6 +610,7 @@ class SnapshotClient(NamespacedClient):
 
         :param repository: A repository name
         :param snapshot: A snapshot name
+        :param feature_states:
         :param ignore_index_settings:
         :param ignore_unavailable:
         :param include_aliases:
@@ -631,6 +633,8 @@ class SnapshotClient(NamespacedClient):
         __body: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
+        if feature_states is not None:
+            __body["feature_states"] = feature_states
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -443,7 +443,7 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters()
-    def start_transform(
+    def schedule_now_transform(
         self,
         *,
         transform_id: str,
@@ -456,11 +456,57 @@ class TransformClient(NamespacedClient):
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
+        Schedules now a transform.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/schedule-now-transform.html>`_
+
+        :param transform_id: Identifier for the transform.
+        :param timeout: Controls the time to wait for the scheduling to take place
+        """
+        if transform_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'transform_id'")
+        __path = f"/_transform/{_quote(transform_id)}/_schedule_now"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
+        __headers = {"accept": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
+            "POST", __path, params=__query, headers=__headers
+        )
+
+    @_rewrite_parameters(
+        parameter_aliases={"from": "from_"},
+    )
+    def start_transform(
+        self,
+        *,
+        transform_id: str,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        from_: t.Optional[str] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
         Starts one or more transforms.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
 
         :param transform_id: Identifier for the transform.
+        :param from_: Restricts the set of transformed entities to those changed after
+            this time. Relative times like now-30d are supported. Only applicable for
+            continuous transforms.
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
@@ -472,6 +518,8 @@ class TransformClient(NamespacedClient):
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
+        if from_ is not None:
+            __query["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:


### PR DESCRIPTION
This PR adds some missing endpoints changes for Elasticsearch 8.7.0. It includes the following:
- added the [health_report](https://www.elastic.co/guide/en/elasticsearch/reference/current/health-api.html) endpoint;
- added the [transform.schedule_now_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/schedule-now-transform.html) endpoint;
- added the `from` parameter in `transform.start_transform` endpoint;
- added `feature_states` parameter in `snapshot.restore`, fixes #2168;
