### PR TITLE
Pin untrusted Github Action to a commit hash

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,6 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: tibdex/backport@v1
+        uses: tibdex/backport@7005ef85c4562bc23b0e9b4a9940d5922f439750 # v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Infosec recommends third-party actions that are maintained by individuals and not on behalf of trusted orgs like GitHub should be pinned to a specific commit.
