### PR TITLE
List Python v3.11 compatible per #2142

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
👋🏼 howdy, team! I believe appending to [setup.py#L78-L92](https://github.com/elastic/elasticsearch-py/blob/master/setup.py#L78-L92) will resolve https://github.com/elastic/elasticsearch-py/issues/2142 to show v3.11 Python compatible on the [PyPI sidebar](https://pypi.org/project/elasticsearch/). 