### PR TITLE
[8.10] Add Synonyms and Query rules APIs

### DIFF
--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -144,6 +144,12 @@ Nodes
 .. autoclass:: NodesClient
    :members:
 
+Query rules
+-----------
+
+.. autoclass:: QueryRulesetClient
+   :members:
+
 Rollup Indices
 --------------
 
@@ -190,6 +196,12 @@ SQL
 ---
 
 .. autoclass:: SqlClient
+   :members:
+
+Synonyms
+--------
+
+.. autoclass:: SynonymsClient
    :members:
 
 TLS/SSL

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -61,6 +61,7 @@ from .migration import MigrationClient
 from .ml import MlClient
 from .monitoring import MonitoringClient
 from .nodes import NodesClient
+from .query_ruleset import QueryRulesetClient
 from .rollup import RollupClient
 from .search_application import SearchApplicationClient
 from .searchable_snapshots import SearchableSnapshotsClient
@@ -70,6 +71,7 @@ from .slm import SlmClient
 from .snapshot import SnapshotClient
 from .sql import SqlClient
 from .ssl import SslClient
+from .synonyms import SynonymsClient
 from .tasks import TasksClient
 from .text_structure import TextStructureClient
 from .transform import TransformClient
@@ -449,6 +451,7 @@ class AsyncElasticsearch(BaseClient):
         self.migration = MigrationClient(self)
         self.ml = MlClient(self)
         self.monitoring = MonitoringClient(self)
+        self.query_ruleset = QueryRulesetClient(self)
         self.rollup = RollupClient(self)
         self.search_application = SearchApplicationClient(self)
         self.searchable_snapshots = SearchableSnapshotsClient(self)
@@ -457,6 +460,7 @@ class AsyncElasticsearch(BaseClient):
         self.shutdown = ShutdownClient(self)
         self.sql = SqlClient(self)
         self.ssl = SslClient(self)
+        self.synonyms = SynonymsClient(self)
         self.text_structure = TextStructureClient(self)
         self.transform = TransformClient(self)
         self.watcher = WatcherClient(self)

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -641,7 +641,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows to perform multiple index/update/delete operations in a single request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-bulk.html>`_
 
         :param operations:
         :param index: Default index for items which don't provide one
@@ -726,7 +726,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Explicitly clears the search context for a scroll.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-scroll-api.html>`_
 
         :param scroll_id:
         """
@@ -769,7 +769,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Close a point in time
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/point-in-time-api.html>`_
 
         :param id:
         """
@@ -846,7 +846,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns number of documents matching a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-count.html>`_
 
         :param index: A comma-separated list of indices to restrict the results
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -963,7 +963,7 @@ class AsyncElasticsearch(BaseClient):
         Creates a new document in the index. Returns a 409 response when a document with
         a same ID already exists in the index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-index_.html>`_
 
         :param index: The name of the index
         :param id: Document ID
@@ -1048,7 +1048,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Removes a document from the index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-delete.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1176,7 +1176,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Deletes documents matching the provided query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-delete-by-query.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices
@@ -1340,7 +1340,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Changes the number of requests per second for a particular Delete By Query operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-delete-by-query.html>`_
 
         :param task_id: The task id to rethrottle
         :param requests_per_second: The throttle to set on this request in floating sub-requests
@@ -1384,7 +1384,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Deletes a script.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
 
         :param id: Script ID
         :param master_timeout: Specify timeout for connection to master
@@ -1453,7 +1453,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns information about whether a document exists in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1553,7 +1553,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns information about whether a document source exists in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1654,7 +1654,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns information about why a specific matches (or doesn't match) a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-explain.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1775,7 +1775,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns the information about the capabilities of fields among multiple indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-field-caps.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (*). To target all data streams
@@ -1887,7 +1887,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns a document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: Name of the index that contains the document.
         :param id: Unique identifier of the document.
@@ -1967,7 +1967,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns a script.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
 
         :param id: Script ID
         :param master_timeout: Specify timeout for connection to master
@@ -2005,7 +2005,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns all script contexts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.10/painless-contexts.html>`_
         """
         __path = "/_script_context"
         __query: t.Dict[str, t.Any] = {}
@@ -2036,7 +2036,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns available script types, languages and contexts
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
         """
         __path = "/_script_language"
         __query: t.Dict[str, t.Any] = {}
@@ -2095,7 +2095,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns the source of a document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: Name of the index that contains the document.
         :param id: Unique identifier of the document.
@@ -2176,7 +2176,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns the health of the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/health-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/health-api.html>`_
 
         :param feature: A feature of the cluster, as returned by the top-level health
             report API.
@@ -2244,7 +2244,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Creates or updates a document in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-index_.html>`_
 
         :param index: The name of the index
         :param document:
@@ -2335,7 +2335,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns basic information about the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/index.html>`_
         """
         __path = "/"
         __query: t.Dict[str, t.Any] = {}
@@ -2390,7 +2390,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Performs a kNN search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             to perform the operation on all indices
@@ -2493,7 +2493,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows to get multiple documents in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-multi-get.html>`_
 
         :param index: Name of the index to retrieve documents from when `ids` are specified,
             or when a document in the `docs` array does not specify an index.
@@ -2610,7 +2610,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows to execute several search operations in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-multi-search.html>`_
 
         :param searches:
         :param index: Comma-separated list of data streams, indices, and index aliases
@@ -2723,7 +2723,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows to execute several search template operations in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-multi-search.html>`_
 
         :param search_templates:
         :param index: A comma-separated list of index names to use as default
@@ -2807,7 +2807,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns multiple termvectors in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-multi-termvectors.html>`_
 
         :param index: The index in which the document resides.
         :param docs:
@@ -2922,7 +2922,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Open a point in time that can be used in subsequent searches
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/point-in-time-api.html>`_
 
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
@@ -2987,7 +2987,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Creates or updates a script.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
 
         :param id: Script ID
         :param script:
@@ -3069,7 +3069,7 @@ class AsyncElasticsearch(BaseClient):
         Allows to evaluate the quality of ranked search results over a set of typical
         search queries
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-rank-eval.html>`_
 
         :param requests: A set of typical search requests, together with their provided
             ratings.
@@ -3156,7 +3156,7 @@ class AsyncElasticsearch(BaseClient):
         source documents by a query, changing the destination index settings, or fetching
         the documents from a remote cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-reindex.html>`_
 
         :param dest:
         :param source:
@@ -3245,7 +3245,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Changes the number of requests per second for a particular Reindex operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-reindex.html>`_
 
         :param task_id: The task id to rethrottle
         :param requests_per_second: The throttle to set on this request in floating sub-requests
@@ -3291,7 +3291,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows to use the Mustache language to pre-render a search definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/render-search-template-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/render-search-template-api.html>`_
 
         :param id: The id of the stored search template
         :param file:
@@ -3346,7 +3346,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows an arbitrary script to be executed and a result to be returned
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.10/painless-execute-api.html>`_
 
         :param context:
         :param context_setup:
@@ -3397,7 +3397,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows to retrieve a large numbers of results from a single search request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-request-body.html#request-body-search-scroll>`_
 
         :param scroll_id: Scroll ID of the search.
         :param rest_total_hits_as_int: If true, the API response’s hit.total property
@@ -3579,131 +3579,188 @@ class AsyncElasticsearch(BaseClient):
         """
         Returns results matching a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-search.html>`_
 
-        :param index: A comma-separated list of index names to search; use `_all` or
-            empty string to perform the operation on all indices
-        :param aggregations:
-        :param aggs:
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param allow_partial_search_results: Indicate if an error should be returned
-            if there is a partial search failure or timeout
-        :param analyze_wildcard: Specify whether wildcard and prefix queries should be
-            analyzed (default: false)
-        :param analyzer: The analyzer to use for the query string
+        :param index: Comma-separated list of data streams, indices, and aliases to search.
+            Supports wildcards (`*`). To search all data streams and indices, omit this
+            parameter or use `*` or `_all`.
+        :param aggregations: Defines the aggregations that are run as part of the search
+            request.
+        :param aggs: Defines the aggregations that are run as part of the search request.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
+        :param allow_partial_search_results: If true, returns partial results if there
+            are shard request timeouts or shard failures. If false, returns an error
+            with no partial results.
+        :param analyze_wildcard: If true, wildcard and prefix queries are analyzed. This
+            parameter can only be used when the q query string parameter is specified.
+        :param analyzer: Analyzer to use for the query string. This parameter can only
+            be used when the q query string parameter is specified.
         :param batched_reduce_size: The number of shard results that should be reduced
             at once on the coordinating node. This value should be used as a protection
             mechanism to reduce the memory overhead per search request if the potential
             number of shards in the request can be large.
-        :param ccs_minimize_roundtrips: Indicates whether network round-trips should
-            be minimized as part of cross-cluster search requests execution
-        :param collapse:
-        :param default_operator: The default operator for query string query (AND or
-            OR)
-        :param df: The field to use as default where no field prefix is given in the
-            query string
-        :param docvalue_fields: Array of wildcard (*) patterns. The request returns doc
-            values for field names matching these patterns in the hits.fields property
+        :param ccs_minimize_roundtrips: If true, network round-trips between the coordinating
+            node and the remote clusters are minimized when executing cross-cluster search
+            (CCS) requests.
+        :param collapse: Collapses search results the values of the specified field.
+        :param default_operator: The default operator for query string query: AND or
+            OR. This parameter can only be used when the `q` query string parameter is
+            specified.
+        :param df: Field to use as default where no field prefix is given in the query
+            string. This parameter can only be used when the q query string parameter
+            is specified.
+        :param docvalue_fields: Array of wildcard (`*`) patterns. The request returns
+            doc values for field names matching these patterns in the `hits.fields` property
             of the response.
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`.
         :param explain: If true, returns detailed information about score computation
             as part of a hit.
         :param ext: Configuration of search extensions defined by Elasticsearch plugins.
-        :param fields: Array of wildcard (*) patterns. The request returns values for
-            field names matching these patterns in the hits.fields property of the response.
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the search_after parameter.
-        :param highlight:
-        :param ignore_throttled: Whether specified concrete, expanded or aliased indices
-            should be ignored when throttled
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
+        :param fields: Array of wildcard (`*`) patterns. The request returns values for
+            field names matching these patterns in the `hits.fields` property of the
+            response.
+        :param from_: Starting document offset. Needs to be non-negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
+        :param highlight: Specifies the highlighter to use for retrieving highlighted
+            snippets from one or more fields in your search results.
+        :param ignore_throttled: If `true`, concrete, expanded or aliased indices will
+            be ignored when frozen.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
         :param indices_boost: Boosts the _score of documents from specified indices.
         :param knn: Defines the approximate kNN search to run.
-        :param lenient: Specify whether format-based query failures (such as providing
-            text to a numeric field) should be ignored
-        :param max_concurrent_shard_requests: The number of concurrent shard requests
-            per node this search executes concurrently. This value should be used to
-            limit the impact of the search on the cluster in order to limit the number
-            of concurrent shard requests
-        :param min_compatible_shard_node: The minimum compatible version that all shards
-            involved in search should have for this request to be successful
-        :param min_score: Minimum _score for matching documents. Documents with a lower
-            _score are not included in the search results.
+        :param lenient: If `true`, format-based query failures (such as providing text
+            to a numeric field) in the query string will be ignored. This parameter can
+            only be used when the `q` query string parameter is specified.
+        :param max_concurrent_shard_requests: Defines the number of concurrent shard
+            requests per node this search executes concurrently. This value should be
+            used to limit the impact of the search on the cluster in order to limit the
+            number of concurrent shard requests.
+        :param min_compatible_shard_node: The minimum version of the node that can handle
+            the request Any handling node with a lower version will fail the request.
+        :param min_score: Minimum `_score` for matching documents. Documents with a lower
+            `_score` are not included in the search results.
         :param pit: Limits the search to a point in time (PIT). If you provide a PIT,
-            you cannot specify an <index> in the request path.
-        :param post_filter:
-        :param pre_filter_shard_size: A threshold that enforces a pre-filter roundtrip
-            to prefilter search shards based on query rewriting if the number of shards
-            the search request expands to exceeds the threshold. This filter roundtrip
-            can limit the number of shards significantly if for instance a shard can
-            not match any documents based on its rewrite method ie. if date filters are
-            mandatory to match but the shard bounds and the query are disjoint.
-        :param preference: Specify the node or shard the operation should be performed
-            on (default: random)
-        :param profile:
-        :param q: Query in the Lucene query string syntax
+            you cannot specify an `<index>` in the request path.
+        :param post_filter: Use the `post_filter` parameter to filter search results.
+            The search hits are filtered after the aggregations are calculated. A post
+            filter has no impact on the aggregation results.
+        :param pre_filter_shard_size: Defines a threshold that enforces a pre-filter
+            roundtrip to prefilter search shards based on query rewriting if the number
+            of shards the search request expands to exceeds the threshold. This filter
+            roundtrip can limit the number of shards significantly if for instance a
+            shard can not match any documents based on its rewrite method (if date filters
+            are mandatory to match but the shard bounds and the query are disjoint).
+            When unspecified, the pre-filter phase is executed if any of these conditions
+            is met: the request targets more than 128 shards; the request targets one
+            or more read-only index; the primary sort of the query targets an indexed
+            field.
+        :param preference: Nodes and shards used for the search. By default, Elasticsearch
+            selects from eligible nodes and shards using adaptive replica selection,
+            accounting for allocation awareness. Valid values are: `_only_local` to run
+            the search only on shards on the local node; `_local` to, if possible, run
+            the search on shards on the local node, or if not, select shards using the
+            default method; `_only_nodes:<node-id>,<node-id>` to run the search on only
+            the specified nodes IDs, where, if suitable shards exist on more than one
+            selected node, use shards on those nodes using the default method, or if
+            none of the specified nodes are available, select shards from any available
+            node using the default method; `_prefer_nodes:<node-id>,<node-id>` to if
+            possible, run the search on the specified nodes IDs, or if not, select shards
+            using the default method; `_shards:<shard>,<shard>` to run the search only
+            on the specified shards; `<custom-string>` (any string that does not start
+            with `_`) to route searches with the same `<custom-string>` to the same shards
+            in the same order.
+        :param profile: Set to `true` to return detailed timing information about the
+            execution of individual components in a search request. NOTE: This is a debugging
+            tool and adds significant overhead to search execution.
+        :param q: Query in the Lucene query string syntax using query parameter search.
+            Query parameter searches do not support the full Elasticsearch Query DSL
+            but are handy for testing.
         :param query: Defines the search definition using the Query DSL.
-        :param rank: Defines the Reciprocal Rank Fusion (RRF) to use
-        :param request_cache: Specify if request cache should be used for this request
-            or not, defaults to index level setting
-        :param rescore:
-        :param rest_total_hits_as_int: Indicates whether hits.total should be rendered
-            as an integer or an object in the rest search response
-        :param routing: A comma-separated list of specific routing values
+        :param rank: Defines the Reciprocal Rank Fusion (RRF) to use.
+        :param request_cache: If `true`, the caching of search results is enabled for
+            requests where `size` is `0`. Defaults to index level settings.
+        :param rescore: Can be used to improve precision by reordering just the top (for
+            example 100 - 500) documents returned by the `query` and `post_filter` phases.
+        :param rest_total_hits_as_int: Indicates whether `hits.total` should be rendered
+            as an integer or an object in the rest search response.
+        :param routing: Custom value used to route operations to a specific shard.
         :param runtime_mappings: Defines one or more runtime fields in the search request.
             These fields take precedence over mapped fields with the same name.
         :param script_fields: Retrieve a script evaluation (based on different fields)
             for each hit.
-        :param scroll: Specify how long a consistent view of the index should be maintained
-            for scrolled search
-        :param search_after:
-        :param search_type: Search operation type
-        :param seq_no_primary_term: If true, returns sequence number and primary term
-            of the last modification of each hit. See Optimistic concurrency control.
+        :param scroll: Period to retain the search context for scrolling. See Scroll
+            search results. By default, this value cannot exceed `1d` (24 hours). You
+            can change this limit using the `search.max_keep_alive` cluster-level setting.
+        :param search_after: Used to retrieve the next page of hits using a set of sort
+            values from the previous page.
+        :param search_type: How distributed term frequencies are calculated for relevance
+            scoring.
+        :param seq_no_primary_term: If `true`, returns sequence number and primary term
+            of the last modification of each hit.
         :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the from and size parameters. To page through
-            more hits, use the search_after parameter.
-        :param slice:
-        :param sort:
+            more than 10,000 hits using the `from` and `size` parameters. To page through
+            more hits, use the `search_after` parameter.
+        :param slice: Can be used to split a scrolled search into multiple slices that
+            can be consumed independently.
+        :param sort: A comma-separated list of <field>:<direction> pairs.
         :param source: Indicates which source fields are returned for matching documents.
             These fields are returned in the hits._source property of the search response.
-        :param source_excludes: A list of fields to exclude from the returned _source
-            field
-        :param source_includes: A list of fields to extract and return from the _source
-            field
+        :param source_excludes: A comma-separated list of source fields to exclude from
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
+        :param source_includes: A comma-separated list of source fields to include in
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
         :param stats: Stats groups to associate with the search. Each group maintains
             a statistics aggregation for its associated searches. You can retrieve these
             stats using the indices stats API.
         :param stored_fields: List of stored fields to return as part of a hit. If no
             fields are specified, no stored fields are included in the response. If this
-            field is specified, the _source parameter defaults to false. You can pass
-            _source: true to return both source fields and stored fields in the search
-            response.
-        :param suggest:
+            field is specified, the `_source` parameter defaults to `false`. You can
+            pass `_source: true` to return both source fields and stored fields in the
+            search response.
+        :param suggest: Defines a suggester that provides similar looking terms based
+            on a provided text.
         :param suggest_field: Specifies which field to use for suggestions.
-        :param suggest_mode: Specify suggest mode
-        :param suggest_size: How many suggestions to return in response
+        :param suggest_mode: Specifies the suggest mode. This parameter can only be used
+            when the `suggest_field` and `suggest_text` query string parameters are specified.
+        :param suggest_size: Number of suggestions to return. This parameter can only
+            be used when the `suggest_field` and `suggest_text` query string parameters
+            are specified.
         :param suggest_text: The source text for which the suggestions should be returned.
+            This parameter can only be used when the `suggest_field` and `suggest_text`
+            query string parameters are specified.
         :param terminate_after: Maximum number of documents to collect for each shard.
             If a query reaches this limit, Elasticsearch terminates the query early.
-            Elasticsearch collects documents before sorting. Defaults to 0, which does
-            not terminate query execution early.
+            Elasticsearch collects documents before sorting. Use with caution. Elasticsearch
+            applies this parameter to each shard handling the request. When possible,
+            let Elasticsearch perform early termination automatically. Avoid specifying
+            this parameter for requests that target data streams with backing indices
+            across multiple data tiers. If set to `0` (default), the query does not terminate
+            early.
         :param timeout: Specifies the period of time to wait for a response from each
             shard. If no response is received before the timeout expires, the request
             fails and returns an error. Defaults to no timeout.
         :param track_scores: If true, calculate and return document scores, even if the
             scores are not used for sorting.
         :param track_total_hits: Number of hits matching the query to count accurately.
-            If true, the exact number of hits is returned at the cost of some performance.
-            If false, the response does not include the total number of hits matching
-            the query. Defaults to 10,000 hits.
-        :param typed_keys: Specify whether aggregation and suggester names should be
-            prefixed by their respective types in the response
+            If `true`, the exact number of hits is returned at the cost of some performance.
+            If `false`, the response does not include the total number of hits matching
+            the query.
+        :param typed_keys: If `true`, aggregation and suggester names are be prefixed
+            by their respective types in the response.
         :param version: If true, returns document version as part of a hit.
         """
         if index not in SKIP_IN_PATH:
@@ -3914,7 +3971,7 @@ class AsyncElasticsearch(BaseClient):
         Searches a vector tile for geospatial values. Returns results as a binary Mapbox
         vector tile.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-vector-tile-api.html>`_
 
         :param index: Comma-separated list of data streams, indices, or aliases to search
         :param field: Field containing geospatial data to return
@@ -4067,7 +4124,7 @@ class AsyncElasticsearch(BaseClient):
         Returns information about the indices and shards that a search request would
         be executed against.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-shards.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices
@@ -4167,7 +4224,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Allows to use the Mustache language to pre-render a search definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-template.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (*).
@@ -4278,7 +4335,7 @@ class AsyncElasticsearch(BaseClient):
         the provided string. It is designed for low-latency look-ups used in auto-complete
         scenarios.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-terms-enum.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-terms-enum.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             to search. Wildcard (*) expressions are supported.
@@ -4372,7 +4429,7 @@ class AsyncElasticsearch(BaseClient):
         Returns information and statistics about terms in the fields of a particular
         document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-termvectors.html>`_
 
         :param index: The index in which the document resides.
         :param id: The id of the document, when not specified a doc param should be supplied.
@@ -4499,7 +4556,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Updates a document with a script or partial document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-update.html>`_
 
         :param index: The name of the index
         :param id: Document ID
@@ -4668,7 +4725,7 @@ class AsyncElasticsearch(BaseClient):
         Performs an update on every document in the index without changing the source,
         for example to pick up a mapping change.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-update-by-query.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices
@@ -4844,7 +4901,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Changes the number of requests per second for a particular Update By Query operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-update-by-query.html>`_
 
         :param task_id: The task id to rethrottle
         :param requests_per_second: The throttle to set on this request in floating sub-requests

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -40,7 +40,7 @@ class AsyncSearchClient(NamespacedClient):
         Deletes an async search by ID. If the search is still running, the search request
         will be cancelled. Otherwise, the saved search results are deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -82,7 +82,7 @@ class AsyncSearchClient(NamespacedClient):
         Retrieves the results of a previously submitted async search request given its
         ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         :param keep_alive: Specifies how long the async search should be available in
@@ -139,7 +139,7 @@ class AsyncSearchClient(NamespacedClient):
         Retrieves the status of a previously submitted async search request given its
         ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -310,7 +310,7 @@ class AsyncSearchClient(NamespacedClient):
         """
         Executes a search request asynchronously.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices

--- a/elasticsearch/_async/client/cat.py
+++ b/elasticsearch/_async/client/cat.py
@@ -67,7 +67,7 @@ class CatClient(NamespacedClient):
         Shows information about currently configured aliases to indices including filter
         and routing infos.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-alias.html>`_
 
         :param name: A comma-separated list of aliases to retrieve. Supports wildcards
             (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
@@ -152,7 +152,7 @@ class CatClient(NamespacedClient):
         Provides a snapshot of how many shards are allocated to each data node and how
         much disk space they are using.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-allocation.html>`_
 
         :param node_id: Comma-separated list of node identifiers or names used to limit
             the returned information.
@@ -230,7 +230,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about existing component_templates templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-component-templates.html>`_
 
         :param name: The name of the component template. Accepts wildcard expressions.
             If omitted, all component templates are returned.
@@ -306,7 +306,7 @@ class CatClient(NamespacedClient):
         Provides quick access to the document count of the entire cluster, or individual
         indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-count.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -388,7 +388,7 @@ class CatClient(NamespacedClient):
         Shows how much heap memory is currently being used by fielddata on every data
         node in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-fielddata.html>`_
 
         :param fields: Comma-separated list of fields used to limit returned information.
             To retrieve all fields, omit this parameter.
@@ -469,7 +469,7 @@ class CatClient(NamespacedClient):
         """
         Returns a concise representation of the cluster health.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-health.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -544,7 +544,7 @@ class CatClient(NamespacedClient):
         """
         Returns help for the Cat APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -642,7 +642,7 @@ class CatClient(NamespacedClient):
         Returns information about indices: number of primaries and replicas, document
         counts, disk size, ...
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-indices.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -737,7 +737,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about the master node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-master.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -856,7 +856,7 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-dfanalytics.html>`_
 
         :param id: The ID of the data frame analytics to fetch
         :param allow_no_match: Whether to ignore if a wildcard expression matches no
@@ -987,7 +987,7 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-datafeeds.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed.
@@ -1124,7 +1124,7 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-anomaly-detectors.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param allow_no_match: Specifies what to do when the request: * Contains wildcard
@@ -1264,17 +1264,21 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about inference trained models.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-trained-model.html>`_
 
-        :param model_id: The ID of the trained models stats to fetch
-        :param allow_no_match: Whether to ignore if a wildcard expression matches no
-            trained models. (This includes `_all` string or when no trained models have
-            been specified)
-        :param bytes: The unit in which to display byte values
+        :param model_id: A unique identifier for the trained model.
+        :param allow_no_match: Specifies what to do when the request: contains wildcard
+            expressions and there are no models that match; contains the `_all` string
+            or no identifiers and there are no matches; contains wildcard expressions
+            and there are only partial matches. If `true`, the API returns an empty array
+            when there are no matches and the subset of results when there are partial
+            matches. If `false`, the API returns a 404 status code when there are no
+            matches or only partial matches.
+        :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
-        :param from_: skips a number of trained models
-        :param h: Comma-separated list of column names to display
+        :param from_: Skips the specified number of transforms.
+        :param h: A comma-separated list of column names to display.
         :param help: When set to `true` will output available columns. This option can't
             be combined with any other query string option.
         :param local: If `true`, the request computes the list of selected nodes from
@@ -1282,8 +1286,9 @@ class CatClient(NamespacedClient):
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
         :param master_timeout: Period to wait for a connection to the master node.
-        :param s: Comma-separated list of column names or column aliases to sort by
-        :param size: specifies a max number of trained models to get
+        :param s: A comma-separated list of column names or aliases used to sort the
+            response.
+        :param size: The maximum number of transforms to display.
         :param v: When set to `true` will enable verbose output.
         """
         if model_id not in SKIP_IN_PATH:
@@ -1349,7 +1354,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about custom node attributes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-nodeattrs.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1423,7 +1428,7 @@ class CatClient(NamespacedClient):
         """
         Returns basic statistics about performance of cluster nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-nodes.html>`_
 
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -1503,7 +1508,7 @@ class CatClient(NamespacedClient):
         """
         Returns a concise representation of the cluster pending tasks.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-pending-tasks.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1572,7 +1577,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about installed plugins across nodes node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-plugins.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1647,7 +1652,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about index shard recoveries, both on-going completed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-recovery.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -1732,7 +1737,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about snapshot repositories registered in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-repositories.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1805,10 +1810,12 @@ class CatClient(NamespacedClient):
         """
         Provides low-level information about the segments in the shards of an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-segments.html>`_
 
-        :param index: A comma-separated list of index names to limit the returned information
-        :param bytes: The unit in which to display byte values
+        :param index: A comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -1885,10 +1892,12 @@ class CatClient(NamespacedClient):
         """
         Provides a detailed view of shard allocation on nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-shards.html>`_
 
-        :param index: A comma-separated list of index names to limit the returned information
-        :param bytes: The unit in which to display byte values
+        :param index: A comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -1965,15 +1974,18 @@ class CatClient(NamespacedClient):
         """
         Returns all snapshots in a specific repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-snapshots.html>`_
 
-        :param repository: Name of repository from which to fetch the snapshot information
+        :param repository: A comma-separated list of snapshot repositories used to limit
+            the request. Accepts wildcard expressions. `_all` returns all repositories.
+            If any repository fails during the request, Elasticsearch returns an error.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
         :param help: When set to `true` will output available columns. This option can't
             be combined with any other query string option.
-        :param ignore_unavailable: Set to true to ignore unavailable snapshots
+        :param ignore_unavailable: If `true`, the response does not include information
+            from unavailable snapshots.
         :param local: If `true`, the request computes the list of selected nodes from
             the local cluster state. If `false` the list of selected nodes are computed
             from the cluster state of the master node. In both cases the coordinating
@@ -2037,7 +2049,7 @@ class CatClient(NamespacedClient):
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
         node_id: t.Optional[t.Union[t.List[str], t.Tuple[str, ...]]] = None,
-        parent_task: t.Optional[int] = None,
+        parent_task_id: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         s: t.Optional[t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]] = None,
         v: t.Optional[bool] = None,
@@ -2046,11 +2058,11 @@ class CatClient(NamespacedClient):
         Returns information about the tasks currently executing on one or more nodes
         in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
-        :param actions: A comma-separated list of actions that should be returned. Leave
-            empty to return all.
-        :param detailed: Return detailed task information (default: false)
+        :param actions: The task action names, which are used to limit the response.
+        :param detailed: If `true`, the response includes detailed information about
+            shard recoveries.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -2061,8 +2073,9 @@ class CatClient(NamespacedClient):
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
         :param master_timeout: Period to wait for a connection to the master node.
-        :param node_id:
-        :param parent_task:
+        :param node_id: Unique node identifiers, which are used to limit the response.
+        :param parent_task_id: The parent task identifier, which is used to limit the
+            response.
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
@@ -2092,8 +2105,8 @@ class CatClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if node_id is not None:
             __query["node_id"] = node_id
-        if parent_task is not None:
-            __query["parent_task"] = parent_task
+        if parent_task_id is not None:
+            __query["parent_task_id"] = parent_task_id
         if pretty is not None:
             __query["pretty"] = pretty
         if s is not None:
@@ -2129,9 +2142,10 @@ class CatClient(NamespacedClient):
         """
         Returns information about existing templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-templates.html>`_
 
-        :param name: A pattern that returned template names must match
+        :param name: The name of the template to return. Accepts wildcard expressions.
+            If omitted, all templates are returned.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -2209,10 +2223,10 @@ class CatClient(NamespacedClient):
         Returns cluster-wide thread pool statistics per node. By default the active,
         queue and rejected statistics are returned for all thread pools.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-thread-pool.html>`_
 
-        :param thread_pool_patterns: List of thread pool names used to limit the request.
-            Accepts wildcard expressions.
+        :param thread_pool_patterns: A comma-separated list of thread pool names used
+            to limit the request. Accepts wildcard expressions.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -2226,7 +2240,7 @@ class CatClient(NamespacedClient):
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
-        :param time: Unit used to display time values.
+        :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
         if thread_pool_patterns not in SKIP_IN_PATH:
@@ -2339,16 +2353,21 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-transforms.html>`_
 
-        :param transform_id: The id of the transform for which to get stats. '_all' or
-            '*' implies all transforms
-        :param allow_no_match: Whether to ignore if a wildcard expression matches no
-            transforms. (This includes `_all` string or when no transforms have been
-            specified)
+        :param transform_id: A transform identifier or a wildcard expression. If you
+            do not specify one of these options, the API returns information for all
+            transforms.
+        :param allow_no_match: Specifies what to do when the request: contains wildcard
+            expressions and there are no transforms that match; contains the `_all` string
+            or no identifiers and there are no matches; contains wildcard expressions
+            and there are only partial matches. If `true`, it returns an empty transforms
+            array when there are no matches and the subset of results when there are
+            partial matches. If `false`, the request returns a 404 status code when there
+            are no matches or only partial matches.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
-        :param from_: skips a number of transform configs, defaults to 0
+        :param from_: Skips the specified number of transforms.
         :param h: Comma-separated list of column names to display.
         :param help: When set to `true` will output available columns. This option can't
             be combined with any other query string option.
@@ -2359,8 +2378,8 @@ class CatClient(NamespacedClient):
         :param master_timeout: Period to wait for a connection to the master node.
         :param s: Comma-separated list of column names or column aliases used to sort
             the response.
-        :param size: specifies a max number of transforms to get, defaults to 100
-        :param time: Unit used to display time values.
+        :param size: The maximum number of transforms to obtain.
+        :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
         if transform_id not in SKIP_IN_PATH:

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -39,7 +39,7 @@ class CcrClient(NamespacedClient):
         """
         Deletes auto-follow patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-delete-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern.
         """
@@ -96,7 +96,7 @@ class CcrClient(NamespacedClient):
         """
         Creates a new follower index configured to follow the referenced leader index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-put-follow.html>`_
 
         :param index: The name of the follower index
         :param leader_index:
@@ -180,7 +180,7 @@ class CcrClient(NamespacedClient):
         Retrieves information about all follower indices, including parameters and status
         for each follower index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-follow-info.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -218,7 +218,7 @@ class CcrClient(NamespacedClient):
         Retrieves follower stats. return shard-level stats about the following tasks
         associated with each shard for the specified indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-follow-stats.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -261,7 +261,7 @@ class CcrClient(NamespacedClient):
         """
         Removes the follower retention leases from the leader.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-forget-follower.html>`_
 
         :param index: the name of the leader index for which specified follower retention
             leases should be removed
@@ -312,7 +312,7 @@ class CcrClient(NamespacedClient):
         Gets configured auto-follow patterns. Returns the specified auto-follow pattern
         collection.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-auto-follow-pattern.html>`_
 
         :param name: Specifies the auto-follow pattern collection that you want to retrieve.
             If you do not specify a name, the API returns information for all collections.
@@ -350,7 +350,7 @@ class CcrClient(NamespacedClient):
         """
         Pauses an auto-follow pattern
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-pause-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern that should pause discovering
             new indices to follow.
@@ -388,7 +388,7 @@ class CcrClient(NamespacedClient):
         Pauses a follower index. The follower index will not fetch any additional operations
         from the leader index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-pause-follow.html>`_
 
         :param index: The name of the follower index that should pause following its
             leader index.
@@ -452,7 +452,7 @@ class CcrClient(NamespacedClient):
         cluster. Newly created indices on the remote cluster matching any of the specified
         patterns will be automatically configured as follower indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-put-auto-follow-pattern.html>`_
 
         :param name: The name of the collection of auto-follow patterns.
         :param remote_cluster: The remote cluster containing the leader indices to match
@@ -566,7 +566,7 @@ class CcrClient(NamespacedClient):
         """
         Resumes an auto-follow pattern that has been paused
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-resume-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern to resume discovering new indices
             to follow.
@@ -619,7 +619,7 @@ class CcrClient(NamespacedClient):
         """
         Resumes a follower index that has been paused
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-resume-follow.html>`_
 
         :param index: The name of the follow index to resume following.
         :param max_outstanding_read_requests:
@@ -693,7 +693,7 @@ class CcrClient(NamespacedClient):
         """
         Gets all stats related to cross-cluster replication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-stats.html>`_
         """
         __path = "/_ccr/stats"
         __query: t.Dict[str, t.Any] = {}
@@ -726,7 +726,7 @@ class CcrClient(NamespacedClient):
         Stops the following task associated with a follower index and removes index metadata
         and settings associated with cross-cluster replication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-unfollow.html>`_
 
         :param index: The name of the follower index that should be turned into a regular
             index.

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -46,7 +46,7 @@ class ClusterClient(NamespacedClient):
         """
         Provides explanations for shard allocations in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-allocation-explain.html>`_
 
         :param current_node: Specifies the node ID or the name of the node to only explain
             a shard that is currently located on the specified node.
@@ -111,12 +111,15 @@ class ClusterClient(NamespacedClient):
         """
         Deletes a component template
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
         :param name: Comma-separated list or wildcard expression of component template
             names used to limit the request.
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -154,7 +157,7 @@ class ClusterClient(NamespacedClient):
         """
         Clears cluster voting config exclusions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/voting-config-exclusions.html>`_
 
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
             be removed from the cluster before clearing the voting configuration exclusions
@@ -199,7 +202,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns information about whether a particular component template exist
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (*) expressions are supported.
@@ -252,15 +255,18 @@ class ClusterClient(NamespacedClient):
         """
         Returns one or more component templates
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
-        :param name: The comma separated names of the component templates
-        :param flat_settings:
+        :param name: Comma-separated list of component template names used to limit the
+            request. Wildcard (`*`) expressions are supported.
+        :param flat_settings: If `true`, returns settings in flat format.
         :param include_defaults: Return all default configurations for the component
             template (default: false)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Explicit operation timeout for connection to master node
+        :param local: If `true`, the request retrieves information from the local node
+            only. If `false`, information is retrieved from the master node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_component_template/{_quote(name)}"
@@ -308,12 +314,16 @@ class ClusterClient(NamespacedClient):
         """
         Returns cluster settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-get-settings.html>`_
 
-        :param flat_settings: Return settings in flat format (default: false)
-        :param include_defaults: Whether to return all default clusters setting.
-        :param master_timeout: Explicit operation timeout for connection to master node
-        :param timeout: Explicit operation timeout
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param include_defaults: If `true`, returns default cluster settings from the
+            local node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
@@ -394,7 +404,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns basic information about the health of the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-health.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported. To target
@@ -471,6 +481,62 @@ class ClusterClient(NamespacedClient):
         )
 
     @_rewrite_parameters()
