### PR TITLE
Document type hints individually

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -25,6 +25,8 @@ extensions = ["sphinx.ext.autodoc", "sphinx.ext.doctest", "sphinx.ext.intersphin
 
 autoclass_content = "both"
 
+autodoc_typehints = "description"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
The bulk() method used to be documented with an unreadable list of types in the signature:

![image](https://github.com/elastic/elasticsearch-py/assets/42327/767488a3-d3f2-49cb-8311-c807854f9e7e)

Now types are listed for each parameter specifically:

![image](https://github.com/elastic/elasticsearch-py/assets/42327/50d044f7-0a67-41d4-9196-f6b46b712f5a)

Which is much easier to read.