### PR TITLE
Fix downloads badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Elasticsearch Python Client
 .. image:: https://img.shields.io/conda/vn/conda-forge/elasticsearch?color=blue
    :target: https://anaconda.org/conda-forge/elasticsearch
 
-.. image:: https://pepy.tech/badge/elasticsearch
+.. image:: https://static.pepy.tech/badge/elasticsearch
    :target: https://pepy.tech/project/elasticsearch?versions=*
 
 .. image:: https://clients-ci.elastic.co/job/elastic+elasticsearch-py+main/badge/icon


### PR DESCRIPTION
You can see the results here: https://github.com/pquentin/elasticsearch-py/tree/badge-url