### PR TITLE
Add missing param `scores` on `ml.put_trained_model_vocabulary`

### DIFF
--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -3302,6 +3302,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         merges: t.Optional[t.Sequence[str]] = None,
+        scores: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3312,11 +3313,14 @@ class MlClient(NamespacedClient):
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
         :param merges: The optional model merges if required by the tokenizer.
+        :param scores: The optional model scores if required by the tokenizer.
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
         if vocabulary is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
+        if scores is not None and len(scores) != len(vocabulary):
+            raise ValueError("The value length for the 'scores' and 'vocabulary' parameters is not the same")
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
@@ -3330,6 +3334,8 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if merges is not None:
             __body["merges"] = merges
+        if scores is not None:
+            __body["scores"] = scores
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json", "content-type": "application/json"}

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -3313,14 +3313,16 @@ class MlClient(NamespacedClient):
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
         :param merges: The optional model merges if required by the tokenizer.
-        :param scores: The optional model scores if required by the tokenizer.
+        :param scores: The optional vocabulary value scores if required by the tokenizer.
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
         if vocabulary is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
         if scores is not None and len(scores) != len(vocabulary):
-            raise ValueError("The value length for the 'scores' and 'vocabulary' parameters is not the same")
+            raise ValueError(
+                "The value length for the 'scores' and 'vocabulary' parameters is not the same"
+            )
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -3302,6 +3302,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         merges: t.Optional[t.Sequence[str]] = None,
+        scores: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -3312,11 +3313,14 @@ class MlClient(NamespacedClient):
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
         :param merges: The optional model merges if required by the tokenizer.
+        :param scores: The optional vocabulary value scores if required by the tokenizer.
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
         if vocabulary is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
+        if scores is not None and len(scores) != len(vocabulary):
+            raise ValueError("The value length for the 'scores' and 'vocabulary' parameters is not the same")
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
@@ -3330,6 +3334,8 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if merges is not None:
             __body["merges"] = merges
+        if scores is not None:
+            __body["scores"] = scores
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json", "content-type": "application/json"}

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -3320,7 +3320,9 @@ class MlClient(NamespacedClient):
         if vocabulary is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
         if scores is not None and len(scores) != len(vocabulary):
-            raise ValueError("The value length for the 'scores' and 'vocabulary' parameters is not the same")
+            raise ValueError(
+                "The value length for the 'scores' and 'vocabulary' parameters is not the same"
+            )
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
         __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}


### PR DESCRIPTION
This adds the missing `scores` parameter that was introduced in v8.9.0.

[Docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/put-trained-model-vocabulary.html#ml-put-trained-model-vocabulary-request-body) say:
> (Optional, array) Vocabulary value scores used by sentence-piece tokenization. Must have the same length as vocabulary. Required for unigram sentence-piece tokenized models like XLMRoberta and T5.