+    async def info(
+        self,
+        *,
+        target: t.Union[
+            t.Union[
+                "t.Literal['_all', 'http', 'ingest', 'script', 'thread_pool']", str
+            ],
+            t.Union[
+                t.List[
+                    t.Union[
+                        "t.Literal['_all', 'http', 'ingest', 'script', 'thread_pool']",
+                        str,
+                    ]
+                ],
+                t.Tuple[
+                    t.Union[
+                        "t.Literal['_all', 'http', 'ingest', 'script', 'thread_pool']",
+                        str,
+                    ],
+                    ...,
+                ],
+            ],
+        ],
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Returns different information about the cluster.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-info.html>`_
+
+        :param target: Limits the information returned to the specific target. Supports
+            a comma-separated list, such as http,ingest.
+        """
+        if target in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'target'")
+        __path = f"/_info/{_quote(target)}"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        __headers = {"accept": "application/json"}
+        return await self.perform_request(  # type: ignore[return-value]
+            "GET", __path, params=__query, headers=__headers
+        )
+
+    @_rewrite_parameters()
     async def pending_tasks(
         self,
         *,
@@ -489,11 +555,13 @@ class ClusterClient(NamespacedClient):
         Returns a list of any cluster-level changes (e.g. create index, update mapping,
         allocate or fail shard) which have not yet been executed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-pending.html>`_
 
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Specify timeout for connection to master
+        :param local: If `true`, the request retrieves information from the local node
+            only. If `false`, information is retrieved from the master node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         __path = "/_cluster/pending_tasks"
         __query: t.Dict[str, t.Any] = {}
@@ -535,7 +603,7 @@ class ClusterClient(NamespacedClient):
         """
         Updates the cluster voting config exclusions by node ids or node names.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/voting-config-exclusions.html>`_
 
         :param node_ids: A comma-separated list of the persistent ids of the nodes to
             exclude from the voting configuration. If specified, you may not also specify
@@ -594,9 +662,17 @@ class ClusterClient(NamespacedClient):
         """
         Creates or updates a component template
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
-        :param name: The name of the template
+        :param name: Name of the component template to create. Elasticsearch includes
+            the following built-in component templates: `logs-mappings`; 'logs-settings`;
+            `metrics-mappings`; `metrics-settings`;`synthetics-mapping`; `synthetics-settings`.
+            Elastic Agent uses these templates to configure backing indices for its data
+            streams. If you use Elastic Agent and want to overwrite one of these templates,
+            set the `version` for your replacement template higher than the current version.
+            If you don’t use Elastic Agent and want to disable all built-in component
+            and index templates, set `stack.templates.enabled` to `false` using the cluster
+            update settings API.
         :param template: The template to be applied which includes mappings, settings,
             or aliases configuration.
         :param allow_auto_create: This setting overrides the value of the `action.auto_create_index`
@@ -604,13 +680,18 @@ class ClusterClient(NamespacedClient):
             created using that template even if auto-creation of indices is disabled
             via `actions.auto_create_index`. If set to `false` then data streams matching
             the template must always be explicitly created.
-        :param create: Whether the index template should only be added if new or can
-            also replace an existing one
-        :param master_timeout: Specify timeout for connection to master
+        :param create: If `true`, this request cannot replace or update existing component
+            templates.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         :param meta: Optional user metadata about the component template. May have any
-            contents. This map is not automatically generated by Elasticsearch.
+            contents. This map is not automatically generated by Elasticsearch. This
+            information is stored in the cluster state, so keeping it short is preferable.
+            To unset `_meta`, replace the template without specifying this information.
         :param version: Version number used to manage component templates externally.
             This number isn't automatically generated or incremented by Elasticsearch.
+            To unset a version, replace the template without specifying a version.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -667,7 +748,7 @@ class ClusterClient(NamespacedClient):
         """
         Updates the cluster settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-update-settings.html>`_
 
         :param flat_settings: Return settings in flat format (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
@@ -715,7 +796,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns the information about configured remote clusters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-remote-info.html>`_
         """
         __path = "/_remote/info"
         __query: t.Dict[str, t.Any] = {}
@@ -761,7 +842,7 @@ class ClusterClient(NamespacedClient):
         """
         Allows to manually change the allocation of individual shards in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-reroute.html>`_
 
         :param commands: Defines the commands to perform.
         :param dry_run: If true, then the request simulates the operation only and returns
@@ -858,7 +939,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns a comprehensive information about the state of the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-state.html>`_
 
         :param metric: Limit the information returned to the specified metrics
         :param index: A comma-separated list of index names; use `_all` or empty string
@@ -936,15 +1017,15 @@ class ClusterClient(NamespacedClient):
         """
         Returns high-level overview of cluster statistics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-stats.html>`_
 
         :param node_id: Comma-separated list of node filters used to limit returned information.
             Defaults to all nodes in the cluster.
-        :param flat_settings: Return settings in flat format (default: false)
+        :param flat_settings: If `true`, returns settings in flat format.
         :param timeout: Period to wait for each node to respond. If a node does not respond
             before its timeout expires, the response does not include its stats. However,
-            timed out nodes are included in the response’s _nodes.failed property. Defaults
-            to no timeout.
+            timed out nodes are included in the response’s `_nodes.failed` property.
+            Defaults to no timeout.
         """
         if node_id not in SKIP_IN_PATH:
             __path = f"/_cluster/stats/nodes/{_quote(node_id)}"

--- a/elasticsearch/_async/client/dangling_indices.py
+++ b/elasticsearch/_async/client/dangling_indices.py
@@ -44,7 +44,7 @@ class DanglingIndicesClient(NamespacedClient):
         """
         Deletes the specified dangling index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-gateway-dangling-indices.html>`_
 
         :param index_uuid: The UUID of the dangling index
         :param accept_data_loss: Must be set to true in order to delete the dangling
@@ -97,7 +97,7 @@ class DanglingIndicesClient(NamespacedClient):
         """
         Imports the specified dangling index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-gateway-dangling-indices.html>`_
 
         :param index_uuid: The UUID of the dangling index
         :param accept_data_loss: Must be set to true in order to import the dangling
@@ -144,7 +144,7 @@ class DanglingIndicesClient(NamespacedClient):
         """
         Returns all dangling indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-gateway-dangling-indices.html>`_
         """
         __path = "/_dangling"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_async/client/enrich.py
+++ b/elasticsearch/_async/client/enrich.py
@@ -39,9 +39,9 @@ class EnrichClient(NamespacedClient):
         """
         Deletes an existing enrich policy and its enrich index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-enrich-policy-api.html>`_
 
-        :param name: The name of the enrich policy
+        :param name: Enrich policy to delete.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -76,11 +76,11 @@ class EnrichClient(NamespacedClient):
         """
         Creates the enrich index for an existing enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/execute-enrich-policy-api.html>`_
 
-        :param name: The name of the enrich policy
-        :param wait_for_completion: Should the request should block until the execution
-            is complete.
+        :param name: Enrich policy to execute.
+        :param wait_for_completion: If `true`, the request blocks other enrich policy
+            execution requests until complete.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -116,9 +116,10 @@ class EnrichClient(NamespacedClient):
         """
         Gets information about an enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-enrich-policy-api.html>`_
 
-        :param name: A comma-separated list of enrich policy names
+        :param name: Comma-separated list of enrich policy names used to limit the request.
+            To return information for all enrich policies, omit this parameter.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_enrich/policy/{_quote(name)}"
@@ -158,12 +159,14 @@ class EnrichClient(NamespacedClient):
         """
         Creates a new enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-enrich-policy-api.html>`_
 
-        :param name: The name of the enrich policy
-        :param geo_match:
-        :param match:
-        :param range:
+        :param name: Name of the enrich policy to create or update.
+        :param geo_match: Matches enrich data to incoming documents based on a `geo_shape`
+            query.
+        :param match: Matches enrich data to incoming documents based on a `term` query.
+        :param range: Matches a number, date, or IP address in incoming documents to
+            a range in the enrich index based on a `term` query.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -204,7 +207,7 @@ class EnrichClient(NamespacedClient):
         Gets enrich coordinator statistics and information about enrich policies that
         are currently executing.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/enrich-stats-api.html>`_
         """
         __path = "/_enrich/_stats"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_async/client/eql.py
+++ b/elasticsearch/_async/client/eql.py
@@ -40,9 +40,11 @@ class EqlClient(NamespacedClient):
         Deletes an async EQL search by ID. If the search is still running, the search
         request will be cancelled. Otherwise, the saved search results are deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/eql-search-api.html>`_
 
-        :param id: Identifier for the search to delete.
+        :param id: Identifier for the search to delete. A search ID is provided in the
+            EQL search API's response for an async search. A search ID is also provided
+            if the request’s `keep_on_completion` parameter is `true`.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -80,7 +82,7 @@ class EqlClient(NamespacedClient):
         """
         Returns async results from previously executed Event Query Language (EQL) search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `< https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-eql-search-api.html>`_
 
         :param id: Identifier for the search.
         :param keep_alive: Period for which the search and its results are stored on
@@ -127,7 +129,7 @@ class EqlClient(NamespacedClient):
         Returns the status of a previously submitted async or stored Event Query Language
         (EQL) search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `< https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-eql-status-api.html>`_
 
         :param id: Identifier for the search.
         """
@@ -215,7 +217,7 @@ class EqlClient(NamespacedClient):
         """
         Returns results matching a query expressed in Event Query Language (EQL)
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/eql-search-api.html>`_
 
         :param index: The name of the index to scope the operation
         :param query: EQL query you wish to run.

--- a/elasticsearch/_async/client/features.py
+++ b/elasticsearch/_async/client/features.py
@@ -39,7 +39,7 @@ class FeaturesClient(NamespacedClient):
         Gets a list of features which can be included in snapshots using the feature_states
         field when creating a snapshot
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-features-api.html>`_
         """
         __path = "/_features"
         __query: t.Dict[str, t.Any] = {}
@@ -70,7 +70,7 @@ class FeaturesClient(NamespacedClient):
         """
         Resets the internal state of features, usually by deleting system indices
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
         """
         __path = "/_features/_reset"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_async/client/fleet.py
+++ b/elasticsearch/_async/client/fleet.py
@@ -44,7 +44,7 @@ class FleetClient(NamespacedClient):
         Returns the current global checkpoints for an index. This API is design for internal
         use by the fleet server project.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-global-checkpoints.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-global-checkpoints.html>`_
 
         :param index: A single index or index alias that resolves to a single index.
         :param checkpoints: A comma separated list of previous global checkpoints. When

--- a/elasticsearch/_async/client/graph.py
+++ b/elasticsearch/_async/client/graph.py
@@ -50,16 +50,20 @@ class GraphClient(NamespacedClient):
         Explore extracted and summarized information about the documents and terms in
         an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/graph-explore-api.html>`_
 
-        :param index: A comma-separated list of index names to search; use `_all` or
-            empty string to perform the operation on all indices
-        :param connections:
-        :param controls:
-        :param query:
-        :param routing: Specific routing value
-        :param timeout: Explicit operation timeout
-        :param vertices:
+        :param index: Name of the index.
+        :param connections: Specifies or more fields from which you want to extract terms
+            that are associated with the specified vertices.
+        :param controls: Direct the Graph API how to build the graph.
+        :param query: A seed query that identifies the documents of interest. Can be
+            any valid Elasticsearch query.
+        :param routing: Custom value used to route operations to a specific shard.
+        :param timeout: Specifies the period of time to wait for a response from each
+            shard. If no response is received before the timeout expires, the request
+            fails and returns an error. Defaults to no timeout.
+        :param vertices: Specifies one or more fields that contain the terms you want
+            to include in the graph as vertices.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")

--- a/elasticsearch/_async/client/ilm.py
+++ b/elasticsearch/_async/client/ilm.py
@@ -44,7 +44,7 @@ class IlmClient(NamespacedClient):
         Deletes the specified lifecycle policy definition. A currently used policy cannot
         be deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-delete-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -96,7 +96,7 @@ class IlmClient(NamespacedClient):
         Retrieves information about the index's current lifecycle state, such as the
         currently executing phase, action, and step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-explain-lifecycle.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to target.
             Supports wildcards (`*`). To target all data streams and indices, use `*`
@@ -157,7 +157,7 @@ class IlmClient(NamespacedClient):
         Returns the specified policy definition. Includes the policy version and last
         modified date.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-get-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -202,7 +202,7 @@ class IlmClient(NamespacedClient):
         """
         Retrieves the current index lifecycle management (ILM) status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-get-status.html>`_
         """
         __path = "/_ilm/status"
         __query: t.Dict[str, t.Any] = {}
@@ -239,7 +239,7 @@ class IlmClient(NamespacedClient):
         Migrates the indices and ILM policies away from custom node attribute allocation
         routing to data tiers routing
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-migrate-to-data-tiers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-migrate-to-data-tiers.html>`_
 
         :param dry_run: If true, simulates the migration from node attributes based allocation
             filters to data tiers, but does not perform the migration. This provides
@@ -292,7 +292,7 @@ class IlmClient(NamespacedClient):
         """
         Manually moves an index into the specified step and executes that step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-move-to-step.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-move-to-step.html>`_
 
         :param index: The name of the index whose lifecycle step is to change
         :param current_step:
@@ -346,7 +346,7 @@ class IlmClient(NamespacedClient):
         """
         Creates a lifecycle policy
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-put-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -399,7 +399,7 @@ class IlmClient(NamespacedClient):
         """
         Removes the assigned lifecycle policy and stops managing the specified index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-remove-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-remove-policy.html>`_
 
         :param index: The name of the index to remove policy on
         """
@@ -435,7 +435,7 @@ class IlmClient(NamespacedClient):
         """
         Retries executing the policy for an index that is in the ERROR step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-retry-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-retry-policy.html>`_
 
         :param index: The name of the indices (comma-separated) whose failed lifecycle
             step is to be retry
@@ -475,7 +475,7 @@ class IlmClient(NamespacedClient):
         """
         Start the index lifecycle management (ILM) plugin.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-start.html>`_
 
         :param master_timeout:
         :param timeout:
@@ -518,7 +518,7 @@ class IlmClient(NamespacedClient):
         Halts all lifecycle management operations and stops the index lifecycle management
         (ILM) plugin
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-stop.html>`_
 
         :param master_timeout:
         :param timeout:

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -64,7 +64,7 @@ class IndicesClient(NamespacedClient):
         """
         Adds a block to an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/index-modules-blocks.html>`_
 
         :param index: A comma separated list of indices to add a block to
         :param block: The block to add (one of read, write, read_only or metadata)
@@ -144,18 +144,28 @@ class IndicesClient(NamespacedClient):
         Performs the analysis process on a text and return the tokens breakdown of the
         text.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-analyze.html>`_
 
-        :param index: The name of the index to scope the operation
-        :param analyzer:
-        :param attributes:
-        :param char_filter:
-        :param explain:
-        :param field:
-        :param filter:
-        :param normalizer:
-        :param text:
-        :param tokenizer:
+        :param index: Index used to derive the analyzer. If specified, the `analyzer`
+            or field parameter overrides this value. If no index is specified or the
+            index does not have a default analyzer, the analyze API uses the standard
+            analyzer.
+        :param analyzer: The name of the analyzer that should be applied to the provided
+            `text`. This could be a built-in analyzer, or an analyzer that’s been configured
+            in the index.
+        :param attributes: Array of token attributes used to filter the output of the
+            `explain` parameter.
+        :param char_filter: Array of character filters used to preprocess characters
+            before the tokenizer.
+        :param explain: If `true`, the response includes token attributes and additional
+            details.
+        :param field: Field used to derive the analyzer. To use this parameter, you must
+            specify an index. If specified, the `analyzer` parameter overrides this value.
+        :param filter: Array of token filters used to apply after the tokenizer.
+        :param normalizer: Normalizer to use to convert text into a single token.
+        :param text: Text to analyze. If an array of strings is provided, it is analyzed
+            as a multi-value field.
+        :param tokenizer: Tokenizer to use to convert text into tokens.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_analyze"
@@ -239,21 +249,26 @@ class IndicesClient(NamespacedClient):
         """
         Clears all or specific caches for one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-clearcache.html>`_
 
-        :param index: A comma-separated list of index name to limit the operation
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param fielddata: Clear field data
-        :param fields: A comma-separated list of fields to clear when using the `fielddata`
-            parameter (default: all)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param query: Clear query caches
-        :param request: Clear request cache
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param fielddata: If `true`, clears the fields cache. Use the `fields` parameter
+            to clear the cache of specific fields only.
+        :param fields: Comma-separated list of field names used to limit the `fielddata`
+            parameter.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param query: If `true`, clears the query cache.
+        :param request: If `true`, clears the request cache.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_cache/clear"
@@ -314,16 +329,20 @@ class IndicesClient(NamespacedClient):
         """
         Clones an index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-clone-index.html>`_
 
-        :param index: The name of the source index to clone
-        :param target: The name of the target index to clone into
-        :param aliases:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the cloned index before the operation returns.
+        :param index: Name of the source index to clone.
+        :param target: Name of the target index to create.
+        :param aliases: Aliases for the resulting index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the target index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -401,20 +420,27 @@ class IndicesClient(NamespacedClient):
         """
         Closes an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-close.html>`_
 
-        :param index: A comma separated list of indices to close
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Sets the number of active shards to wait for before
-            the operation returns.
+        :param index: Comma-separated list or wildcard expression of index names used
+            to limit the request.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -472,17 +498,21 @@ class IndicesClient(NamespacedClient):
         """
         Creates an index with optional settings and mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-create-index.html>`_
 
-        :param index: The name of the index
-        :param aliases:
+        :param index: Name of the index you wish to create.
+        :param aliases: Aliases for the index.
         :param mappings: Mapping for fields in the index. If specified, this mapping
             can include: - Field names - Field data types - Mapping parameters
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for before
-            the operation returns.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -533,9 +563,13 @@ class IndicesClient(NamespacedClient):
         """
         Creates a data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: The name of the data stream
+        :param name: Name of the data stream, which must meet the following criteria:
+            Lowercase only; Cannot include `\\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`,
+            `#`, `:`, or a space character; Cannot start with `-`, `_`, `+`, or `.ds-`;
+            Cannot be `.` or `..`; Cannot be longer than 255 bytes. Multi-byte characters
+            count towards this limit faster.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -587,11 +621,13 @@ class IndicesClient(NamespacedClient):
         """
         Provides statistics on operations happening in a data stream.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: A comma-separated list of data stream names; use `_all` or empty
-            string to perform the operation on all data streams
-        :param expand_wildcards:
+        :param name: Comma-separated list of data streams used to limit the request.
+            Wildcard expressions (`*`) are supported. To target all data streams in a
+            cluster, omit this parameter or use `*`.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_data_stream/{_quote(name)}/_stats"
@@ -652,17 +688,26 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-delete-index.html>`_
 
-        :param index: A comma-separated list of indices to delete; use `_all` or `*`
-            string to delete all indices
-        :param allow_no_indices: Ignore if a wildcard expression resolves to no concrete
-            indices (default: false)
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open, closed, or hidden indices
-        :param ignore_unavailable: Ignore unavailable indexes (default: false)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param index: Comma-separated list of indices to delete. You cannot specify index
+            aliases. By default, this parameter does not support wildcards (`*`) or `_all`.
+            To use wildcards or `_all`, set the `action.destructive_requires_name` cluster
+            setting to `false`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -711,14 +756,17 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param index: A comma-separated list of index names (supports wildcards); use
-            `_all` for all indices
-        :param name: A comma-separated list of aliases to delete (supports wildcards);
-            use `_all` to delete all aliases for the specified indices.
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit timestamp for the document
+        :param index: Comma-separated list of data streams or indices used to limit the
+            request. Supports wildcards (`*`).
+        :param name: Comma-separated list of aliases to remove. Supports wildcards (`*`).
+            To remove all aliases, use `*` or `_all`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -780,7 +828,7 @@ class IndicesClient(NamespacedClient):
         """
         Deletes the data lifecycle of the selected data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-delete-lifecycle.html>`_
 
         :param name: A comma-separated list of data streams of which the data lifecycle
             will be deleted; use `*` to get all data streams
@@ -845,12 +893,12 @@ class IndicesClient(NamespacedClient):
         """
         Deletes a data stream.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: A comma-separated list of data streams to delete; use `*` to delete
-            all data streams
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
+        :param name: Comma-separated list of data streams to delete. Wildcard (`*`) expressions
+            are supported.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values,such as `open,hidden`.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -890,7 +938,7 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -940,11 +988,15 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
-        :param name: The name of the template
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param name: The name of the legacy index template to delete. Wildcard (`*`)
+            expressions are supported.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -1004,27 +1056,27 @@ class IndicesClient(NamespacedClient):
         """
         Analyzes the disk usage of each field of an index or data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-disk-usage.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. It’s recommended to execute this API with a single
             index (or the latest backing index of a data stream) as the API consumes
             resources significantly.
         :param allow_no_indices: If false, the request returns an error if any wildcard
-            expression, index alias, or _all value targets only missing or closed indices.
+            expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
-            example, a request targeting foo*,bar* returns an error if an index starts
-            with foo but no index starts with bar.
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
         :param expand_wildcards: Type of index that wildcard patterns can match. If the
             request can target data streams, this argument determines whether wildcard
             expressions match hidden data streams. Supports comma-separated values, such
-            as open,hidden.
-        :param flush: If true, the API performs a flush before analysis. If false, the
-            response may not include uncommitted data.
-        :param ignore_unavailable: If true, missing or closed indices are not included
+            as `open,hidden`.
+        :param flush: If `true`, the API performs a flush before analysis. If `false`,
+            the response may not include uncommitted data.
+        :param ignore_unavailable: If `true`, missing or closed indices are not included
             in the response.
         :param run_expensive_tasks: Analyzing field disk usage is resource-intensive.
-            To use the API, this parameter must be set to true.
+            To use the API, this parameter must be set to `true`.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1072,10 +1124,10 @@ class IndicesClient(NamespacedClient):
         """
         Downsample an index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-rollup.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-downsample-data-stream.html>`_
 
-        :param index: The index to downsample
-        :param target_index: The name of the target index to store downsampled data
+        :param index: Name of the time series index to downsample.
+        :param target_index: Name of the index to create.
         :param config:
         """
         if index in SKIP_IN_PATH:
@@ -1138,19 +1190,23 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular index exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-exists.html>`_
 
-        :param index: A comma-separated list of index names
-        :param allow_no_indices: Ignore if a wildcard expression resolves to no concrete
-            indices (default: false)
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
-        :param flat_settings: Return settings in flat format (default: false)
-        :param ignore_unavailable: Ignore unavailable indexes (default: false)
-        :param include_defaults: Whether to return all default setting for each of the
-            indices.
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param index: Comma-separated list of data streams, indices, and aliases. Supports
+            wildcards (`*`).
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param include_defaults: If `true`, return all default settings in the response.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1218,19 +1274,23 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular alias exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param name: A comma-separated list of alias names to return
-        :param index: A comma-separated list of index names to filter aliases
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param name: Comma-separated list of aliases to check. Supports wildcards (`*`).
+        :param index: Comma-separated list of data streams or indices used to limit the
+            request. Supports wildcards (`*`). To target all data streams and indices,
+            omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, requests that include a missing data stream
+            or index in the target indices or data streams return an error.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -1280,7 +1340,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular index template exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1327,7 +1387,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular index template exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: The comma separated names of the index templates
         :param flat_settings: Return settings in flat format (default: false)
@@ -1378,7 +1438,7 @@ class IndicesClient(NamespacedClient):
         Retrieves information about the index's current DLM lifecycle, such as any potential
         encountered error, time since creation etc.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-explain-lifecycle.html>`_
 
         :param index: The name of the index to explain
         :param include_defaults: indicates if the API should return the default values
@@ -1451,12 +1511,12 @@ class IndicesClient(NamespacedClient):
         """
         Returns the field usage stats for each field of an index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/field-usage-stats.html>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
-        :param allow_no_indices: If false, the request returns an error if any wildcard
-            expression, index alias, or _all value targets only missing or closed indices.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
             example, a request targeting `foo*,bar*` returns an error if an index starts
             with `foo` but no index starts with `bar`.
@@ -1466,7 +1526,7 @@ class IndicesClient(NamespacedClient):
             as `open,hidden`.
         :param fields: Comma-separated list or wildcard expressions of fields to include
             in the statistics.
-        :param ignore_unavailable: If true, missing or closed indices are not included
+        :param ignore_unavailable: If `true`, missing or closed indices are not included
             in the response.
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -1545,25 +1605,25 @@ class IndicesClient(NamespacedClient):
         """
         Performs the flush operation on one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-flush.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            for all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param force: Whether a flush should be forced even if it is not necessarily
-            needed ie. if no changes will be committed to the index. This is useful if
-            transaction log IDs should be incremented even if no uncommitted changes
-            are present. (This setting can be considered as internal)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param wait_if_ongoing: If set to true the flush operation will block until the
-            flush can be executed if another flush operation is already executing. The
-            default is true. If set to false the flush will be skipped iff if another
-            flush operation is already running.
+        :param index: Comma-separated list of data streams, indices, and aliases to flush.
+            Supports wildcards (`*`). To flush all data streams and indices, omit this
+            parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param force: If `true`, the request forces a flush even if there are no changes
+            to commit to the index.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param wait_if_ongoing: If `true`, the flush operation blocks until execution
+            when another flush operation is running. If `false`, Elasticsearch returns
+            an error if you request a flush when another flush operation is running.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_flush"
@@ -1632,7 +1692,7 @@ class IndicesClient(NamespacedClient):
         """
         Performs the force merge operation on one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-forcemerge.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -1739,7 +1799,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-index.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported.
@@ -1834,19 +1894,24 @@ class IndicesClient(NamespacedClient):
         """
         Returns an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param index: A comma-separated list of index names to filter aliases
-        :param name: A comma-separated list of alias names to return
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param index: Comma-separated list of data streams or indices used to limit the
+            request. Supports wildcards (`*`). To target all data streams and indices,
+            omit this parameter or use `*` or `_all`.
+        :param name: Comma-separated list of aliases to retrieve. Supports wildcards
+            (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_alias/{_quote(name)}"
@@ -1912,14 +1977,15 @@ class IndicesClient(NamespacedClient):
         """
         Returns the data lifecycle of the selected data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-get-lifecycle.html>`_
 
-        :param name: A comma-separated list of data streams to get; use `*` to get all
-            data streams
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
-        :param include_defaults: Return all relevant default configurations for the data
-            stream (default: false)
+        :param name: Comma-separated list of data streams to limit the request. Supports
+            wildcards (`*`). To target all data streams, omit this parameter or use `*`
+            or `_all`.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`. Valid values are:
+            `all`, `open`, `closed`, `hidden`, `none`.
+        :param include_defaults: If `true`, return all default settings in the response.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -1976,12 +2042,13 @@ class IndicesClient(NamespacedClient):
         """
         Returns data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: A comma-separated list of data streams to get; use `*` to get all
-            data streams
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
+        :param name: Comma-separated list of data stream names used to limit the request.
+            Wildcard (`*`) expressions are supported. If omitted, all data streams are
+            returned.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`.
         :param include_defaults: If true, returns all relevant default configurations
             for the index template.
         """
@@ -2045,21 +2112,25 @@ class IndicesClient(NamespacedClient):
         """
         Returns mapping for one or more fields.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-field-mapping.html>`_
 
-        :param fields: A comma-separated list of fields
-        :param index: A comma-separated list of index names
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param include_defaults: Whether the default mapping values should be returned
-            as well
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param fields: Comma-separated list or wildcard expression of fields used to
+            limit returned information.
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param include_defaults: If `true`, return all default settings in the response.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if fields in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'fields'")
@@ -2114,7 +2185,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -2193,19 +2264,25 @@ class IndicesClient(NamespacedClient):
         """
         Returns mappings for one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-mapping.html>`_
 
-        :param index: A comma-separated list of index names
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Specify timeout for connection to master
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_mapping"
@@ -2277,24 +2354,30 @@ class IndicesClient(NamespacedClient):
         """
         Returns settings for one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-settings.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param name: The name of the settings that should be included
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param flat_settings: Return settings in flat format (default: false)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param include_defaults: Whether to return all default setting for each of the
-            indices.
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Specify timeout for connection to master
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param name: Comma-separated list or wildcard expression of settings to retrieve.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with foo but no index starts with `bar`.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param include_defaults: If `true`, return all default settings in the response.
+        :param local: If `true`, the request retrieves information from the local node
+            only. If `false`, information is retrieved from the master node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_settings/{_quote(name)}"
@@ -2352,13 +2435,17 @@ class IndicesClient(NamespacedClient):
         """
         Returns an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
-        :param name: The comma separated names of the index templates
-        :param flat_settings: Return settings in flat format (default: false)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Explicit operation timeout for connection to master node
+        :param name: Comma-separated list of index template names used to limit the request.
+            Wildcard (`*`) expressions are supported. To return all index templates,
+            omit this parameter or use a value of `_all` or `*`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_template/{_quote(name)}"
@@ -2399,9 +2486,9 @@ class IndicesClient(NamespacedClient):
         """
         Migrates an alias to a data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: The name of the alias to migrate
+        :param name: Name of the index alias to convert to a data stream.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -2439,7 +2526,7 @@ class IndicesClient(NamespacedClient):
         """
         Modifies a data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
         :param actions: Actions to perform.
         """
@@ -2505,20 +2592,31 @@ class IndicesClient(NamespacedClient):
         """
         Opens an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-open-close.html>`_
 
-        :param index: A comma separated list of indices to open
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Sets the number of active shards to wait for before
-            the operation returns.
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). By default, you must explicitly
+            name the indices you using to limit the request. To limit a request using
+            `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name`
+            setting to false. You can update this setting in the `elasticsearch.yml`
+            file or using the cluster update settings API.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2565,7 +2663,7 @@ class IndicesClient(NamespacedClient):
         Promotes a data stream from a replicated data stream managed by CCR to a regular
         data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
         :param name: The name of the data stream
         """
@@ -2613,18 +2711,33 @@ class IndicesClient(NamespacedClient):
         """
         Creates or updates an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param index: A comma-separated list of index names the alias should point to
-            (supports wildcards); use `_all` to perform the operation on all indices.
-        :param name: The name of the alias to be created or updated
-        :param filter:
-        :param index_routing:
-        :param is_write_index:
-        :param master_timeout: Specify timeout for connection to master
-        :param routing:
-        :param search_routing:
-        :param timeout: Explicit timestamp for the document
+        :param index: Comma-separated list of data streams or indices to add. Supports
+            wildcards (`*`). Wildcard patterns that match both data streams and indices
+            return an error.
+        :param name: Alias to update. If the alias doesn’t exist, the request creates
+            it. Index alias names support date math.
+        :param filter: Query used to limit documents the alias can access.
+        :param index_routing: Value used to route indexing operations to a specific shard.
+            If specified, this overwrites the `routing` value for indexing operations.
+            Data stream aliases don’t support this parameter.
+        :param is_write_index: If `true`, sets the write index or data stream for the
+            alias. If an alias points to multiple indices or data streams and `is_write_index`
+            isn’t set, the alias rejects write requests. If an index alias points to
+            one index and `is_write_index` isn’t set, the index automatically acts as
+            the write index. Data stream aliases don’t automatically set a write data
+            stream, even if the alias points to one data stream.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param routing: Value used to route indexing and search operations to a specific
+            shard. Data stream aliases don’t support this parameter.
+        :param search_routing: Value used to route search operations to a specific shard.
+            If specified, this overwrites the `routing` value for search operations.
+            Data stream aliases don’t support this parameter.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2706,15 +2819,22 @@ class IndicesClient(NamespacedClient):
         """
         Updates the data lifecycle of the selected data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-put-lifecycle.html>`_
 
-        :param name: A comma-separated list of data streams whose lifecycle will be updated;
-            use `*` to set the lifecycle to all data streams
-        :param data_retention:
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit timestamp for the document
+        :param name: Comma-separated list of data streams used to limit the request.
+            Supports wildcards (`*`). To target all data streams use `*` or `_all`.
+        :param data_retention: If defined, every document added to this data stream will
+            be stored at least for this time frame. Any time after this duration the
+            document could be deleted. When empty, every document in this data stream
+            will be stored indefinitely.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`. Valid values are:
+            `all`, `hidden`, `open`, `closed`, `none`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -2774,18 +2894,29 @@ class IndicesClient(NamespacedClient):
         """
         Creates or updates an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Index or template name
-        :param composed_of:
-        :param create: Whether the index template should only be added if new or can
-            also replace an existing one
-        :param data_stream:
-        :param index_patterns:
-        :param meta:
-        :param priority:
-        :param template:
-        :param version:
+        :param composed_of: An ordered list of component template names. Component templates
+            are merged in the order specified, meaning that the last component template
+            specified has the highest precedence.
+        :param create: If `true`, this request cannot replace or update existing index
+            templates.
+        :param data_stream: If this object is included, the template is used to create
+            data streams and their backing indices. Supports an empty object. Data streams
+            require a matching index template with a `data_stream` object.
+        :param index_patterns: Name of the index template to create.
+        :param meta: Optional user metadata about the index template. May have any contents.
+            This map is not automatically generated by Elasticsearch.
+        :param priority: Priority to determine index template precedence when a new data
+            stream or index is created. The index template with the highest priority
+            is chosen. If no priority is specified the template is treated as though
+            it is of priority 0 (lowest priority). This number is not automatically generated
+            by Elasticsearch.
+        :param template: Template to be applied. It may optionally include an `aliases`,
+            `mappings`, or `settings` configuration.
+        :param version: Version number used to manage index templates externally. This
+            number is not automatically generated by Elasticsearch.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -2892,25 +3023,29 @@ class IndicesClient(NamespacedClient):
         """
         Updates the index mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-put-mapping.html>`_
 
         :param index: A comma-separated list of index names the mapping should be added
             to (supports wildcards); use `_all` or omit to add the mapping on all indices.
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
         :param date_detection: Controls whether dynamic date detection is enabled.
         :param dynamic: Controls whether new fields are added dynamically.
         :param dynamic_date_formats: If date detection is enabled then new string fields
             are checked against 'dynamic_date_formats' and if the value matches then
             a new date field is added instead of string.
         :param dynamic_templates: Specify dynamic templates for the mapping.
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         :param field_names: Control whether field names are enabled for the index.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         :param meta: A mapping type can have custom meta data associated with it. These
             are not used at all by Elasticsearch, but can be used to store application-specific
             metadata.
@@ -2921,9 +3056,10 @@ class IndicesClient(NamespacedClient):
         :param routing: Enable making a routing value required on indexed documents.
         :param runtime: Mapping of runtime fields for the index.
         :param source: Control whether the _source field is enabled on the index.
-        :param timeout: Explicit operation timeout
-        :param write_index_only: When true, applies mappings only to the write index
-            of an alias or data stream
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param write_index_only: If `true`, the mappings are applied only to the current
+            write index for the target.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3021,23 +3157,29 @@ class IndicesClient(NamespacedClient):
         """
         Updates the index settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-update-settings.html>`_
 
         :param settings:
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param flat_settings: Return settings in flat format (default: false)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param preserve_existing: Whether to update existing settings. If set to `true`
-            existing settings on an index remain unchanged, the default is `false`
-        :param timeout: Explicit operation timeout
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param ignore_unavailable: If `true`, returns settings in flat format.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param preserve_existing: If `true`, existing index settings remain unchanged.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if settings is None:
             raise ValueError("Empty value passed for parameter 'settings'")
@@ -3105,13 +3247,13 @@ class IndicesClient(NamespacedClient):
         """
         Creates or updates an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: The name of the template
         :param aliases: Aliases for the index.
         :param create: If true, this request cannot replace or update existing index
             templates.
-        :param flat_settings:
+        :param flat_settings: If `true`, returns settings in flat format.
         :param index_patterns: Array of wildcard expressions used to match the names
             of indices during creation.
         :param mappings: Mapping for fields in the index.
@@ -3123,7 +3265,8 @@ class IndicesClient(NamespacedClient):
             Templates with higher 'order' values are merged later, overriding templates
             with lower values.
         :param settings: Configuration options for the index.
-        :param timeout:
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         :param version: Version number used to manage index templates externally. This
             number is not automatically generated by Elasticsearch.
         """
@@ -3182,12 +3325,14 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about ongoing index shard recoveries.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-recovery.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param active_only: Display only those recoveries that are currently on-going
-        :param detailed: Whether to display detailed information about shard recovery
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param active_only: If `true`, the response only includes ongoing shard recoveries.
+        :param detailed: If `true`, the response includes detailed information about
+            shard recoveries.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_recovery"
@@ -3246,17 +3391,20 @@ class IndicesClient(NamespacedClient):
         """
         Performs the refresh operation in one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-refresh.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_refresh"
@@ -3317,7 +3465,7 @@ class IndicesClient(NamespacedClient):
         """
         Reloads an index's search analyzers and their resources.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-reload-analyzers.html>`_
 
         :param index: A comma-separated list of index names to reload analyzers for
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -3384,11 +3532,15 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about any matching indices, aliases, and data streams
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-resolve-index-api.html>`_
 
-        :param name: A comma-separated list of names or wildcard expressions
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
+        :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
+            and data streams to resolve. Resources on remote clusters can be specified
+            using the `<cluster>`:`<name>` syntax.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -3440,20 +3592,33 @@ class IndicesClient(NamespacedClient):
         Updates an alias to point to a new index when the existing index is considered
         to be too large or too old.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-rollover-index.html>`_
 
