### PR TITLE
Fix arguments in 'update' example

### DIFF
--- a/docs/guide/examples.asciidoc
+++ b/docs/guide/examples.asciidoc
@@ -93,7 +93,7 @@ doc = {
     'text': 'Interensting modified content...',
     'timestamp': datetime.now(),
 }
-resp = client.update(index="test-index", id=1, document=doc)
+resp = client.update(index="test-index", id=1, doc=doc)
 print(resp['result'])
 ----------------------------
 


### PR DESCRIPTION
Noticed that this example didn't match actual functionality; fixed to align with correct argument described at https://elasticsearch-py.readthedocs.io/en/v8.9.0/api.html#elasticsearch.Elasticsearch.update.