### PR TITLE
[8.10] [Docs] Link to Elasticsearch labs on landing pages (#2281)

### DIFF
--- a/docs/guide/index-custom-title-page.html
+++ b/docs/guide/index-custom-title-page.html
@@ -144,6 +144,10 @@
     </ul>
   </div>
 
+  <div style="background-color: #e6f7ff; padding: 15px; border: 1px solid #b8daff; margin: 10px 0; border-radius: 8px; width: 50%;">
+    ℹ️ The <a href="https://github.com/elastic/elasticsearch-labs" style="font-weight: bold; color: #0077cc; text-decoration: none;"> elasticsearch-labs</a> repo contains many interactive Python notebooks for testing out Elasticsearch using the Python client. These examples are mainly focused on vector search, hybrid search and generative AI use cases.
+</div>
+
   <h3 class="explore">Explore by use case</h3>
 
   <div class="row my-4">

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -65,6 +65,12 @@ Example Usage
         print("%(timestamp)s %(author)s: %(text)s" % hit["_source"])
 
 
+Interactive examples
+--------------------
+
+The `elasticsearch-labs <https://github.com/elastic/elasticsearch-labs>`_ repo contains interactive and executable Python notebooks, sample apps, and resources for testing out Elasticsearch, using the Python client. These examples are mainly focused on vector search, hybrid search and generative AI use cases, but you'll also find examples of basic operations like creating index mappings and performing lexical search.
+
+
 Features
 --------
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Docs] Link to Elasticsearch labs on landing pages (#2281)](https://github.com/elastic/elasticsearch-py/pull/2281)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)