-        :param alias: The name of the alias to rollover
-        :param new_index: The name of the rollover index
-        :param aliases:
-        :param conditions:
-        :param dry_run: If set to true the rollover action will only be validated but
-            not actually performed even if a condition matches. The default is false
-        :param mappings:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the newly created rollover index before the operation returns.
+        :param alias: Name of the data stream or index alias to roll over.
+        :param new_index: Name of the index to create. Supports date math. Data streams
+            do not support this parameter.
+        :param aliases: Aliases for the target index. Data streams do not support this
+            parameter.
+        :param conditions: Conditions for the rollover. If specified, Elasticsearch only
+            performs the rollover if the current index satisfies these conditions. If
+            this parameter is not specified, Elasticsearch performs the rollover unconditionally.
+            If conditions are specified, at least one of them must be a `max_*` condition.
+            The index will rollover if any `max_*` condition is satisfied and all `min_*`
+            conditions are satisfied.
+        :param dry_run: If `true`, checks whether the current index satisfies the specified
+            conditions but does not perform a rollover.
+        :param mappings: Mapping for fields in the index. If specified, this mapping
+            can include field names, field data types, and mapping paramaters.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the index. Data streams do not support
+            this parameter.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to all or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'alias'")
@@ -3534,18 +3699,21 @@ class IndicesClient(NamespacedClient):
         """
         Provides low-level information about segments in a Lucene index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-segments.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param verbose: Includes detailed memory usage by Lucene.
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param verbose: If `true`, the request returns a verbose response.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_segments"
@@ -3619,7 +3787,7 @@ class IndicesClient(NamespacedClient):
         """
         Provides store information for shard copies of indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-shards-stores.html>`_
 
         :param index: List of data streams, indices, and aliases used to limit the request.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -3685,16 +3853,20 @@ class IndicesClient(NamespacedClient):
         """
         Allow to shrink an existing index into a new index with fewer primary shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-shrink-index.html>`_
 
-        :param index: The name of the source index to shrink
-        :param target: The name of the target index to shrink into
-        :param aliases:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the shrunken index before the operation returns.
+        :param index: Name of the source index to shrink.
+        :param target: Name of the target index to create.
+        :param aliases: The key is the alias name. Index alias names support date math.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the target index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3763,26 +3935,43 @@ class IndicesClient(NamespacedClient):
         """
         Simulate matching the given index name against the index templates in the system
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Index or template name to simulate
-        :param allow_auto_create:
-        :param composed_of:
+        :param allow_auto_create: This setting overrides the value of the `action.auto_create_index`
+            cluster setting. If set to `true` in a template, then indices can be automatically
+            created using that template even if auto-creation of indices is disabled
+            via `actions.auto_create_index`. If set to `false`, then indices or data
+            streams matching the template must always be explicitly created, and may
+            never be automatically created.
+        :param composed_of: An ordered list of component template names. Component templates
+            are merged in the order specified, meaning that the last component template
+            specified has the highest precedence.
         :param create: If `true`, the template passed in the body is only used if no
             existing templates match the same index patterns. If `false`, the simulation
             uses the template with the highest priority. Note that the template is not
             permanently added or updated in either case; it is only used for the simulation.
-        :param data_stream:
+        :param data_stream: If this object is included, the template is used to create
+            data streams and their backing indices. Supports an empty object. Data streams
+            require a matching index template with a `data_stream` object.
         :param include_defaults: If true, returns all relevant default configurations
             for the index template.
-        :param index_patterns:
+        :param index_patterns: Array of wildcard (`*`) expressions used to match the
+            names of data streams and indices during creation.
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
             returns an error.
-        :param meta:
-        :param priority:
-        :param template:
-        :param version:
+        :param meta: Optional user metadata about the index template. May have any contents.
+            This map is not automatically generated by Elasticsearch.
+        :param priority: Priority to determine index template precedence when a new data
+            stream or index is created. The index template with the highest priority
+            is chosen. If no priority is specified the template is treated as though
+            it is of priority 0 (lowest priority). This number is not automatically generated
+            by Elasticsearch.
+        :param template: Template to be applied. It may optionally include an `aliases`,
+            `mappings`, or `settings` configuration.
+        :param version: Version number used to manage index templates externally. This
+            number is not automatically generated by Elasticsearch.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -3851,7 +4040,7 @@ class IndicesClient(NamespacedClient):
         """
         Simulate resolving the given template name or body
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Name of the index template to simulate. To test a template configuration
             before you add it to the cluster, omit this parameter and specify the template
@@ -3923,16 +4112,20 @@ class IndicesClient(NamespacedClient):
         """
         Allows you to split an existing index into a new index with more primary shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-split-index.html>`_
 
-        :param index: The name of the source index to split
-        :param target: The name of the target index to split into
-        :param aliases:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the shrunken index before the operation returns.
+        :param index: Name of the source index to split.
+        :param target: Name of the target index to create.
+        :param aliases: Aliases for the resulting index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the target index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -4022,7 +4215,7 @@ class IndicesClient(NamespacedClient):
         """
         Provides statistics on operations happening in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-stats.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -4130,20 +4323,26 @@ class IndicesClient(NamespacedClient):
         Unfreezes an index. When a frozen index is unfrozen, the index goes through the
         normal recovery process and becomes writeable again.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/unfreeze-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/unfreeze-index-api.html>`_
 
-        :param index: The name of the index to unfreeze
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Sets the number of active shards to wait for before
-            the operation returns.
+        :param index: Identifier for the index.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -4197,11 +4396,14 @@ class IndicesClient(NamespacedClient):
         """
         Updates index aliases.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param actions:
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Request timeout
+        :param actions: Actions to perform.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         __path = "/_aliases"
         __body: t.Dict[str, t.Any] = {}
@@ -4272,33 +4474,38 @@ class IndicesClient(NamespacedClient):
         """
         Allows a user to validate a potentially expensive query without executing it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-validate.html>`_
 
-        :param index: A comma-separated list of index names to restrict the operation;
-            use `_all` or empty string to perform the operation on all indices
-        :param all_shards: Execute validation on all shards instead of one random shard
-            per index
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param analyze_wildcard: Specify whether wildcard and prefix queries should be
-            analyzed (default: false)
-        :param analyzer: The analyzer to use for the query string
-        :param default_operator: The default operator for query string query (AND or
-            OR)
-        :param df: The field to use as default where no field prefix is given in the
-            query string
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param explain: Return detailed information about the error
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param lenient: Specify whether format-based query failures (such as providing
-            text to a numeric field) should be ignored
-        :param q: Query in the Lucene query string syntax
-        :param query:
-        :param rewrite: Provide a more detailed explanation showing the actual Lucene
-            query that will be executed.
+        :param index: Comma-separated list of data streams, indices, and aliases to search.
+            Supports wildcards (`*`). To search all data streams or indices, omit this
+            parameter or use `*` or `_all`.
+        :param all_shards: If `true`, the validation is executed on all shards instead
+            of one random shard per index.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param analyze_wildcard: If `true`, wildcard and prefix queries are analyzed.
+        :param analyzer: Analyzer to use for the query string. This parameter can only
+            be used when the `q` query string parameter is specified.
+        :param default_operator: The default operator for query string query: `AND` or
+            `OR`.
+        :param df: Field to use as default where no field prefix is given in the query
+            string. This parameter can only be used when the `q` query string parameter
+            is specified.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param explain: If `true`, the response returns detailed information if an error
+            has occurred.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param lenient: If `true`, format-based query failures (such as providing text
+            to a numeric field) in the query string will be ignored.
+        :param q: Query in the Lucene query string syntax.
+        :param query: Query in the Lucene query string syntax.
+        :param rewrite: If `true`, returns a more detailed explanation showing the actual
+            Lucene query that will be executed.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_validate/query"

--- a/elasticsearch/_async/client/ingest.py
+++ b/elasticsearch/_async/client/ingest.py
@@ -43,11 +43,15 @@ class IngestClient(NamespacedClient):
         """
         Deletes a pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-pipeline-api.html>`_
 
-        :param id: Pipeline ID
-        :param master_timeout: Explicit operation timeout for connection to master node
-        :param timeout: Explicit operation timeout
+        :param id: Pipeline ID or wildcard expression of pipeline IDs used to limit the
+            request. To delete all ingest pipelines in a cluster, use a value of `*`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -84,7 +88,7 @@ class IngestClient(NamespacedClient):
         """
         Returns statistical information about geoip databases
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/geoip-processor.html>`_
         """
         __path = "/_ingest/geoip/stats"
         __query: t.Dict[str, t.Any] = {}
@@ -120,10 +124,13 @@ class IngestClient(NamespacedClient):
         """
         Returns a pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-pipeline-api.html>`_
 
-        :param id: Comma separated list of pipeline ids. Wildcards supported
-        :param master_timeout: Explicit operation timeout for connection to master node
+        :param id: Comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions
+            are supported. To get all ingest pipelines, omit this parameter or use `*`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         :param summary: Return pipelines without their definitions (default: false)
         """
         if id not in SKIP_IN_PATH:
@@ -162,7 +169,7 @@ class IngestClient(NamespacedClient):
         """
         Returns a list of the built-in patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/grok-processor.html>`_
         """
         __path = "/_ingest/processor/grok"
         __query: t.Dict[str, t.Any] = {}
@@ -211,7 +218,7 @@ class IngestClient(NamespacedClient):
         """
         Creates or updates a pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ingest.html>`_
 
         :param id: ID of the ingest pipeline to create or update.
         :param description: Description of the ingest pipeline.
@@ -292,13 +299,16 @@ class IngestClient(NamespacedClient):
         """
         Allows to simulate a pipeline with example documents.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/simulate-pipeline-api.html>`_
 
-        :param id: Pipeline ID
-        :param docs:
-        :param pipeline:
-        :param verbose: Verbose mode. Display data output for each processor in executed
-            pipeline
+        :param id: Pipeline to test. If you don’t specify a `pipeline` in the request
+            body, this parameter is required.
+        :param docs: Sample documents to test in the pipeline.
+        :param pipeline: Pipeline to test. If you don’t specify the `pipeline` request
+            path parameter, this parameter is required. If you specify both this and
+            the request path parameter, the API only uses the request path parameter.
+        :param verbose: If `true`, the response includes output data for each processor
+            in the executed pipeline.
         """
         if id not in SKIP_IN_PATH:
             __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -38,7 +38,7 @@ class LicenseClient(NamespacedClient):
         """
         Deletes licensing information for the cluster
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-license.html>`_
         """
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
@@ -71,7 +71,7 @@ class LicenseClient(NamespacedClient):
         """
         Retrieves licensing information for the cluster
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-license.html>`_
 
         :param accept_enterprise: If `true`, this parameter returns enterprise for Enterprise
             license types. If `false`, this parameter returns platinum for both platinum
@@ -113,7 +113,7 @@ class LicenseClient(NamespacedClient):
         """
         Retrieves information about the status of the basic license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-basic-status.html>`_
         """
         __path = "/_license/basic_status"
         __query: t.Dict[str, t.Any] = {}
@@ -144,7 +144,7 @@ class LicenseClient(NamespacedClient):
         """
         Retrieves information about the status of the trial license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-trial-status.html>`_
         """
         __path = "/_license/trial_status"
         __query: t.Dict[str, t.Any] = {}
@@ -182,7 +182,7 @@ class LicenseClient(NamespacedClient):
         """
         Updates the license for the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/update-license.html>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:
@@ -230,7 +230,7 @@ class LicenseClient(NamespacedClient):
         """
         Starts an indefinite basic license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-basic.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
@@ -268,7 +268,7 @@ class LicenseClient(NamespacedClient):
         """
         starts a limited time trial license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-trial.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)

--- a/elasticsearch/_async/client/logstash.py
+++ b/elasticsearch/_async/client/logstash.py
@@ -39,9 +39,9 @@ class LogstashClient(NamespacedClient):
         """
         Deletes Logstash Pipelines used by Central Management
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-delete-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/logstash-api-delete-pipeline.html>`_
 
-        :param id: The ID of the Pipeline
+        :param id: Identifier for the pipeline.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -75,9 +75,9 @@ class LogstashClient(NamespacedClient):
         """
         Retrieves Logstash Pipelines used by Central Management
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-get-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/logstash-api-get-pipeline.html>`_
 
-        :param id: A comma-separated list of Pipeline IDs
+        :param id: Comma-separated list of pipeline identifiers.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -117,9 +117,9 @@ class LogstashClient(NamespacedClient):
         """
         Adds and updates Logstash Pipelines used for Central Management
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-put-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/logstash-api-put-pipeline.html>`_
 
-        :param id: The ID of the Pipeline
+        :param id: Identifier for the pipeline.
         :param pipeline:
         """
         if id in SKIP_IN_PATH:

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -39,7 +39,7 @@ class MlClient(NamespacedClient):
         """
         Clear the cached results from a trained model deployment
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-trained-model-deployment-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-trained-model-deployment-cache.html>`_
 
         :param model_id: The unique identifier of the trained model.
         """
@@ -81,7 +81,7 @@ class MlClient(NamespacedClient):
         Closes one or more anomaly detection jobs. A job can be opened and closed multiple
         times throughout its lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-close-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. You can close multiple anomaly detection
@@ -136,7 +136,7 @@ class MlClient(NamespacedClient):
         """
         Deletes a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         """
@@ -173,7 +173,7 @@ class MlClient(NamespacedClient):
         """
         Deletes scheduled events from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-calendar-event.html>`_
 
         :param calendar_id: The ID of the calendar to modify
         :param event_id: The ID of the event to remove from the calendar
@@ -213,7 +213,7 @@ class MlClient(NamespacedClient):
         """
         Deletes anomaly detection jobs from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -255,7 +255,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param force: If `true`, it deletes a job that is not stopped; this method is
@@ -299,7 +299,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -346,7 +346,7 @@ class MlClient(NamespacedClient):
         """
         Deletes expired and unused machine learning data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-expired-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-expired-data.html>`_
 
         :param job_id: Identifier for an anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression.
@@ -397,7 +397,7 @@ class MlClient(NamespacedClient):
         """
         Deletes a filter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         """
@@ -436,7 +436,7 @@ class MlClient(NamespacedClient):
         """
         Deletes forecasts from a machine learning job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param forecast_id: A comma-separated list of forecast identifiers. If you do
@@ -494,7 +494,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -544,7 +544,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing model snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -585,7 +585,7 @@ class MlClient(NamespacedClient):
         Deletes an existing trained inference model that is currently not referenced
         by an ingest pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param force: Forcefully deletes a trained model that is referenced by ingest
@@ -626,7 +626,7 @@ class MlClient(NamespacedClient):
         """
         Deletes a model alias that refers to the trained model
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-trained-models-aliases.html>`_
 
         :param model_id: The trained model ID to which the model alias refers.
         :param model_alias: The model alias to delete.
@@ -669,7 +669,7 @@ class MlClient(NamespacedClient):
         """
         Estimates the model memory
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-apis.html>`_
 
         :param analysis_config: For a list of the properties that you can specify in
             the `analysis_config` component of the body of this API.
@@ -727,7 +727,7 @@ class MlClient(NamespacedClient):
         """
         Evaluates the data frame analytics for an annotated index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/evaluate-dfanalytics.html>`_
 
         :param evaluation: Defines the type of evaluation you want to perform.
         :param index: Defines the `index` in which the evaluation will be performed.
@@ -785,7 +785,7 @@ class MlClient(NamespacedClient):
         """
         Explains a data frame analytics config.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/explain-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -876,7 +876,7 @@ class MlClient(NamespacedClient):
         """
         Forces any buffered data to be processed by the job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-flush-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-flush-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param advance_time: Refer to the description for the `advance_time` query parameter.
@@ -937,7 +937,7 @@ class MlClient(NamespacedClient):
         """
         Predicts the future behavior of a time series by using its historical behavior.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must be open
             when you create a forecast; otherwise, an error occurs.
@@ -1003,7 +1003,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly detection job results for one or more buckets.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-bucket.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-bucket.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timestamp: The timestamp of a single bucket result. If you do not specify
@@ -1090,7 +1090,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves information about the scheduled events in calendars.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1151,7 +1151,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for calendars.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1215,7 +1215,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly detection job results for one or more categories.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-category.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-category.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param category_id: Identifier for the category, which is unique in the job.
@@ -1283,7 +1283,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1349,7 +1349,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-dfanalytics-stats.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1410,7 +1410,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-datafeed-stats.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1462,7 +1462,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1521,7 +1521,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves filters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param from_: Skips the specified number of filters.
@@ -1576,7 +1576,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly detection job results for one or more influencers.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-influencer.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-influencer.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: If true, the results are sorted in descending order.
@@ -1650,7 +1650,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-job-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs, or a wildcard expression. If
@@ -1703,7 +1703,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. If you do not specify one of these
@@ -1760,7 +1760,7 @@ class MlClient(NamespacedClient):
         """
         Returns information on how ML is using memory.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-memory.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-ml-memory.html>`_
 
         :param node_id: The names of particular nodes in the cluster to target. For example,
             `nodeId1,nodeId2` or `ml:true`
@@ -1809,7 +1809,7 @@ class MlClient(NamespacedClient):
         """
         Gets stats for anomaly detection job model snapshot upgrades that are in progress.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-model-snapshot-upgrade-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-job-model-snapshot-upgrade-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -1872,7 +1872,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves information about model snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -1954,7 +1954,7 @@ class MlClient(NamespacedClient):
         Retrieves overall bucket results that summarize the bucket results of multiple
         anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-overall-buckets.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-overall-buckets.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs or groups, or a wildcard expression.
@@ -2034,7 +2034,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly records for an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-record.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-record.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: Refer to the description for the `desc` query parameter.
@@ -2117,7 +2117,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for a trained inference model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: - Contains wildcard
@@ -2193,7 +2193,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for trained inference models.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-trained-models-stats.html>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             It can be a comma-separated list or a wildcard expression.
@@ -2251,7 +2251,7 @@ class MlClient(NamespacedClient):
         """
         Evaluate a trained model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/infer-trained-model.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param docs: An array of objects to pass to the model for inference. The objects
@@ -2302,7 +2302,7 @@ class MlClient(NamespacedClient):
         """
         Returns defaults and limits used by machine learning.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-ml-info.html>`_
         """
         __path = "/_ml/info"
         __query: t.Dict[str, t.Any] = {}
@@ -2337,7 +2337,7 @@ class MlClient(NamespacedClient):
         """
         Opens one or more anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-open-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-open-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timeout: Refer to the description for the `timeout` query parameter.
@@ -2386,7 +2386,7 @@ class MlClient(NamespacedClient):
         """
         Posts scheduled events in a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-post-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param events: A list of one of more scheduled events. The event’s start and
@@ -2435,7 +2435,7 @@ class MlClient(NamespacedClient):
         """
         Sends data to an anomaly detection job for analysis.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-post-data.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must have a
             state of open to receive and process the data.
@@ -2488,7 +2488,7 @@ class MlClient(NamespacedClient):
         """
         Previews that will be analyzed given a data frame analytics config.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/preview-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param config: A data frame analytics config as described in create data frame
@@ -2541,7 +2541,7 @@ class MlClient(NamespacedClient):
         """
         Previews a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-preview-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-preview-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -2608,7 +2608,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param description: A description of the calendar.
@@ -2656,7 +2656,7 @@ class MlClient(NamespacedClient):
         """
         Adds an anomaly detection job to a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -2711,7 +2711,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -2872,7 +2872,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3018,7 +3018,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a filter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param description: A description of the filter.
@@ -3081,7 +3081,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-job.html>`_
 
         :param job_id: The identifier for the anomaly detection job. This identifier
             can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and
@@ -3217,7 +3217,6 @@ class MlClient(NamespacedClient):
         self,
         *,
         model_id: str,
-        inference_config: t.Mapping[str, t.Any],
         compressed_definition: t.Optional[str] = None,
         defer_definition_decompression: t.Optional[bool] = None,
         definition: t.Optional[t.Mapping[str, t.Any]] = None,
@@ -3227,6 +3226,7 @@ class MlClient(NamespacedClient):
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
         human: t.Optional[bool] = None,
+        inference_config: t.Optional[t.Mapping[str, t.Any]] = None,
         input: t.Optional[t.Mapping[str, t.Any]] = None,
         metadata: t.Optional[t.Any] = None,
         model_size_bytes: t.Optional[int] = None,
@@ -3239,12 +3239,9 @@ class MlClient(NamespacedClient):
         """
         Creates an inference trained model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
-        :param inference_config: The default configuration for inference. This can be
-            either a regression or classification configuration. It must match the underlying
-            definition.trained_model's target_type.
         :param compressed_definition: The compressed (GZipped and Base64 encoded) inference
             definition of the model. If compressed_definition is specified, then definition
             cannot be specified.
@@ -3254,6 +3251,10 @@ class MlClient(NamespacedClient):
         :param definition: The inference definition for the model. If definition is specified,
             then compressed_definition cannot be specified.
         :param description: A human-readable description of the inference trained model.
+        :param inference_config: The default configuration for inference. This can be
+            either a regression or classification configuration. It must match the underlying
+            definition.trained_model's target_type. For pre-packaged models such as ELSER
+            the config is not required.
         :param input: The input field names for the model definition.
         :param metadata: An object map that contains metadata about the model.
         :param model_size_bytes: The estimated memory usage in bytes to keep the trained
@@ -3264,13 +3265,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if inference_config is None:
-            raise ValueError("Empty value passed for parameter 'inference_config'")
         __path = f"/_ml/trained_models/{_quote(model_id)}"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
         if compressed_definition is not None:
             __body["compressed_definition"] = compressed_definition
         if defer_definition_decompression is not None:
@@ -3285,6 +3282,8 @@ class MlClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if inference_config is not None:
+            __body["inference_config"] = inference_config
         if input is not None:
             __body["input"] = input
         if metadata is not None:
@@ -3320,7 +3319,7 @@ class MlClient(NamespacedClient):
         Creates a new model alias (or reassigns an existing one) to refer to the trained
         model
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-models-aliases.html>`_
 
         :param model_id: The identifier for the trained model that the alias refers to.
         :param model_alias: The alias to create or update. This value cannot end in numbers.
@@ -3370,7 +3369,7 @@ class MlClient(NamespacedClient):
         """
         Creates part of a trained model definition
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-definition-part.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-model-definition-part.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param part: The definition part number. When the definition is loaded for inference
@@ -3436,7 +3435,7 @@ class MlClient(NamespacedClient):
         """
         Creates a trained model vocabulary
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-vocabulary.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-model-vocabulary.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
@@ -3483,7 +3482,7 @@ class MlClient(NamespacedClient):
         """
         Resets an existing anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-reset-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-reset-job.html>`_
 
         :param job_id: The ID of the job to reset.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -3532,7 +3531,7 @@ class MlClient(NamespacedClient):
         """
         Reverts to a specific snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-revert-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-revert-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: You can specify `empty` as the <snapshot_id>. Reverting to
@@ -3584,7 +3583,7 @@ class MlClient(NamespacedClient):
         Sets a cluster wide upgrade_mode setting that prepares machine learning indices
         for an upgrade.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-set-upgrade-mode.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-set-upgrade-mode.html>`_
 
         :param enabled: When `true`, it enables `upgrade_mode` which temporarily halts
             all job and datafeed tasks and prohibits new job and datafeed tasks from
@@ -3626,7 +3625,7 @@ class MlClient(NamespacedClient):
         """
         Starts a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3673,7 +3672,7 @@ class MlClient(NamespacedClient):
         """
         Starts one or more datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-start-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3735,7 +3734,7 @@ class MlClient(NamespacedClient):
         """
         Start a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
@@ -3811,7 +3810,7 @@ class MlClient(NamespacedClient):
         """
         Stops one or more data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/stop-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3871,7 +3870,7 @@ class MlClient(NamespacedClient):
         """
         Stops one or more datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-stop-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-stop-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. You can stop multiple datafeeds
             in a single API request by using a comma-separated list of datafeeds or a
@@ -3927,7 +3926,7 @@ class MlClient(NamespacedClient):
         """
         Stop a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/stop-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -3982,7 +3981,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/update-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4078,7 +4077,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -4234,7 +4233,7 @@ class MlClient(NamespacedClient):
         """
         Updates the description of a filter, adds items, or removes items.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param add_items: The items to add to the filter.
@@ -4305,7 +4304,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-job.html>`_
 
         :param job_id: Identifier for the job.
         :param allow_lazy_open: Advanced configuration option. Specifies whether this
