### PR TITLE
Finish fixing Read the Docs theme

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,11 @@
 version: 2
-sphinx:
-  configuration: docs/sphinx/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
 
 python:
-  version: 3.7
   install:
     - requirements: dev-requirements.txt
     - path: .

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -17,7 +17,6 @@
 #  under the License.
 
 import datetime
-import os
 
 import elasticsearch
 
@@ -45,13 +44,7 @@ release = version
 
 pygments_style = "sphinx"
 
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
I had missed a few more differences with elasticsearch-py-dsl, including https://blog.readthedocs.com/use-build-os-config/ to use a newer Python and Sphinx version and the complicated conf.py logic that had to go away.