### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,38 +19,17 @@ jobs:
       - name: Lint the code
         run: nox -s lint
 
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          python3 -m pip install nox
-      - name: Build the docs
-        run: nox -s docs
-
   test-linux:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        experimental: [false]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         nox-session: [""]
         runs-on: ["ubuntu-latest"]
-        include:
-          - python-version: 3.11-dev
-            experimental: true
-            nox-session: test-3.11
-            runs-on: "ubuntu-latest"
 
     runs-on: ${{ matrix.runs-on }}
     name: test-${{ matrix.python-version }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python3 -m pip install nox

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.11"
 
 python:
   install:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,6 +15,9 @@ twine
 build
 nox
 
+numpy
+pandas
+
 # Testing the 'search_mvt' API response
 mapbox-vector-tile
 # Python 3.7 gets an old version of mapbox-vector-tile, requiring an

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,12 +15,11 @@ twine
 build
 nox
 
-# No wheels for Python 3.10 yet!
-numpy; python_version<"3.10"
-pandas; python_version<"3.10"
-
 # Testing the 'search_mvt' API response
-mapbox-vector-tile; python_version<"3.10"
+mapbox-vector-tile
+# Python 3.7 gets an old version of mapbox-vector-tile, requiring an
+# old version of protobuf
+protobuf<4; python_version<="3.7"
 
 # Docs
 # Override Read the Docs default (sphinx<2 and sphinx-rtd-theme<0.5)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ ignore = E203, E266, E501, W503
 
 [tool:pytest]
 junit_family=legacy
-addopts = -vvv -p no:logging --cov-report=term-missing --cov=elasticsearch --cov-config=.coveragerc
+addopts = -vvv --cov-report=term-missing --cov=elasticsearch --cov-config=.coveragerc
 
 [tool:isort]
 profile=black


### PR DESCRIPTION
This makes CI green, without adding support for Python 3.12 or figuring out why the server tests are not running anymore.