### PR TITLE
[DOCS] Changes getting started button link on landing page

### DIFF
--- a/docs/guide/index-custom-title-page.html
+++ b/docs/guide/index-custom-title-page.html
@@ -63,7 +63,7 @@
         The official Python client provides one-to-one mapping with Elasticsearch REST APIs.
       </p>
       <p>
-        <a href="https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/overview.html">
+        <a href="https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/getting-started-python.html">
           <button class="btn btn-primary">Get started</button>
         </a>
       </p>


### PR DESCRIPTION
## Overview

This PR changes the URL of the getting started button on the landing page.