### PR TITLE
[DOCS] Adds quickstart guide to ES Py Read The Docs

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -110,6 +110,7 @@ Contents
 .. toctree::
    :maxdepth: 3
 
+   quickstart
    api
    exceptions
    async

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -29,11 +29,8 @@ You can connect to the Elastic Cloud using an API key and the Cloud ID.
 .. code-block:: python
 
     from elasticsearch import Elasticsearch
-    
-    client = Elasticsearch(
-    cloud_id="YOUR_CLOUD_ID",
-    api_key="YOUR_API_KEY"
-    )
+
+    client = Elasticsearch(cloud_id="YOUR_CLOUD_ID", api_key="YOUR_API_KEY")
 
 Your Cloud ID can be found on the **My deployment** page of your deployment 
 under **Cloud ID**.
@@ -77,7 +74,7 @@ This is a simple way of indexing a documentby using the index API:
         document={
             "foo": "foo",
             "bar": "bar",
-        }
+        },
     )
 
 
@@ -102,12 +99,8 @@ This is how you can create a single match query with the Python client:
 .. code-block:: python
 
     from elasticsearch import Elasticsearch
-    
-    client.search(index="my_index", query={
-        "match": {
-            "foo": "foo"
-        }
-    })
+
+    client.search(index="my_index", query={"match": {"foo": "foo"}})
 
 
 Updating documents
@@ -119,10 +112,14 @@ This is how you can update a document, for example to add a new field:
 
     from elasticsearch import Elasticsearch
 
-    client.update(index="my_index", id="my_document_id", doc={
-        "foo": "bar",
-        "new_field": "new value",
-    })
+    client.update(
+        index="my_index",
+        id="my_document_id",
+        doc={
+            "foo": "bar",
+            "new_field": "new value",
+        },
+    )
 
 
 Deleting documents

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -45,8 +45,7 @@ Using the client
 
 Time to use Elasticsearch! This section walks you through the most important 
 operations of Elasticsearch. The following examples assume that the Python 
-client has already initiated and don't contain the Elasticsearch `include` 
-statement.
+client was instantiated as above.
 
 
 Creating an index
@@ -94,7 +93,7 @@ This is how you can create a single match query with the Python client:
 
 .. code-block:: python
 
-    client.search(index="my_index", query={"match": {"foo": "foo"}})
+    client.search(index="my_index", query={"match": {"foo": {"query": "foo"}}})
 
 
 Updating documents

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -44,7 +44,9 @@ Using the client
 ----------------
 
 Time to use Elasticsearch! This section walks you through the most important 
-operations of Elasticsearch.
+operations of Elasticsearch. The following examples assume that the Python 
+client has already initiated and don't contain the Elasticsearch `include` 
+statement.
 
 
 Creating an index
@@ -53,8 +55,6 @@ Creating an index
 This is how you create the `my_index` index:
 
 .. code-block:: python
-
-    from elasticsearch import Elasticsearch 
 
     client.indices.create(index="my_index")
 
@@ -65,8 +65,6 @@ Indexing documents
 This indexes a document with the index API:
 
 .. code-block:: python