@@ -4426,7 +4425,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -4477,7 +4476,7 @@ class MlClient(NamespacedClient):
         """
         Upgrades a given job snapshot to the current major version.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-upgrade-job-model-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -4535,7 +4534,7 @@ class MlClient(NamespacedClient):
         """
         Validates an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/machine-learning/master/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.10/ml-jobs.html>`_
 
         :param analysis_config:
         :param analysis_limits:
@@ -4598,7 +4597,7 @@ class MlClient(NamespacedClient):
         """
         Validates an anomaly detection detector.
 
-        `<https://www.elastic.co/guide/en/machine-learning/master/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.10/ml-jobs.html>`_
 
         :param detector:
         """

--- a/elasticsearch/_async/client/monitoring.py
+++ b/elasticsearch/_async/client/monitoring.py
@@ -46,7 +46,7 @@ class MonitoringClient(NamespacedClient):
         """
         Used by the monitoring features to send monitoring data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/monitor-elasticsearch-cluster.html>`_
 
         :param interval: Collection interval (e.g., '10s' or '10000ms') of the payload
         :param operations:

--- a/elasticsearch/_async/client/nodes.py
+++ b/elasticsearch/_async/client/nodes.py
@@ -40,7 +40,7 @@ class NodesClient(NamespacedClient):
         """
         Removes the archived repositories metering information present in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-repositories-metering-archive-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-repositories-metering-archive-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -81,7 +81,7 @@ class NodesClient(NamespacedClient):
         """
         Returns cluster repositories metering information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-repositories-metering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-repositories-metering-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -134,7 +134,7 @@ class NodesClient(NamespacedClient):
         """
         Returns information about hot threads on each node in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-hot-threads.html>`_
 
         :param node_id: List of node IDs or names used to limit returned information.
         :param ignore_idle_threads: If true, known idle threads (e.g. waiting in a socket
@@ -209,7 +209,7 @@ class NodesClient(NamespacedClient):
         """
         Returns information about nodes in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-info.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -271,7 +271,7 @@ class NodesClient(NamespacedClient):
         """
         Reloads secure settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/secure-settings.html#reloadable-secure-settings>`_
 
         :param node_id: A comma-separated list of node IDs to span the reload/reinit
             call. Should stay empty because reloading usually involves all cluster nodes.
@@ -348,7 +348,7 @@ class NodesClient(NamespacedClient):
         """
         Returns statistical information about nodes in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-stats.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -450,7 +450,7 @@ class NodesClient(NamespacedClient):
         """
         Returns low-level information about REST actions usage on nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-usage.html>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting

--- a/elasticsearch/_async/client/query_ruleset.py
+++ b/elasticsearch/_async/client/query_ruleset.py
@@ -15,20 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import typing as t
-
-from elastic_transport import ObjectApiResponse
-
-from ._base import NamespacedClient
-from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
-
-
-class MigrationClient(NamespacedClient):
+class C:
     @_rewrite_parameters()
-    async def deprecations(
+    async def delete(
         self,
         *,
-        index: t.Optional[str] = None,
+        ruleset_id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -37,19 +29,51 @@ class MigrationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Retrieves information about different cluster, node, and index level settings
-        that use deprecated features that will be removed or changed in the next major
-        version.
+        Deletes a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/migration-api-deprecation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-query-ruleset.html>`_
 
-        :param index: Comma-separate list of data streams or indices to check. Wildcard
-            (*) expressions are supported.
+        :param ruleset_id: The unique identifier of the query ruleset to delete
         """
-        if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_migration/deprecations"
-        else:
-            __path = "/_migration/deprecations"
+        if ruleset_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'ruleset_id'")
+        __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        __headers = {"accept": "application/json"}
+        return await self.perform_request(  # type: ignore[return-value]
+            "DELETE", __path, params=__query, headers=__headers
+        )
+
+    @_rewrite_parameters()
+    async def get(
+        self,
+        *,
+        ruleset_id: str,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Returns the details about a query ruleset.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-query-ruleset.html>`_
+
+        :param ruleset_id: The unique identifier of the query ruleset
+        """
+        if ruleset_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'ruleset_id'")
+        __path = f"/_query_rules/{_quote(ruleset_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -64,41 +88,56 @@ class MigrationClient(NamespacedClient):
             "GET", __path, params=__query, headers=__headers
         )
 
-    @_rewrite_parameters()
-    async def get_feature_upgrade_status(
+    @_rewrite_parameters(
+        parameter_aliases={"from": "from_"},
+    )
+    async def list(
         self,
         *,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
+        from_: t.Optional[int] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Find out whether system features need to be upgraded or not
+        Lists query rulesets.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/migration-api-feature-upgrade.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-query-rulesets.html>`_
+
+        :param from_: Starting offset (default: 0)
+        :param size: specifies a max number of results to get
         """
-        __path = "/_migration/system_features"
+        __path = "/_query_rules"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
+        if from_ is not None:
+            __query["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if size is not None:
+            __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "GET", __path, params=__query, headers=__headers
         )
 
-    @_rewrite_parameters()
-    async def post_feature_upgrade(
+    @_rewrite_parameters(
+        body_name="query_ruleset",
+    )
+    async def put(
         self,
         *,
+        ruleset_id: str,
+        query_ruleset: t.Mapping[str, t.Any],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -107,11 +146,19 @@ class MigrationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Begin upgrades for system features
+        Creates or updates a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/migration-api-feature-upgrade.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-query-ruleset.html>`_
+
+        :param ruleset_id: The unique identifier of the query ruleset to be created or
+            updated
+        :param query_ruleset:
         """
-        __path = "/_migration/system_features"
+        if ruleset_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'ruleset_id'")
+        if query_ruleset is None:
+            raise ValueError("Empty value passed for parameter 'query_ruleset'")
+        __path = f"/_query_rules/{_quote(ruleset_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -121,7 +168,8 @@ class MigrationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __headers = {"accept": "application/json"}
+        __body = query_ruleset
+        __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "PUT", __path, params=__query, headers=__headers, body=__body
         )

--- a/elasticsearch/_async/client/query_ruleset.py
+++ b/elasticsearch/_async/client/query_ruleset.py
@@ -15,7 +15,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
+
+
+class QueryRulesetClient(NamespacedClient):
     @_rewrite_parameters()
     async def delete(
         self,

--- a/elasticsearch/_async/client/query_ruleset.py
+++ b/elasticsearch/_async/client/query_ruleset.py
@@ -139,13 +139,15 @@ class QueryRulesetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_name="query_ruleset",
+        body_fields=True,
     )
     async def put(
         self,
         *,
         ruleset_id: str,
-        query_ruleset: t.Mapping[str, t.Any],
+        rules: t.Union[
+            t.List[t.Mapping[str, t.Any]], t.Tuple[t.Mapping[str, t.Any], ...]
+        ],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -160,14 +162,17 @@ class QueryRulesetClient(NamespacedClient):
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated
-        :param query_ruleset:
+        :param rules:
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        if query_ruleset is None:
-            raise ValueError("Empty value passed for parameter 'query_ruleset'")
+        if rules is None:
+            raise ValueError("Empty value passed for parameter 'rules'")
         __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        if rules is not None:
+            __body["rules"] = rules
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -176,7 +181,6 @@ class QueryRulesetClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = query_ruleset
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/rollup.py
+++ b/elasticsearch/_async/client/rollup.py
@@ -39,7 +39,7 @@ class RollupClient(NamespacedClient):
         """
         Deletes an existing rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-delete-job.html>`_
 
         :param id: The ID of the job to delete
         """
@@ -75,7 +75,7 @@ class RollupClient(NamespacedClient):
         """
         Retrieves the configuration, stats, and status of rollup jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-get-job.html>`_
 
         :param id: The ID of the job(s) to fetch. Accepts glob patterns, or left blank
             for all jobs
@@ -114,7 +114,7 @@ class RollupClient(NamespacedClient):
         Returns the capabilities of any rollup jobs that have been configured for a specific
         index or index pattern.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-get-rollup-caps.html>`_
 
         :param id: The ID of the index to check rollup capabilities on, or left blank
             for all jobs
@@ -153,7 +153,7 @@ class RollupClient(NamespacedClient):
         Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
         index where rollup data is stored).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-get-rollup-index-caps.html>`_
 
         :param index: The rollup index or index pattern to obtain rollup capabilities
             from.
@@ -205,7 +205,7 @@ class RollupClient(NamespacedClient):
         """
         Creates a rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-put-job.html>`_
 
         :param id: Identifier for the rollup job. This can be any alphanumeric string
             and uniquely identifies the data that is associated with the rollup job.
@@ -314,7 +314,7 @@ class RollupClient(NamespacedClient):
         """
         Enables searching rolled-up data using the standard query DSL.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-search.html>`_
 
         :param index: The indices or index-pattern(s) (containing rollup or regular data)
             that should be searched
@@ -372,7 +372,7 @@ class RollupClient(NamespacedClient):
         """
         Starts an existing, stopped rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-start-job.html>`_
 
         :param id: The ID of the job to start
         """
@@ -410,7 +410,7 @@ class RollupClient(NamespacedClient):
         """
         Stops an existing, started rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-stop-job.html>`_
 
         :param id: The ID of the job to stop
         :param timeout: Block for (at maximum) the specified duration while waiting for

--- a/elasticsearch/_async/client/searchable_snapshots.py
+++ b/elasticsearch/_async/client/searchable_snapshots.py
@@ -44,7 +44,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Retrieve node-level cache statistics about searchable snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-apis.html>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting
@@ -106,7 +106,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Clear the cache of searchable snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-apis.html>`_
 
         :param index: A comma-separated list of index names
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -170,7 +170,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Mount a snapshot as a searchable index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-api-mount-snapshot.html>`_
 
         :param repository: The name of the repository containing the snapshot of the
             index to mount
@@ -239,7 +239,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Retrieve shard-level statistics about searchable snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-apis.html>`_
 
         :param index: A comma-separated list of index names
         :param level: Return stats aggregated at cluster, index or shard level

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -44,7 +44,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates or updates the user profile on behalf of another user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-activate-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-activate-user-profile.html>`_
 
         :param grant_type:
         :param access_token:
@@ -92,7 +92,7 @@ class SecurityClient(NamespacedClient):
         Enables authentication as a user and retrieve information about the authenticated
         user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-authenticate.html>`_
         """
         __path = "/_security/_authenticate"
         __query: t.Dict[str, t.Any] = {}
@@ -131,7 +131,7 @@ class SecurityClient(NamespacedClient):
         """
         Changes the passwords of users in the native realm and built-in users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-change-password.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-change-password.html>`_
 
         :param username: The user whose password you want to change. If you do not specify
             this parameter, the password is changed for the current user.
@@ -185,9 +185,10 @@ class SecurityClient(NamespacedClient):
         """
         Clear a subset or all entries from the API key cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-api-key-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-api-key-cache.html>`_
 
-        :param ids: A comma-separated list of IDs of API keys to clear from the cache
+        :param ids: Comma-separated list of API key IDs to evict from the API key cache.
+            To evict all API keys, use `*`. Does not support other wildcard patterns.
         """
         if ids in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ids'")
@@ -221,7 +222,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts application privileges from the native application privileges cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-privilege-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-privilege-cache.html>`_
 
         :param application: A comma-separated list of application names
         """
@@ -259,7 +260,7 @@ class SecurityClient(NamespacedClient):
         Evicts users from the user cache. Can completely clear the cache or evict specific
         users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-cache.html>`_
 
         :param realms: Comma-separated list of realms to clear
         :param usernames: Comma-separated list of usernames to clear from the cache
@@ -298,7 +299,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts roles from the native role cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-role-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-role-cache.html>`_
 
         :param name: Role name
         """
@@ -336,7 +337,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts tokens from the service account token caches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-service-token-caches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-service-token-caches.html>`_
 
         :param namespace: An identifier for the namespace
         :param service: An identifier for the service name
@@ -386,13 +387,13 @@ class SecurityClient(NamespacedClient):
         """
         Creates an API key for access without requiring basic authentication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-create-api-key.html>`_
 
         :param expiration: Expiration time for the API key. By default, API keys never
             expire.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
             It supports nested data structure. Within the metadata object, keys beginning
-            with _ are reserved for system usage.
+            with `_` are reserved for system usage.
         :param name: Specifies the name for this API key.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
@@ -452,7 +453,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates a service account token for access without requiring basic authentication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-create-service-token.html>`_
 
         :param namespace: An identifier for the namespace
         :param service: An identifier for the service name
@@ -512,7 +513,7 @@ class SecurityClient(NamespacedClient):
         """
         Removes application privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-privilege.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-privilege.html>`_
 
         :param application: Application name
         :param name: Privilege name
@@ -559,7 +560,7 @@ class SecurityClient(NamespacedClient):
         """
         Removes roles in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-role.html>`_
 
         :param name: Role name
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -603,7 +604,7 @@ class SecurityClient(NamespacedClient):
         """
         Removes role mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-role-mapping.html>`_
 
         :param name: Role-mapping name
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -649,7 +650,7 @@ class SecurityClient(NamespacedClient):
         """
         Deletes a service account token.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-service-token.html>`_
 
         :param namespace: An identifier for the namespace
         :param service: An identifier for the service name
@@ -699,7 +700,7 @@ class SecurityClient(NamespacedClient):
         """
         Deletes users from the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-user.html>`_
 
         :param username: username
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -743,7 +744,7 @@ class SecurityClient(NamespacedClient):
         """
         Disables users in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-disable-user.html>`_
 
         :param username: The username of the user to disable
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -787,7 +788,7 @@ class SecurityClient(NamespacedClient):
         """
         Disables a user profile so it's not visible in user profile searches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-disable-user-profile.html>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -831,7 +832,7 @@ class SecurityClient(NamespacedClient):
         """
         Enables users in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-enable-user.html>`_
 
         :param username: The username of the user to enable
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -875,7 +876,7 @@ class SecurityClient(NamespacedClient):
         """
         Enables a user profile so it's visible in user profile searches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-enable-user-profile.html>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -916,7 +917,7 @@ class SecurityClient(NamespacedClient):
         Allows a kibana instance to configure itself to communicate with a secured elasticsearch
         cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-kibana-enrollment.html>`_
         """
         __path = "/_security/enroll/kibana"
         __query: t.Dict[str, t.Any] = {}
@@ -947,7 +948,7 @@ class SecurityClient(NamespacedClient):
         """
         Allows a new node to enroll to an existing cluster with security enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-node-enrollment.html>`_
         """
         __path = "/_security/enroll/node"
         __query: t.Dict[str, t.Any] = {}
@@ -984,13 +985,20 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information for one or more API keys.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-api-key.html>`_
 
-        :param id: API key id of the API key to be retrieved
-        :param name: API key name of the API key to be retrieved
-        :param owner: flag to query API keys owned by the currently authenticated user
-        :param realm_name: realm name of the user who created this API key to be retrieved
-        :param username: user name of the user who created this API key to be retrieved
+        :param id: An API key id. This parameter cannot be used with any of `name`, `realm_name`
+            or `username`.
+        :param name: An API key name. This parameter cannot be used with any of `id`,
+            `realm_name` or `username`. It supports prefix search with wildcard.
+        :param owner: A boolean flag that can be used to query API keys owned by the
+            currently authenticated user. The `realm_name` or `username` parameters cannot
+            be specified when this parameter is set to `true` as they are assumed to
+            be the currently authenticated ones.
+        :param realm_name: The name of an authentication realm. This parameter cannot
+            be used with either `id` or `name` or when `owner` flag is set to `true`.
+        :param username: The username of a user. This parameter cannot be used with either
+            `id` or `name` or when `owner` flag is set to `true`.
         :param with_limited_by: Return the snapshot of the owner user's role descriptors
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
@@ -1037,7 +1045,7 @@ class SecurityClient(NamespacedClient):
         Retrieves the list of cluster privileges and index privileges that are available
         in this version of Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-builtin-privileges.html>`_
         """
         __path = "/_security/privilege/_builtin"
         __query: t.Dict[str, t.Any] = {}
@@ -1070,7 +1078,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves application privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-privileges.html>`_
 
         :param application: Application name
         :param name: Privilege name
@@ -1110,7 +1118,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves roles in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-role.html>`_
 
         :param name: The name of the role. You can specify multiple roles as a comma-separated
             list. If you do not specify this parameter, the API returns information about
@@ -1149,7 +1157,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves role mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-role-mapping.html>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1191,7 +1199,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information about service accounts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-accounts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-service-accounts.html>`_
 
         :param namespace: Name of the namespace. Omit this parameter to retrieve information
             about all service accounts. If you omit this parameter, you must also omit
@@ -1235,7 +1243,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information of all service credentials for a service account.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-credentials.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-service-credentials.html>`_
 
         :param namespace: Name of the namespace.
         :param service: Name of the service name.
@@ -1286,7 +1294,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates a bearer token for access without requiring basic authentication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-token.html>`_
 
         :param grant_type:
         :param kerberos_ticket:
@@ -1341,7 +1349,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information about users in the native realm and built-in users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-user.html>`_
 
         :param username: An identifier for the user. You can specify multiple usernames
             as a comma-separated list. If you omit this parameter, the API retrieves
@@ -1386,7 +1394,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves security privileges for the logged in user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-user-privileges.html>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -1432,7 +1440,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves user profiles for the given unique ID(s).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-user-profile.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: List of filters for the `data` field of the profile document. To
@@ -1482,14 +1490,20 @@ class SecurityClient(NamespacedClient):
         """
         Creates an API key on behalf of another user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-grant-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-grant-api-key.html>`_
 
-        :param api_key:
-        :param grant_type:
-        :param access_token:
-        :param password:
-        :param run_as:
-        :param username:
+        :param api_key: Defines the API key.
+        :param grant_type: The type of grant. Supported grant types are: `access_token`,
+            `password`.
+        :param access_token: The user’s access token. If you specify the `access_token`
+            grant type, this parameter is required. It is not valid with other grant
+            types.
+        :param password: The user’s password. If you specify the `password` grant type,
+            this parameter is required. It is not valid with other grant types.
+        :param run_as: The name of the user to be impersonated.
+        :param username: The user name that identifies the user. If you specify the `password`
+            grant type, this parameter is required. It is not valid with other grant
+            types.
         """
         if api_key is None:
             raise ValueError("Empty value passed for parameter 'api_key'")
@@ -1563,7 +1577,7 @@ class SecurityClient(NamespacedClient):
         """
         Determines whether the specified user has a specified list of privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-has-privileges.html>`_
 
         :param user: Username
         :param application:
@@ -1614,7 +1628,7 @@ class SecurityClient(NamespacedClient):
         Determines whether the users associated with the specified profile IDs have all
         the requested privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-has-privileges-user-profile.html>`_
 
         :param privileges:
         :param uids: A list of profile IDs. The privileges are checked for associated
@@ -1666,14 +1680,21 @@ class SecurityClient(NamespacedClient):
         """
         Invalidates one or more API keys.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-invalidate-api-key.html>`_
 
         :param id:
-        :param ids:
-        :param name:
-        :param owner:
-        :param realm_name:
-        :param username:
+        :param ids: A list of API key ids. This parameter cannot be used with any of
+            `name`, `realm_name`, or `username`.
+        :param name: An API key name. This parameter cannot be used with any of `ids`,
+            `realm_name` or `username`.
+        :param owner: Can be used to query API keys owned by the currently authenticated
+            user. The `realm_name` or `username` parameters cannot be specified when
+            this parameter is set to `true` as they are assumed to be the currently authenticated
+            ones.
+        :param realm_name: The name of an authentication realm. This parameter cannot
+            be used with either `ids` or `name`, or when `owner` flag is set to `true`.
+        :param username: The username of a user. This parameter cannot be used with either
+            `ids` or `name`, or when `owner` flag is set to `true`.
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
@@ -1723,7 +1744,7 @@ class SecurityClient(NamespacedClient):
         """
         Invalidates one or more access tokens or refresh tokens.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-invalidate-token.html>`_
 
         :param realm_name:
         :param refresh_token:
@@ -1774,7 +1795,7 @@ class SecurityClient(NamespacedClient):
         """
         Adds or updates application privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-privileges.html>`_
 
         :param privileges:
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1849,7 +1870,7 @@ class SecurityClient(NamespacedClient):
         """
         Adds and updates roles in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-role.html>`_
 
         :param name: The name of the role.
         :param applications: A list of application privilege entries.
@@ -1931,7 +1952,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates and updates role mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-role-mapping.html>`_
 
         :param name: Role-mapping name
         :param enabled:
@@ -2001,7 +2022,7 @@ class SecurityClient(NamespacedClient):
         Adds and updates users in the native realm. These users are commonly referred
         to as native users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-user.html>`_
 
         :param username: The username of the User
         :param email:
@@ -2085,20 +2106,22 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information for API keys using a subset of query DSL
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-query-api-key.html>`_
 
         :param from_: Starting document offset. By default, you cannot page through more
             than 10,000 hits using the from and size parameters. To page through more
-            hits, use the search_after parameter.
+            hits, use the `search_after` parameter.
         :param query: A query to filter which API keys to return. The query supports
-            a subset of query types, including match_all, bool, term, terms, ids, prefix,
-            wildcard, and range. You can query all public information associated with
-            an API key
-        :param search_after:
+            a subset of query types, including `match_all`, `bool`, `term`, `terms`,
+            `ids`, `prefix`, `wildcard`, and `range`. You can query all public information
+            associated with an API key.
+        :param search_after: Search after definition
         :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the from and size parameters. To page through
-            more hits, use the search_after parameter.
-        :param sort:
+            more than 10,000 hits using the `from` and `size` parameters. To page through
+            more hits, use the `search_after` parameter.
+        :param sort: Other than `id`, all public fields of an API key are eligible for
+            sorting. In addition, sort can also be applied to the `_doc` field to sort
+            by index order.
         :param with_limited_by: Return the snapshot of the owner user's role descriptors
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
@@ -2166,7 +2189,7 @@ class SecurityClient(NamespacedClient):
         Exchanges a SAML Response message for an Elasticsearch access token and refresh
         token pair
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-authenticate.html>`_
 
         :param content: The SAML response as it was sent by the user’s browser, usually
             a Base64 encoded XML document.
@@ -2221,7 +2244,7 @@ class SecurityClient(NamespacedClient):
         """
         Verifies the logout response sent from the SAML IdP
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-complete-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-complete-logout.html>`_
 
         :param ids: A json array with all the valid SAML Request Ids that the caller
             of the API has for the current user.
@@ -2280,7 +2303,7 @@ class SecurityClient(NamespacedClient):
         """
         Consumes a SAML LogoutRequest
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-invalidate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-invalidate.html>`_
 
         :param query_string: The query part of the URL that the user was redirected to
             by the SAML IdP to initiate the Single Logout. This query should include
@@ -2341,7 +2364,7 @@ class SecurityClient(NamespacedClient):
         Invalidates an access token and a refresh token that were generated via the SAML
         Authenticate API
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-logout.html>`_
 
         :param token: The access token that was returned as a response to calling the
             SAML authenticate API. Alternatively, the most recent token that was received
@@ -2391,7 +2414,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates a SAML authentication request
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-prepare-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-prepare-authentication.html>`_
 
         :param acs: The Assertion Consumer Service URL that matches the one of the SAML
             realms in Elasticsearch. The realm is used to generate the authentication
@@ -2440,7 +2463,7 @@ class SecurityClient(NamespacedClient):
         """
         Generates SAML metadata for the Elastic stack SAML 2.0 Service Provider
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-sp-metadata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-sp-metadata.html>`_
 
         :param realm_name: The name of the SAML realm in Elasticsearch.
         """
@@ -2481,7 +2504,7 @@ class SecurityClient(NamespacedClient):
         """
         Get suggestions for user profiles that match specified search criteria.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-suggest-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-suggest-user-profile.html>`_
 
         :param data: List of filters for the `data` field of the profile document. To
             return all content use `data=*`. To return a subset of content use `data=<key>`
@@ -2542,7 +2565,7 @@ class SecurityClient(NamespacedClient):
         """
         Updates attributes of an existing API key.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-update-api-key.html>`_
 
         :param id: The ID of the API key to update.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
@@ -2607,7 +2630,7 @@ class SecurityClient(NamespacedClient):
         """
         Update application specific data for the user profile of the given unique ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-user-profile-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-update-user-profile-data.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: Non-searchable data that you want to associate with the user profile.

--- a/elasticsearch/_async/client/slm.py
+++ b/elasticsearch/_async/client/slm.py
@@ -39,7 +39,7 @@ class SlmClient(NamespacedClient):
         """
         Deletes an existing snapshot lifecycle policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-delete-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-delete-policy.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to remove
         """
@@ -76,7 +76,7 @@ class SlmClient(NamespacedClient):
         Immediately creates a snapshot according to the lifecycle policy, without waiting
         for the scheduled time.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-execute-lifecycle.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to be executed
         """
@@ -111,7 +111,7 @@ class SlmClient(NamespacedClient):
         """
         Deletes any snapshots that are expired according to the policy's retention rules.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-execute-retention.html>`_
         """
         __path = "/_slm/_execute_retention"
         __query: t.Dict[str, t.Any] = {}
@@ -146,7 +146,7 @@ class SlmClient(NamespacedClient):
         Retrieves one or more snapshot lifecycle policy definitions and information about
         the latest snapshot attempts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-get-policy.html>`_
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         """
@@ -183,7 +183,7 @@ class SlmClient(NamespacedClient):
         Returns global and policy-level statistics about actions taken by snapshot lifecycle
         management.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-get-stats.html>`_
         """
         __path = "/_slm/stats"
         __query: t.Dict[str, t.Any] = {}
@@ -214,7 +214,7 @@ class SlmClient(NamespacedClient):
         """
         Retrieves the status of snapshot lifecycle management (SLM).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-get-status.html>`_
         """
         __path = "/_slm/status"
         __query: t.Dict[str, t.Any] = {}
@@ -257,7 +257,7 @@ class SlmClient(NamespacedClient):
         """
         Creates or updates a snapshot lifecycle policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-put-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-put-policy.html>`_
 
         :param policy_id: ID for the snapshot lifecycle policy you want to create or
             update.
@@ -328,7 +328,7 @@ class SlmClient(NamespacedClient):
         """
         Turns on snapshot lifecycle management (SLM).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-start.html>`_
         """
         __path = "/_slm/start"
         __query: t.Dict[str, t.Any] = {}
@@ -359,7 +359,7 @@ class SlmClient(NamespacedClient):
         """
         Turns off snapshot lifecycle management (SLM).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-stop.html>`_
         """
         __path = "/_slm/stop"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -43,7 +43,7 @@ class SnapshotClient(NamespacedClient):
         """
         Removes stale data from repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clean-up-snapshot-repo-api.html>`_
 
         :param name: Snapshot repository to clean up.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -94,7 +94,7 @@ class SnapshotClient(NamespacedClient):
         """
         Clones indices from one snapshot into another snapshot in the same repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: The name of the snapshot to clone from
@@ -163,7 +163,7 @@ class SnapshotClient(NamespacedClient):
         """
         Creates a snapshot in a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: Repository for the snapshot.
         :param snapshot: Name of the snapshot. Must be unique in the repository.
@@ -261,7 +261,7 @@ class SnapshotClient(NamespacedClient):
         """
         Creates a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: A repository name
         :param settings:
@@ -324,7 +324,7 @@ class SnapshotClient(NamespacedClient):
         """
         Deletes one or more snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -370,7 +370,7 @@ class SnapshotClient(NamespacedClient):
         """
         Deletes a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: Name of the snapshot repository to unregister. Wildcard (`*`) patterns
             are supported.
@@ -434,7 +434,7 @@ class SnapshotClient(NamespacedClient):
         """
         Returns information about a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: Comma-separated list of snapshot repository names used to
             limit the request. Wildcard (*) expressions are supported.
@@ -541,7 +541,7 @@ class SnapshotClient(NamespacedClient):
         """
         Returns information about a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: A comma-separated list of repository names
         :param local: Return local information, do not retrieve the state from master
@@ -606,7 +606,7 @@ class SnapshotClient(NamespacedClient):
         """
         Restores a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: A snapshot name
@@ -694,7 +694,7 @@ class SnapshotClient(NamespacedClient):
         """
         Returns information about the status of a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -745,7 +745,7 @@ class SnapshotClient(NamespacedClient):
         """
         Verifies a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: A repository name
         :param master_timeout: Explicit operation timeout for connection to master node

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -41,7 +41,7 @@ class SqlClient(NamespacedClient):
         """
         Clears the SQL cursor
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-sql-cursor-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-sql-cursor-api.html>`_
 
         :param cursor:
         """
@@ -81,7 +81,7 @@ class SqlClient(NamespacedClient):
         Deletes an async SQL search or a stored synchronous SQL search. If the search
         is still running, the API cancels it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-async-sql-search-api.html>`_
 
         :param id: The async search ID
         """
@@ -124,7 +124,7 @@ class SqlClient(NamespacedClient):
         Returns the current status and available results for an async SQL search or stored
         synchronous SQL search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-sql-search-api.html>`_
 
         :param id: The async search ID
         :param delimiter: Separator for CSV results. The API only supports this parameter
@@ -178,7 +178,7 @@ class SqlClient(NamespacedClient):
         Returns the current status of an async SQL search or a stored synchronous SQL
         search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-sql-search-status-api.html>`_
 
         :param id: The async search ID
         """
@@ -237,7 +237,7 @@ class SqlClient(NamespacedClient):
         """
         Executes a SQL request
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/sql-search-api.html>`_
 
         :param catalog: Default catalog (cluster) for queries. If unspecified, the queries
             execute on the data in the local cluster only.
@@ -339,7 +339,7 @@ class SqlClient(NamespacedClient):
         """
         Translates SQL into Elasticsearch queries
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/sql-translate-api.html>`_
 
         :param query:
         :param fetch_size:

--- a/elasticsearch/_async/client/ssl.py
+++ b/elasticsearch/_async/client/ssl.py
@@ -39,7 +39,7 @@ class SslClient(NamespacedClient):
         Retrieves information about the X.509 certificates used to encrypt communications
         in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-ssl.html>`_
         """
         __path = "/_ssl/certificates"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_async/client/synonyms.py
+++ b/elasticsearch/_async/client/synonyms.py
@@ -15,20 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import typing as t
-
-from elastic_transport import ObjectApiResponse
-
-from ._base import NamespacedClient
-from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
-
-
-class SearchApplicationClient(NamespacedClient):
+class C:
     @_rewrite_parameters()
-    async def delete(
+    async def delete_synonym(
         self,
         *,
-        name: str,
+        id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -37,15 +29,15 @@ class SearchApplicationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a search application.
+        Deletes a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-synonyms-set.html>`_
 
-        :param name: The name of the search application to delete
+        :param id: The id of the synonyms set to be deleted
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        __path = f"/_synonyms/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -61,10 +53,11 @@ class SearchApplicationClient(NamespacedClient):
         )
 
     @_rewrite_parameters()
-    async def delete_behavioral_analytics(
+    async def delete_synonym_rule(
         self,
         *,
-        name: str,
+        set_id: str,
+        rule_id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -73,15 +66,18 @@ class SearchApplicationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete a behavioral analytics collection.
+        Deletes a synonym rule in a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-synonym-rule.html>`_
 
-        :param name: The name of the analytics collection to be deleted
+        :param set_id: The id of the synonym set to be updated
+        :param rule_id: The id of the synonym rule to be deleted
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
+        if set_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'set_id'")
+        if rule_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'rule_id'")
+        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -96,47 +92,58 @@ class SearchApplicationClient(NamespacedClient):
             "DELETE", __path, params=__query, headers=__headers
         )
 
-    @_rewrite_parameters()
-    async def get(
+    @_rewrite_parameters(
+        parameter_aliases={"from": "from_"},
+    )
+    async def get_synonym(
         self,
         *,
-        name: str,
+        id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
+        from_: t.Optional[int] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the details about a search application.
+        Retrieves a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-synonyms-set.html>`_
 
-        :param name: The name of the search application
+        :param id: "The id of the synonyms set to be retrieved
+        :param from_: Starting offset for query rules to be retrieved
+        :param size: specifies a max number of query rules to retrieve
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        __path = f"/_synonyms/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
+        if from_ is not None:
+            __query["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if size is not None:
+            __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "GET", __path, params=__query, headers=__headers
         )
 
     @_rewrite_parameters()
-    async def get_behavioral_analytics(
+    async def get_synonym_rule(
         self,
         *,
-        name: t.Optional[t.Union[t.List[str], t.Tuple[str, ...]]] = None,
+        set_id: str,
+        rule_id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -145,16 +152,18 @@ class SearchApplicationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the existing behavioral analytics collections.
+        Retrieves a synonym rule from a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-synonym-rule.html>`_
 
-        :param name: A list of analytics collections to limit the returned information
+        :param set_id: The id of the synonym set to retrieve the synonym rule from
+        :param rule_id: The id of the synonym rule to retrieve
         """
-        if name not in SKIP_IN_PATH:
-            __path = f"/_application/analytics/{_quote(name)}"
-        else:
-            __path = "/_application/analytics"
+        if set_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'set_id'")
+        if rule_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'rule_id'")
+        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -172,7 +181,7 @@ class SearchApplicationClient(NamespacedClient):
     @_rewrite_parameters(
         parameter_aliases={"from": "from_"},
     )
-    async def list(
+    async def get_synonyms_sets(
         self,
         *,
         error_trace: t.Optional[bool] = None,
@@ -182,19 +191,17 @@ class SearchApplicationClient(NamespacedClient):
         from_: t.Optional[int] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
-        q: t.Optional[str] = None,
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the existing search applications.
+        Retrieves a summary of all defined synonym sets
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-search-applications.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-synonyms-sets.html>`_
 
-        :param from_: Starting offset (default: 0)
-        :param q: Query in the Lucene query string syntax"
+        :param from_: Starting offset
         :param size: specifies a max number of results to get
         """
-        __path = "/_application/search_application"
+        __path = "/_synonyms"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -206,8 +213,6 @@ class SearchApplicationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if q is not None:
-            __query["q"] = q
         if size is not None:
             __query["size"] = size
         __headers = {"accept": "application/json"}
@@ -216,14 +221,15 @@ class SearchApplicationClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_name="search_application",
+        body_fields=True,
     )
-    async def put(
+    async def put_synonym(
         self,
         *,
-        name: str,
-        search_application: t.Mapping[str, t.Any],
-        create: t.Optional[bool] = None,
+        id: str,
+        synonyms_set: t.Union[
+            t.List[t.Mapping[str, t.Any]], t.Tuple[t.Mapping[str, t.Any], ...]
+        ],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -232,23 +238,22 @@ class SearchApplicationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a search application.
+        Creates or updates a synonyms set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-synonyms-set.html>`_
 
-        :param name: The name of the search application to be created or updated
-        :param search_application:
-        :param create: If true, requires that a search application with the specified
-            resource_id does not already exist. (default: false)
+        :param id: The id of the synonyms set to be created or updated
+        :param synonyms_set: The synonym set information to update
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        if search_application is None:
-            raise ValueError("Empty value passed for parameter 'search_application'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        if synonyms_set is None:
+            raise ValueError("Empty value passed for parameter 'synonyms_set'")
+        __path = f"/_synonyms/{_quote(id)}"
+        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if create is not None:
-            __query["create"] = create
+        if synonyms_set is not None:
+            __body["synonyms_set"] = synonyms_set
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -257,92 +262,56 @@ class SearchApplicationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = search_application
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
-    @_rewrite_parameters()
-    async def put_behavioral_analytics(
-        self,
-        *,
-        name: str,
-        error_trace: t.Optional[bool] = None,
-        filter_path: t.Optional[
-            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
-        ] = None,
-        human: t.Optional[bool] = None,
-        pretty: t.Optional[bool] = None,
-    ) -> ObjectApiResponse[t.Any]:
-        """
-        Creates a behavioral analytics collection.
-
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-analytics-collection.html>`_
-
-        :param name: The name of the analytics collection to be created or updated
-        """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
-        __query: t.Dict[str, t.Any] = {}
-        if error_trace is not None:
-            __query["error_trace"] = error_trace
-        if filter_path is not None:
-            __query["filter_path"] = filter_path
-        if human is not None:
-            __query["human"] = human
-        if pretty is not None:
-            __query["pretty"] = pretty
-        __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
-        )
-
     @_rewrite_parameters(
         body_fields=True,
-        ignore_deprecated_options={"params"},
     )
-    async def search(
+    async def put_synonym_rule(
         self,
         *,
-        name: str,
+        set_id: str,
+        rule_id: str,
+        synonyms: t.Union[t.List[str], t.Tuple[str, ...]],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
         human: t.Optional[bool] = None,
-        params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Perform a search against a search application
+        Creates or updates a synonym rule in a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-application-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-synonym-rule.html>`_
 
-        :param name: The name of the search application to be searched
-        :param params:
+        :param set_id: The id of the synonym set to be updated with the synonym rule
+        :param rule_id: The id of the synonym rule to be updated or created
+        :param synonyms:
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}/_search"
-        __query: t.Dict[str, t.Any] = {}
+        if set_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'set_id'")
+        if rule_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'rule_id'")
+        if synonyms is None:
+            raise ValueError("Empty value passed for parameter 'synonyms'")
+        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
         __body: t.Dict[str, t.Any] = {}
+        __query: t.Dict[str, t.Any] = {}
+        if synonyms is not None:
+            __body["synonyms"] = synonyms
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if not __body:
-            __body = None  # type: ignore[assignment]
-        __headers = {"accept": "application/json"}
-        if __body is not None:
-            __headers["content-type"] = "application/json"
+        __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "PUT", __path, params=__query, headers=__headers, body=__body
         )

--- a/elasticsearch/_async/client/synonyms.py
+++ b/elasticsearch/_async/client/synonyms.py
@@ -15,7 +15,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
+
+
+class SynonymsClient(NamespacedClient):
     @_rewrite_parameters()
     async def delete_synonym(
         self,

--- a/elasticsearch/_async/client/tasks.py
+++ b/elasticsearch/_async/client/tasks.py
@@ -45,7 +45,7 @@ class TasksClient(NamespacedClient):
         """
         Cancels a task, if it can be cancelled through an API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
         :param task_id: Cancel the task with specified task id (node_id:task_number)
         :param actions: A comma-separated list of actions that should be cancelled. Leave
@@ -101,7 +101,7 @@ class TasksClient(NamespacedClient):
         """
         Returns information about a task.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
         :param task_id: Return the task with specified id (node_id:task_number)
         :param timeout: Explicit operation timeout
@@ -157,7 +157,7 @@ class TasksClient(NamespacedClient):
         """
         Returns a list of tasks.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
         :param actions: Comma-separated list or wildcard expression of actions used to
             limit the request.

--- a/elasticsearch/_async/client/text_structure.py
+++ b/elasticsearch/_async/client/text_structure.py
@@ -50,7 +50,7 @@ class TextStructureClient(NamespacedClient):
         Finds the structure of a text file. The text file must contain data that is suitable
         to be ingested into Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/find-structure.html>`_
 
         :param text_files:
         :param charset: The text’s character set. It must be a character set that is

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -41,7 +41,7 @@ class TransformClient(NamespacedClient):
         """
         Deletes an existing transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param force: If this value is false, the transform must be stopped before it
@@ -94,7 +94,7 @@ class TransformClient(NamespacedClient):
         """
         Retrieves configuration information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-transform.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -157,7 +157,7 @@ class TransformClient(NamespacedClient):
         """
         Retrieves usage information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-transform-stats.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -223,7 +223,7 @@ class TransformClient(NamespacedClient):
         """
         Previews a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/preview-transform.html>`_
 
         :param transform_id: Identifier for the transform to preview. If you specify
             this path parameter, you cannot provide transform configuration details in
@@ -320,7 +320,7 @@ class TransformClient(NamespacedClient):
         """
         Instantiates a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -414,7 +414,7 @@ class TransformClient(NamespacedClient):
         """
         Resets an existing transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/reset-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/reset-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -458,7 +458,7 @@ class TransformClient(NamespacedClient):
         """
         Schedules now a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/schedule-now-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/schedule-now-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param timeout: Controls the time to wait for the scheduling to take place
@@ -501,7 +501,7 @@ class TransformClient(NamespacedClient):
         """
         Starts one or more transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param from_: Restricts the set of transformed entities to those changed after
@@ -551,7 +551,7 @@ class TransformClient(NamespacedClient):
         """
         Stops one or more transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/stop-transform.html>`_
 
         :param transform_id: Identifier for the transform. To stop multiple transforms,
             use a comma-separated list or a wildcard expression. To stop all transforms,
@@ -630,7 +630,7 @@ class TransformClient(NamespacedClient):
         """
         Updates certain properties of a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/update-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -705,7 +705,7 @@ class TransformClient(NamespacedClient):
         """
         Upgrades all transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/upgrade-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/upgrade-transforms.html>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -42,7 +42,7 @@ class WatcherClient(NamespacedClient):
         """
         Acknowledges a watch, manually throttling the execution of the watch's actions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-ack-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-ack-watch.html>`_
 
         :param watch_id: Watch ID
         :param action_id: A comma-separated list of the action ids to be acked
@@ -84,7 +84,7 @@ class WatcherClient(NamespacedClient):
         """
         Activates a currently inactive watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-activate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-activate-watch.html>`_
 
         :param watch_id: Watch ID
         """
@@ -120,7 +120,7 @@ class WatcherClient(NamespacedClient):
         """
         Deactivates a currently active watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-deactivate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-deactivate-watch.html>`_
 
         :param watch_id: Watch ID
         """
@@ -156,7 +156,7 @@ class WatcherClient(NamespacedClient):
         """
         Removes a watch from Watcher.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-delete-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-delete-watch.html>`_
 
         :param id: Watch ID
         """
@@ -210,7 +210,7 @@ class WatcherClient(NamespacedClient):
         """
         Forces the execution of a stored watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-execute-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-execute-watch.html>`_
 
         :param id: Identifier for the watch.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -285,7 +285,7 @@ class WatcherClient(NamespacedClient):
         """
         Retrieves a watch by its ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-get-watch.html>`_
 
         :param id: Watch ID
         """
@@ -334,7 +334,7 @@ class WatcherClient(NamespacedClient):
         """
         Creates a new watch, or updates an existing one.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-put-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-put-watch.html>`_
 
         :param id: Watch ID
         :param actions:
@@ -430,7 +430,7 @@ class WatcherClient(NamespacedClient):
         """
         Retrieves stored watches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-query-watches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-query-watches.html>`_
 
         :param from_: The offset from the first result to fetch. Needs to be non-negative.
         :param query: Optional, query filter watches to be returned.
@@ -494,7 +494,7 @@ class WatcherClient(NamespacedClient):
         """
         Starts Watcher if it is not already running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-start.html>`_
         """
         __path = "/_watcher/_start"
         __query: t.Dict[str, t.Any] = {}
@@ -549,7 +549,7 @@ class WatcherClient(NamespacedClient):
         """
         Retrieves the current Watcher metrics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-stats.html>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -589,7 +589,7 @@ class WatcherClient(NamespacedClient):
         """
         Stops Watcher if it is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-stop.html>`_
         """
         __path = "/_watcher/_stop"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_async/client/xpack.py
+++ b/elasticsearch/_async/client/xpack.py
@@ -45,7 +45,7 @@ class XPackClient(NamespacedClient):
         """
         Retrieves information about the installed X-Pack features.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/info-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/info-api.html>`_
 
         :param accept_enterprise: If this param is used it must be set to true
         :param categories: A comma-separated list of the information categories to include
@@ -87,7 +87,7 @@ class XPackClient(NamespacedClient):
         """
         Retrieves usage information about the installed X-Pack features.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/usage-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/usage-api.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -639,7 +639,7 @@ class Elasticsearch(BaseClient):
         """
         Allows to perform multiple index/update/delete operations in a single request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-bulk.html>`_
 
         :param operations:
         :param index: Default index for items which don't provide one
@@ -724,7 +724,7 @@ class Elasticsearch(BaseClient):
         """
         Explicitly clears the search context for a scroll.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-scroll-api.html>`_
 
         :param scroll_id:
         """
@@ -767,7 +767,7 @@ class Elasticsearch(BaseClient):
         """
         Close a point in time
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/point-in-time-api.html>`_
 
         :param id:
         """
@@ -844,7 +844,7 @@ class Elasticsearch(BaseClient):
         """
         Returns number of documents matching a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-count.html>`_
 
         :param index: A comma-separated list of indices to restrict the results
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -961,7 +961,7 @@ class Elasticsearch(BaseClient):
         Creates a new document in the index. Returns a 409 response when a document with
         a same ID already exists in the index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-index_.html>`_
 
         :param index: The name of the index
         :param id: Document ID
@@ -1046,7 +1046,7 @@ class Elasticsearch(BaseClient):
         """
         Removes a document from the index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-delete.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1174,7 +1174,7 @@ class Elasticsearch(BaseClient):
         """
         Deletes documents matching the provided query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-delete-by-query.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices
@@ -1338,7 +1338,7 @@ class Elasticsearch(BaseClient):
         """
         Changes the number of requests per second for a particular Delete By Query operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-delete-by-query.html>`_
 
         :param task_id: The task id to rethrottle
         :param requests_per_second: The throttle to set on this request in floating sub-requests
@@ -1382,7 +1382,7 @@ class Elasticsearch(BaseClient):
         """
         Deletes a script.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
 
         :param id: Script ID
         :param master_timeout: Specify timeout for connection to master
@@ -1451,7 +1451,7 @@ class Elasticsearch(BaseClient):
         """
         Returns information about whether a document exists in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1551,7 +1551,7 @@ class Elasticsearch(BaseClient):
         """
         Returns information about whether a document source exists in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1652,7 +1652,7 @@ class Elasticsearch(BaseClient):
         """
         Returns information about why a specific matches (or doesn't match) a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-explain.html>`_
 
         :param index: The name of the index
         :param id: The document ID
@@ -1773,7 +1773,7 @@ class Elasticsearch(BaseClient):
         """
         Returns the information about the capabilities of fields among multiple indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-field-caps.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (*). To target all data streams
@@ -1885,7 +1885,7 @@ class Elasticsearch(BaseClient):
         """
         Returns a document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: Name of the index that contains the document.
         :param id: Unique identifier of the document.
@@ -1965,7 +1965,7 @@ class Elasticsearch(BaseClient):
         """
         Returns a script.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
 
         :param id: Script ID
         :param master_timeout: Specify timeout for connection to master
@@ -2003,7 +2003,7 @@ class Elasticsearch(BaseClient):
         """
         Returns all script contexts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.10/painless-contexts.html>`_
         """
         __path = "/_script_context"
         __query: t.Dict[str, t.Any] = {}
@@ -2034,7 +2034,7 @@ class Elasticsearch(BaseClient):
         """
         Returns available script types, languages and contexts
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
         """
         __path = "/_script_language"
         __query: t.Dict[str, t.Any] = {}
@@ -2093,7 +2093,7 @@ class Elasticsearch(BaseClient):
         """
         Returns the source of a document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-get.html>`_
 
         :param index: Name of the index that contains the document.
         :param id: Unique identifier of the document.
@@ -2174,7 +2174,7 @@ class Elasticsearch(BaseClient):
         """
         Returns the health of the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/health-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/health-api.html>`_
 
         :param feature: A feature of the cluster, as returned by the top-level health
             report API.
@@ -2242,7 +2242,7 @@ class Elasticsearch(BaseClient):
         """
         Creates or updates a document in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-index_.html>`_
 
         :param index: The name of the index
         :param document:
@@ -2333,7 +2333,7 @@ class Elasticsearch(BaseClient):
         """
         Returns basic information about the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/index.html>`_
         """
         __path = "/"
         __query: t.Dict[str, t.Any] = {}
@@ -2388,7 +2388,7 @@ class Elasticsearch(BaseClient):
         """
         Performs a kNN search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             to perform the operation on all indices
@@ -2491,7 +2491,7 @@ class Elasticsearch(BaseClient):
         """
         Allows to get multiple documents in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-multi-get.html>`_
 
         :param index: Name of the index to retrieve documents from when `ids` are specified,
             or when a document in the `docs` array does not specify an index.
@@ -2608,7 +2608,7 @@ class Elasticsearch(BaseClient):
         """
         Allows to execute several search operations in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-multi-search.html>`_
 
         :param searches:
         :param index: Comma-separated list of data streams, indices, and index aliases
@@ -2721,7 +2721,7 @@ class Elasticsearch(BaseClient):
         """
         Allows to execute several search template operations in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-multi-search.html>`_
 
         :param search_templates:
         :param index: A comma-separated list of index names to use as default
@@ -2805,7 +2805,7 @@ class Elasticsearch(BaseClient):
         """
         Returns multiple termvectors in one request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-multi-termvectors.html>`_
 
         :param index: The index in which the document resides.
         :param docs:
@@ -2920,7 +2920,7 @@ class Elasticsearch(BaseClient):
         """
         Open a point in time that can be used in subsequent searches
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/point-in-time-api.html>`_
 
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
@@ -2985,7 +2985,7 @@ class Elasticsearch(BaseClient):
         """
         Creates or updates a script.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-scripting.html>`_
 
         :param id: Script ID
         :param script:
@@ -3067,7 +3067,7 @@ class Elasticsearch(BaseClient):
         Allows to evaluate the quality of ranked search results over a set of typical
         search queries
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-rank-eval.html>`_
 
         :param requests: A set of typical search requests, together with their provided
             ratings.
@@ -3154,7 +3154,7 @@ class Elasticsearch(BaseClient):
         source documents by a query, changing the destination index settings, or fetching
         the documents from a remote cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-reindex.html>`_
 
         :param dest:
         :param source:
@@ -3243,7 +3243,7 @@ class Elasticsearch(BaseClient):
         """
         Changes the number of requests per second for a particular Reindex operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-reindex.html>`_
 
         :param task_id: The task id to rethrottle
         :param requests_per_second: The throttle to set on this request in floating sub-requests
@@ -3289,7 +3289,7 @@ class Elasticsearch(BaseClient):
         """
         Allows to use the Mustache language to pre-render a search definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/render-search-template-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/render-search-template-api.html>`_
 
         :param id: The id of the stored search template
         :param file:
@@ -3344,7 +3344,7 @@ class Elasticsearch(BaseClient):
         """
         Allows an arbitrary script to be executed and a result to be returned
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.10/painless-execute-api.html>`_
 
         :param context:
         :param context_setup:
@@ -3395,7 +3395,7 @@ class Elasticsearch(BaseClient):
         """
         Allows to retrieve a large numbers of results from a single search request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-request-body.html#request-body-search-scroll>`_
 
         :param scroll_id: Scroll ID of the search.
         :param rest_total_hits_as_int: If true, the API response’s hit.total property
@@ -3577,131 +3577,188 @@ class Elasticsearch(BaseClient):
         """
         Returns results matching a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-search.html>`_
 
-        :param index: A comma-separated list of index names to search; use `_all` or
-            empty string to perform the operation on all indices
-        :param aggregations:
-        :param aggs:
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param allow_partial_search_results: Indicate if an error should be returned
-            if there is a partial search failure or timeout
-        :param analyze_wildcard: Specify whether wildcard and prefix queries should be
-            analyzed (default: false)
-        :param analyzer: The analyzer to use for the query string
+        :param index: Comma-separated list of data streams, indices, and aliases to search.
+            Supports wildcards (`*`). To search all data streams and indices, omit this
+            parameter or use `*` or `_all`.
+        :param aggregations: Defines the aggregations that are run as part of the search
+            request.
+        :param aggs: Defines the aggregations that are run as part of the search request.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
+        :param allow_partial_search_results: If true, returns partial results if there
+            are shard request timeouts or shard failures. If false, returns an error
+            with no partial results.
+        :param analyze_wildcard: If true, wildcard and prefix queries are analyzed. This
+            parameter can only be used when the q query string parameter is specified.
+        :param analyzer: Analyzer to use for the query string. This parameter can only
+            be used when the q query string parameter is specified.
         :param batched_reduce_size: The number of shard results that should be reduced
             at once on the coordinating node. This value should be used as a protection
             mechanism to reduce the memory overhead per search request if the potential
             number of shards in the request can be large.
-        :param ccs_minimize_roundtrips: Indicates whether network round-trips should
-            be minimized as part of cross-cluster search requests execution
-        :param collapse:
-        :param default_operator: The default operator for query string query (AND or
-            OR)
-        :param df: The field to use as default where no field prefix is given in the
-            query string
-        :param docvalue_fields: Array of wildcard (*) patterns. The request returns doc
-            values for field names matching these patterns in the hits.fields property
+        :param ccs_minimize_roundtrips: If true, network round-trips between the coordinating
+            node and the remote clusters are minimized when executing cross-cluster search
+            (CCS) requests.
+        :param collapse: Collapses search results the values of the specified field.
+        :param default_operator: The default operator for query string query: AND or
+            OR. This parameter can only be used when the `q` query string parameter is
+            specified.
+        :param df: Field to use as default where no field prefix is given in the query
+            string. This parameter can only be used when the q query string parameter
+            is specified.
+        :param docvalue_fields: Array of wildcard (`*`) patterns. The request returns
+            doc values for field names matching these patterns in the `hits.fields` property
             of the response.
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`.
         :param explain: If true, returns detailed information about score computation
             as part of a hit.
         :param ext: Configuration of search extensions defined by Elasticsearch plugins.
-        :param fields: Array of wildcard (*) patterns. The request returns values for
-            field names matching these patterns in the hits.fields property of the response.
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the search_after parameter.
-        :param highlight:
-        :param ignore_throttled: Whether specified concrete, expanded or aliased indices
-            should be ignored when throttled
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
+        :param fields: Array of wildcard (`*`) patterns. The request returns values for
+            field names matching these patterns in the `hits.fields` property of the
+            response.
+        :param from_: Starting document offset. Needs to be non-negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
+        :param highlight: Specifies the highlighter to use for retrieving highlighted
+            snippets from one or more fields in your search results.
+        :param ignore_throttled: If `true`, concrete, expanded or aliased indices will
+            be ignored when frozen.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
         :param indices_boost: Boosts the _score of documents from specified indices.
         :param knn: Defines the approximate kNN search to run.
-        :param lenient: Specify whether format-based query failures (such as providing
-            text to a numeric field) should be ignored
-        :param max_concurrent_shard_requests: The number of concurrent shard requests
-            per node this search executes concurrently. This value should be used to
-            limit the impact of the search on the cluster in order to limit the number
-            of concurrent shard requests
-        :param min_compatible_shard_node: The minimum compatible version that all shards
-            involved in search should have for this request to be successful
-        :param min_score: Minimum _score for matching documents. Documents with a lower
-            _score are not included in the search results.
+        :param lenient: If `true`, format-based query failures (such as providing text
+            to a numeric field) in the query string will be ignored. This parameter can
+            only be used when the `q` query string parameter is specified.
+        :param max_concurrent_shard_requests: Defines the number of concurrent shard
+            requests per node this search executes concurrently. This value should be
+            used to limit the impact of the search on the cluster in order to limit the
+            number of concurrent shard requests.
+        :param min_compatible_shard_node: The minimum version of the node that can handle
+            the request Any handling node with a lower version will fail the request.
+        :param min_score: Minimum `_score` for matching documents. Documents with a lower
+            `_score` are not included in the search results.
         :param pit: Limits the search to a point in time (PIT). If you provide a PIT,
-            you cannot specify an <index> in the request path.
-        :param post_filter:
-        :param pre_filter_shard_size: A threshold that enforces a pre-filter roundtrip
-            to prefilter search shards based on query rewriting if the number of shards
-            the search request expands to exceeds the threshold. This filter roundtrip
-            can limit the number of shards significantly if for instance a shard can
-            not match any documents based on its rewrite method ie. if date filters are
-            mandatory to match but the shard bounds and the query are disjoint.
-        :param preference: Specify the node or shard the operation should be performed
-            on (default: random)
-        :param profile:
-        :param q: Query in the Lucene query string syntax
+            you cannot specify an `<index>` in the request path.
+        :param post_filter: Use the `post_filter` parameter to filter search results.
+            The search hits are filtered after the aggregations are calculated. A post
+            filter has no impact on the aggregation results.
+        :param pre_filter_shard_size: Defines a threshold that enforces a pre-filter
+            roundtrip to prefilter search shards based on query rewriting if the number
+            of shards the search request expands to exceeds the threshold. This filter
+            roundtrip can limit the number of shards significantly if for instance a
+            shard can not match any documents based on its rewrite method (if date filters
+            are mandatory to match but the shard bounds and the query are disjoint).
+            When unspecified, the pre-filter phase is executed if any of these conditions
+            is met: the request targets more than 128 shards; the request targets one
+            or more read-only index; the primary sort of the query targets an indexed
+            field.
+        :param preference: Nodes and shards used for the search. By default, Elasticsearch
+            selects from eligible nodes and shards using adaptive replica selection,
+            accounting for allocation awareness. Valid values are: `_only_local` to run
+            the search only on shards on the local node; `_local` to, if possible, run
+            the search on shards on the local node, or if not, select shards using the
+            default method; `_only_nodes:<node-id>,<node-id>` to run the search on only
+            the specified nodes IDs, where, if suitable shards exist on more than one
+            selected node, use shards on those nodes using the default method, or if
+            none of the specified nodes are available, select shards from any available
+            node using the default method; `_prefer_nodes:<node-id>,<node-id>` to if
+            possible, run the search on the specified nodes IDs, or if not, select shards
+            using the default method; `_shards:<shard>,<shard>` to run the search only
+            on the specified shards; `<custom-string>` (any string that does not start
+            with `_`) to route searches with the same `<custom-string>` to the same shards
+            in the same order.
+        :param profile: Set to `true` to return detailed timing information about the
+            execution of individual components in a search request. NOTE: This is a debugging
+            tool and adds significant overhead to search execution.
+        :param q: Query in the Lucene query string syntax using query parameter search.
+            Query parameter searches do not support the full Elasticsearch Query DSL
+            but are handy for testing.
         :param query: Defines the search definition using the Query DSL.
-        :param rank: Defines the Reciprocal Rank Fusion (RRF) to use
-        :param request_cache: Specify if request cache should be used for this request
-            or not, defaults to index level setting
-        :param rescore:
-        :param rest_total_hits_as_int: Indicates whether hits.total should be rendered
-            as an integer or an object in the rest search response
-        :param routing: A comma-separated list of specific routing values
+        :param rank: Defines the Reciprocal Rank Fusion (RRF) to use.
+        :param request_cache: If `true`, the caching of search results is enabled for
+            requests where `size` is `0`. Defaults to index level settings.
+        :param rescore: Can be used to improve precision by reordering just the top (for
+            example 100 - 500) documents returned by the `query` and `post_filter` phases.
+        :param rest_total_hits_as_int: Indicates whether `hits.total` should be rendered
+            as an integer or an object in the rest search response.
+        :param routing: Custom value used to route operations to a specific shard.
         :param runtime_mappings: Defines one or more runtime fields in the search request.
             These fields take precedence over mapped fields with the same name.
         :param script_fields: Retrieve a script evaluation (based on different fields)
             for each hit.
-        :param scroll: Specify how long a consistent view of the index should be maintained
-            for scrolled search
-        :param search_after:
-        :param search_type: Search operation type
-        :param seq_no_primary_term: If true, returns sequence number and primary term
-            of the last modification of each hit. See Optimistic concurrency control.
+        :param scroll: Period to retain the search context for scrolling. See Scroll
+            search results. By default, this value cannot exceed `1d` (24 hours). You
+            can change this limit using the `search.max_keep_alive` cluster-level setting.
+        :param search_after: Used to retrieve the next page of hits using a set of sort
+            values from the previous page.
+        :param search_type: How distributed term frequencies are calculated for relevance
+            scoring.
+        :param seq_no_primary_term: If `true`, returns sequence number and primary term
+            of the last modification of each hit.
         :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the from and size parameters. To page through
-            more hits, use the search_after parameter.
-        :param slice:
-        :param sort:
+            more than 10,000 hits using the `from` and `size` parameters. To page through
+            more hits, use the `search_after` parameter.
+        :param slice: Can be used to split a scrolled search into multiple slices that
+            can be consumed independently.
+        :param sort: A comma-separated list of <field>:<direction> pairs.
         :param source: Indicates which source fields are returned for matching documents.
             These fields are returned in the hits._source property of the search response.
-        :param source_excludes: A list of fields to exclude from the returned _source
-            field
-        :param source_includes: A list of fields to extract and return from the _source
-            field
+        :param source_excludes: A comma-separated list of source fields to exclude from
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
+        :param source_includes: A comma-separated list of source fields to include in
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
         :param stats: Stats groups to associate with the search. Each group maintains
             a statistics aggregation for its associated searches. You can retrieve these
             stats using the indices stats API.
         :param stored_fields: List of stored fields to return as part of a hit. If no
             fields are specified, no stored fields are included in the response. If this
-            field is specified, the _source parameter defaults to false. You can pass
-            _source: true to return both source fields and stored fields in the search
-            response.
-        :param suggest:
+            field is specified, the `_source` parameter defaults to `false`. You can
+            pass `_source: true` to return both source fields and stored fields in the
+            search response.
+        :param suggest: Defines a suggester that provides similar looking terms based
+            on a provided text.
         :param suggest_field: Specifies which field to use for suggestions.
-        :param suggest_mode: Specify suggest mode
-        :param suggest_size: How many suggestions to return in response
+        :param suggest_mode: Specifies the suggest mode. This parameter can only be used
+            when the `suggest_field` and `suggest_text` query string parameters are specified.
+        :param suggest_size: Number of suggestions to return. This parameter can only
+            be used when the `suggest_field` and `suggest_text` query string parameters
+            are specified.
         :param suggest_text: The source text for which the suggestions should be returned.
+            This parameter can only be used when the `suggest_field` and `suggest_text`
+            query string parameters are specified.
         :param terminate_after: Maximum number of documents to collect for each shard.
             If a query reaches this limit, Elasticsearch terminates the query early.
-            Elasticsearch collects documents before sorting. Defaults to 0, which does
-            not terminate query execution early.
+            Elasticsearch collects documents before sorting. Use with caution. Elasticsearch
+            applies this parameter to each shard handling the request. When possible,
+            let Elasticsearch perform early termination automatically. Avoid specifying
+            this parameter for requests that target data streams with backing indices
+            across multiple data tiers. If set to `0` (default), the query does not terminate
+            early.
         :param timeout: Specifies the period of time to wait for a response from each
             shard. If no response is received before the timeout expires, the request
             fails and returns an error. Defaults to no timeout.
         :param track_scores: If true, calculate and return document scores, even if the
             scores are not used for sorting.
         :param track_total_hits: Number of hits matching the query to count accurately.
-            If true, the exact number of hits is returned at the cost of some performance.
-            If false, the response does not include the total number of hits matching
-            the query. Defaults to 10,000 hits.
-        :param typed_keys: Specify whether aggregation and suggester names should be
-            prefixed by their respective types in the response
+            If `true`, the exact number of hits is returned at the cost of some performance.
+            If `false`, the response does not include the total number of hits matching
+            the query.
+        :param typed_keys: If `true`, aggregation and suggester names are be prefixed
+            by their respective types in the response.
         :param version: If true, returns document version as part of a hit.
         """
         if index not in SKIP_IN_PATH:
@@ -3912,7 +3969,7 @@ class Elasticsearch(BaseClient):
         Searches a vector tile for geospatial values. Returns results as a binary Mapbox
         vector tile.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-vector-tile-api.html>`_
 
         :param index: Comma-separated list of data streams, indices, or aliases to search
         :param field: Field containing geospatial data to return
@@ -4065,7 +4122,7 @@ class Elasticsearch(BaseClient):
         Returns information about the indices and shards that a search request would
         be executed against.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-shards.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices
@@ -4165,7 +4222,7 @@ class Elasticsearch(BaseClient):
         """
         Allows to use the Mustache language to pre-render a search definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-template.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (*).
@@ -4276,7 +4333,7 @@ class Elasticsearch(BaseClient):
         the provided string. It is designed for low-latency look-ups used in auto-complete
         scenarios.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-terms-enum.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-terms-enum.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             to search. Wildcard (*) expressions are supported.
@@ -4370,7 +4427,7 @@ class Elasticsearch(BaseClient):
         Returns information and statistics about terms in the fields of a particular
         document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-termvectors.html>`_
 
         :param index: The index in which the document resides.
         :param id: The id of the document, when not specified a doc param should be supplied.
@@ -4497,7 +4554,7 @@ class Elasticsearch(BaseClient):
         """
         Updates a document with a script or partial document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-update.html>`_
 
         :param index: The name of the index
         :param id: Document ID
@@ -4666,7 +4723,7 @@ class Elasticsearch(BaseClient):
         Performs an update on every document in the index without changing the source,
         for example to pick up a mapping change.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-update-by-query.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices
@@ -4842,7 +4899,7 @@ class Elasticsearch(BaseClient):
         """
         Changes the number of requests per second for a particular Update By Query operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/docs-update-by-query.html>`_
 
         :param task_id: The task id to rethrottle
         :param requests_per_second: The throttle to set on this request in floating sub-requests

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -61,6 +61,7 @@ from .migration import MigrationClient
 from .ml import MlClient
 from .monitoring import MonitoringClient
 from .nodes import NodesClient
+from .query_ruleset import QueryRulesetClient
 from .rollup import RollupClient
 from .search_application import SearchApplicationClient
 from .searchable_snapshots import SearchableSnapshotsClient
@@ -70,6 +71,7 @@ from .slm import SlmClient
 from .snapshot import SnapshotClient
 from .sql import SqlClient
 from .ssl import SslClient
+from .synonyms import SynonymsClient
 from .tasks import TasksClient
 from .text_structure import TextStructureClient
 from .transform import TransformClient
@@ -449,12 +451,14 @@ class Elasticsearch(BaseClient):
         self.migration = MigrationClient(self)
         self.ml = MlClient(self)
         self.monitoring = MonitoringClient(self)
+        self.query_ruleset = QueryRulesetClient(self)
         self.rollup = RollupClient(self)
         self.search_application = SearchApplicationClient(self)
         self.searchable_snapshots = SearchableSnapshotsClient(self)
         self.security = SecurityClient(self)
         self.slm = SlmClient(self)
         self.shutdown = ShutdownClient(self)
+        self.synonyms = SynonymsClient(self)
         self.sql = SqlClient(self)
         self.ssl = SslClient(self)
         self.text_structure = TextStructureClient(self)

--- a/elasticsearch/_sync/client/async_search.py
+++ b/elasticsearch/_sync/client/async_search.py
@@ -40,7 +40,7 @@ class AsyncSearchClient(NamespacedClient):
         Deletes an async search by ID. If the search is still running, the search request
         will be cancelled. Otherwise, the saved search results are deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -82,7 +82,7 @@ class AsyncSearchClient(NamespacedClient):
         Retrieves the results of a previously submitted async search request given its
         ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         :param keep_alive: Specifies how long the async search should be available in
@@ -139,7 +139,7 @@ class AsyncSearchClient(NamespacedClient):
         Retrieves the status of a previously submitted async search request given its
         ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -310,7 +310,7 @@ class AsyncSearchClient(NamespacedClient):
         """
         Executes a search request asynchronously.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/async-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices

--- a/elasticsearch/_sync/client/autoscaling.py
+++ b/elasticsearch/_sync/client/autoscaling.py
@@ -40,7 +40,7 @@ class AutoscalingClient(NamespacedClient):
         Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
         Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-delete-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-delete-autoscaling-policy.html>`_
 
         :param name: the name of the autoscaling policy
         """
@@ -76,7 +76,7 @@ class AutoscalingClient(NamespacedClient):
         Gets the current autoscaling capacity based on the configured autoscaling policy.
         Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-get-autoscaling-capacity.html>`_
         """
         __path = "/_autoscaling/capacity"
         __query: t.Dict[str, t.Any] = {}
@@ -109,7 +109,7 @@ class AutoscalingClient(NamespacedClient):
         Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
         Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-get-autoscaling-capacity.html>`_
 
         :param name: the name of the autoscaling policy
         """
@@ -149,7 +149,7 @@ class AutoscalingClient(NamespacedClient):
         Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
         Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-put-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-put-autoscaling-policy.html>`_
 
         :param name: the name of the autoscaling policy
         :param policy:

--- a/elasticsearch/_sync/client/cat.py
+++ b/elasticsearch/_sync/client/cat.py
@@ -67,7 +67,7 @@ class CatClient(NamespacedClient):
         Shows information about currently configured aliases to indices including filter
         and routing infos.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-alias.html>`_
 
         :param name: A comma-separated list of aliases to retrieve. Supports wildcards
             (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
@@ -152,7 +152,7 @@ class CatClient(NamespacedClient):
         Provides a snapshot of how many shards are allocated to each data node and how
         much disk space they are using.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-allocation.html>`_
 
         :param node_id: Comma-separated list of node identifiers or names used to limit
             the returned information.
@@ -230,7 +230,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about existing component_templates templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-component-templates.html>`_
 
         :param name: The name of the component template. Accepts wildcard expressions.
             If omitted, all component templates are returned.
@@ -306,7 +306,7 @@ class CatClient(NamespacedClient):
         Provides quick access to the document count of the entire cluster, or individual
         indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-count.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -388,7 +388,7 @@ class CatClient(NamespacedClient):
         Shows how much heap memory is currently being used by fielddata on every data
         node in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-fielddata.html>`_
 
         :param fields: Comma-separated list of fields used to limit returned information.
             To retrieve all fields, omit this parameter.
@@ -469,7 +469,7 @@ class CatClient(NamespacedClient):
         """
         Returns a concise representation of the cluster health.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-health.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -544,7 +544,7 @@ class CatClient(NamespacedClient):
         """
         Returns help for the Cat APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -642,7 +642,7 @@ class CatClient(NamespacedClient):
         Returns information about indices: number of primaries and replicas, document
         counts, disk size, ...
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-indices.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -737,7 +737,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about the master node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-master.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -856,7 +856,7 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-dfanalytics.html>`_
 
         :param id: The ID of the data frame analytics to fetch
         :param allow_no_match: Whether to ignore if a wildcard expression matches no
@@ -987,7 +987,7 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-datafeeds.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed.
@@ -1124,7 +1124,7 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-anomaly-detectors.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param allow_no_match: Specifies what to do when the request: * Contains wildcard
@@ -1264,17 +1264,21 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about inference trained models.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-trained-model.html>`_
 
-        :param model_id: The ID of the trained models stats to fetch
-        :param allow_no_match: Whether to ignore if a wildcard expression matches no
-            trained models. (This includes `_all` string or when no trained models have
-            been specified)
-        :param bytes: The unit in which to display byte values
+        :param model_id: A unique identifier for the trained model.
+        :param allow_no_match: Specifies what to do when the request: contains wildcard
+            expressions and there are no models that match; contains the `_all` string
+            or no identifiers and there are no matches; contains wildcard expressions
+            and there are only partial matches. If `true`, the API returns an empty array
+            when there are no matches and the subset of results when there are partial
+            matches. If `false`, the API returns a 404 status code when there are no
+            matches or only partial matches.
+        :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
-        :param from_: skips a number of trained models
-        :param h: Comma-separated list of column names to display
+        :param from_: Skips the specified number of transforms.
+        :param h: A comma-separated list of column names to display.
         :param help: When set to `true` will output available columns. This option can't
             be combined with any other query string option.
         :param local: If `true`, the request computes the list of selected nodes from
@@ -1282,8 +1286,9 @@ class CatClient(NamespacedClient):
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
         :param master_timeout: Period to wait for a connection to the master node.
-        :param s: Comma-separated list of column names or column aliases to sort by
-        :param size: specifies a max number of trained models to get
+        :param s: A comma-separated list of column names or aliases used to sort the
+            response.
+        :param size: The maximum number of transforms to display.
         :param v: When set to `true` will enable verbose output.
         """
         if model_id not in SKIP_IN_PATH:
@@ -1349,7 +1354,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about custom node attributes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-nodeattrs.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1423,7 +1428,7 @@ class CatClient(NamespacedClient):
         """
         Returns basic statistics about performance of cluster nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-nodes.html>`_
 
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -1503,7 +1508,7 @@ class CatClient(NamespacedClient):
         """
         Returns a concise representation of the cluster pending tasks.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-pending-tasks.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1572,7 +1577,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about installed plugins across nodes node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-plugins.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1647,7 +1652,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about index shard recoveries, both on-going completed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-recovery.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -1732,7 +1737,7 @@ class CatClient(NamespacedClient):
         """
         Returns information about snapshot repositories registered in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-repositories.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1805,10 +1810,12 @@ class CatClient(NamespacedClient):
         """
         Provides low-level information about the segments in the shards of an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-segments.html>`_
 
-        :param index: A comma-separated list of index names to limit the returned information
-        :param bytes: The unit in which to display byte values
+        :param index: A comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -1885,10 +1892,12 @@ class CatClient(NamespacedClient):
         """
         Provides a detailed view of shard allocation on nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-shards.html>`_
 
-        :param index: A comma-separated list of index names to limit the returned information
-        :param bytes: The unit in which to display byte values
+        :param index: A comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -1965,15 +1974,18 @@ class CatClient(NamespacedClient):
         """
         Returns all snapshots in a specific repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-snapshots.html>`_
 
-        :param repository: Name of repository from which to fetch the snapshot information
+        :param repository: A comma-separated list of snapshot repositories used to limit
+            the request. Accepts wildcard expressions. `_all` returns all repositories.
+            If any repository fails during the request, Elasticsearch returns an error.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
         :param help: When set to `true` will output available columns. This option can't
             be combined with any other query string option.
-        :param ignore_unavailable: Set to true to ignore unavailable snapshots
+        :param ignore_unavailable: If `true`, the response does not include information
+            from unavailable snapshots.
         :param local: If `true`, the request computes the list of selected nodes from
             the local cluster state. If `false` the list of selected nodes are computed
             from the cluster state of the master node. In both cases the coordinating
@@ -2037,7 +2049,7 @@ class CatClient(NamespacedClient):
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
         node_id: t.Optional[t.Union[t.List[str], t.Tuple[str, ...]]] = None,
-        parent_task: t.Optional[int] = None,
+        parent_task_id: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         s: t.Optional[t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]] = None,
         v: t.Optional[bool] = None,
@@ -2046,11 +2058,11 @@ class CatClient(NamespacedClient):
         Returns information about the tasks currently executing on one or more nodes
         in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
-        :param actions: A comma-separated list of actions that should be returned. Leave
-            empty to return all.
-        :param detailed: Return detailed task information (default: false)
+        :param actions: The task action names, which are used to limit the response.
+        :param detailed: If `true`, the response includes detailed information about
+            shard recoveries.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -2061,8 +2073,9 @@ class CatClient(NamespacedClient):
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
         :param master_timeout: Period to wait for a connection to the master node.
-        :param node_id:
-        :param parent_task:
+        :param node_id: Unique node identifiers, which are used to limit the response.
+        :param parent_task_id: The parent task identifier, which is used to limit the
+            response.
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
@@ -2092,8 +2105,8 @@ class CatClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if node_id is not None:
             __query["node_id"] = node_id
-        if parent_task is not None:
-            __query["parent_task"] = parent_task
+        if parent_task_id is not None:
+            __query["parent_task_id"] = parent_task_id
         if pretty is not None:
             __query["pretty"] = pretty
         if s is not None:
@@ -2129,9 +2142,10 @@ class CatClient(NamespacedClient):
         """
         Returns information about existing templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-templates.html>`_
 
-        :param name: A pattern that returned template names must match
+        :param name: The name of the template to return. Accepts wildcard expressions.
+            If omitted, all templates are returned.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -2209,10 +2223,10 @@ class CatClient(NamespacedClient):
         Returns cluster-wide thread pool statistics per node. By default the active,
         queue and rejected statistics are returned for all thread pools.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-thread-pool.html>`_
 
-        :param thread_pool_patterns: List of thread pool names used to limit the request.
-            Accepts wildcard expressions.
+        :param thread_pool_patterns: A comma-separated list of thread pool names used
+            to limit the request. Accepts wildcard expressions.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -2226,7 +2240,7 @@ class CatClient(NamespacedClient):
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
-        :param time: Unit used to display time values.
+        :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
         if thread_pool_patterns not in SKIP_IN_PATH:
@@ -2339,16 +2353,21 @@ class CatClient(NamespacedClient):
         """
         Gets configuration and usage information about transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cat-transforms.html>`_
 
-        :param transform_id: The id of the transform for which to get stats. '_all' or
-            '*' implies all transforms
-        :param allow_no_match: Whether to ignore if a wildcard expression matches no
-            transforms. (This includes `_all` string or when no transforms have been
-            specified)
+        :param transform_id: A transform identifier or a wildcard expression. If you
+            do not specify one of these options, the API returns information for all
+            transforms.
+        :param allow_no_match: Specifies what to do when the request: contains wildcard
+            expressions and there are no transforms that match; contains the `_all` string
+            or no identifiers and there are no matches; contains wildcard expressions
+            and there are only partial matches. If `true`, it returns an empty transforms
+            array when there are no matches and the subset of results when there are
+            partial matches. If `false`, the request returns a 404 status code when there
+            are no matches or only partial matches.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
-        :param from_: skips a number of transform configs, defaults to 0
+        :param from_: Skips the specified number of transforms.
         :param h: Comma-separated list of column names to display.
         :param help: When set to `true` will output available columns. This option can't
             be combined with any other query string option.
@@ -2359,8 +2378,8 @@ class CatClient(NamespacedClient):
         :param master_timeout: Period to wait for a connection to the master node.
         :param s: Comma-separated list of column names or column aliases used to sort
             the response.
-        :param size: specifies a max number of transforms to get, defaults to 100
-        :param time: Unit used to display time values.
+        :param size: The maximum number of transforms to obtain.
+        :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
         if transform_id not in SKIP_IN_PATH:

--- a/elasticsearch/_sync/client/ccr.py
+++ b/elasticsearch/_sync/client/ccr.py
@@ -39,7 +39,7 @@ class CcrClient(NamespacedClient):
         """
         Deletes auto-follow patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-delete-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern.
         """
@@ -96,7 +96,7 @@ class CcrClient(NamespacedClient):
         """
         Creates a new follower index configured to follow the referenced leader index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-put-follow.html>`_
 
         :param index: The name of the follower index
         :param leader_index:
@@ -180,7 +180,7 @@ class CcrClient(NamespacedClient):
         Retrieves information about all follower indices, including parameters and status
         for each follower index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-follow-info.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -218,7 +218,7 @@ class CcrClient(NamespacedClient):
         Retrieves follower stats. return shard-level stats about the following tasks
         associated with each shard for the specified indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-follow-stats.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -261,7 +261,7 @@ class CcrClient(NamespacedClient):
         """
         Removes the follower retention leases from the leader.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-forget-follower.html>`_
 
         :param index: the name of the leader index for which specified follower retention
             leases should be removed
@@ -312,7 +312,7 @@ class CcrClient(NamespacedClient):
         Gets configured auto-follow patterns. Returns the specified auto-follow pattern
         collection.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-auto-follow-pattern.html>`_
 
         :param name: Specifies the auto-follow pattern collection that you want to retrieve.
             If you do not specify a name, the API returns information for all collections.
@@ -350,7 +350,7 @@ class CcrClient(NamespacedClient):
         """
         Pauses an auto-follow pattern
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-pause-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern that should pause discovering
             new indices to follow.
@@ -388,7 +388,7 @@ class CcrClient(NamespacedClient):
         Pauses a follower index. The follower index will not fetch any additional operations
         from the leader index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-pause-follow.html>`_
 
         :param index: The name of the follower index that should pause following its
             leader index.
@@ -452,7 +452,7 @@ class CcrClient(NamespacedClient):
         cluster. Newly created indices on the remote cluster matching any of the specified
         patterns will be automatically configured as follower indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-put-auto-follow-pattern.html>`_
 
         :param name: The name of the collection of auto-follow patterns.
         :param remote_cluster: The remote cluster containing the leader indices to match
@@ -566,7 +566,7 @@ class CcrClient(NamespacedClient):
         """
         Resumes an auto-follow pattern that has been paused
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-resume-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern to resume discovering new indices
             to follow.
@@ -619,7 +619,7 @@ class CcrClient(NamespacedClient):
         """
         Resumes a follower index that has been paused
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-resume-follow.html>`_
 
         :param index: The name of the follow index to resume following.
         :param max_outstanding_read_requests:
@@ -693,7 +693,7 @@ class CcrClient(NamespacedClient):
         """
         Gets all stats related to cross-cluster replication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-get-stats.html>`_
         """
         __path = "/_ccr/stats"
         __query: t.Dict[str, t.Any] = {}
@@ -726,7 +726,7 @@ class CcrClient(NamespacedClient):
         Stops the following task associated with a follower index and removes index metadata
         and settings associated with cross-cluster replication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ccr-post-unfollow.html>`_
 
         :param index: The name of the follower index that should be turned into a regular
             index.

--- a/elasticsearch/_sync/client/cluster.py
+++ b/elasticsearch/_sync/client/cluster.py
@@ -46,7 +46,7 @@ class ClusterClient(NamespacedClient):
         """
         Provides explanations for shard allocations in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-allocation-explain.html>`_
 
         :param current_node: Specifies the node ID or the name of the node to only explain
             a shard that is currently located on the specified node.
@@ -111,12 +111,15 @@ class ClusterClient(NamespacedClient):
         """
         Deletes a component template
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
         :param name: Comma-separated list or wildcard expression of component template
             names used to limit the request.
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -154,7 +157,7 @@ class ClusterClient(NamespacedClient):
         """
         Clears cluster voting config exclusions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/voting-config-exclusions.html>`_
 
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
             be removed from the cluster before clearing the voting configuration exclusions
@@ -199,7 +202,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns information about whether a particular component template exist
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (*) expressions are supported.
@@ -252,15 +255,18 @@ class ClusterClient(NamespacedClient):
         """
         Returns one or more component templates
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
-        :param name: The comma separated names of the component templates
-        :param flat_settings:
+        :param name: Comma-separated list of component template names used to limit the
+            request. Wildcard (`*`) expressions are supported.
+        :param flat_settings: If `true`, returns settings in flat format.
         :param include_defaults: Return all default configurations for the component
             template (default: false)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Explicit operation timeout for connection to master node
+        :param local: If `true`, the request retrieves information from the local node
+            only. If `false`, information is retrieved from the master node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_component_template/{_quote(name)}"
@@ -308,12 +314,16 @@ class ClusterClient(NamespacedClient):
         """
         Returns cluster settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-get-settings.html>`_
 
-        :param flat_settings: Return settings in flat format (default: false)
-        :param include_defaults: Whether to return all default clusters setting.
-        :param master_timeout: Explicit operation timeout for connection to master node
-        :param timeout: Explicit operation timeout
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param include_defaults: If `true`, returns default cluster settings from the
+            local node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
@@ -394,7 +404,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns basic information about the health of the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-health.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported. To target
@@ -471,6 +481,62 @@ class ClusterClient(NamespacedClient):
         )
 
     @_rewrite_parameters()
+    def info(
+        self,
+        *,
+        target: t.Union[
+            t.Union[
+                "t.Literal['_all', 'http', 'ingest', 'script', 'thread_pool']", str
+            ],
+            t.Union[
+                t.List[
+                    t.Union[
+                        "t.Literal['_all', 'http', 'ingest', 'script', 'thread_pool']",
+                        str,
+                    ]
+                ],
+                t.Tuple[
+                    t.Union[
+                        "t.Literal['_all', 'http', 'ingest', 'script', 'thread_pool']",
+                        str,
+                    ],
+                    ...,
+                ],
+            ],
+        ],
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Returns different information about the cluster.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-info.html>`_
+
+        :param target: Limits the information returned to the specific target. Supports
+            a comma-separated list, such as http,ingest.
+        """
+        if target in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'target'")
+        __path = f"/_info/{_quote(target)}"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        __headers = {"accept": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
+            "GET", __path, params=__query, headers=__headers
+        )
+
+    @_rewrite_parameters()
     def pending_tasks(
         self,
         *,
@@ -489,11 +555,13 @@ class ClusterClient(NamespacedClient):
         Returns a list of any cluster-level changes (e.g. create index, update mapping,
         allocate or fail shard) which have not yet been executed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-pending.html>`_
 
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Specify timeout for connection to master
+        :param local: If `true`, the request retrieves information from the local node
+            only. If `false`, information is retrieved from the master node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         __path = "/_cluster/pending_tasks"
         __query: t.Dict[str, t.Any] = {}
@@ -535,7 +603,7 @@ class ClusterClient(NamespacedClient):
         """
         Updates the cluster voting config exclusions by node ids or node names.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/voting-config-exclusions.html>`_
 
         :param node_ids: A comma-separated list of the persistent ids of the nodes to
             exclude from the voting configuration. If specified, you may not also specify
@@ -594,9 +662,17 @@ class ClusterClient(NamespacedClient):
         """
         Creates or updates a component template
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-component-template.html>`_
 
-        :param name: The name of the template
+        :param name: Name of the component template to create. Elasticsearch includes
+            the following built-in component templates: `logs-mappings`; 'logs-settings`;
+            `metrics-mappings`; `metrics-settings`;`synthetics-mapping`; `synthetics-settings`.
+            Elastic Agent uses these templates to configure backing indices for its data
+            streams. If you use Elastic Agent and want to overwrite one of these templates,
+            set the `version` for your replacement template higher than the current version.
+            If you don’t use Elastic Agent and want to disable all built-in component
+            and index templates, set `stack.templates.enabled` to `false` using the cluster
+            update settings API.
         :param template: The template to be applied which includes mappings, settings,
             or aliases configuration.
         :param allow_auto_create: This setting overrides the value of the `action.auto_create_index`
@@ -604,13 +680,18 @@ class ClusterClient(NamespacedClient):
             created using that template even if auto-creation of indices is disabled
             via `actions.auto_create_index`. If set to `false` then data streams matching
             the template must always be explicitly created.
-        :param create: Whether the index template should only be added if new or can
-            also replace an existing one
-        :param master_timeout: Specify timeout for connection to master
+        :param create: If `true`, this request cannot replace or update existing component
+            templates.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         :param meta: Optional user metadata about the component template. May have any
-            contents. This map is not automatically generated by Elasticsearch.
+            contents. This map is not automatically generated by Elasticsearch. This
+            information is stored in the cluster state, so keeping it short is preferable.
+            To unset `_meta`, replace the template without specifying this information.
         :param version: Version number used to manage component templates externally.
             This number isn't automatically generated or incremented by Elasticsearch.
+            To unset a version, replace the template without specifying a version.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -667,7 +748,7 @@ class ClusterClient(NamespacedClient):
         """
         Updates the cluster settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-update-settings.html>`_
 
         :param flat_settings: Return settings in flat format (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
@@ -715,7 +796,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns the information about configured remote clusters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-remote-info.html>`_
         """
         __path = "/_remote/info"
         __query: t.Dict[str, t.Any] = {}
@@ -761,7 +842,7 @@ class ClusterClient(NamespacedClient):
         """
         Allows to manually change the allocation of individual shards in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-reroute.html>`_
 
         :param commands: Defines the commands to perform.
         :param dry_run: If true, then the request simulates the operation only and returns
@@ -858,7 +939,7 @@ class ClusterClient(NamespacedClient):
         """
         Returns a comprehensive information about the state of the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-state.html>`_
 
         :param metric: Limit the information returned to the specified metrics
         :param index: A comma-separated list of index names; use `_all` or empty string
@@ -936,15 +1017,15 @@ class ClusterClient(NamespacedClient):
         """
         Returns high-level overview of cluster statistics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-stats.html>`_
 
         :param node_id: Comma-separated list of node filters used to limit returned information.
             Defaults to all nodes in the cluster.
-        :param flat_settings: Return settings in flat format (default: false)
+        :param flat_settings: If `true`, returns settings in flat format.
         :param timeout: Period to wait for each node to respond. If a node does not respond
             before its timeout expires, the response does not include its stats. However,
-            timed out nodes are included in the response’s _nodes.failed property. Defaults
-            to no timeout.
+            timed out nodes are included in the response’s `_nodes.failed` property.
+            Defaults to no timeout.
         """
         if node_id not in SKIP_IN_PATH:
             __path = f"/_cluster/stats/nodes/{_quote(node_id)}"

--- a/elasticsearch/_sync/client/dangling_indices.py
+++ b/elasticsearch/_sync/client/dangling_indices.py
@@ -44,7 +44,7 @@ class DanglingIndicesClient(NamespacedClient):
         """
         Deletes the specified dangling index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-gateway-dangling-indices.html>`_
 
         :param index_uuid: The UUID of the dangling index
         :param accept_data_loss: Must be set to true in order to delete the dangling
@@ -97,7 +97,7 @@ class DanglingIndicesClient(NamespacedClient):
         """
         Imports the specified dangling index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-gateway-dangling-indices.html>`_
 
         :param index_uuid: The UUID of the dangling index
         :param accept_data_loss: Must be set to true in order to import the dangling
@@ -144,7 +144,7 @@ class DanglingIndicesClient(NamespacedClient):
         """
         Returns all dangling indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-gateway-dangling-indices.html>`_
         """
         __path = "/_dangling"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/enrich.py
+++ b/elasticsearch/_sync/client/enrich.py
@@ -39,9 +39,9 @@ class EnrichClient(NamespacedClient):
         """
         Deletes an existing enrich policy and its enrich index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-enrich-policy-api.html>`_
 
-        :param name: The name of the enrich policy
+        :param name: Enrich policy to delete.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -76,11 +76,11 @@ class EnrichClient(NamespacedClient):
         """
         Creates the enrich index for an existing enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/execute-enrich-policy-api.html>`_
 
-        :param name: The name of the enrich policy
-        :param wait_for_completion: Should the request should block until the execution
-            is complete.
+        :param name: Enrich policy to execute.
+        :param wait_for_completion: If `true`, the request blocks other enrich policy
+            execution requests until complete.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -116,9 +116,10 @@ class EnrichClient(NamespacedClient):
         """
         Gets information about an enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-enrich-policy-api.html>`_
 
-        :param name: A comma-separated list of enrich policy names
+        :param name: Comma-separated list of enrich policy names used to limit the request.
+            To return information for all enrich policies, omit this parameter.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_enrich/policy/{_quote(name)}"
@@ -158,12 +159,14 @@ class EnrichClient(NamespacedClient):
         """
         Creates a new enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-enrich-policy-api.html>`_
 
-        :param name: The name of the enrich policy
-        :param geo_match:
-        :param match:
-        :param range:
+        :param name: Name of the enrich policy to create or update.
+        :param geo_match: Matches enrich data to incoming documents based on a `geo_shape`
+            query.
+        :param match: Matches enrich data to incoming documents based on a `term` query.
+        :param range: Matches a number, date, or IP address in incoming documents to
+            a range in the enrich index based on a `term` query.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -204,7 +207,7 @@ class EnrichClient(NamespacedClient):
         Gets enrich coordinator statistics and information about enrich policies that
         are currently executing.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/enrich-stats-api.html>`_
         """
         __path = "/_enrich/_stats"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/eql.py
+++ b/elasticsearch/_sync/client/eql.py
@@ -40,9 +40,11 @@ class EqlClient(NamespacedClient):
         Deletes an async EQL search by ID. If the search is still running, the search
         request will be cancelled. Otherwise, the saved search results are deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/eql-search-api.html>`_
 
-        :param id: Identifier for the search to delete.
+        :param id: Identifier for the search to delete. A search ID is provided in the
+            EQL search API's response for an async search. A search ID is also provided
+            if the request’s `keep_on_completion` parameter is `true`.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -80,7 +82,7 @@ class EqlClient(NamespacedClient):
         """
         Returns async results from previously executed Event Query Language (EQL) search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `< https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-eql-search-api.html>`_
 
         :param id: Identifier for the search.
         :param keep_alive: Period for which the search and its results are stored on
@@ -127,7 +129,7 @@ class EqlClient(NamespacedClient):
         Returns the status of a previously submitted async or stored Event Query Language
         (EQL) search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `< https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-eql-status-api.html>`_
 
         :param id: Identifier for the search.
         """
@@ -215,7 +217,7 @@ class EqlClient(NamespacedClient):
         """
         Returns results matching a query expressed in Event Query Language (EQL)
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/eql-search-api.html>`_
 
         :param index: The name of the index to scope the operation
         :param query: EQL query you wish to run.

--- a/elasticsearch/_sync/client/features.py
+++ b/elasticsearch/_sync/client/features.py
@@ -39,7 +39,7 @@ class FeaturesClient(NamespacedClient):
         Gets a list of features which can be included in snapshots using the feature_states
         field when creating a snapshot
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-features-api.html>`_
         """
         __path = "/_features"
         __query: t.Dict[str, t.Any] = {}
@@ -70,7 +70,7 @@ class FeaturesClient(NamespacedClient):
         """
         Resets the internal state of features, usually by deleting system indices
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
         """
         __path = "/_features/_reset"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/fleet.py
+++ b/elasticsearch/_sync/client/fleet.py
@@ -44,7 +44,7 @@ class FleetClient(NamespacedClient):
         Returns the current global checkpoints for an index. This API is design for internal
         use by the fleet server project.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-global-checkpoints.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-global-checkpoints.html>`_
 
         :param index: A single index or index alias that resolves to a single index.
         :param checkpoints: A comma separated list of previous global checkpoints. When

--- a/elasticsearch/_sync/client/graph.py
+++ b/elasticsearch/_sync/client/graph.py
@@ -50,16 +50,20 @@ class GraphClient(NamespacedClient):
         Explore extracted and summarized information about the documents and terms in
         an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/graph-explore-api.html>`_
 
-        :param index: A comma-separated list of index names to search; use `_all` or
-            empty string to perform the operation on all indices
-        :param connections:
-        :param controls:
-        :param query:
-        :param routing: Specific routing value
-        :param timeout: Explicit operation timeout
-        :param vertices:
+        :param index: Name of the index.
+        :param connections: Specifies or more fields from which you want to extract terms
+            that are associated with the specified vertices.
+        :param controls: Direct the Graph API how to build the graph.
+        :param query: A seed query that identifies the documents of interest. Can be
+            any valid Elasticsearch query.
+        :param routing: Custom value used to route operations to a specific shard.
+        :param timeout: Specifies the period of time to wait for a response from each
+            shard. If no response is received before the timeout expires, the request
+            fails and returns an error. Defaults to no timeout.
+        :param vertices: Specifies one or more fields that contain the terms you want
+            to include in the graph as vertices.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")

--- a/elasticsearch/_sync/client/ilm.py
+++ b/elasticsearch/_sync/client/ilm.py
@@ -44,7 +44,7 @@ class IlmClient(NamespacedClient):
         Deletes the specified lifecycle policy definition. A currently used policy cannot
         be deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-delete-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -96,7 +96,7 @@ class IlmClient(NamespacedClient):
         Retrieves information about the index's current lifecycle state, such as the
         currently executing phase, action, and step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-explain-lifecycle.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to target.
             Supports wildcards (`*`). To target all data streams and indices, use `*`
@@ -157,7 +157,7 @@ class IlmClient(NamespacedClient):
         Returns the specified policy definition. Includes the policy version and last
         modified date.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-get-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -202,7 +202,7 @@ class IlmClient(NamespacedClient):
         """
         Retrieves the current index lifecycle management (ILM) status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-get-status.html>`_
         """
         __path = "/_ilm/status"
         __query: t.Dict[str, t.Any] = {}
@@ -239,7 +239,7 @@ class IlmClient(NamespacedClient):
         Migrates the indices and ILM policies away from custom node attribute allocation
         routing to data tiers routing
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-migrate-to-data-tiers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-migrate-to-data-tiers.html>`_
 
         :param dry_run: If true, simulates the migration from node attributes based allocation
             filters to data tiers, but does not perform the migration. This provides
@@ -292,7 +292,7 @@ class IlmClient(NamespacedClient):
         """
         Manually moves an index into the specified step and executes that step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-move-to-step.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-move-to-step.html>`_
 
         :param index: The name of the index whose lifecycle step is to change
         :param current_step:
@@ -346,7 +346,7 @@ class IlmClient(NamespacedClient):
         """
         Creates a lifecycle policy
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-put-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -399,7 +399,7 @@ class IlmClient(NamespacedClient):
         """
         Removes the assigned lifecycle policy and stops managing the specified index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-remove-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-remove-policy.html>`_
 
         :param index: The name of the index to remove policy on
         """
@@ -435,7 +435,7 @@ class IlmClient(NamespacedClient):
         """
         Retries executing the policy for an index that is in the ERROR step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-retry-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-retry-policy.html>`_
 
         :param index: The name of the indices (comma-separated) whose failed lifecycle
             step is to be retry
@@ -475,7 +475,7 @@ class IlmClient(NamespacedClient):
         """
         Start the index lifecycle management (ILM) plugin.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-start.html>`_
 
         :param master_timeout:
         :param timeout:
@@ -518,7 +518,7 @@ class IlmClient(NamespacedClient):
         Halts all lifecycle management operations and stops the index lifecycle management
         (ILM) plugin
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ilm-stop.html>`_
 
         :param master_timeout:
         :param timeout:

--- a/elasticsearch/_sync/client/indices.py
+++ b/elasticsearch/_sync/client/indices.py
@@ -64,7 +64,7 @@ class IndicesClient(NamespacedClient):
         """
         Adds a block to an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/index-modules-blocks.html>`_
 
         :param index: A comma separated list of indices to add a block to
         :param block: The block to add (one of read, write, read_only or metadata)
@@ -144,18 +144,28 @@ class IndicesClient(NamespacedClient):
         Performs the analysis process on a text and return the tokens breakdown of the
         text.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-analyze.html>`_
 
-        :param index: The name of the index to scope the operation
-        :param analyzer:
-        :param attributes:
-        :param char_filter:
-        :param explain:
-        :param field:
-        :param filter:
-        :param normalizer:
-        :param text:
-        :param tokenizer:
+        :param index: Index used to derive the analyzer. If specified, the `analyzer`
+            or field parameter overrides this value. If no index is specified or the
+            index does not have a default analyzer, the analyze API uses the standard
+            analyzer.
+        :param analyzer: The name of the analyzer that should be applied to the provided
+            `text`. This could be a built-in analyzer, or an analyzer that’s been configured
+            in the index.
+        :param attributes: Array of token attributes used to filter the output of the
+            `explain` parameter.
+        :param char_filter: Array of character filters used to preprocess characters
+            before the tokenizer.
+        :param explain: If `true`, the response includes token attributes and additional
+            details.
+        :param field: Field used to derive the analyzer. To use this parameter, you must
+            specify an index. If specified, the `analyzer` parameter overrides this value.
+        :param filter: Array of token filters used to apply after the tokenizer.
+        :param normalizer: Normalizer to use to convert text into a single token.
+        :param text: Text to analyze. If an array of strings is provided, it is analyzed
+            as a multi-value field.
+        :param tokenizer: Tokenizer to use to convert text into tokens.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_analyze"
@@ -239,21 +249,26 @@ class IndicesClient(NamespacedClient):
         """
         Clears all or specific caches for one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-clearcache.html>`_
 
-        :param index: A comma-separated list of index name to limit the operation
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param fielddata: Clear field data
-        :param fields: A comma-separated list of fields to clear when using the `fielddata`
-            parameter (default: all)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param query: Clear query caches
-        :param request: Clear request cache
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param fielddata: If `true`, clears the fields cache. Use the `fields` parameter
+            to clear the cache of specific fields only.
+        :param fields: Comma-separated list of field names used to limit the `fielddata`
+            parameter.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param query: If `true`, clears the query cache.
+        :param request: If `true`, clears the request cache.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_cache/clear"
@@ -314,16 +329,20 @@ class IndicesClient(NamespacedClient):
         """
         Clones an index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-clone-index.html>`_
 
-        :param index: The name of the source index to clone
-        :param target: The name of the target index to clone into
-        :param aliases:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the cloned index before the operation returns.
+        :param index: Name of the source index to clone.
+        :param target: Name of the target index to create.
+        :param aliases: Aliases for the resulting index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the target index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -401,20 +420,27 @@ class IndicesClient(NamespacedClient):
         """
         Closes an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-close.html>`_
 
-        :param index: A comma separated list of indices to close
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Sets the number of active shards to wait for before
-            the operation returns.
+        :param index: Comma-separated list or wildcard expression of index names used
+            to limit the request.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -472,17 +498,21 @@ class IndicesClient(NamespacedClient):
         """
         Creates an index with optional settings and mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-create-index.html>`_
 
-        :param index: The name of the index
-        :param aliases:
+        :param index: Name of the index you wish to create.
+        :param aliases: Aliases for the index.
         :param mappings: Mapping for fields in the index. If specified, this mapping
             can include: - Field names - Field data types - Mapping parameters
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for before
-            the operation returns.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -533,9 +563,13 @@ class IndicesClient(NamespacedClient):
         """
         Creates a data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: The name of the data stream
+        :param name: Name of the data stream, which must meet the following criteria:
+            Lowercase only; Cannot include `\\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`,
+            `#`, `:`, or a space character; Cannot start with `-`, `_`, `+`, or `.ds-`;
+            Cannot be `.` or `..`; Cannot be longer than 255 bytes. Multi-byte characters
+            count towards this limit faster.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -587,11 +621,13 @@ class IndicesClient(NamespacedClient):
         """
         Provides statistics on operations happening in a data stream.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: A comma-separated list of data stream names; use `_all` or empty
-            string to perform the operation on all data streams
-        :param expand_wildcards:
+        :param name: Comma-separated list of data streams used to limit the request.
+            Wildcard expressions (`*`) are supported. To target all data streams in a
+            cluster, omit this parameter or use `*`.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_data_stream/{_quote(name)}/_stats"
@@ -652,17 +688,26 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-delete-index.html>`_
 
-        :param index: A comma-separated list of indices to delete; use `_all` or `*`
-            string to delete all indices
-        :param allow_no_indices: Ignore if a wildcard expression resolves to no concrete
-            indices (default: false)
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open, closed, or hidden indices
-        :param ignore_unavailable: Ignore unavailable indexes (default: false)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param index: Comma-separated list of indices to delete. You cannot specify index
+            aliases. By default, this parameter does not support wildcards (`*`) or `_all`.
+            To use wildcards or `_all`, set the `action.destructive_requires_name` cluster
+            setting to `false`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -711,14 +756,17 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param index: A comma-separated list of index names (supports wildcards); use
-            `_all` for all indices
-        :param name: A comma-separated list of aliases to delete (supports wildcards);
-            use `_all` to delete all aliases for the specified indices.
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit timestamp for the document
+        :param index: Comma-separated list of data streams or indices used to limit the
+            request. Supports wildcards (`*`).
+        :param name: Comma-separated list of aliases to remove. Supports wildcards (`*`).
+            To remove all aliases, use `*` or `_all`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -780,7 +828,7 @@ class IndicesClient(NamespacedClient):
         """
         Deletes the data lifecycle of the selected data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-delete-lifecycle.html>`_
 
         :param name: A comma-separated list of data streams of which the data lifecycle
             will be deleted; use `*` to get all data streams
@@ -845,12 +893,12 @@ class IndicesClient(NamespacedClient):
         """
         Deletes a data stream.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: A comma-separated list of data streams to delete; use `*` to delete
-            all data streams
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
+        :param name: Comma-separated list of data streams to delete. Wildcard (`*`) expressions
+            are supported.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values,such as `open,hidden`.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -890,7 +938,7 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -940,11 +988,15 @@ class IndicesClient(NamespacedClient):
         """
         Deletes an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
-        :param name: The name of the template
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param name: The name of the legacy index template to delete. Wildcard (`*`)
+            expressions are supported.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -1004,27 +1056,27 @@ class IndicesClient(NamespacedClient):
         """
         Analyzes the disk usage of each field of an index or data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-disk-usage.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. It’s recommended to execute this API with a single
             index (or the latest backing index of a data stream) as the API consumes
             resources significantly.
         :param allow_no_indices: If false, the request returns an error if any wildcard
-            expression, index alias, or _all value targets only missing or closed indices.
+            expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
-            example, a request targeting foo*,bar* returns an error if an index starts
-            with foo but no index starts with bar.
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
         :param expand_wildcards: Type of index that wildcard patterns can match. If the
             request can target data streams, this argument determines whether wildcard
             expressions match hidden data streams. Supports comma-separated values, such
-            as open,hidden.
-        :param flush: If true, the API performs a flush before analysis. If false, the
-            response may not include uncommitted data.
-        :param ignore_unavailable: If true, missing or closed indices are not included
+            as `open,hidden`.
+        :param flush: If `true`, the API performs a flush before analysis. If `false`,
+            the response may not include uncommitted data.
+        :param ignore_unavailable: If `true`, missing or closed indices are not included
             in the response.
         :param run_expensive_tasks: Analyzing field disk usage is resource-intensive.
-            To use the API, this parameter must be set to true.
+            To use the API, this parameter must be set to `true`.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1072,10 +1124,10 @@ class IndicesClient(NamespacedClient):
         """
         Downsample an index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-rollup.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-downsample-data-stream.html>`_
 
-        :param index: The index to downsample
-        :param target_index: The name of the target index to store downsampled data
+        :param index: Name of the time series index to downsample.
+        :param target_index: Name of the index to create.
         :param config:
         """
         if index in SKIP_IN_PATH:
@@ -1138,19 +1190,23 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular index exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-exists.html>`_
 
-        :param index: A comma-separated list of index names
-        :param allow_no_indices: Ignore if a wildcard expression resolves to no concrete
-            indices (default: false)
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
-        :param flat_settings: Return settings in flat format (default: false)
-        :param ignore_unavailable: Ignore unavailable indexes (default: false)
-        :param include_defaults: Whether to return all default setting for each of the
-            indices.
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param index: Comma-separated list of data streams, indices, and aliases. Supports
+            wildcards (`*`).
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param include_defaults: If `true`, return all default settings in the response.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1218,19 +1274,23 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular alias exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param name: A comma-separated list of alias names to return
-        :param index: A comma-separated list of index names to filter aliases
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param name: Comma-separated list of aliases to check. Supports wildcards (`*`).
+        :param index: Comma-separated list of data streams or indices used to limit the
+            request. Supports wildcards (`*`). To target all data streams and indices,
+            omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, requests that include a missing data stream
+            or index in the target indices or data streams return an error.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -1280,7 +1340,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular index template exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1327,7 +1387,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about whether a particular index template exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: The comma separated names of the index templates
         :param flat_settings: Return settings in flat format (default: false)
@@ -1378,7 +1438,7 @@ class IndicesClient(NamespacedClient):
         Retrieves information about the index's current DLM lifecycle, such as any potential
         encountered error, time since creation etc.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-explain-lifecycle.html>`_
 
         :param index: The name of the index to explain
         :param include_defaults: indicates if the API should return the default values
@@ -1451,12 +1511,12 @@ class IndicesClient(NamespacedClient):
         """
         Returns the field usage stats for each field of an index
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/field-usage-stats.html>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
-        :param allow_no_indices: If false, the request returns an error if any wildcard
-            expression, index alias, or _all value targets only missing or closed indices.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
             example, a request targeting `foo*,bar*` returns an error if an index starts
             with `foo` but no index starts with `bar`.
@@ -1466,7 +1526,7 @@ class IndicesClient(NamespacedClient):
             as `open,hidden`.
         :param fields: Comma-separated list or wildcard expressions of fields to include
             in the statistics.
-        :param ignore_unavailable: If true, missing or closed indices are not included
+        :param ignore_unavailable: If `true`, missing or closed indices are not included
             in the response.
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -1545,25 +1605,25 @@ class IndicesClient(NamespacedClient):
         """
         Performs the flush operation on one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-flush.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            for all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param force: Whether a flush should be forced even if it is not necessarily
-            needed ie. if no changes will be committed to the index. This is useful if
-            transaction log IDs should be incremented even if no uncommitted changes
-            are present. (This setting can be considered as internal)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param wait_if_ongoing: If set to true the flush operation will block until the
-            flush can be executed if another flush operation is already executing. The
-            default is true. If set to false the flush will be skipped iff if another
-            flush operation is already running.
+        :param index: Comma-separated list of data streams, indices, and aliases to flush.
+            Supports wildcards (`*`). To flush all data streams and indices, omit this
+            parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param force: If `true`, the request forces a flush even if there are no changes
+            to commit to the index.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param wait_if_ongoing: If `true`, the flush operation blocks until execution
+            when another flush operation is running. If `false`, Elasticsearch returns
+            an error if you request a flush when another flush operation is running.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_flush"
@@ -1632,7 +1692,7 @@ class IndicesClient(NamespacedClient):
         """
         Performs the force merge operation on one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-forcemerge.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -1739,7 +1799,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-index.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported.
@@ -1834,19 +1894,24 @@ class IndicesClient(NamespacedClient):
         """
         Returns an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param index: A comma-separated list of index names to filter aliases
-        :param name: A comma-separated list of alias names to return
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param index: Comma-separated list of data streams or indices used to limit the
+            request. Supports wildcards (`*`). To target all data streams and indices,
+            omit this parameter or use `*` or `_all`.
+        :param name: Comma-separated list of aliases to retrieve. Supports wildcards
+            (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_alias/{_quote(name)}"
@@ -1912,14 +1977,15 @@ class IndicesClient(NamespacedClient):
         """
         Returns the data lifecycle of the selected data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-get-lifecycle.html>`_
 
-        :param name: A comma-separated list of data streams to get; use `*` to get all
-            data streams
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
-        :param include_defaults: Return all relevant default configurations for the data
-            stream (default: false)
+        :param name: Comma-separated list of data streams to limit the request. Supports
+            wildcards (`*`). To target all data streams, omit this parameter or use `*`
+            or `_all`.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`. Valid values are:
+            `all`, `open`, `closed`, `hidden`, `none`.
+        :param include_defaults: If `true`, return all default settings in the response.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -1976,12 +2042,13 @@ class IndicesClient(NamespacedClient):
         """
         Returns data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: A comma-separated list of data streams to get; use `*` to get all
-            data streams
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
+        :param name: Comma-separated list of data stream names used to limit the request.
+            Wildcard (`*`) expressions are supported. If omitted, all data streams are
+            returned.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`.
         :param include_defaults: If true, returns all relevant default configurations
             for the index template.
         """
@@ -2045,21 +2112,25 @@ class IndicesClient(NamespacedClient):
         """
         Returns mapping for one or more fields.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-field-mapping.html>`_
 
-        :param fields: A comma-separated list of fields
-        :param index: A comma-separated list of index names
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param include_defaults: Whether the default mapping values should be returned
-            as well
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
+        :param fields: Comma-separated list or wildcard expression of fields used to
+            limit returned information.
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param include_defaults: If `true`, return all default settings in the response.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
         """
         if fields in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'fields'")
@@ -2114,7 +2185,7 @@ class IndicesClient(NamespacedClient):
         """
         Returns an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -2193,19 +2264,25 @@ class IndicesClient(NamespacedClient):
         """
         Returns mappings for one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-mapping.html>`_
 
-        :param index: A comma-separated list of index names
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Specify timeout for connection to master
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_mapping"
@@ -2277,24 +2354,30 @@ class IndicesClient(NamespacedClient):
         """
         Returns settings for one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-get-settings.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param name: The name of the settings that should be included
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param flat_settings: Return settings in flat format (default: false)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param include_defaults: Whether to return all default setting for each of the
-            indices.
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Specify timeout for connection to master
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param name: Comma-separated list or wildcard expression of settings to retrieve.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with foo but no index starts with `bar`.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param include_defaults: If `true`, return all default settings in the response.
+        :param local: If `true`, the request retrieves information from the local node
+            only. If `false`, information is retrieved from the master node.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_settings/{_quote(name)}"
@@ -2352,13 +2435,17 @@ class IndicesClient(NamespacedClient):
         """
         Returns an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
-        :param name: The comma separated names of the index templates
-        :param flat_settings: Return settings in flat format (default: false)
-        :param local: Return local information, do not retrieve the state from master
-            node (default: false)
-        :param master_timeout: Explicit operation timeout for connection to master node
+        :param name: Comma-separated list of index template names used to limit the request.
+            Wildcard (`*`) expressions are supported. To return all index templates,
+            omit this parameter or use a value of `_all` or `*`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param local: If `true`, the request retrieves information from the local node
+            only.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if name not in SKIP_IN_PATH:
             __path = f"/_template/{_quote(name)}"
@@ -2399,9 +2486,9 @@ class IndicesClient(NamespacedClient):
         """
         Migrates an alias to a data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
-        :param name: The name of the alias to migrate
+        :param name: Name of the index alias to convert to a data stream.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -2439,7 +2526,7 @@ class IndicesClient(NamespacedClient):
         """
         Modifies a data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
         :param actions: Actions to perform.
         """
@@ -2505,20 +2592,31 @@ class IndicesClient(NamespacedClient):
         """
         Opens an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-open-close.html>`_
 
-        :param index: A comma separated list of indices to open
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Sets the number of active shards to wait for before
-            the operation returns.
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). By default, you must explicitly
+            name the indices you using to limit the request. To limit a request using
+            `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name`
+            setting to false. You can update this setting in the `elasticsearch.yml`
+            file or using the cluster update settings API.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2565,7 +2663,7 @@ class IndicesClient(NamespacedClient):
         Promotes a data stream from a replicated data stream managed by CCR to a regular
         data stream
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/data-streams.html>`_
 
         :param name: The name of the data stream
         """
@@ -2613,18 +2711,33 @@ class IndicesClient(NamespacedClient):
         """
         Creates or updates an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param index: A comma-separated list of index names the alias should point to
-            (supports wildcards); use `_all` to perform the operation on all indices.
-        :param name: The name of the alias to be created or updated
-        :param filter:
-        :param index_routing:
-        :param is_write_index:
-        :param master_timeout: Specify timeout for connection to master
-        :param routing:
-        :param search_routing:
-        :param timeout: Explicit timestamp for the document
+        :param index: Comma-separated list of data streams or indices to add. Supports
+            wildcards (`*`). Wildcard patterns that match both data streams and indices
+            return an error.
+        :param name: Alias to update. If the alias doesn’t exist, the request creates
+            it. Index alias names support date math.
+        :param filter: Query used to limit documents the alias can access.
+        :param index_routing: Value used to route indexing operations to a specific shard.
+            If specified, this overwrites the `routing` value for indexing operations.
+            Data stream aliases don’t support this parameter.
+        :param is_write_index: If `true`, sets the write index or data stream for the
+            alias. If an alias points to multiple indices or data streams and `is_write_index`
+            isn’t set, the alias rejects write requests. If an index alias points to
+            one index and `is_write_index` isn’t set, the index automatically acts as
+            the write index. Data stream aliases don’t automatically set a write data
+            stream, even if the alias points to one data stream.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param routing: Value used to route indexing and search operations to a specific
+            shard. Data stream aliases don’t support this parameter.
+        :param search_routing: Value used to route search operations to a specific shard.
+            If specified, this overwrites the `routing` value for search operations.
+            Data stream aliases don’t support this parameter.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2706,15 +2819,22 @@ class IndicesClient(NamespacedClient):
         """
         Updates the data lifecycle of the selected data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/dlm-put-lifecycle.html>`_
 
-        :param name: A comma-separated list of data streams whose lifecycle will be updated;
-            use `*` to set the lifecycle to all data streams
-        :param data_retention:
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit timestamp for the document
+        :param name: Comma-separated list of data streams used to limit the request.
+            Supports wildcards (`*`). To target all data streams use `*` or `_all`.
+        :param data_retention: If defined, every document added to this data stream will
+            be stored at least for this time frame. Any time after this duration the
+            document could be deleted. When empty, every document in this data stream
+            will be stored indefinitely.
+        :param expand_wildcards: Type of data stream that wildcard patterns can match.
+            Supports comma-separated values, such as `open,hidden`. Valid values are:
+            `all`, `hidden`, `open`, `closed`, `none`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -2774,18 +2894,29 @@ class IndicesClient(NamespacedClient):
         """
         Creates or updates an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Index or template name
-        :param composed_of:
-        :param create: Whether the index template should only be added if new or can
-            also replace an existing one
-        :param data_stream:
-        :param index_patterns:
-        :param meta:
-        :param priority:
-        :param template:
-        :param version:
+        :param composed_of: An ordered list of component template names. Component templates
+            are merged in the order specified, meaning that the last component template
+            specified has the highest precedence.
+        :param create: If `true`, this request cannot replace or update existing index
+            templates.
+        :param data_stream: If this object is included, the template is used to create
+            data streams and their backing indices. Supports an empty object. Data streams
+            require a matching index template with a `data_stream` object.
+        :param index_patterns: Name of the index template to create.
+        :param meta: Optional user metadata about the index template. May have any contents.
+            This map is not automatically generated by Elasticsearch.
+        :param priority: Priority to determine index template precedence when a new data
+            stream or index is created. The index template with the highest priority
+            is chosen. If no priority is specified the template is treated as though
+            it is of priority 0 (lowest priority). This number is not automatically generated
+            by Elasticsearch.
+        :param template: Template to be applied. It may optionally include an `aliases`,
+            `mappings`, or `settings` configuration.
+        :param version: Version number used to manage index templates externally. This
+            number is not automatically generated by Elasticsearch.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -2892,25 +3023,29 @@ class IndicesClient(NamespacedClient):
         """
         Updates the index mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-put-mapping.html>`_
 
         :param index: A comma-separated list of index names the mapping should be added
             to (supports wildcards); use `_all` or omit to add the mapping on all indices.
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
         :param date_detection: Controls whether dynamic date detection is enabled.
         :param dynamic: Controls whether new fields are added dynamically.
         :param dynamic_date_formats: If date detection is enabled then new string fields
             are checked against 'dynamic_date_formats' and if the value matches then
             a new date field is added instead of string.
         :param dynamic_templates: Specify dynamic templates for the mapping.
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         :param field_names: Control whether field names are enabled for the index.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         :param meta: A mapping type can have custom meta data associated with it. These
             are not used at all by Elasticsearch, but can be used to store application-specific
             metadata.
@@ -2921,9 +3056,10 @@ class IndicesClient(NamespacedClient):
         :param routing: Enable making a routing value required on indexed documents.
         :param runtime: Mapping of runtime fields for the index.
         :param source: Control whether the _source field is enabled on the index.
-        :param timeout: Explicit operation timeout
-        :param write_index_only: When true, applies mappings only to the write index
-            of an alias or data stream
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param write_index_only: If `true`, the mappings are applied only to the current
+            write index for the target.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3021,23 +3157,29 @@ class IndicesClient(NamespacedClient):
         """
         Updates the index settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-update-settings.html>`_
 
         :param settings:
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param flat_settings: Return settings in flat format (default: false)
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param preserve_existing: Whether to update existing settings. If set to `true`
-            existing settings on an index remain unchanged, the default is `false`
-        :param timeout: Explicit operation timeout
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`.
+        :param flat_settings: If `true`, returns settings in flat format.
+        :param ignore_unavailable: If `true`, returns settings in flat format.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param preserve_existing: If `true`, existing index settings remain unchanged.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if settings is None:
             raise ValueError("Empty value passed for parameter 'settings'")
@@ -3105,13 +3247,13 @@ class IndicesClient(NamespacedClient):
         """
         Creates or updates an index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: The name of the template
         :param aliases: Aliases for the index.
         :param create: If true, this request cannot replace or update existing index
             templates.
-        :param flat_settings:
+        :param flat_settings: If `true`, returns settings in flat format.
         :param index_patterns: Array of wildcard expressions used to match the names
             of indices during creation.
         :param mappings: Mapping for fields in the index.
@@ -3123,7 +3265,8 @@ class IndicesClient(NamespacedClient):
             Templates with higher 'order' values are merged later, overriding templates
             with lower values.
         :param settings: Configuration options for the index.
-        :param timeout:
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         :param version: Version number used to manage index templates externally. This
             number is not automatically generated by Elasticsearch.
         """
@@ -3182,12 +3325,14 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about ongoing index shard recoveries.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-recovery.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param active_only: Display only those recoveries that are currently on-going
-        :param detailed: Whether to display detailed information about shard recovery
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param active_only: If `true`, the response only includes ongoing shard recoveries.
+        :param detailed: If `true`, the response includes detailed information about
+            shard recoveries.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_recovery"
@@ -3246,17 +3391,20 @@ class IndicesClient(NamespacedClient):
         """
         Performs the refresh operation in one or more indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-refresh.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_refresh"
@@ -3317,7 +3465,7 @@ class IndicesClient(NamespacedClient):
         """
         Reloads an index's search analyzers and their resources.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-reload-analyzers.html>`_
 
         :param index: A comma-separated list of index names to reload analyzers for
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -3384,11 +3532,15 @@ class IndicesClient(NamespacedClient):
         """
         Returns information about any matching indices, aliases, and data streams
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-resolve-index-api.html>`_
 
-        :param name: A comma-separated list of names or wildcard expressions
-        :param expand_wildcards: Whether wildcard expressions should get expanded to
-            open or closed indices (default: open)
+        :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
+            and data streams to resolve. Resources on remote clusters can be specified
+            using the `<cluster>`:`<name>` syntax.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -3440,20 +3592,33 @@ class IndicesClient(NamespacedClient):
         Updates an alias to point to a new index when the existing index is considered
         to be too large or too old.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-rollover-index.html>`_
 
-        :param alias: The name of the alias to rollover
-        :param new_index: The name of the rollover index
-        :param aliases:
-        :param conditions:
-        :param dry_run: If set to true the rollover action will only be validated but
-            not actually performed even if a condition matches. The default is false
-        :param mappings:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the newly created rollover index before the operation returns.
+        :param alias: Name of the data stream or index alias to roll over.
+        :param new_index: Name of the index to create. Supports date math. Data streams
+            do not support this parameter.
+        :param aliases: Aliases for the target index. Data streams do not support this
+            parameter.
+        :param conditions: Conditions for the rollover. If specified, Elasticsearch only
+            performs the rollover if the current index satisfies these conditions. If
+            this parameter is not specified, Elasticsearch performs the rollover unconditionally.
+            If conditions are specified, at least one of them must be a `max_*` condition.
+            The index will rollover if any `max_*` condition is satisfied and all `min_*`
+            conditions are satisfied.
+        :param dry_run: If `true`, checks whether the current index satisfies the specified
+            conditions but does not perform a rollover.
+        :param mappings: Mapping for fields in the index. If specified, this mapping
+            can include field names, field data types, and mapping paramaters.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the index. Data streams do not support
+            this parameter.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to all or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'alias'")
@@ -3534,18 +3699,21 @@ class IndicesClient(NamespacedClient):
         """
         Provides low-level information about segments in a Lucene index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-segments.html>`_
 
-        :param index: A comma-separated list of index names; use `_all` or empty string
-            to perform the operation on all indices
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param verbose: Includes detailed memory usage by Lucene.
+        :param index: Comma-separated list of data streams, indices, and aliases used
+            to limit the request. Supports wildcards (`*`). To target all data streams
+            and indices, omit this parameter or use `*` or `_all`.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param verbose: If `true`, the request returns a verbose response.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_segments"
@@ -3619,7 +3787,7 @@ class IndicesClient(NamespacedClient):
         """
         Provides store information for shard copies of indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-shards-stores.html>`_
 
         :param index: List of data streams, indices, and aliases used to limit the request.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -3685,16 +3853,20 @@ class IndicesClient(NamespacedClient):
         """
         Allow to shrink an existing index into a new index with fewer primary shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-shrink-index.html>`_
 
-        :param index: The name of the source index to shrink
-        :param target: The name of the target index to shrink into
-        :param aliases:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the shrunken index before the operation returns.
+        :param index: Name of the source index to shrink.
+        :param target: Name of the target index to create.
+        :param aliases: The key is the alias name. Index alias names support date math.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the target index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3763,26 +3935,43 @@ class IndicesClient(NamespacedClient):
         """
         Simulate matching the given index name against the index templates in the system
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Index or template name to simulate
-        :param allow_auto_create:
-        :param composed_of:
+        :param allow_auto_create: This setting overrides the value of the `action.auto_create_index`
+            cluster setting. If set to `true` in a template, then indices can be automatically
+            created using that template even if auto-creation of indices is disabled
+            via `actions.auto_create_index`. If set to `false`, then indices or data
+            streams matching the template must always be explicitly created, and may
+            never be automatically created.
+        :param composed_of: An ordered list of component template names. Component templates
+            are merged in the order specified, meaning that the last component template
+            specified has the highest precedence.
         :param create: If `true`, the template passed in the body is only used if no
             existing templates match the same index patterns. If `false`, the simulation
             uses the template with the highest priority. Note that the template is not
             permanently added or updated in either case; it is only used for the simulation.
-        :param data_stream:
+        :param data_stream: If this object is included, the template is used to create
+            data streams and their backing indices. Supports an empty object. Data streams
+            require a matching index template with a `data_stream` object.
         :param include_defaults: If true, returns all relevant default configurations
             for the index template.
-        :param index_patterns:
+        :param index_patterns: Array of wildcard (`*`) expressions used to match the
+            names of data streams and indices during creation.
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
             returns an error.
-        :param meta:
-        :param priority:
-        :param template:
-        :param version:
+        :param meta: Optional user metadata about the index template. May have any contents.
+            This map is not automatically generated by Elasticsearch.
+        :param priority: Priority to determine index template precedence when a new data
+            stream or index is created. The index template with the highest priority
+            is chosen. If no priority is specified the template is treated as though
+            it is of priority 0 (lowest priority). This number is not automatically generated
+            by Elasticsearch.
+        :param template: Template to be applied. It may optionally include an `aliases`,
+            `mappings`, or `settings` configuration.
+        :param version: Version number used to manage index templates externally. This
+            number is not automatically generated by Elasticsearch.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -3851,7 +4040,7 @@ class IndicesClient(NamespacedClient):
         """
         Simulate resolving the given template name or body
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-templates.html>`_
 
         :param name: Name of the index template to simulate. To test a template configuration
             before you add it to the cluster, omit this parameter and specify the template
@@ -3923,16 +4112,20 @@ class IndicesClient(NamespacedClient):
         """
         Allows you to split an existing index into a new index with more primary shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-split-index.html>`_
 
-        :param index: The name of the source index to split
-        :param target: The name of the target index to split into
-        :param aliases:
-        :param master_timeout: Specify timeout for connection to master
-        :param settings:
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Set the number of active shards to wait for on
-            the shrunken index before the operation returns.
+        :param index: Name of the source index to split.
+        :param target: Name of the target index to create.
+        :param aliases: Aliases for the resulting index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param settings: Configuration options for the target index.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -4022,7 +4215,7 @@ class IndicesClient(NamespacedClient):
         """
         Provides statistics on operations happening in an index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-stats.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -4130,20 +4323,26 @@ class IndicesClient(NamespacedClient):
         Unfreezes an index. When a frozen index is unfrozen, the index goes through the
         normal recovery process and becomes writeable again.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/unfreeze-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/unfreeze-index-api.html>`_
 
-        :param index: The name of the index to unfreeze
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
-        :param wait_for_active_shards: Sets the number of active shards to wait for before
-            the operation returns.
+        :param index: Identifier for the index.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
+        :param wait_for_active_shards: The number of shard copies that must be active
+            before proceeding with the operation. Set to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`).
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -4197,11 +4396,14 @@ class IndicesClient(NamespacedClient):
         """
         Updates index aliases.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/indices-aliases.html>`_
 
-        :param actions:
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Request timeout
+        :param actions: Actions to perform.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         __path = "/_aliases"
         __body: t.Dict[str, t.Any] = {}
@@ -4272,33 +4474,38 @@ class IndicesClient(NamespacedClient):
         """
         Allows a user to validate a potentially expensive query without executing it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-validate.html>`_
 
-        :param index: A comma-separated list of index names to restrict the operation;
-            use `_all` or empty string to perform the operation on all indices
-        :param all_shards: Execute validation on all shards instead of one random shard
-            per index
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param analyze_wildcard: Specify whether wildcard and prefix queries should be
-            analyzed (default: false)
-        :param analyzer: The analyzer to use for the query string
-        :param default_operator: The default operator for query string query (AND or
-            OR)
-        :param df: The field to use as default where no field prefix is given in the
-            query string
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param explain: Return detailed information about the error
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param lenient: Specify whether format-based query failures (such as providing
-            text to a numeric field) should be ignored
-        :param q: Query in the Lucene query string syntax
-        :param query:
-        :param rewrite: Provide a more detailed explanation showing the actual Lucene
-            query that will be executed.
+        :param index: Comma-separated list of data streams, indices, and aliases to search.
+            Supports wildcards (`*`). To search all data streams or indices, omit this
+            parameter or use `*` or `_all`.
+        :param all_shards: If `true`, the validation is executed on all shards instead
+            of one random shard per index.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices.
+        :param analyze_wildcard: If `true`, wildcard and prefix queries are analyzed.
+        :param analyzer: Analyzer to use for the query string. This parameter can only
+            be used when the `q` query string parameter is specified.
+        :param default_operator: The default operator for query string query: `AND` or
+            `OR`.
+        :param df: Field to use as default where no field prefix is given in the query
+            string. This parameter can only be used when the `q` query string parameter
+            is specified.
+        :param expand_wildcards: Type of index that wildcard patterns can match. If the
+            request can target data streams, this argument determines whether wildcard
+            expressions match hidden data streams. Supports comma-separated values, such
+            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param explain: If `true`, the response returns detailed information if an error
+            has occurred.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param lenient: If `true`, format-based query failures (such as providing text
+            to a numeric field) in the query string will be ignored.
+        :param q: Query in the Lucene query string syntax.
+        :param query: Query in the Lucene query string syntax.
+        :param rewrite: If `true`, returns a more detailed explanation showing the actual
+            Lucene query that will be executed.
         """
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_validate/query"

--- a/elasticsearch/_sync/client/ingest.py
+++ b/elasticsearch/_sync/client/ingest.py
@@ -43,11 +43,15 @@ class IngestClient(NamespacedClient):
         """
         Deletes a pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-pipeline-api.html>`_
 
-        :param id: Pipeline ID
-        :param master_timeout: Explicit operation timeout for connection to master node
-        :param timeout: Explicit operation timeout
+        :param id: Pipeline ID or wildcard expression of pipeline IDs used to limit the
+            request. To delete all ingest pipelines in a cluster, use a value of `*`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
+        :param timeout: Period to wait for a response. If no response is received before
+            the timeout expires, the request fails and returns an error.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -84,7 +88,7 @@ class IngestClient(NamespacedClient):
         """
         Returns statistical information about geoip databases
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/geoip-processor.html>`_
         """
         __path = "/_ingest/geoip/stats"
         __query: t.Dict[str, t.Any] = {}
@@ -120,10 +124,13 @@ class IngestClient(NamespacedClient):
         """
         Returns a pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-pipeline-api.html>`_
 
-        :param id: Comma separated list of pipeline ids. Wildcards supported
-        :param master_timeout: Explicit operation timeout for connection to master node
+        :param id: Comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions
+            are supported. To get all ingest pipelines, omit this parameter or use `*`.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         :param summary: Return pipelines without their definitions (default: false)
         """
         if id not in SKIP_IN_PATH:
@@ -162,7 +169,7 @@ class IngestClient(NamespacedClient):
         """
         Returns a list of the built-in patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/grok-processor.html>`_
         """
         __path = "/_ingest/processor/grok"
         __query: t.Dict[str, t.Any] = {}
@@ -211,7 +218,7 @@ class IngestClient(NamespacedClient):
         """
         Creates or updates a pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ingest.html>`_
 
         :param id: ID of the ingest pipeline to create or update.
         :param description: Description of the ingest pipeline.
@@ -292,13 +299,16 @@ class IngestClient(NamespacedClient):
         """
         Allows to simulate a pipeline with example documents.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/simulate-pipeline-api.html>`_
 
-        :param id: Pipeline ID
-        :param docs:
-        :param pipeline:
-        :param verbose: Verbose mode. Display data output for each processor in executed
-            pipeline
+        :param id: Pipeline to test. If you don’t specify a `pipeline` in the request
+            body, this parameter is required.
+        :param docs: Sample documents to test in the pipeline.
+        :param pipeline: Pipeline to test. If you don’t specify the `pipeline` request
+            path parameter, this parameter is required. If you specify both this and
+            the request path parameter, the API only uses the request path parameter.
+        :param verbose: If `true`, the response includes output data for each processor
+            in the executed pipeline.
         """
         if id not in SKIP_IN_PATH:
             __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"

--- a/elasticsearch/_sync/client/license.py
+++ b/elasticsearch/_sync/client/license.py
@@ -38,7 +38,7 @@ class LicenseClient(NamespacedClient):
         """
         Deletes licensing information for the cluster
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-license.html>`_
         """
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
@@ -71,7 +71,7 @@ class LicenseClient(NamespacedClient):
         """
         Retrieves licensing information for the cluster
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-license.html>`_
 
         :param accept_enterprise: If `true`, this parameter returns enterprise for Enterprise
             license types. If `false`, this parameter returns platinum for both platinum
@@ -113,7 +113,7 @@ class LicenseClient(NamespacedClient):
         """
         Retrieves information about the status of the basic license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-basic-status.html>`_
         """
         __path = "/_license/basic_status"
         __query: t.Dict[str, t.Any] = {}
@@ -144,7 +144,7 @@ class LicenseClient(NamespacedClient):
         """
         Retrieves information about the status of the trial license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-trial-status.html>`_
         """
         __path = "/_license/trial_status"
         __query: t.Dict[str, t.Any] = {}
@@ -182,7 +182,7 @@ class LicenseClient(NamespacedClient):
         """
         Updates the license for the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/update-license.html>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:
@@ -230,7 +230,7 @@ class LicenseClient(NamespacedClient):
         """
         Starts an indefinite basic license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-basic.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
@@ -268,7 +268,7 @@ class LicenseClient(NamespacedClient):
         """
         starts a limited time trial license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-trial.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)

--- a/elasticsearch/_sync/client/logstash.py
+++ b/elasticsearch/_sync/client/logstash.py
@@ -39,9 +39,9 @@ class LogstashClient(NamespacedClient):
         """
         Deletes Logstash Pipelines used by Central Management
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-delete-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/logstash-api-delete-pipeline.html>`_
 
-        :param id: The ID of the Pipeline
+        :param id: Identifier for the pipeline.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -75,9 +75,9 @@ class LogstashClient(NamespacedClient):
         """
         Retrieves Logstash Pipelines used by Central Management
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-get-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/logstash-api-get-pipeline.html>`_
 
-        :param id: A comma-separated list of Pipeline IDs
+        :param id: Comma-separated list of pipeline identifiers.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -117,9 +117,9 @@ class LogstashClient(NamespacedClient):
         """
         Adds and updates Logstash Pipelines used for Central Management
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-put-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/logstash-api-put-pipeline.html>`_
 
-        :param id: The ID of the Pipeline
+        :param id: Identifier for the pipeline.
         :param pipeline:
         """
         if id in SKIP_IN_PATH:

--- a/elasticsearch/_sync/client/migration.py
+++ b/elasticsearch/_sync/client/migration.py
@@ -41,7 +41,7 @@ class MigrationClient(NamespacedClient):
         that use deprecated features that will be removed or changed in the next major
         version.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/migration-api-deprecation.html>`_
 
         :param index: Comma-separate list of data streams or indices to check. Wildcard
             (*) expressions are supported.
@@ -78,7 +78,7 @@ class MigrationClient(NamespacedClient):
         """
         Find out whether system features need to be upgraded or not
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-feature-upgrade.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/migration-api-feature-upgrade.html>`_
         """
         __path = "/_migration/system_features"
         __query: t.Dict[str, t.Any] = {}
@@ -109,7 +109,7 @@ class MigrationClient(NamespacedClient):
         """
         Begin upgrades for system features
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-feature-upgrade.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/migration-api-feature-upgrade.html>`_
         """
         __path = "/_migration/system_features"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -39,7 +39,7 @@ class MlClient(NamespacedClient):
         """
         Clear the cached results from a trained model deployment
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-trained-model-deployment-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-trained-model-deployment-cache.html>`_
 
         :param model_id: The unique identifier of the trained model.
         """
@@ -81,7 +81,7 @@ class MlClient(NamespacedClient):
         Closes one or more anomaly detection jobs. A job can be opened and closed multiple
         times throughout its lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-close-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. You can close multiple anomaly detection
@@ -136,7 +136,7 @@ class MlClient(NamespacedClient):
         """
         Deletes a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         """
@@ -173,7 +173,7 @@ class MlClient(NamespacedClient):
         """
         Deletes scheduled events from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-calendar-event.html>`_
 
         :param calendar_id: The ID of the calendar to modify
         :param event_id: The ID of the event to remove from the calendar
@@ -213,7 +213,7 @@ class MlClient(NamespacedClient):
         """
         Deletes anomaly detection jobs from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -255,7 +255,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param force: If `true`, it deletes a job that is not stopped; this method is
@@ -299,7 +299,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -346,7 +346,7 @@ class MlClient(NamespacedClient):
         """
         Deletes expired and unused machine learning data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-expired-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-expired-data.html>`_
 
         :param job_id: Identifier for an anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression.
@@ -397,7 +397,7 @@ class MlClient(NamespacedClient):
         """
         Deletes a filter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         """
@@ -436,7 +436,7 @@ class MlClient(NamespacedClient):
         """
         Deletes forecasts from a machine learning job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param forecast_id: A comma-separated list of forecast identifiers. If you do
@@ -494,7 +494,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -544,7 +544,7 @@ class MlClient(NamespacedClient):
         """
         Deletes an existing model snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-delete-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -585,7 +585,7 @@ class MlClient(NamespacedClient):
         Deletes an existing trained inference model that is currently not referenced
         by an ingest pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param force: Forcefully deletes a trained model that is referenced by ingest
@@ -626,7 +626,7 @@ class MlClient(NamespacedClient):
         """
         Deletes a model alias that refers to the trained model
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-trained-models-aliases.html>`_
 
         :param model_id: The trained model ID to which the model alias refers.
         :param model_alias: The model alias to delete.
@@ -669,7 +669,7 @@ class MlClient(NamespacedClient):
         """
         Estimates the model memory
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-apis.html>`_
 
         :param analysis_config: For a list of the properties that you can specify in
             the `analysis_config` component of the body of this API.
@@ -727,7 +727,7 @@ class MlClient(NamespacedClient):
         """
         Evaluates the data frame analytics for an annotated index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/evaluate-dfanalytics.html>`_
 
         :param evaluation: Defines the type of evaluation you want to perform.
         :param index: Defines the `index` in which the evaluation will be performed.
@@ -785,7 +785,7 @@ class MlClient(NamespacedClient):
         """
         Explains a data frame analytics config.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/explain-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -876,7 +876,7 @@ class MlClient(NamespacedClient):
         """
         Forces any buffered data to be processed by the job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-flush-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-flush-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param advance_time: Refer to the description for the `advance_time` query parameter.
@@ -937,7 +937,7 @@ class MlClient(NamespacedClient):
         """
         Predicts the future behavior of a time series by using its historical behavior.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must be open
             when you create a forecast; otherwise, an error occurs.
@@ -1003,7 +1003,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly detection job results for one or more buckets.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-bucket.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-bucket.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timestamp: The timestamp of a single bucket result. If you do not specify
@@ -1090,7 +1090,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves information about the scheduled events in calendars.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1151,7 +1151,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for calendars.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1215,7 +1215,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly detection job results for one or more categories.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-category.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-category.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param category_id: Identifier for the category, which is unique in the job.
@@ -1283,7 +1283,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1349,7 +1349,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-dfanalytics-stats.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1410,7 +1410,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-datafeed-stats.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1462,7 +1462,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1521,7 +1521,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves filters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param from_: Skips the specified number of filters.
@@ -1576,7 +1576,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly detection job results for one or more influencers.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-influencer.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-influencer.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: If true, the results are sorted in descending order.
@@ -1650,7 +1650,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-job-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs, or a wildcard expression. If
@@ -1703,7 +1703,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. If you do not specify one of these
@@ -1760,7 +1760,7 @@ class MlClient(NamespacedClient):
         """
         Returns information on how ML is using memory.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-memory.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-ml-memory.html>`_
 
         :param node_id: The names of particular nodes in the cluster to target. For example,
             `nodeId1,nodeId2` or `ml:true`
@@ -1809,7 +1809,7 @@ class MlClient(NamespacedClient):
         """
         Gets stats for anomaly detection job model snapshot upgrades that are in progress.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-model-snapshot-upgrade-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-job-model-snapshot-upgrade-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -1872,7 +1872,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves information about model snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -1954,7 +1954,7 @@ class MlClient(NamespacedClient):
         Retrieves overall bucket results that summarize the bucket results of multiple
         anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-overall-buckets.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-overall-buckets.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs or groups, or a wildcard expression.
@@ -2034,7 +2034,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves anomaly records for an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-record.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-get-record.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: Refer to the description for the `desc` query parameter.
@@ -2117,7 +2117,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves configuration information for a trained inference model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: - Contains wildcard
@@ -2193,7 +2193,7 @@ class MlClient(NamespacedClient):
         """
         Retrieves usage information for trained inference models.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-trained-models-stats.html>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             It can be a comma-separated list or a wildcard expression.
@@ -2251,7 +2251,7 @@ class MlClient(NamespacedClient):
         """
         Evaluate a trained model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/infer-trained-model.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param docs: An array of objects to pass to the model for inference. The objects
@@ -2302,7 +2302,7 @@ class MlClient(NamespacedClient):
         """
         Returns defaults and limits used by machine learning.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-ml-info.html>`_
         """
         __path = "/_ml/info"
         __query: t.Dict[str, t.Any] = {}
@@ -2337,7 +2337,7 @@ class MlClient(NamespacedClient):
         """
         Opens one or more anomaly detection jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-open-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-open-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timeout: Refer to the description for the `timeout` query parameter.
@@ -2386,7 +2386,7 @@ class MlClient(NamespacedClient):
         """
         Posts scheduled events in a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-post-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param events: A list of one of more scheduled events. The event’s start and
@@ -2435,7 +2435,7 @@ class MlClient(NamespacedClient):
         """
         Sends data to an anomaly detection job for analysis.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-post-data.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must have a
             state of open to receive and process the data.
@@ -2488,7 +2488,7 @@ class MlClient(NamespacedClient):
         """
         Previews that will be analyzed given a data frame analytics config.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/preview-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param config: A data frame analytics config as described in create data frame
@@ -2541,7 +2541,7 @@ class MlClient(NamespacedClient):
         """
         Previews a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-preview-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-preview-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -2608,7 +2608,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param description: A description of the calendar.
@@ -2656,7 +2656,7 @@ class MlClient(NamespacedClient):
         """
         Adds an anomaly detection job to a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -2711,7 +2711,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -2872,7 +2872,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3018,7 +3018,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates a filter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param description: A description of the filter.
@@ -3081,7 +3081,7 @@ class MlClient(NamespacedClient):
         """
         Instantiates an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-put-job.html>`_
 
         :param job_id: The identifier for the anomaly detection job. This identifier
             can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and
@@ -3217,7 +3217,6 @@ class MlClient(NamespacedClient):
         self,
         *,
         model_id: str,
-        inference_config: t.Mapping[str, t.Any],
         compressed_definition: t.Optional[str] = None,
         defer_definition_decompression: t.Optional[bool] = None,
         definition: t.Optional[t.Mapping[str, t.Any]] = None,
@@ -3227,6 +3226,7 @@ class MlClient(NamespacedClient):
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
         human: t.Optional[bool] = None,
+        inference_config: t.Optional[t.Mapping[str, t.Any]] = None,
         input: t.Optional[t.Mapping[str, t.Any]] = None,
         metadata: t.Optional[t.Any] = None,
         model_size_bytes: t.Optional[int] = None,
@@ -3239,12 +3239,9 @@ class MlClient(NamespacedClient):
         """
         Creates an inference trained model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
-        :param inference_config: The default configuration for inference. This can be
-            either a regression or classification configuration. It must match the underlying
-            definition.trained_model's target_type.
         :param compressed_definition: The compressed (GZipped and Base64 encoded) inference
             definition of the model. If compressed_definition is specified, then definition
             cannot be specified.
@@ -3254,6 +3251,10 @@ class MlClient(NamespacedClient):
         :param definition: The inference definition for the model. If definition is specified,
             then compressed_definition cannot be specified.
         :param description: A human-readable description of the inference trained model.
+        :param inference_config: The default configuration for inference. This can be
+            either a regression or classification configuration. It must match the underlying
+            definition.trained_model's target_type. For pre-packaged models such as ELSER
+            the config is not required.
         :param input: The input field names for the model definition.
         :param metadata: An object map that contains metadata about the model.
         :param model_size_bytes: The estimated memory usage in bytes to keep the trained
@@ -3264,13 +3265,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if inference_config is None:
-            raise ValueError("Empty value passed for parameter 'inference_config'")
         __path = f"/_ml/trained_models/{_quote(model_id)}"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
         if compressed_definition is not None:
             __body["compressed_definition"] = compressed_definition
         if defer_definition_decompression is not None:
@@ -3285,6 +3282,8 @@ class MlClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if inference_config is not None:
+            __body["inference_config"] = inference_config
         if input is not None:
             __body["input"] = input
         if metadata is not None:
@@ -3320,7 +3319,7 @@ class MlClient(NamespacedClient):
         Creates a new model alias (or reassigns an existing one) to refer to the trained
         model
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-models-aliases.html>`_
 
         :param model_id: The identifier for the trained model that the alias refers to.
         :param model_alias: The alias to create or update. This value cannot end in numbers.
@@ -3370,7 +3369,7 @@ class MlClient(NamespacedClient):
         """
         Creates part of a trained model definition
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-definition-part.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-model-definition-part.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param part: The definition part number. When the definition is loaded for inference
@@ -3436,7 +3435,7 @@ class MlClient(NamespacedClient):
         """
         Creates a trained model vocabulary
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-vocabulary.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-trained-model-vocabulary.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
@@ -3483,7 +3482,7 @@ class MlClient(NamespacedClient):
         """
         Resets an existing anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-reset-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-reset-job.html>`_
 
         :param job_id: The ID of the job to reset.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -3532,7 +3531,7 @@ class MlClient(NamespacedClient):
         """
         Reverts to a specific snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-revert-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-revert-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: You can specify `empty` as the <snapshot_id>. Reverting to
@@ -3584,7 +3583,7 @@ class MlClient(NamespacedClient):
         Sets a cluster wide upgrade_mode setting that prepares machine learning indices
         for an upgrade.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-set-upgrade-mode.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-set-upgrade-mode.html>`_
 
         :param enabled: When `true`, it enables `upgrade_mode` which temporarily halts
             all job and datafeed tasks and prohibits new job and datafeed tasks from
@@ -3626,7 +3625,7 @@ class MlClient(NamespacedClient):
         """
         Starts a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3673,7 +3672,7 @@ class MlClient(NamespacedClient):
         """
         Starts one or more datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-start-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3735,7 +3734,7 @@ class MlClient(NamespacedClient):
         """
         Start a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
@@ -3811,7 +3810,7 @@ class MlClient(NamespacedClient):
         """
         Stops one or more data frame analytics jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/stop-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3871,7 +3870,7 @@ class MlClient(NamespacedClient):
         """
         Stops one or more datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-stop-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-stop-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. You can stop multiple datafeeds
             in a single API request by using a comma-separated list of datafeeds or a
@@ -3927,7 +3926,7 @@ class MlClient(NamespacedClient):
         """
         Stop a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/stop-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -3982,7 +3981,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/update-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4078,7 +4077,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -4234,7 +4233,7 @@ class MlClient(NamespacedClient):
         """
         Updates the description of a filter, adds items, or removes items.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param add_items: The items to add to the filter.
@@ -4305,7 +4304,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-job.html>`_
 
         :param job_id: Identifier for the job.
         :param allow_lazy_open: Advanced configuration option. Specifies whether this
@@ -4426,7 +4425,7 @@ class MlClient(NamespacedClient):
         """
         Updates certain properties of a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-update-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -4477,7 +4476,7 @@ class MlClient(NamespacedClient):
         """
         Upgrades a given job snapshot to the current major version.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/ml-upgrade-job-model-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -4535,7 +4534,7 @@ class MlClient(NamespacedClient):
         """
         Validates an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/machine-learning/master/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.10/ml-jobs.html>`_
 
         :param analysis_config:
         :param analysis_limits:
@@ -4598,7 +4597,7 @@ class MlClient(NamespacedClient):
         """
         Validates an anomaly detection detector.
 
-        `<https://www.elastic.co/guide/en/machine-learning/master/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.10/ml-jobs.html>`_
 
         :param detector:
         """

--- a/elasticsearch/_sync/client/monitoring.py
+++ b/elasticsearch/_sync/client/monitoring.py
@@ -46,7 +46,7 @@ class MonitoringClient(NamespacedClient):
         """
         Used by the monitoring features to send monitoring data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/monitor-elasticsearch-cluster.html>`_
 
         :param interval: Collection interval (e.g., '10s' or '10000ms') of the payload
         :param operations:

--- a/elasticsearch/_sync/client/nodes.py
+++ b/elasticsearch/_sync/client/nodes.py
@@ -40,7 +40,7 @@ class NodesClient(NamespacedClient):
         """
         Removes the archived repositories metering information present in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-repositories-metering-archive-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-repositories-metering-archive-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -81,7 +81,7 @@ class NodesClient(NamespacedClient):
         """
         Returns cluster repositories metering information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-repositories-metering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-repositories-metering-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -134,7 +134,7 @@ class NodesClient(NamespacedClient):
         """
         Returns information about hot threads on each node in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-hot-threads.html>`_
 
         :param node_id: List of node IDs or names used to limit returned information.
         :param ignore_idle_threads: If true, known idle threads (e.g. waiting in a socket
@@ -209,7 +209,7 @@ class NodesClient(NamespacedClient):
         """
         Returns information about nodes in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-info.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -271,7 +271,7 @@ class NodesClient(NamespacedClient):
         """
         Reloads secure settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/secure-settings.html#reloadable-secure-settings>`_
 
         :param node_id: A comma-separated list of node IDs to span the reload/reinit
             call. Should stay empty because reloading usually involves all cluster nodes.
@@ -348,7 +348,7 @@ class NodesClient(NamespacedClient):
         """
         Returns statistical information about nodes in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-stats.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -450,7 +450,7 @@ class NodesClient(NamespacedClient):
         """
         Returns low-level information about REST actions usage on nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/cluster-nodes-usage.html>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting

--- a/elasticsearch/_sync/client/query_ruleset.py
+++ b/elasticsearch/_sync/client/query_ruleset.py
@@ -139,13 +139,15 @@ class QueryRulesetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_name="query_ruleset",
+        body_fields=True,
     )
     def put(
         self,
         *,
         ruleset_id: str,
-        query_ruleset: t.Mapping[str, t.Any],
+        rules: t.Union[
+            t.List[t.Mapping[str, t.Any]], t.Tuple[t.Mapping[str, t.Any], ...]
+        ],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -160,14 +162,17 @@ class QueryRulesetClient(NamespacedClient):
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated
-        :param query_ruleset:
+        :param rules:
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        if query_ruleset is None:
-            raise ValueError("Empty value passed for parameter 'query_ruleset'")
+        if rules is None:
+            raise ValueError("Empty value passed for parameter 'rules'")
         __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        if rules is not None:
+            __body["rules"] = rules
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -176,7 +181,6 @@ class QueryRulesetClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = query_ruleset
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/query_ruleset.py
+++ b/elasticsearch/_sync/client/query_ruleset.py
@@ -15,7 +15,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
+
+
+class QueryRulesetClient(NamespacedClient):
     @_rewrite_parameters()
     def delete(
         self,

--- a/elasticsearch/_sync/client/query_ruleset.py
+++ b/elasticsearch/_sync/client/query_ruleset.py
@@ -15,20 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import typing as t
-
-from elastic_transport import ObjectApiResponse
-
-from ._base import NamespacedClient
-from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
-
-
-class AutoscalingClient(NamespacedClient):
+class C:
     @_rewrite_parameters()
-    async def delete_autoscaling_policy(
+    def delete(
         self,
         *,
-        name: str,
+        ruleset_id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -37,16 +29,15 @@ class AutoscalingClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
-        Direct use is not supported.
+        Deletes a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-delete-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-query-ruleset.html>`_
 
-        :param name: the name of the autoscaling policy
+        :param ruleset_id: The unique identifier of the query ruleset to delete
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        if ruleset_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'ruleset_id'")
+        __path = f"/_query_rules/{_quote(ruleset_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -57,14 +48,15 @@ class AutoscalingClient(NamespacedClient):
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
+        return self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers
         )
 
     @_rewrite_parameters()
-    async def get_autoscaling_capacity(
+    def get(
         self,
         *,
+        ruleset_id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -73,12 +65,15 @@ class AutoscalingClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Gets the current autoscaling capacity based on the configured autoscaling policy.
-        Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
+        Returns the details about a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-query-ruleset.html>`_
+
+        :param ruleset_id: The unique identifier of the query ruleset
         """
-        __path = "/_autoscaling/capacity"
+        if ruleset_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'ruleset_id'")
+        __path = f"/_query_rules/{_quote(ruleset_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -89,55 +84,60 @@ class AutoscalingClient(NamespacedClient):
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
-        )
-
-    @_rewrite_parameters()
-    async def get_autoscaling_policy(
-        self,
-        *,
-        name: str,
-        error_trace: t.Optional[bool] = None,
-        filter_path: t.Optional[
-            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
-        ] = None,
-        human: t.Optional[bool] = None,
-        pretty: t.Optional[bool] = None,
-    ) -> ObjectApiResponse[t.Any]:
-        """
-        Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
-        Direct use is not supported.
-
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-get-autoscaling-capacity.html>`_
-
-        :param name: the name of the autoscaling policy
-        """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
-        __query: t.Dict[str, t.Any] = {}
-        if error_trace is not None:
-            __query["error_trace"] = error_trace
-        if filter_path is not None:
-            __query["filter_path"] = filter_path
-        if human is not None:
-            __query["human"] = human
-        if pretty is not None:
-            __query["pretty"] = pretty
-        __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
+        return self.perform_request(  # type: ignore[return-value]
             "GET", __path, params=__query, headers=__headers
         )
 
     @_rewrite_parameters(
-        body_name="policy",
+        parameter_aliases={"from": "from_"},
     )
-    async def put_autoscaling_policy(
+    def list(
         self,
         *,
-        name: str,
-        policy: t.Mapping[str, t.Any],
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        from_: t.Optional[int] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        size: t.Optional[int] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Lists query rulesets.
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-query-rulesets.html>`_
+
+        :param from_: Starting offset (default: 0)
+        :param size: specifies a max number of results to get
+        """
+        __path = "/_query_rules"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if from_ is not None:
+            __query["from"] = from_
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if size is not None:
+            __query["size"] = size
+        __headers = {"accept": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
+            "GET", __path, params=__query, headers=__headers
+        )
+
+    @_rewrite_parameters(
+        body_name="query_ruleset",
+    )
+    def put(
+        self,
+        *,
+        ruleset_id: str,
+        query_ruleset: t.Mapping[str, t.Any],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -146,19 +146,19 @@ class AutoscalingClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK.
-        Direct use is not supported.
+        Creates or updates a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/autoscaling-put-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-query-ruleset.html>`_
 
-        :param name: the name of the autoscaling policy
-        :param policy:
+        :param ruleset_id: The unique identifier of the query ruleset to be created or
+            updated
+        :param query_ruleset:
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        if policy is None:
-            raise ValueError("Empty value passed for parameter 'policy'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        if ruleset_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'ruleset_id'")
+        if query_ruleset is None:
+            raise ValueError("Empty value passed for parameter 'query_ruleset'")
+        __path = f"/_query_rules/{_quote(ruleset_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -168,8 +168,8 @@ class AutoscalingClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = policy
+        __body = query_ruleset
         __headers = {"accept": "application/json", "content-type": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
+        return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )

--- a/elasticsearch/_sync/client/rollup.py
+++ b/elasticsearch/_sync/client/rollup.py
@@ -39,7 +39,7 @@ class RollupClient(NamespacedClient):
         """
         Deletes an existing rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-delete-job.html>`_
 
         :param id: The ID of the job to delete
         """
@@ -75,7 +75,7 @@ class RollupClient(NamespacedClient):
         """
         Retrieves the configuration, stats, and status of rollup jobs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-get-job.html>`_
 
         :param id: The ID of the job(s) to fetch. Accepts glob patterns, or left blank
             for all jobs
@@ -114,7 +114,7 @@ class RollupClient(NamespacedClient):
         Returns the capabilities of any rollup jobs that have been configured for a specific
         index or index pattern.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-get-rollup-caps.html>`_
 
         :param id: The ID of the index to check rollup capabilities on, or left blank
             for all jobs
@@ -153,7 +153,7 @@ class RollupClient(NamespacedClient):
         Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
         index where rollup data is stored).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-get-rollup-index-caps.html>`_
 
         :param index: The rollup index or index pattern to obtain rollup capabilities
             from.
@@ -205,7 +205,7 @@ class RollupClient(NamespacedClient):
         """
         Creates a rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-put-job.html>`_
 
         :param id: Identifier for the rollup job. This can be any alphanumeric string
             and uniquely identifies the data that is associated with the rollup job.
@@ -314,7 +314,7 @@ class RollupClient(NamespacedClient):
         """
         Enables searching rolled-up data using the standard query DSL.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-search.html>`_
 
         :param index: The indices or index-pattern(s) (containing rollup or regular data)
             that should be searched
@@ -372,7 +372,7 @@ class RollupClient(NamespacedClient):
         """
         Starts an existing, stopped rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-start-job.html>`_
 
         :param id: The ID of the job to start
         """
@@ -410,7 +410,7 @@ class RollupClient(NamespacedClient):
         """
         Stops an existing, started rollup job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/rollup-stop-job.html>`_
 
         :param id: The ID of the job to stop
         :param timeout: Block for (at maximum) the specified duration while waiting for

--- a/elasticsearch/_sync/client/search_application.py
+++ b/elasticsearch/_sync/client/search_application.py
@@ -39,7 +39,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Deletes a search application.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-search-application.html>`_
 
         :param name: The name of the search application to delete
         """
@@ -75,7 +75,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Delete a behavioral analytics collection.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-analytics-collection.html>`_
 
         :param name: The name of the analytics collection to be deleted
         """
@@ -111,7 +111,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Returns the details about a search application.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-search-application.html>`_
 
         :param name: The name of the search application
         """
@@ -147,7 +147,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Returns the existing behavioral analytics collections.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-analytics-collection.html>`_
 
         :param name: A list of analytics collections to limit the returned information
         """
@@ -188,7 +188,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Returns the existing search applications.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-search-applications.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-search-applications.html>`_
 
         :param from_: Starting offset (default: 0)
         :param q: Query in the Lucene query string syntax"
@@ -234,7 +234,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Creates or updates a search application.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-search-application.html>`_
 
         :param name: The name of the search application to be created or updated
         :param search_application:
@@ -278,7 +278,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Creates a behavioral analytics collection.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-analytics-collection.html>`_
 
         :param name: The name of the analytics collection to be created or updated
         """
@@ -318,7 +318,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Perform a search against a search application
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-application-search.html>`_
 
         :param name: The name of the search application to be searched
         :param params:

--- a/elasticsearch/_sync/client/searchable_snapshots.py
+++ b/elasticsearch/_sync/client/searchable_snapshots.py
@@ -44,7 +44,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Retrieve node-level cache statistics about searchable snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-apis.html>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting
@@ -106,7 +106,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Clear the cache of searchable snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-apis.html>`_
 
         :param index: A comma-separated list of index names
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -170,7 +170,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Mount a snapshot as a searchable index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-api-mount-snapshot.html>`_
 
         :param repository: The name of the repository containing the snapshot of the
             index to mount
@@ -239,7 +239,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Retrieve shard-level statistics about searchable snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/searchable-snapshots-apis.html>`_
 
         :param index: A comma-separated list of index names
         :param level: Return stats aggregated at cluster, index or shard level

--- a/elasticsearch/_sync/client/security.py
+++ b/elasticsearch/_sync/client/security.py
@@ -44,7 +44,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates or updates the user profile on behalf of another user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-activate-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-activate-user-profile.html>`_
 
         :param grant_type:
         :param access_token:
@@ -92,7 +92,7 @@ class SecurityClient(NamespacedClient):
         Enables authentication as a user and retrieve information about the authenticated
         user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-authenticate.html>`_
         """
         __path = "/_security/_authenticate"
         __query: t.Dict[str, t.Any] = {}
@@ -131,7 +131,7 @@ class SecurityClient(NamespacedClient):
         """
         Changes the passwords of users in the native realm and built-in users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-change-password.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-change-password.html>`_
 
         :param username: The user whose password you want to change. If you do not specify
             this parameter, the password is changed for the current user.
@@ -185,9 +185,10 @@ class SecurityClient(NamespacedClient):
         """
         Clear a subset or all entries from the API key cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-api-key-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-api-key-cache.html>`_
 
-        :param ids: A comma-separated list of IDs of API keys to clear from the cache
+        :param ids: Comma-separated list of API key IDs to evict from the API key cache.
+            To evict all API keys, use `*`. Does not support other wildcard patterns.
         """
         if ids in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ids'")
@@ -221,7 +222,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts application privileges from the native application privileges cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-privilege-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-privilege-cache.html>`_
 
         :param application: A comma-separated list of application names
         """
@@ -259,7 +260,7 @@ class SecurityClient(NamespacedClient):
         Evicts users from the user cache. Can completely clear the cache or evict specific
         users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-cache.html>`_
 
         :param realms: Comma-separated list of realms to clear
         :param usernames: Comma-separated list of usernames to clear from the cache
@@ -298,7 +299,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts roles from the native role cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-role-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-role-cache.html>`_
 
         :param name: Role name
         """
@@ -336,7 +337,7 @@ class SecurityClient(NamespacedClient):
         """
         Evicts tokens from the service account token caches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-service-token-caches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-clear-service-token-caches.html>`_
 
         :param namespace: An identifier for the namespace
         :param service: An identifier for the service name
@@ -386,13 +387,13 @@ class SecurityClient(NamespacedClient):
         """
         Creates an API key for access without requiring basic authentication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-create-api-key.html>`_
 
         :param expiration: Expiration time for the API key. By default, API keys never
             expire.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
             It supports nested data structure. Within the metadata object, keys beginning
-            with _ are reserved for system usage.
+            with `_` are reserved for system usage.
         :param name: Specifies the name for this API key.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
@@ -452,7 +453,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates a service account token for access without requiring basic authentication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-create-service-token.html>`_
 
         :param namespace: An identifier for the namespace
         :param service: An identifier for the service name
@@ -512,7 +513,7 @@ class SecurityClient(NamespacedClient):
         """
         Removes application privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-privilege.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-privilege.html>`_
 
         :param application: Application name
         :param name: Privilege name
@@ -559,7 +560,7 @@ class SecurityClient(NamespacedClient):
         """
         Removes roles in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-role.html>`_
 
         :param name: Role name
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -603,7 +604,7 @@ class SecurityClient(NamespacedClient):
         """
         Removes role mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-role-mapping.html>`_
 
         :param name: Role-mapping name
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -649,7 +650,7 @@ class SecurityClient(NamespacedClient):
         """
         Deletes a service account token.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-service-token.html>`_
 
         :param namespace: An identifier for the namespace
         :param service: An identifier for the service name
@@ -699,7 +700,7 @@ class SecurityClient(NamespacedClient):
         """
         Deletes users from the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-delete-user.html>`_
 
         :param username: username
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -743,7 +744,7 @@ class SecurityClient(NamespacedClient):
         """
         Disables users in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-disable-user.html>`_
 
         :param username: The username of the user to disable
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -787,7 +788,7 @@ class SecurityClient(NamespacedClient):
         """
         Disables a user profile so it's not visible in user profile searches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-disable-user-profile.html>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -831,7 +832,7 @@ class SecurityClient(NamespacedClient):
         """
         Enables users in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-enable-user.html>`_
 
         :param username: The username of the user to enable
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -875,7 +876,7 @@ class SecurityClient(NamespacedClient):
         """
         Enables a user profile so it's visible in user profile searches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-enable-user-profile.html>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -916,7 +917,7 @@ class SecurityClient(NamespacedClient):
         Allows a kibana instance to configure itself to communicate with a secured elasticsearch
         cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-kibana-enrollment.html>`_
         """
         __path = "/_security/enroll/kibana"
         __query: t.Dict[str, t.Any] = {}
@@ -947,7 +948,7 @@ class SecurityClient(NamespacedClient):
         """
         Allows a new node to enroll to an existing cluster with security enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-node-enrollment.html>`_
         """
         __path = "/_security/enroll/node"
         __query: t.Dict[str, t.Any] = {}
@@ -984,13 +985,20 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information for one or more API keys.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-api-key.html>`_
 
-        :param id: API key id of the API key to be retrieved
-        :param name: API key name of the API key to be retrieved
-        :param owner: flag to query API keys owned by the currently authenticated user
-        :param realm_name: realm name of the user who created this API key to be retrieved
-        :param username: user name of the user who created this API key to be retrieved
+        :param id: An API key id. This parameter cannot be used with any of `name`, `realm_name`
+            or `username`.
+        :param name: An API key name. This parameter cannot be used with any of `id`,
+            `realm_name` or `username`. It supports prefix search with wildcard.
+        :param owner: A boolean flag that can be used to query API keys owned by the
+            currently authenticated user. The `realm_name` or `username` parameters cannot
+            be specified when this parameter is set to `true` as they are assumed to
+            be the currently authenticated ones.
+        :param realm_name: The name of an authentication realm. This parameter cannot
+            be used with either `id` or `name` or when `owner` flag is set to `true`.
+        :param username: The username of a user. This parameter cannot be used with either
+            `id` or `name` or when `owner` flag is set to `true`.
         :param with_limited_by: Return the snapshot of the owner user's role descriptors
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
@@ -1037,7 +1045,7 @@ class SecurityClient(NamespacedClient):
         Retrieves the list of cluster privileges and index privileges that are available
         in this version of Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-builtin-privileges.html>`_
         """
         __path = "/_security/privilege/_builtin"
         __query: t.Dict[str, t.Any] = {}
@@ -1070,7 +1078,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves application privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-privileges.html>`_
 
         :param application: Application name
         :param name: Privilege name
@@ -1110,7 +1118,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves roles in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-role.html>`_
 
         :param name: The name of the role. You can specify multiple roles as a comma-separated
             list. If you do not specify this parameter, the API returns information about
@@ -1149,7 +1157,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves role mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-role-mapping.html>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1191,7 +1199,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information about service accounts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-accounts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-service-accounts.html>`_
 
         :param namespace: Name of the namespace. Omit this parameter to retrieve information
             about all service accounts. If you omit this parameter, you must also omit
@@ -1235,7 +1243,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information of all service credentials for a service account.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-credentials.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-service-credentials.html>`_
 
         :param namespace: Name of the namespace.
         :param service: Name of the service name.
@@ -1286,7 +1294,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates a bearer token for access without requiring basic authentication.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-token.html>`_
 
         :param grant_type:
         :param kerberos_ticket:
@@ -1341,7 +1349,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information about users in the native realm and built-in users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-user.html>`_
 
         :param username: An identifier for the user. You can specify multiple usernames
             as a comma-separated list. If you omit this parameter, the API retrieves
@@ -1386,7 +1394,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves security privileges for the logged in user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-user-privileges.html>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -1432,7 +1440,7 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves user profiles for the given unique ID(s).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-get-user-profile.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: List of filters for the `data` field of the profile document. To
@@ -1482,14 +1490,20 @@ class SecurityClient(NamespacedClient):
         """
         Creates an API key on behalf of another user.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-grant-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-grant-api-key.html>`_
 
-        :param api_key:
-        :param grant_type:
-        :param access_token:
-        :param password:
-        :param run_as:
-        :param username:
+        :param api_key: Defines the API key.
+        :param grant_type: The type of grant. Supported grant types are: `access_token`,
+            `password`.
+        :param access_token: The user’s access token. If you specify the `access_token`
+            grant type, this parameter is required. It is not valid with other grant
+            types.
+        :param password: The user’s password. If you specify the `password` grant type,
+            this parameter is required. It is not valid with other grant types.
+        :param run_as: The name of the user to be impersonated.
+        :param username: The user name that identifies the user. If you specify the `password`
+            grant type, this parameter is required. It is not valid with other grant
+            types.
         """
         if api_key is None:
             raise ValueError("Empty value passed for parameter 'api_key'")
@@ -1563,7 +1577,7 @@ class SecurityClient(NamespacedClient):
         """
         Determines whether the specified user has a specified list of privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-has-privileges.html>`_
 
         :param user: Username
         :param application:
@@ -1614,7 +1628,7 @@ class SecurityClient(NamespacedClient):
         Determines whether the users associated with the specified profile IDs have all
         the requested privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-has-privileges-user-profile.html>`_
 
         :param privileges:
         :param uids: A list of profile IDs. The privileges are checked for associated
@@ -1666,14 +1680,21 @@ class SecurityClient(NamespacedClient):
         """
         Invalidates one or more API keys.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-invalidate-api-key.html>`_
 
         :param id:
-        :param ids:
-        :param name:
-        :param owner:
-        :param realm_name:
-        :param username:
+        :param ids: A list of API key ids. This parameter cannot be used with any of
+            `name`, `realm_name`, or `username`.
+        :param name: An API key name. This parameter cannot be used with any of `ids`,
+            `realm_name` or `username`.
+        :param owner: Can be used to query API keys owned by the currently authenticated
+            user. The `realm_name` or `username` parameters cannot be specified when
+            this parameter is set to `true` as they are assumed to be the currently authenticated
+            ones.
+        :param realm_name: The name of an authentication realm. This parameter cannot
+            be used with either `ids` or `name`, or when `owner` flag is set to `true`.
+        :param username: The username of a user. This parameter cannot be used with either
+            `ids` or `name`, or when `owner` flag is set to `true`.
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
@@ -1723,7 +1744,7 @@ class SecurityClient(NamespacedClient):
         """
         Invalidates one or more access tokens or refresh tokens.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-invalidate-token.html>`_
 
         :param realm_name:
         :param refresh_token:
@@ -1774,7 +1795,7 @@ class SecurityClient(NamespacedClient):
         """
         Adds or updates application privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-privileges.html>`_
 
         :param privileges:
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1849,7 +1870,7 @@ class SecurityClient(NamespacedClient):
         """
         Adds and updates roles in the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-role.html>`_
 
         :param name: The name of the role.
         :param applications: A list of application privilege entries.
@@ -1931,7 +1952,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates and updates role mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-role-mapping.html>`_
 
         :param name: Role-mapping name
         :param enabled:
@@ -2001,7 +2022,7 @@ class SecurityClient(NamespacedClient):
         Adds and updates users in the native realm. These users are commonly referred
         to as native users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-put-user.html>`_
 
         :param username: The username of the User
         :param email:
@@ -2085,20 +2106,22 @@ class SecurityClient(NamespacedClient):
         """
         Retrieves information for API keys using a subset of query DSL
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-query-api-key.html>`_
 
         :param from_: Starting document offset. By default, you cannot page through more
             than 10,000 hits using the from and size parameters. To page through more
-            hits, use the search_after parameter.
+            hits, use the `search_after` parameter.
         :param query: A query to filter which API keys to return. The query supports
-            a subset of query types, including match_all, bool, term, terms, ids, prefix,
-            wildcard, and range. You can query all public information associated with
-            an API key
-        :param search_after:
+            a subset of query types, including `match_all`, `bool`, `term`, `terms`,
+            `ids`, `prefix`, `wildcard`, and `range`. You can query all public information
+            associated with an API key.
+        :param search_after: Search after definition
         :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the from and size parameters. To page through
-            more hits, use the search_after parameter.
-        :param sort:
+            more than 10,000 hits using the `from` and `size` parameters. To page through
+            more hits, use the `search_after` parameter.
+        :param sort: Other than `id`, all public fields of an API key are eligible for
+            sorting. In addition, sort can also be applied to the `_doc` field to sort
+            by index order.
         :param with_limited_by: Return the snapshot of the owner user's role descriptors
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
@@ -2166,7 +2189,7 @@ class SecurityClient(NamespacedClient):
         Exchanges a SAML Response message for an Elasticsearch access token and refresh
         token pair
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-authenticate.html>`_
 
         :param content: The SAML response as it was sent by the user’s browser, usually
             a Base64 encoded XML document.
@@ -2221,7 +2244,7 @@ class SecurityClient(NamespacedClient):
         """
         Verifies the logout response sent from the SAML IdP
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-complete-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-complete-logout.html>`_
 
         :param ids: A json array with all the valid SAML Request Ids that the caller
             of the API has for the current user.
@@ -2280,7 +2303,7 @@ class SecurityClient(NamespacedClient):
         """
         Consumes a SAML LogoutRequest
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-invalidate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-invalidate.html>`_
 
         :param query_string: The query part of the URL that the user was redirected to
             by the SAML IdP to initiate the Single Logout. This query should include
@@ -2341,7 +2364,7 @@ class SecurityClient(NamespacedClient):
         Invalidates an access token and a refresh token that were generated via the SAML
         Authenticate API
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-logout.html>`_
 
         :param token: The access token that was returned as a response to calling the
             SAML authenticate API. Alternatively, the most recent token that was received
@@ -2391,7 +2414,7 @@ class SecurityClient(NamespacedClient):
         """
         Creates a SAML authentication request
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-prepare-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-prepare-authentication.html>`_
 
         :param acs: The Assertion Consumer Service URL that matches the one of the SAML
             realms in Elasticsearch. The realm is used to generate the authentication
@@ -2440,7 +2463,7 @@ class SecurityClient(NamespacedClient):
         """
         Generates SAML metadata for the Elastic stack SAML 2.0 Service Provider
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-sp-metadata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-saml-sp-metadata.html>`_
 
         :param realm_name: The name of the SAML realm in Elasticsearch.
         """
@@ -2481,7 +2504,7 @@ class SecurityClient(NamespacedClient):
         """
         Get suggestions for user profiles that match specified search criteria.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-suggest-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-suggest-user-profile.html>`_
 
         :param data: List of filters for the `data` field of the profile document. To
             return all content use `data=*`. To return a subset of content use `data=<key>`
@@ -2542,7 +2565,7 @@ class SecurityClient(NamespacedClient):
         """
         Updates attributes of an existing API key.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-update-api-key.html>`_
 
         :param id: The ID of the API key to update.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
@@ -2607,7 +2630,7 @@ class SecurityClient(NamespacedClient):
         """
         Update application specific data for the user profile of the given unique ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-user-profile-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-update-user-profile-data.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: Non-searchable data that you want to associate with the user profile.

--- a/elasticsearch/_sync/client/slm.py
+++ b/elasticsearch/_sync/client/slm.py
@@ -39,7 +39,7 @@ class SlmClient(NamespacedClient):
         """
         Deletes an existing snapshot lifecycle policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-delete-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-delete-policy.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to remove
         """
@@ -76,7 +76,7 @@ class SlmClient(NamespacedClient):
         Immediately creates a snapshot according to the lifecycle policy, without waiting
         for the scheduled time.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-execute-lifecycle.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to be executed
         """
@@ -111,7 +111,7 @@ class SlmClient(NamespacedClient):
         """
         Deletes any snapshots that are expired according to the policy's retention rules.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-execute-retention.html>`_
         """
         __path = "/_slm/_execute_retention"
         __query: t.Dict[str, t.Any] = {}
@@ -146,7 +146,7 @@ class SlmClient(NamespacedClient):
         Retrieves one or more snapshot lifecycle policy definitions and information about
         the latest snapshot attempts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-get-policy.html>`_
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         """
@@ -183,7 +183,7 @@ class SlmClient(NamespacedClient):
         Returns global and policy-level statistics about actions taken by snapshot lifecycle
         management.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-get-stats.html>`_
         """
         __path = "/_slm/stats"
         __query: t.Dict[str, t.Any] = {}
@@ -214,7 +214,7 @@ class SlmClient(NamespacedClient):
         """
         Retrieves the status of snapshot lifecycle management (SLM).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-get-status.html>`_
         """
         __path = "/_slm/status"
         __query: t.Dict[str, t.Any] = {}
@@ -257,7 +257,7 @@ class SlmClient(NamespacedClient):
         """
         Creates or updates a snapshot lifecycle policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-put-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-put-policy.html>`_
 
         :param policy_id: ID for the snapshot lifecycle policy you want to create or
             update.
@@ -328,7 +328,7 @@ class SlmClient(NamespacedClient):
         """
         Turns on snapshot lifecycle management (SLM).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-start.html>`_
         """
         __path = "/_slm/start"
         __query: t.Dict[str, t.Any] = {}
@@ -359,7 +359,7 @@ class SlmClient(NamespacedClient):
         """
         Turns off snapshot lifecycle management (SLM).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/slm-api-stop.html>`_
         """
         __path = "/_slm/stop"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/snapshot.py
+++ b/elasticsearch/_sync/client/snapshot.py
@@ -43,7 +43,7 @@ class SnapshotClient(NamespacedClient):
         """
         Removes stale data from repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clean-up-snapshot-repo-api.html>`_
 
         :param name: Snapshot repository to clean up.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -94,7 +94,7 @@ class SnapshotClient(NamespacedClient):
         """
         Clones indices from one snapshot into another snapshot in the same repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: The name of the snapshot to clone from
@@ -163,7 +163,7 @@ class SnapshotClient(NamespacedClient):
         """
         Creates a snapshot in a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: Repository for the snapshot.
         :param snapshot: Name of the snapshot. Must be unique in the repository.
@@ -261,7 +261,7 @@ class SnapshotClient(NamespacedClient):
         """
         Creates a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: A repository name
         :param settings:
@@ -324,7 +324,7 @@ class SnapshotClient(NamespacedClient):
         """
         Deletes one or more snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -370,7 +370,7 @@ class SnapshotClient(NamespacedClient):
         """
         Deletes a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: Name of the snapshot repository to unregister. Wildcard (`*`) patterns
             are supported.
@@ -434,7 +434,7 @@ class SnapshotClient(NamespacedClient):
         """
         Returns information about a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: Comma-separated list of snapshot repository names used to
             limit the request. Wildcard (*) expressions are supported.
@@ -541,7 +541,7 @@ class SnapshotClient(NamespacedClient):
         """
         Returns information about a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: A comma-separated list of repository names
         :param local: Return local information, do not retrieve the state from master
@@ -606,7 +606,7 @@ class SnapshotClient(NamespacedClient):
         """
         Restores a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: A snapshot name
@@ -694,7 +694,7 @@ class SnapshotClient(NamespacedClient):
         """
         Returns information about the status of a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -745,7 +745,7 @@ class SnapshotClient(NamespacedClient):
         """
         Verifies a repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/modules-snapshots.html>`_
 
         :param name: A repository name
         :param master_timeout: Explicit operation timeout for connection to master node

--- a/elasticsearch/_sync/client/sql.py
+++ b/elasticsearch/_sync/client/sql.py
@@ -41,7 +41,7 @@ class SqlClient(NamespacedClient):
         """
         Clears the SQL cursor
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-sql-cursor-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/clear-sql-cursor-api.html>`_
 
         :param cursor:
         """
@@ -81,7 +81,7 @@ class SqlClient(NamespacedClient):
         Deletes an async SQL search or a stored synchronous SQL search. If the search
         is still running, the API cancels it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-async-sql-search-api.html>`_
 
         :param id: The async search ID
         """
@@ -124,7 +124,7 @@ class SqlClient(NamespacedClient):
         Returns the current status and available results for an async SQL search or stored
         synchronous SQL search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-sql-search-api.html>`_
 
         :param id: The async search ID
         :param delimiter: Separator for CSV results. The API only supports this parameter
@@ -178,7 +178,7 @@ class SqlClient(NamespacedClient):
         Returns the current status of an async SQL search or a stored synchronous SQL
         search
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-async-sql-search-status-api.html>`_
 
         :param id: The async search ID
         """
@@ -237,7 +237,7 @@ class SqlClient(NamespacedClient):
         """
         Executes a SQL request
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/sql-search-api.html>`_
 
         :param catalog: Default catalog (cluster) for queries. If unspecified, the queries
             execute on the data in the local cluster only.
@@ -339,7 +339,7 @@ class SqlClient(NamespacedClient):
         """
         Translates SQL into Elasticsearch queries
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/sql-translate-api.html>`_
 
         :param query:
         :param fetch_size:

--- a/elasticsearch/_sync/client/ssl.py
+++ b/elasticsearch/_sync/client/ssl.py
@@ -39,7 +39,7 @@ class SslClient(NamespacedClient):
         Retrieves information about the X.509 certificates used to encrypt communications
         in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/security-api-ssl.html>`_
         """
         __path = "/_ssl/certificates"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/synonyms.py
+++ b/elasticsearch/_sync/client/synonyms.py
@@ -15,7 +15,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
+
+
+class SynonymsClient(NamespacedClient):
     @_rewrite_parameters()
     def delete_synonym(
         self,

--- a/elasticsearch/_sync/client/synonyms.py
+++ b/elasticsearch/_sync/client/synonyms.py
@@ -15,20 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import typing as t
-
-from elastic_transport import ObjectApiResponse
-
-from ._base import NamespacedClient
-from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
-
-
-class SearchApplicationClient(NamespacedClient):
+class C:
     @_rewrite_parameters()
-    async def delete(
+    def delete_synonym(
         self,
         *,
-        name: str,
+        id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -37,15 +29,15 @@ class SearchApplicationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a search application.
+        Deletes a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-synonyms-set.html>`_
 
-        :param name: The name of the search application to delete
+        :param id: The id of the synonyms set to be deleted
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        __path = f"/_synonyms/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,15 +48,16 @@ class SearchApplicationClient(NamespacedClient):
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
+        return self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers
         )
 
     @_rewrite_parameters()
-    async def delete_behavioral_analytics(
+    def delete_synonym_rule(
         self,
         *,
-        name: str,
+        set_id: str,
+        rule_id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -73,15 +66,18 @@ class SearchApplicationClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete a behavioral analytics collection.
+        Deletes a synonym rule in a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-synonym-rule.html>`_
 
-        :param name: The name of the analytics collection to be deleted
+        :param set_id: The id of the synonym set to be updated
+        :param rule_id: The id of the synonym rule to be deleted
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
+        if set_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'set_id'")
+        if rule_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'rule_id'")
+        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -92,89 +88,17 @@ class SearchApplicationClient(NamespacedClient):
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
+        return self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers
-        )
-
-    @_rewrite_parameters()
-    async def get(
-        self,
-        *,
-        name: str,
-        error_trace: t.Optional[bool] = None,
-        filter_path: t.Optional[
-            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
-        ] = None,
-        human: t.Optional[bool] = None,
-        pretty: t.Optional[bool] = None,
-    ) -> ObjectApiResponse[t.Any]:
-        """
-        Returns the details about a search application.
-
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-search-application.html>`_
-
-        :param name: The name of the search application
-        """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
-        __query: t.Dict[str, t.Any] = {}
-        if error_trace is not None:
-            __query["error_trace"] = error_trace
-        if filter_path is not None:
-            __query["filter_path"] = filter_path
-        if human is not None:
-            __query["human"] = human
-        if pretty is not None:
-            __query["pretty"] = pretty
-        __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
-        )
-
-    @_rewrite_parameters()
-    async def get_behavioral_analytics(
-        self,
-        *,
-        name: t.Optional[t.Union[t.List[str], t.Tuple[str, ...]]] = None,
-        error_trace: t.Optional[bool] = None,
-        filter_path: t.Optional[
-            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
-        ] = None,
-        human: t.Optional[bool] = None,
-        pretty: t.Optional[bool] = None,
-    ) -> ObjectApiResponse[t.Any]:
-        """
-        Returns the existing behavioral analytics collections.
-
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-analytics-collection.html>`_
-
-        :param name: A list of analytics collections to limit the returned information
-        """
-        if name not in SKIP_IN_PATH:
-            __path = f"/_application/analytics/{_quote(name)}"
-        else:
-            __path = "/_application/analytics"
-        __query: t.Dict[str, t.Any] = {}
-        if error_trace is not None:
-            __query["error_trace"] = error_trace
-        if filter_path is not None:
-            __query["filter_path"] = filter_path
-        if human is not None:
-            __query["human"] = human
-        if pretty is not None:
-            __query["pretty"] = pretty
-        __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
         )
 
     @_rewrite_parameters(
         parameter_aliases={"from": "from_"},
     )
-    async def list(
+    def get_synonym(
         self,
         *,
+        id: str,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
@@ -182,19 +106,20 @@ class SearchApplicationClient(NamespacedClient):
         from_: t.Optional[int] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
-        q: t.Optional[str] = None,
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the existing search applications.
+        Retrieves a synonym set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-search-applications.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-synonyms-set.html>`_
 
-        :param from_: Starting offset (default: 0)
-        :param q: Query in the Lucene query string syntax"
-        :param size: specifies a max number of results to get
+        :param id: "The id of the synonyms set to be retrieved
+        :param from_: Starting offset for query rules to be retrieved
+        :param size: specifies a max number of query rules to retrieve
         """
-        __path = "/_application/search_application"
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        __path = f"/_synonyms/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -206,143 +131,187 @@ class SearchApplicationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if q is not None:
-            __query["q"] = q
         if size is not None:
             __query["size"] = size
         __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
+        return self.perform_request(  # type: ignore[return-value]
+            "GET", __path, params=__query, headers=__headers
+        )
+
+    @_rewrite_parameters()
+    def get_synonym_rule(
+        self,
+        *,
+        set_id: str,
+        rule_id: str,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Retrieves a synonym rule from a synonym set
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-synonym-rule.html>`_
+
+        :param set_id: The id of the synonym set to retrieve the synonym rule from
+        :param rule_id: The id of the synonym rule to retrieve
+        """
+        if set_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'set_id'")
+        if rule_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'rule_id'")
+        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __query: t.Dict[str, t.Any] = {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        __headers = {"accept": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
             "GET", __path, params=__query, headers=__headers
         )
 
     @_rewrite_parameters(
-        body_name="search_application",
+        parameter_aliases={"from": "from_"},
     )
-    async def put(
+    def get_synonyms_sets(
         self,
         *,
-        name: str,
-        search_application: t.Mapping[str, t.Any],
-        create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
+        from_: t.Optional[int] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a search application.
+        Retrieves a summary of all defined synonym sets
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/list-synonyms-sets.html>`_
 
-        :param name: The name of the search application to be created or updated
-        :param search_application:
-        :param create: If true, requires that a search application with the specified
-            resource_id does not already exist. (default: false)
+        :param from_: Starting offset
+        :param size: specifies a max number of results to get
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        if search_application is None:
-            raise ValueError("Empty value passed for parameter 'search_application'")
-        __path = f"/_application/search_application/{_quote(name)}"
-        __query: t.Dict[str, t.Any] = {}
-        if create is not None:
-            __query["create"] = create
-        if error_trace is not None:
-            __query["error_trace"] = error_trace
-        if filter_path is not None:
-            __query["filter_path"] = filter_path
-        if human is not None:
-            __query["human"] = human
-        if pretty is not None:
-            __query["pretty"] = pretty
-        __body = search_application
-        __headers = {"accept": "application/json", "content-type": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
-        )
-
-    @_rewrite_parameters()
-    async def put_behavioral_analytics(
-        self,
-        *,
-        name: str,
-        error_trace: t.Optional[bool] = None,
-        filter_path: t.Optional[
-            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
-        ] = None,
-        human: t.Optional[bool] = None,
-        pretty: t.Optional[bool] = None,
-    ) -> ObjectApiResponse[t.Any]:
-        """
-        Creates a behavioral analytics collection.
-
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-analytics-collection.html>`_
-
-        :param name: The name of the analytics collection to be created or updated
-        """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
+        __path = "/_synonyms"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
+        if from_ is not None:
+            __query["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if size is not None:
+            __query["size"] = size
         __headers = {"accept": "application/json"}
-        return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+        return self.perform_request(  # type: ignore[return-value]
+            "GET", __path, params=__query, headers=__headers
         )
 
     @_rewrite_parameters(
         body_fields=True,
-        ignore_deprecated_options={"params"},
     )
-    async def search(
+    def put_synonym(
         self,
         *,
-        name: str,
+        id: str,
+        synonyms_set: t.Union[
+            t.List[t.Mapping[str, t.Any]], t.Tuple[t.Mapping[str, t.Any], ...]
+        ],
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[
             t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
         ] = None,
         human: t.Optional[bool] = None,
-        params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Perform a search against a search application
+        Creates or updates a synonyms set
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-application-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-synonyms-set.html>`_
 
-        :param name: The name of the search application to be searched
-        :param params:
+        :param id: The id of the synonyms set to be created or updated
+        :param synonyms_set: The synonym set information to update
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}/_search"
-        __query: t.Dict[str, t.Any] = {}
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        if synonyms_set is None:
+            raise ValueError("Empty value passed for parameter 'synonyms_set'")
+        __path = f"/_synonyms/{_quote(id)}"
         __body: t.Dict[str, t.Any] = {}
+        __query: t.Dict[str, t.Any] = {}
+        if synonyms_set is not None:
+            __body["synonyms_set"] = synonyms_set
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if not __body:
-            __body = None  # type: ignore[assignment]
-        __headers = {"accept": "application/json"}
-        if __body is not None:
-            __headers["content-type"] = "application/json"
-        return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+        __headers = {"accept": "application/json", "content-type": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
+            "PUT", __path, params=__query, headers=__headers, body=__body
+        )
+
+    @_rewrite_parameters(
+        body_fields=True,
+    )
+    def put_synonym_rule(
+        self,
+        *,
+        set_id: str,
+        rule_id: str,
+        synonyms: t.Union[t.List[str], t.Tuple[str, ...]],
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[
+            t.Union[str, t.Union[t.List[str], t.Tuple[str, ...]]]
+        ] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        Creates or updates a synonym rule in a synonym set
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-synonym-rule.html>`_
+
+        :param set_id: The id of the synonym set to be updated with the synonym rule
+        :param rule_id: The id of the synonym rule to be updated or created
+        :param synonyms:
+        """
+        if set_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'set_id'")
+        if rule_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'rule_id'")
+        if synonyms is None:
+            raise ValueError("Empty value passed for parameter 'synonyms'")
+        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __body: t.Dict[str, t.Any] = {}
+        __query: t.Dict[str, t.Any] = {}
+        if synonyms is not None:
+            __body["synonyms"] = synonyms
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        __headers = {"accept": "application/json", "content-type": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
+            "PUT", __path, params=__query, headers=__headers, body=__body
         )

--- a/elasticsearch/_sync/client/tasks.py
+++ b/elasticsearch/_sync/client/tasks.py
@@ -45,7 +45,7 @@ class TasksClient(NamespacedClient):
         """
         Cancels a task, if it can be cancelled through an API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
         :param task_id: Cancel the task with specified task id (node_id:task_number)
         :param actions: A comma-separated list of actions that should be cancelled. Leave
@@ -101,7 +101,7 @@ class TasksClient(NamespacedClient):
         """
         Returns information about a task.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
         :param task_id: Return the task with specified id (node_id:task_number)
         :param timeout: Explicit operation timeout
@@ -157,7 +157,7 @@ class TasksClient(NamespacedClient):
         """
         Returns a list of tasks.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/tasks.html>`_
 
         :param actions: Comma-separated list or wildcard expression of actions used to
             limit the request.

--- a/elasticsearch/_sync/client/text_structure.py
+++ b/elasticsearch/_sync/client/text_structure.py
@@ -50,7 +50,7 @@ class TextStructureClient(NamespacedClient):
         Finds the structure of a text file. The text file must contain data that is suitable
         to be ingested into Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/find-structure.html>`_
 
         :param text_files:
         :param charset: The text’s character set. It must be a character set that is

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -41,7 +41,7 @@ class TransformClient(NamespacedClient):
         """
         Deletes an existing transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/delete-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param force: If this value is false, the transform must be stopped before it
@@ -94,7 +94,7 @@ class TransformClient(NamespacedClient):
         """
         Retrieves configuration information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-transform.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -157,7 +157,7 @@ class TransformClient(NamespacedClient):
         """
         Retrieves usage information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/get-transform-stats.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -223,7 +223,7 @@ class TransformClient(NamespacedClient):
         """
         Previews a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/preview-transform.html>`_
 
         :param transform_id: Identifier for the transform to preview. If you specify
             this path parameter, you cannot provide transform configuration details in
@@ -320,7 +320,7 @@ class TransformClient(NamespacedClient):
         """
         Instantiates a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/put-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -414,7 +414,7 @@ class TransformClient(NamespacedClient):
         """
         Resets an existing transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/reset-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/reset-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -458,7 +458,7 @@ class TransformClient(NamespacedClient):
         """
         Schedules now a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/schedule-now-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/schedule-now-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param timeout: Controls the time to wait for the scheduling to take place
@@ -501,7 +501,7 @@ class TransformClient(NamespacedClient):
         """
         Starts one or more transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/start-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param from_: Restricts the set of transformed entities to those changed after
@@ -551,7 +551,7 @@ class TransformClient(NamespacedClient):
         """
         Stops one or more transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/stop-transform.html>`_
 
         :param transform_id: Identifier for the transform. To stop multiple transforms,
             use a comma-separated list or a wildcard expression. To stop all transforms,
@@ -630,7 +630,7 @@ class TransformClient(NamespacedClient):
         """
         Updates certain properties of a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/update-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -705,7 +705,7 @@ class TransformClient(NamespacedClient):
         """
         Upgrades all transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/upgrade-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/upgrade-transforms.html>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_sync/client/watcher.py
+++ b/elasticsearch/_sync/client/watcher.py
@@ -42,7 +42,7 @@ class WatcherClient(NamespacedClient):
         """
         Acknowledges a watch, manually throttling the execution of the watch's actions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-ack-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-ack-watch.html>`_
 
         :param watch_id: Watch ID
         :param action_id: A comma-separated list of the action ids to be acked
@@ -84,7 +84,7 @@ class WatcherClient(NamespacedClient):
         """
         Activates a currently inactive watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-activate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-activate-watch.html>`_
 
         :param watch_id: Watch ID
         """
@@ -120,7 +120,7 @@ class WatcherClient(NamespacedClient):
         """
         Deactivates a currently active watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-deactivate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-deactivate-watch.html>`_
 
         :param watch_id: Watch ID
         """
@@ -156,7 +156,7 @@ class WatcherClient(NamespacedClient):
         """
         Removes a watch from Watcher.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-delete-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-delete-watch.html>`_
 
         :param id: Watch ID
         """
@@ -210,7 +210,7 @@ class WatcherClient(NamespacedClient):
         """
         Forces the execution of a stored watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-execute-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-execute-watch.html>`_
 
         :param id: Identifier for the watch.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -285,7 +285,7 @@ class WatcherClient(NamespacedClient):
         """
         Retrieves a watch by its ID.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-get-watch.html>`_
 
         :param id: Watch ID
         """
@@ -334,7 +334,7 @@ class WatcherClient(NamespacedClient):
         """
         Creates a new watch, or updates an existing one.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-put-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-put-watch.html>`_
 
         :param id: Watch ID
         :param actions:
@@ -430,7 +430,7 @@ class WatcherClient(NamespacedClient):
         """
         Retrieves stored watches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-query-watches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-query-watches.html>`_
 
         :param from_: The offset from the first result to fetch. Needs to be non-negative.
         :param query: Optional, query filter watches to be returned.
@@ -494,7 +494,7 @@ class WatcherClient(NamespacedClient):
         """
         Starts Watcher if it is not already running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-start.html>`_
         """
         __path = "/_watcher/_start"
         __query: t.Dict[str, t.Any] = {}
@@ -549,7 +549,7 @@ class WatcherClient(NamespacedClient):
         """
         Retrieves the current Watcher metrics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-stats.html>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -589,7 +589,7 @@ class WatcherClient(NamespacedClient):
         """
         Stops Watcher if it is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/watcher-api-stop.html>`_
         """
         __path = "/_watcher/_stop"
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/xpack.py
+++ b/elasticsearch/_sync/client/xpack.py
@@ -45,7 +45,7 @@ class XPackClient(NamespacedClient):
         """
         Retrieves information about the installed X-Pack features.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/info-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/info-api.html>`_
 
         :param accept_enterprise: If this param is used it must be set to true
         :param categories: A comma-separated list of the information categories to include
@@ -87,7 +87,7 @@ class XPackClient(NamespacedClient):
         """
         Retrieves usage information about the installed X-Pack features.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/usage-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.10/usage-api.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and

--- a/elasticsearch/client.py
+++ b/elasticsearch/client.py
@@ -44,6 +44,9 @@ from ._sync.client.migration import MigrationClient as MigrationClient  # noqa: 
 from ._sync.client.ml import MlClient as MlClient  # noqa: F401
 from ._sync.client.monitoring import MonitoringClient as MonitoringClient  # noqa: F401
 from ._sync.client.nodes import NodesClient as NodesClient  # noqa: F401
+from ._sync.client.query_ruleset import (  # noqa: F401
+    QueryRulesetClient as QueryRulesetClient,
+)
 from ._sync.client.rollup import RollupClient as RollupClient  # noqa: F401
 from ._sync.client.search_application import (  # noqa: F401
     SearchApplicationClient as SearchApplicationClient,
@@ -57,6 +60,7 @@ from ._sync.client.slm import SlmClient as SlmClient  # noqa: F401
 from ._sync.client.snapshot import SnapshotClient as SnapshotClient  # noqa: F401
 from ._sync.client.sql import SqlClient as SqlClient  # noqa: F401
 from ._sync.client.ssl import SslClient as SslClient  # noqa: F401
+from ._sync.client.synonyms import SynonymsClient as SynonymsClient  # noqa: F401
 from ._sync.client.tasks import TasksClient as TasksClient  # noqa: F401
 from ._sync.client.text_structure import (  # noqa: F401
     TextStructureClient as TextStructureClient,


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-py/pull/2299 with generated code using the 8.10 branch of elasticsearch-specification, which fixes the URLs to the Elasticsearch docs.