### PR TITLE
Remove deprecation warnings when using body parameter

### DIFF
--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -379,15 +379,6 @@ def _rewrite_parameters(
                                 f"'{body_name}' parameter. See https://github.com/elastic/elasticsearch-py/"
                                 "issues/1698 for more information"
                             )
-
-                        warnings.warn(
-                            "The 'body' parameter is deprecated and will be removed "
-                            f"in a future version. Instead use the '{body_name}' parameter. "
-                            "See https://github.com/elastic/elasticsearch-py/issues/1698 "
-                            "for more information",
-                            category=DeprecationWarning,
-                            stacklevel=warn_stacklevel(),
-                        )
                         kwargs[body_name] = body
 
                     elif body_fields:
@@ -396,12 +387,6 @@ def _rewrite_parameters(
                                 "Couldn't merge 'body' with other parameters as it wasn't a mapping. "
                                 "Instead of using 'body' use individual API parameters"
                             )
-                        warnings.warn(
-                            "The 'body' parameter is deprecated and will be removed "
-                            "in a future version. Instead use individual parameters.",
-                            category=DeprecationWarning,
-                            stacklevel=warn_stacklevel(),
-                        )
                         _merge_kwargs_no_duplicates(kwargs, body)
 
             if parameter_aliases:

--- a/test_elasticsearch/test_client/test_rewrite_parameters.py
+++ b/test_elasticsearch/test_client/test_rewrite_parameters.py
@@ -87,17 +87,11 @@ class TestRewriteParameters:
                 api_key=("id", "api_key"), body={"query": {"match_all": {}}}
             )
 
-        assert len(w) == 2
+        assert len(w) == 1
         assert w[0].category == DeprecationWarning
         assert (
             str(w[0].message)
             == "Passing transport options in the API method is deprecated. Use 'Elasticsearch.options()' instead."
-        )
-        assert w[1].category == DeprecationWarning
-        assert str(w[1].message) == (
-            "The 'body' parameter is deprecated and will be removed in a "
-            "future version. Instead use the 'document' parameter. See https://github.com/elastic/elasticsearch-py/issues/1698 "
-            "for more information"
         )
 
         assert self.calls == [
@@ -139,15 +133,11 @@ class TestRewriteParameters:
                 api_key=("id", "api_key"), body={"query": {"match_all": {}}}
             )
 
-        assert len(w) == 2
+        assert len(w) == 1
         assert w[0].category == DeprecationWarning
         assert (
             str(w[0].message)
             == "Passing transport options in the API method is deprecated. Use 'Elasticsearch.options()' instead."
-        )
-        assert w[1].category == DeprecationWarning
-        assert str(w[1].message) == (
-            "The 'body' parameter is deprecated and will be removed in a future version. Instead use individual parameters."
         )
 
         assert self.calls == [


### PR DESCRIPTION
Relates #2181 

This pull request removes the `body` parameter deprecation messages, but does not allow using `body` for unknown parameters yet.