-
-    from elasticsearch import Elasticsearch
 
     client.index(
         index="my_index",
@@ -84,8 +82,6 @@ Getting documents
 You can get documents by using the following code:
 
 .. code-block:: python
-
-    from elasticsearch import Elasticsearch
     
     client.get(index="my_index", id="my_document_id")
 
@@ -98,8 +94,6 @@ This is how you can create a single match query with the Python client:
 
 .. code-block:: python
 
-    from elasticsearch import Elasticsearch
-
     client.search(index="my_index", query={"match": {"foo": "foo"}})
 
 
@@ -109,8 +103,6 @@ Updating documents
 This is how you can update a document, for example to add a new field:
 
 .. code-block:: python
-
-    from elasticsearch import Elasticsearch
 
     client.update(
         index="my_index",
@@ -126,8 +118,6 @@ Deleting documents
 ^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
-
-    from elasticsearch import Elasticsearch
     
     client.delete(index="my_index", id="my_document_id")
 
@@ -136,7 +126,5 @@ Deleting an index
 ^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
-
-    from elasticsearch import Elasticsearch
     
     client.indices.delete(index="my_index")

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -1,8 +1,8 @@
 Quickstart 
 ==========
 
-This guide shows you how to install Elasticsearch and perform basic operations 
-with it by using the Python client.
+This guide shows you how to install the Elasticsearch Python client and perform basic
+operations like indexing or searching documents.
 
 Requirements
 ------------
@@ -24,7 +24,7 @@ To install the latest version of the client, run the following command:
 Connecting
 ----------
 
-You can connect to the Elastic Cloud using an API key and the Cloud ID.
+You can connect to Elastic Cloud using an API key and the Cloud ID.
 
 .. code-block:: python
 
@@ -62,7 +62,7 @@ This is how you create the `my_index` index:
 Indexing documents
 ^^^^^^^^^^^^^^^^^^
 
-This is a simple way of indexing a documentby using the index API:
+This indexes a document with the index API:
 
 .. code-block:: python
 

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -7,7 +7,7 @@ with it by using the Python client.
 Requirements
 ------------
 
-- `Python <https://www.python.org/>_` 3.6 or newer
+- `Python <https://www.python.org/>`_ 3.6 or newer
 - `pip <https://pip.pypa.io/en/stable/>`_
 
 

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -34,7 +34,7 @@ endpoint.
     client = Elasticsearch(
     "https://...",  # Elasticsearch endpoint
     api_key=('api-key-id', 'api-key-secret'),  # API key ID and secret
-)
+    )
 
 Your Elasticsearch endpoint can be found on the **My deployment** page of your 
 deployment:

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -1,0 +1,148 @@
+Quickstart 
+==========
+
+This guide shows you how to install Elasticsearch and perform basic operations 
+with it by using the Python client.
+
+Requirements
+------------
+
+- `Python <https://www.python.org/>_` 3.6 or newer
+- `pip <https://pip.pypa.io/en/stable/>`_
+
+
+Installation
+------------
+
+To install the latest version of the client, run the following command:
+
+.. code-block:: console
+
+    $ python -m pip install elasticsearch
+
+
+Connecting
+----------
+
+You can connect to the Elastic Cloud using an API key and the Elasticsearch 
+endpoint.
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch
+    
+    client = Elasticsearch(
+    "https://...",  # Elasticsearch endpoint
+    api_key=('api-key-id', 'api-key-secret'),  # API key ID and secret
+)
+
+Your Elasticsearch endpoint can be found on the **My deployment** page of your 
+deployment:
+
+.. image:: ../guide/images/es-endpoint.jpg
+
+You can generate an API key on the **Management** page under Security.
+
+.. image:: ../guide/images/create-api-key.png
+
+
+Using the client
+----------------
+
+Time to use Elasticsearch! This section walks you through the most important 
+operations of Elasticsearch.
+
+
+Creating an index
+^^^^^^^^^^^^^^^^^
+
+This is how you create the `my_index` index:
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch 
+
+    client.indices.create(index="my_index")
+
+
+Indexing documents
+^^^^^^^^^^^^^^^^^^
+
+This is a simple way of indexing a documentby using the index API:
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch
+
+    client.index(
+        index="my_index",
+        id="my_document_id",
+        document={
+            "foo": "foo",
+            "bar": "bar",
+        }
+    )
+
+
+Getting documents
+^^^^^^^^^^^^^^^^^
+
+You can get documents by using the following code:
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch
+    
+    client.get(index="my_index", id="my_document_id")
+
+
+Searching documents
+^^^^^^^^^^^^^^^^^^^
+
+This is how you can create a single match query with the Python client: 
+
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch
+    
+    client.search(index="my_index", query={
+        "match": {
+            "foo": "foo"
+        }
+    })
+
+
+Updating documents
+^^^^^^^^^^^^^^^^^^
+
+This is how you can update a document, for example to add a new field:
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch
+
+    client.update(index="my_index", id="my_document_id", doc={
+        "foo": "bar",
+        "new_field": "new value",
+    })
+
+
+Deleting documents
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch
+    
+    client.delete(index="my_index", id="my_document_id")
+
+
+Deleting an index
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    from elasticsearch import Elasticsearch
+    
+    client.indices.delete(index="my_index")

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -24,22 +24,19 @@ To install the latest version of the client, run the following command:
 Connecting
 ----------
 
-You can connect to the Elastic Cloud using an API key and the Elasticsearch 
-endpoint.
+You can connect to the Elastic Cloud using an API key and the Cloud ID.
 
 .. code-block:: python
 
     from elasticsearch import Elasticsearch
     
     client = Elasticsearch(
-    "https://...",  # Elasticsearch endpoint
-    api_key=('api-key-id', 'api-key-secret'),  # API key ID and secret
+    cloud_id="YOUR_CLOUD_ID",
+    api_key="YOUR_API_KEY"
     )
 
-Your Elasticsearch endpoint can be found on the **My deployment** page of your 
-deployment:
-
-.. image:: ../guide/images/es-endpoint.jpg
+Your Cloud ID can be found on the **My deployment** page of your deployment 
+under **Cloud ID**.
 
 You can generate an API key on the **Management** page under Security.
 

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -14,7 +14,7 @@ Requirements
 Installation
 ------------
 
-To install the latest version of the client, run the following command:
+To install the client, run the following command:
 
 .. code-block:: console
 


### PR DESCRIPTION
## Overview

This PR adds a quick start guide to the Elasticsearch Python Client Read The Docs documentation site.