### PR TITLE
Fix CI user's PATH to include pip-installed executables

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -7,6 +7,7 @@ ARG BUILDER_UID=1000
 ARG BUILDER_GID=1000
 ENV BUILDER_USER elastic
 ENV BUILDER_GROUP elastic
+ENV PATH="${PATH}:/var/lib/elastic/.local/bin"
 
 # Create user
 RUN groupadd --system -g ${BUILDER_GID} ${BUILDER_GROUP} \

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -7,6 +7,7 @@ ARG BUILDER_UID=1000
 ARG BUILDER_GID=1000
 ENV BUILDER_USER elastic
 ENV BUILDER_GROUP elastic
+ENV PATH="$PATH:/var/lib/elastic/.local/bin"
 
 # Create user
 RUN groupadd --system -g ${BUILDER_GID} ${BUILDER_GROUP} \

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -7,7 +7,6 @@ ARG BUILDER_UID=1000
 ARG BUILDER_GID=1000
 ENV BUILDER_USER elastic
 ENV BUILDER_GROUP elastic
-ENV PATH="$PATH:/var/lib/elastic/.local/bin"
 
 # Create user
 RUN groupadd --system -g ${BUILDER_GID} ${BUILDER_GROUP} \

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -26,14 +26,16 @@ echo -e "\033[1m>>>>> Build [elastic/elasticsearch-py container] >>>>>>>>>>>>>>>
 docker build \
        --file .ci/Dockerfile \
        --tag elastic/elasticsearch-py \
-       --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+       --build-arg "PYTHON_VERSION=${PYTHON_VERSION}" \
+       --build-arg "BUILDER_UID=$(id -u)" \
+       --build-arg "BUILDER_GID=$(id -g)" \
        .
 
 echo -e "\033[1m>>>>> Run [elastic/elasticsearch-py container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 
 mkdir -p junit
 docker run \
-  -u "$(id -u)" \
+  -u "$(id -u):$(id -g)" \
   --network=${network_name} \
   --env "STACK_VERSION=${STACK_VERSION}" \
   --env "ELASTICSEARCH_URL=${elasticsearch_url}" \
@@ -43,4 +45,4 @@ docker run \
   --name elasticsearch-py \
   --rm \
   elastic/elasticsearch-py \
-  bash -c "export PATH=$PATH:/var/lib/elastic/.local/bin && nox -s test-${PYTHON_VERSION}"
+  nox -s test-${PYTHON_VERSION}

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -40,6 +40,7 @@ docker run \
   --env "TEST_SUITE=${TEST_SUITE}" \
   --env "PYTHON_CONNECTION_CLASS=${PYTHON_CONNECTION_CLASS}" \
   --env "TEST_TYPE=server" \
+  --env "PATH=$PATH:/var/lib/elastic/.local/bin" \
   --name elasticsearch-py \
   --rm \
   elastic/elasticsearch-py \

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -40,8 +40,7 @@ docker run \
   --env "TEST_SUITE=${TEST_SUITE}" \
   --env "PYTHON_CONNECTION_CLASS=${PYTHON_CONNECTION_CLASS}" \
   --env "TEST_TYPE=server" \
-  --env "PATH=$PATH:/var/lib/elastic/.local/bin" \
   --name elasticsearch-py \
   --rm \
   elastic/elasticsearch-py \
-  nox -s test-${PYTHON_VERSION}
+  bash -c "export PATH=$PATH:/var/lib/elastic/.local/bin && nox -s test-${PYTHON_VERSION}"


### PR DESCRIPTION
`elastic+elasticsearch-py+pull-request` Jenkins job started failing due to pip executables being installed to `/var/lib/elastic/.local/bin`. See https://github.com/elastic/elasticsearch-py/pull/2241 and https://github.com/elastic/elasticsearch-py/pull/2243 for examples of failure.
