### PR TITLE
Fix type annotation of source parameter.

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -3322,7 +3322,7 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
         explain: t.Optional[bool] = None,
         ext: t.Optional[t.Mapping[str, t.Any]] = None,
-        fields: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        fields: t.Optional[t.Sequence[t.Union[t.Mapping[str, t.Any], str]]] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         from_: t.Optional[int] = None,
         highlight: t.Optional[t.Mapping[str, t.Any]] = None,

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -3370,7 +3370,7 @@ class AsyncElasticsearch(BaseClient):
                 t.Union[str, t.Mapping[str, t.Any]],
             ]
         ] = None,
-        source: t.Optional[t.Union[bool, t.Mapping[str, t.Any]]] = None,
+        source: t.Optional[t.Union[bool, t.Sequence[str]]] = None,
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stats: t.Optional[t.Sequence[str]] = None,

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -3320,7 +3320,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         explain: t.Optional[bool] = None,
         ext: t.Optional[t.Mapping[str, t.Any]] = None,
-        fields: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        fields: t.Optional[t.Sequence[t.Union[t.Mapping[str, t.Any], str]]] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         from_: t.Optional[int] = None,
         highlight: t.Optional[t.Mapping[str, t.Any]] = None,

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -3368,7 +3368,7 @@ class Elasticsearch(BaseClient):
                 t.Union[str, t.Mapping[str, t.Any]],
             ]
         ] = None,
-        source: t.Optional[t.Union[bool, t.Mapping[str, t.Any]]] = None,
+        source: t.Optional[t.Union[bool, t.Sequence[str]]] = None,
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stats: t.Optional[t.Sequence[str]] = None,


### PR DESCRIPTION
This might be completely wrong, but I think the type hinting of the `source` parameter for `Elasticsearch().search()` should be `Sequence[str]` and not `Mapping[str, Any]` (s. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#source-filtering)
Also `fields` should be accepting `str` as well as `Mapping[str, Any]`