### PR TITLE
Changed project metadata to use group email address

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     version=package_version,
-    author="Honza Král, Nick Lang",
-    author_email="honza.kral@gmail.com, nick@nicklang.com",
-    maintainer="Clients Team",
-    maintainer_email="clients-team@elastic.co",
+    author="Elastic Client Library Maintainers",
+    author_email="client-libs@elastic.co",
     project_urls={
         "Documentation": "https://elasticsearch-py.readthedocs.io",
         "Source Code": "https://github.com/elastic/elasticsearch-py",


### PR DESCRIPTION
This PR removes individual names and email addresses and replaces those with the new (external) [group email address](mailto:client-libs@elastic.co).

The _author_ and _maintainer_ fields have also been collapsed down into just _author_. According to [setuptools](https://setuptools.pypa.io/en/latest/references/keywords.html), the _maintainer_ is used as an override for _author_, so the former is removed to use only the primary field.