### PR TITLE
Add search applications API to imports and generated docs

### DIFF
--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -150,6 +150,12 @@ Rollup Indices
 .. autoclass:: RollupClient
    :members:
 
+Search Applications
+-------------------
+
+.. autoclass:: SearchApplicationClient
+   :members:
+
 Searchable Snapshots
 --------------------
 

--- a/elasticsearch/client.py
+++ b/elasticsearch/client.py
@@ -45,6 +45,9 @@ from ._sync.client.ml import MlClient as MlClient  # noqa: F401
 from ._sync.client.monitoring import MonitoringClient as MonitoringClient  # noqa: F401
 from ._sync.client.nodes import NodesClient as NodesClient  # noqa: F401
 from ._sync.client.rollup import RollupClient as RollupClient  # noqa: F401
+from ._sync.client.search_application import (  # noqa: F401
+    SearchApplicationClient as SearchApplicationClient,
+)
 from ._sync.client.searchable_snapshots import (  # noqa: F401
     SearchableSnapshotsClient as SearchableSnapshotsClient,
 )
@@ -94,6 +97,7 @@ __all__ = [
     "MonitoringClient",
     "NodesClient",
     "RollupClient",
+    "SearchApplicationClient",
     "SearchableSnapshotsClient",
     "SecurityClient",
     "ShutdownClient",

--- a/utils/run-black.py
+++ b/utils/run-black.py
@@ -30,9 +30,9 @@ def sleep_if_hot() -> None:
                     map(
                         int,
                         re.findall(
-                            r"\s\+([0-9]{2})\.[0-9]",
+                            r"_input\:\s([0-9]{2})\.[0-9]",
                             subprocess.check_output(
-                                "sensors",
+                                "sensors -u",
                                 shell=True,
                                 stderr=subprocess.STDOUT,
                             ).decode("utf-8"),


### PR DESCRIPTION
Apparently we have to manually add new API namespaces to client.py and the sphinx API doc for them to be fully accessible to end users.

For https://github.com/elastic/elasticsearch-py/issues/2253