### PR TITLE
helpers.async_bulk to return explicit tuple.

### DIFF
--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -345,7 +345,7 @@ async def async_bulk(
         else:
             success += 1
 
-    return success, failed if stats_only else errors
+    return (success, failed) if stats_only else errors
 
 
 async def async_scan(


### PR DESCRIPTION
in Python3.11, when `stats_only` is False, it returns a tuple of `(success, errors)` instead of only list of `errors`.
The fix makes sure that it returns a tuple when `stats_only` is True and list otherwise.

Legacy:
```
elasticsearch/_async/helpers.py:348
return success, failed if stats_only else errors
```
will return, `<success>, errors` in case `stats_only` is False./
