### PR TITLE
Fix Read the Docs theme

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,6 @@ pytest
 pytest-cov
 pytest-asyncio
 coverage
-sphinx
 jinja2
 python-dateutil
 unasync
@@ -22,3 +21,9 @@ pandas; python_version<"3.10"
 
 # Testing the 'search_mvt' API response
 mapbox-vector-tile; python_version<"3.10"
+
+# Docs
+# Override Read the Docs default (sphinx<2 and sphinx-rtd-theme<0.5)
+sphinx>2
+sphinx-rtd-theme>0.5
+sphinx-autodoc-typehints

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,9 +109,7 @@ def lint(session):
 
 @nox.session()
 def docs(session):
-    session.install(
-        "-rdev-requirements.txt", "sphinx-rtd-theme", "sphinx-autodoc-typehints"
-    )
+    session.install("-rdev-requirements.txt")
     session.install(".")
     session.run("python", "-m", "pip", "install", "sphinx-autodoc-typehints")
 


### PR DESCRIPTION
As done in https://github.com/elastic/elasticsearch-dsl-py/pull/1668. The current docs use an old Sphinx and sphinx-rtd-theme version: https://elasticsearch-py.readthedocs.io/en/v8.10.0/