### PR TITLE
Fix Sphinx index page

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -33,7 +33,7 @@ Language clients are forward compatible; meaning that clients support communicat
 with greater or equal minor versions of Elasticsearch. Elasticsearch language clients
 are only backwards compatible with default distributions and without guarantees made.
 
-If you have a need to have multiple versions installed at the same time versions are
+If you need multiple versions installed at the same time, versions are
 also released, such as ``elasticsearch7`` and ``elasticsearch8``.
 
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -33,8 +33,8 @@ Language clients are forward compatible; meaning that clients support communicat
 with greater or equal minor versions of Elasticsearch. Elasticsearch language clients
 are only backwards compatible with default distributions and without guarantees made.
 
-If you have a need to have multiple versions installed at the same time older
-versions are also released as ``elasticsearch2``, ``elasticsearch5`` and ``elasticsearch6``.
+If you have a need to have multiple versions installed at the same time versions are
+also released, such as ``elasticsearch7`` and ``elasticsearch8``.
 
 
 Example Usage
@@ -44,25 +44,28 @@ Example Usage
 
     from datetime import datetime
     from elasticsearch import Elasticsearch
-    es = Elasticsearch()
+
+    es = Elasticsearch("http://localhost:9200")
 
     doc = {
-        'author': 'kimchy',
-        'text': 'Elasticsearch: cool. bonsai cool.',
-        'timestamp': datetime.now(),
+        "author": "kimchy",
+        "text": "Elasticsearch: cool. bonsai cool.",
+        "timestamp": datetime.now(),
     }
     resp = es.index(index="test-index", id=1, document=doc)
-    print(resp['result'])
+    print(resp["result"])
 
     resp = es.get(index="test-index", id=1)
-    print(resp['_source'])
+    print(resp["_source"])
 
     es.indices.refresh(index="test-index")
 
     resp = es.search(index="test-index", query={"match_all": {}})
-    print("Got %d Hits:" % resp['hits']['total']['value'])
-    for hit in resp['hits']['hits']:
-        print("%(timestamp)s %(author)s: %(text)s" % hit["_source"])
+    print("Got {} hits:".format(resp["hits"]["total"]["value"]))
+    for hit in resp["hits"]["hits"]:
+        print("{timestamp} {author} {text}".format(**hit["_source"]))
+
+See more examples in the :ref:`quickstart` page.
 
 
 Interactive examples

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -1,4 +1,6 @@
-Quickstart 
+.. _quickstart:
+
+Quickstart
 ==========
 
 This guide shows you how to install the Elasticsearch Python client and perform basic


### PR DESCRIPTION
It failed to provide an URL when instantiating the client, did not link to the Quickstart page and generally use older Python idioms.