### PR TITLE
Allow unrestricted body again

### DIFF
--- a/docs/guide/migration.asciidoc
+++ b/docs/guide/migration.asciidoc
@@ -167,7 +167,7 @@ with the `security.grant_api_key` API:
 
 [source,python]
 ------------------------------------
-# 8.0+ SUPPORTED USAGES:
+# 8.0+ SUPPORTED USAGE:
 resp = (
     client.options(
         # This is the API key being used for the request
@@ -183,13 +183,36 @@ resp = (
     )
 )
 
-# 7.x DEPRECATED USAGES (Don't do this!):
+# 7.x DEPRECATED USAGE (Don't do this!):
 resp = (
     # This is the API key being used for the request
     client.security.grant_api_key(
         api_key=("request-id", "request-api-key"),
-        # This is the API key being granted
         body={
+            # This is the API key being granted
+            "api_key": {
+                "name": "granted-api-key"
+            },
+            "grant_type": "password",
+            "username": "elastic",
+            "password": "changeme"
+        }
+    )
+)
+------------------------------------
+
+Starting with the 8.12 client, using a body parameter is fully supported again, meaning you can also use `grant_api_key` like this:
+
+[source,python]
+------------------------------------
+# 8.12+ SUPPORTED USAGE:
+resp = (
+    client.options(
+        # This is the API key being used for the request
+        api_key=("request-id", "request-api-key")
+    ).security.grant_api_key(
+        body={
+            # This is the API key being granted
             "api_key": {
                 "name": "granted-api-key"
             },
@@ -295,7 +318,7 @@ from elasticsearch import TransportError, Elasticsearch
 try:
     client.indices.get(index="index-that-does-not-exist")
 
-# In elasticsearch-python v7.x this would capture the resulting
+# In elasticsearch-py v7.x this would capture the resulting
 # 'NotFoundError' that would be raised above. But in 8.0.0 this
 # 'except TransportError' won't capture 'NotFoundError'.
 except TransportError as err:

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -612,7 +612,8 @@ class AsyncElasticsearch(BaseClient):
     async def bulk(
         self,
         *,
-        operations: t.Sequence[t.Mapping[str, t.Any]],
+        operations: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -663,8 +664,12 @@ class AsyncElasticsearch(BaseClient):
             before proceeding with the operation. Set to all or any positive integer
             up to the total number of shards in the index (`number_of_replicas+1`).
         """
-        if operations is None:
-            raise ValueError("Empty value passed for parameter 'operations'")
+        if operations is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'operations' and 'body', one of them should be set."
+            )
+        elif operations is not None and body is not None:
+            raise ValueError("Cannot set both 'operations' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_bulk"
         else:
@@ -696,7 +701,7 @@ class AsyncElasticsearch(BaseClient):
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = operations
+        __body = operations if operations is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -706,7 +711,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("scroll_id",),
     )
     async def clear_scroll(
         self,
@@ -716,6 +721,7 @@ class AsyncElasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         scroll_id: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explicitly clears the search context for a scroll.
@@ -726,7 +732,7 @@ class AsyncElasticsearch(BaseClient):
         """
         __path = "/_search/scroll"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -735,8 +741,9 @@ class AsyncElasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if scroll_id is not None:
-            __body["scroll_id"] = scroll_id
+        if not __body:
+            if scroll_id is not None:
+                __body["scroll_id"] = scroll_id
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -747,16 +754,17 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("id",),
     )
     async def close_point_in_time(
         self,
         *,
-        id: str,
+        id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Close a point in time
@@ -765,13 +773,11 @@ class AsyncElasticsearch(BaseClient):
 
         :param id: The ID of the point-in-time.
         """
-        if id is None:
+        if id is None and body is None:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = "/_pit"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if id is not None:
-            __body["id"] = id
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -780,6 +786,9 @@ class AsyncElasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if id is not None:
+                __body["id"] = id
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -790,7 +799,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
     )
     async def count(
         self,
@@ -822,6 +831,7 @@ class AsyncElasticsearch(BaseClient):
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         routing: t.Optional[str] = None,
         terminate_after: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns number of documents matching a query.
@@ -870,7 +880,7 @@ class AsyncElasticsearch(BaseClient):
         else:
             __path = "/_count"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if analyze_wildcard is not None:
@@ -903,12 +913,13 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if terminate_after is not None:
             __query["terminate_after"] = terminate_after
+        if not __body:
+            if query is not None:
+                __body["query"] = query
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -926,7 +937,8 @@ class AsyncElasticsearch(BaseClient):
         *,
         index: str,
         id: str,
-        document: t.Mapping[str, t.Any],
+        document: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -982,8 +994,12 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if document is None:
-            raise ValueError("Empty value passed for parameter 'document'")
+        if document is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'document' and 'body', one of them should be set."
+            )
+        elif document is not None and body is not None:
+            raise ValueError("Cannot set both 'document' and 'body'")
         __path = f"/{_quote(index)}/_create/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1008,7 +1024,7 @@ class AsyncElasticsearch(BaseClient):
             __query["version_type"] = version_type
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = document
+        __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -1100,7 +1116,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("max_docs", "query", "slice"),
         parameter_aliases={"from": "from_"},
     )
     async def delete_by_query(
@@ -1155,6 +1171,7 @@ class AsyncElasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Deletes documents matching the provided query.
@@ -1228,7 +1245,7 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_delete_by_query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -1266,16 +1283,12 @@ class AsyncElasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if lenient is not None:
             __query["lenient"] = lenient
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if refresh is not None:
             __query["refresh"] = refresh
         if request_cache is not None:
@@ -1292,8 +1305,6 @@ class AsyncElasticsearch(BaseClient):
             __query["search_timeout"] = search_timeout
         if search_type is not None:
             __query["search_type"] = search_type
-        if slice is not None:
-            __body["slice"] = slice
         if slices is not None:
             __query["slices"] = slices
         if sort is not None:
@@ -1310,6 +1321,13 @@ class AsyncElasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if query is not None:
+                __body["query"] = query
+            if slice is not None:
+                __body["slice"] = slice
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -1588,7 +1606,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -1617,6 +1635,7 @@ class AsyncElasticsearch(BaseClient):
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns information about why a specific matches (or doesn't match) a query.
@@ -1655,7 +1674,7 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/{_quote(index)}/_explain/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if analyze_wildcard is not None:
             __query["analyze_wildcard"] = analyze_wildcard
         if analyzer is not None:
@@ -1678,8 +1697,6 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if source is not None:
@@ -1691,6 +1708,9 @@ class AsyncElasticsearch(BaseClient):
         if stored_fields is not None:
             __query["stored_fields"] = stored_fields
         if not __body:
+            if query is not None:
+                __body["query"] = query
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -1700,7 +1720,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("fields", "index_filter", "runtime_mappings"),
     )
     async def field_caps(
         self,
@@ -1726,6 +1746,7 @@ class AsyncElasticsearch(BaseClient):
         pretty: t.Optional[bool] = None,
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         types: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns the information about the capabilities of fields among multiple indices.
@@ -1764,15 +1785,13 @@ class AsyncElasticsearch(BaseClient):
         else:
             __path = "/_field_caps"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if filters is not None:
@@ -1783,14 +1802,17 @@ class AsyncElasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if include_unmapped is not None:
             __query["include_unmapped"] = include_unmapped
-        if index_filter is not None:
-            __body["index_filter"] = index_filter
         if pretty is not None:
             __query["pretty"] = pretty
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
         if types is not None:
             __query["types"] = types
+        if not __body:
+            if fields is not None:
+                __body["fields"] = fields
+            if index_filter is not None:
+                __body["index_filter"] = index_filter
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2141,7 +2163,8 @@ class AsyncElasticsearch(BaseClient):
         self,
         *,
         index: str,
-        document: t.Mapping[str, t.Any],
+        document: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2205,8 +2228,12 @@ class AsyncElasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if document is None:
-            raise ValueError("Empty value passed for parameter 'document'")
+        if document is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'document' and 'body', one of them should be set."
+            )
+        elif document is not None and body is not None:
+            raise ValueError("Cannot set both 'document' and 'body'")
         if index not in SKIP_IN_PATH and id not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_doc/{_quote(id)}"
             __method = "PUT"
@@ -2246,7 +2273,7 @@ class AsyncElasticsearch(BaseClient):
             __query["version_type"] = version_type
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = document
+        __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             __method, __path, params=__query, headers=__headers, body=__body
@@ -2282,14 +2309,21 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "knn",
+            "docvalue_fields",
+            "fields",
+            "filter",
+            "source",
+            "stored_fields",
+        ),
         parameter_aliases={"_source": "source"},
     )
     async def knn_search(
         self,
         *,
         index: t.Union[str, t.Sequence[str]],
-        knn: t.Mapping[str, t.Any],
+        knn: t.Optional[t.Mapping[str, t.Any]] = None,
         docvalue_fields: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2302,6 +2336,7 @@ class AsyncElasticsearch(BaseClient):
         routing: t.Optional[str] = None,
         source: t.Optional[t.Union[bool, t.Mapping[str, t.Any]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs a kNN search.
@@ -2331,21 +2366,13 @@ class AsyncElasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if knn is None:
+        if knn is None and body is None:
             raise ValueError("Empty value passed for parameter 'knn'")
         __path = f"/{_quote(index)}/_knn_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if knn is not None:
-            __body["knn"] = knn
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fields is not None:
-            __body["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -2354,10 +2381,19 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         if routing is not None:
             __query["routing"] = routing
-        if source is not None:
-            __body["_source"] = source
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
+        if not __body:
+            if knn is not None:
+                __body["knn"] = knn
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if fields is not None:
+                __body["fields"] = fields
+            if filter is not None:
+                __body["filter"] = filter
+            if source is not None:
+                __body["_source"] = source
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2368,7 +2404,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "ids"),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -2393,6 +2429,7 @@ class AsyncElasticsearch(BaseClient):
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to get multiple documents in one request.
@@ -2428,18 +2465,14 @@ class AsyncElasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_mget"
         else:
             __path = "/_mget"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ids is not None:
-            __body["ids"] = ids
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
@@ -2458,6 +2491,11 @@ class AsyncElasticsearch(BaseClient):
             __query["_source_includes"] = source_includes
         if stored_fields is not None:
             __query["stored_fields"] = stored_fields
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if ids is not None:
+                __body["ids"] = ids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2469,7 +2507,8 @@ class AsyncElasticsearch(BaseClient):
     async def msearch(
         self,
         *,
-        searches: t.Sequence[t.Mapping[str, t.Any]],
+        searches: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         ccs_minimize_roundtrips: t.Optional[bool] = None,
@@ -2538,8 +2577,12 @@ class AsyncElasticsearch(BaseClient):
         :param typed_keys: Specifies whether aggregation and suggester names should be
             prefixed by their respective types in the response.
         """
-        if searches is None:
-            raise ValueError("Empty value passed for parameter 'searches'")
+        if searches is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'searches' and 'body', one of them should be set."
+            )
+        elif searches is not None and body is not None:
+            raise ValueError("Cannot set both 'searches' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_msearch"
         else:
@@ -2577,7 +2620,7 @@ class AsyncElasticsearch(BaseClient):
             __query["search_type"] = search_type
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        __body = searches
+        __body = searches if searches is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2592,7 +2635,8 @@ class AsyncElasticsearch(BaseClient):
     async def msearch_template(
         self,
         *,
-        search_templates: t.Sequence[t.Mapping[str, t.Any]],
+        search_templates: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         ccs_minimize_roundtrips: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2626,8 +2670,12 @@ class AsyncElasticsearch(BaseClient):
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
-        if search_templates is None:
-            raise ValueError("Empty value passed for parameter 'search_templates'")
+        if search_templates is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'search_templates' and 'body', one of them should be set."
+            )
+        elif search_templates is not None and body is not None:
+            raise ValueError("Cannot set both 'search_templates' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_msearch/template"
         else:
@@ -2651,7 +2699,7 @@ class AsyncElasticsearch(BaseClient):
             __query["search_type"] = search_type
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        __body = search_templates
+        __body = search_templates if search_templates is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2661,7 +2709,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "ids"),
     )
     async def mtermvectors(
         self,
@@ -2686,6 +2734,7 @@ class AsyncElasticsearch(BaseClient):
         version_type: t.Optional[
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns multiple termvectors in one request.
@@ -2717,10 +2766,8 @@ class AsyncElasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_mtermvectors"
         else:
             __path = "/_mtermvectors"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if field_statistics is not None:
@@ -2731,8 +2778,6 @@ class AsyncElasticsearch(BaseClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ids is not None:
-            __body["ids"] = ids
         if offsets is not None:
             __query["offsets"] = offsets
         if payloads is not None:
@@ -2753,6 +2798,11 @@ class AsyncElasticsearch(BaseClient):
             __query["version"] = version
         if version_type is not None:
             __query["version_type"] = version_type
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if ids is not None:
+                __body["ids"] = ids
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2832,13 +2882,13 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("script",),
     )
     async def put_script(
         self,
         *,
         id: str,
-        script: t.Mapping[str, t.Any],
+        script: t.Optional[t.Mapping[str, t.Any]] = None,
         context: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2848,6 +2898,7 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a script.
@@ -2869,7 +2920,7 @@ class AsyncElasticsearch(BaseClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if script is None:
+        if script is None and body is None:
             raise ValueError("Empty value passed for parameter 'script'")
         if id not in SKIP_IN_PATH and context not in SKIP_IN_PATH:
             __path = f"/_scripts/{_quote(id)}/{_quote(context)}"
@@ -2877,10 +2928,8 @@ class AsyncElasticsearch(BaseClient):
             __path = f"/_scripts/{_quote(id)}"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if script is not None:
-            __body["script"] = script
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2893,18 +2942,21 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if script is not None:
+                __body["script"] = script
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("requests", "metric"),
     )
     async def rank_eval(
         self,
         *,
-        requests: t.Sequence[t.Mapping[str, t.Any]],
+        requests: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2922,6 +2974,7 @@ class AsyncElasticsearch(BaseClient):
         metric: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         search_type: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to evaluate the quality of ranked search results over a set of typical
@@ -2947,16 +3000,14 @@ class AsyncElasticsearch(BaseClient):
         :param metric: Definition of the evaluation metric to calculate.
         :param search_type: Search operation type
         """
-        if requests is None:
+        if requests is None and body is None:
             raise ValueError("Empty value passed for parameter 'requests'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_rank_eval"
         else:
             __path = "/_rank_eval"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if requests is not None:
-            __body["requests"] = requests
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if error_trace is not None:
@@ -2969,25 +3020,28 @@ class AsyncElasticsearch(BaseClient):
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if metric is not None:
-            __body["metric"] = metric
         if pretty is not None:
             __query["pretty"] = pretty
         if search_type is not None:
             __query["search_type"] = search_type
+        if not __body:
+            if requests is not None:
+                __body["requests"] = requests
+            if metric is not None:
+                __body["metric"] = metric
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("dest", "source", "conflicts", "max_docs", "script", "size"),
     )
     async def reindex(
         self,
         *,
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         conflicts: t.Optional[t.Union["t.Literal['abort', 'proceed']", str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -3006,6 +3060,7 @@ class AsyncElasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to copy documents from one index to another, optionally filtering the
@@ -3038,27 +3093,19 @@ class AsyncElasticsearch(BaseClient):
         :param wait_for_completion: If `true`, the request blocks until the operation
             is complete.
         """
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = "/_reindex"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
-        if conflicts is not None:
-            __body["conflicts"] = conflicts
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
@@ -3067,12 +3114,8 @@ class AsyncElasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         if require_alias is not None:
             __query["require_alias"] = require_alias
-        if script is not None:
-            __body["script"] = script
         if scroll is not None:
             __query["scroll"] = scroll
-        if size is not None:
-            __body["size"] = size
         if slices is not None:
             __query["slices"] = slices
         if timeout is not None:
@@ -3081,6 +3124,19 @@ class AsyncElasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if conflicts is not None:
+                __body["conflicts"] = conflicts
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if script is not None:
+                __body["script"] = script
+            if size is not None:
+                __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -3126,7 +3182,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("file", "params", "source"),
         ignore_deprecated_options={"params"},
     )
     async def render_search_template(
@@ -3140,6 +3196,7 @@ class AsyncElasticsearch(BaseClient):
         params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         source: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to use the Mustache language to pre-render a search definition.
@@ -3160,21 +3217,22 @@ class AsyncElasticsearch(BaseClient):
         else:
             __path = "/_render/template"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if file is not None:
-            __body["file"] = file
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if source is not None:
-            __body["source"] = source
+        if not __body:
+            if file is not None:
+                __body["file"] = file
+            if params is not None:
+                __body["params"] = params
+            if source is not None:
+                __body["source"] = source
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3185,7 +3243,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("context", "context_setup", "script"),
     )
     async def scripts_painless_execute(
         self,
@@ -3197,6 +3255,7 @@ class AsyncElasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         script: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows an arbitrary script to be executed and a result to be returned
@@ -3208,12 +3267,8 @@ class AsyncElasticsearch(BaseClient):
         :param script: The Painless script to execute.
         """
         __path = "/_scripts/painless/_execute"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if context is not None:
-            __body["context"] = context
-        if context_setup is not None:
-            __body["context_setup"] = context_setup
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3222,8 +3277,13 @@ class AsyncElasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if script is not None:
-            __body["script"] = script
+        if not __body:
+            if context is not None:
+                __body["context"] = context
+            if context_setup is not None:
+                __body["context_setup"] = context_setup
+            if script is not None:
+                __body["script"] = script
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3234,18 +3294,19 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("scroll_id", "scroll"),
     )
     async def scroll(
         self,
         *,
-        scroll_id: str,
+        scroll_id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         rest_total_hits_as_int: t.Optional[bool] = None,
         scroll: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to retrieve a large numbers of results from a single search request.
@@ -3258,13 +3319,11 @@ class AsyncElasticsearch(BaseClient):
             is returned as an object.
         :param scroll: Period to retain the search context for scrolling.
         """
-        if scroll_id is None:
+        if scroll_id is None and body is None:
             raise ValueError("Empty value passed for parameter 'scroll_id'")
         __path = "/_search/scroll"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if scroll_id is not None:
-            __body["scroll_id"] = scroll_id
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3275,8 +3334,11 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
-        if scroll is not None:
-            __body["scroll"] = scroll
+        if not __body:
+            if scroll_id is not None:
+                __body["scroll_id"] = scroll_id
+            if scroll is not None:
+                __body["scroll"] = scroll
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3287,7 +3349,42 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "knn",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rank",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -3388,6 +3485,7 @@ class AsyncElasticsearch(BaseClient):
         track_total_hits: t.Optional[t.Union[bool, int]] = None,
         typed_keys: t.Optional[bool] = None,
         version: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns results matching a query.
@@ -3580,8 +3678,8 @@ class AsyncElasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_search"
         else:
             __path = "/_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -3593,10 +3691,6 @@ class AsyncElasticsearch(BaseClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -3609,104 +3703,50 @@ class AsyncElasticsearch(BaseClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
-        if knn is not None:
-            __body["knn"] = knn
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
-        if rank is not None:
-            __body["rank"] = rank
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -3715,18 +3755,77 @@ class AsyncElasticsearch(BaseClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if knn is not None:
+                __body["knn"] = knn
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rank is not None:
+                __body["rank"] = rank
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3737,7 +3836,22 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggs",
+            "buffer",
+            "exact_bounds",
+            "extent",
+            "fields",
+            "grid_agg",
+            "grid_precision",
+            "grid_type",
+            "query",
+            "runtime_mappings",
+            "size",
+            "sort",
+            "track_total_hits",
+            "with_labels",
+        ),
     )
     async def search_mvt(
         self,
@@ -3772,6 +3886,7 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
         track_total_hits: t.Optional[t.Union[bool, int]] = None,
         with_labels: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> BinaryApiResponse:
         """
         Searches a vector tile for geospatial values. Returns results as a binary Mapbox
@@ -3833,8 +3948,8 @@ class AsyncElasticsearch(BaseClient):
         if y in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'y'")
         __path = f"/{_quote(index)}/_mvt/{_quote(field)}/{_quote(zoom)}/{_quote(x)}/{_quote(y)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -3846,42 +3961,43 @@ class AsyncElasticsearch(BaseClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggs is not None:
-            __body["aggs"] = aggs
-        if buffer is not None:
-            __body["buffer"] = buffer
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exact_bounds is not None:
-            __body["exact_bounds"] = exact_bounds
-        if extent is not None:
-            __body["extent"] = extent
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if grid_agg is not None:
-            __body["grid_agg"] = grid_agg
-        if grid_precision is not None:
-            __body["grid_precision"] = grid_precision
-        if grid_type is not None:
-            __body["grid_type"] = grid_type
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
-        if with_labels is not None:
-            __body["with_labels"] = with_labels
+        if not __body:
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if buffer is not None:
+                __body["buffer"] = buffer
+            if exact_bounds is not None:
+                __body["exact_bounds"] = exact_bounds
+            if extent is not None:
+                __body["extent"] = extent
+            if fields is not None:
+                __body["fields"] = fields
+            if grid_agg is not None:
+                __body["grid_agg"] = grid_agg
+            if grid_precision is not None:
+                __body["grid_precision"] = grid_precision
+            if grid_type is not None:
+                __body["grid_type"] = grid_type
+            if query is not None:
+                __body["query"] = query
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if with_labels is not None:
+                __body["with_labels"] = with_labels
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/vnd.mapbox-vector-tile"}
@@ -3970,7 +4086,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("explain", "id", "params", "profile", "source"),
         ignore_deprecated_options={"params"},
     )
     async def search_template(
@@ -4006,6 +4122,7 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
         source: t.Optional[str] = None,
         typed_keys: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to use the Mustache language to pre-render a search definition.
@@ -4055,7 +4172,7 @@ class AsyncElasticsearch(BaseClient):
         else:
             __path = "/_search/template"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if ccs_minimize_roundtrips is not None:
@@ -4064,26 +4181,18 @@ class AsyncElasticsearch(BaseClient):
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if id is not None:
-            __body["id"] = id
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if params is not None:
-            __body["params"] = params
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
@@ -4092,23 +4201,40 @@ class AsyncElasticsearch(BaseClient):
             __query["scroll"] = scroll
         if search_type is not None:
             __query["search_type"] = search_type
-        if source is not None:
-            __body["source"] = source
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
+        if not __body:
+            if explain is not None:
+                __body["explain"] = explain
+            if id is not None:
+                __body["id"] = id
+            if params is not None:
+                __body["params"] = params
+            if profile is not None:
+                __body["profile"] = profile
+            if source is not None:
+                __body["source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "field",
+            "case_insensitive",
+            "index_filter",
+            "search_after",
+            "size",
+            "string",
+            "timeout",
+        ),
     )
     async def terms_enum(
         self,
         *,
         index: str,
-        field: str,
+        field: t.Optional[str] = None,
         case_insensitive: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -4119,6 +4245,7 @@ class AsyncElasticsearch(BaseClient):
         size: t.Optional[int] = None,
         string: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         The terms enum API can be used to discover terms in the index that begin with
@@ -4146,33 +4273,34 @@ class AsyncElasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if field is None:
+        if field is None and body is None:
             raise ValueError("Empty value passed for parameter 'field'")
         __path = f"/{_quote(index)}/_terms_enum"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if field is not None:
-            __body["field"] = field
-        if case_insensitive is not None:
-            __body["case_insensitive"] = case_insensitive
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_filter is not None:
-            __body["index_filter"] = index_filter
         if pretty is not None:
             __query["pretty"] = pretty
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if string is not None:
-            __body["string"] = string
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if field is not None:
+                __body["field"] = field
+            if case_insensitive is not None:
+                __body["case_insensitive"] = case_insensitive
+            if index_filter is not None:
+                __body["index_filter"] = index_filter
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if string is not None:
+                __body["string"] = string
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -4183,7 +4311,7 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("doc", "filter", "per_field_analyzer"),
     )
     async def termvectors(
         self,
@@ -4210,6 +4338,7 @@ class AsyncElasticsearch(BaseClient):
         version_type: t.Optional[
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns information and statistics about terms in the fields of a particular
@@ -4248,18 +4377,14 @@ class AsyncElasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_termvectors"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if doc is not None:
-            __body["doc"] = doc
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if field_statistics is not None:
             __query["field_statistics"] = field_statistics
         if fields is not None:
             __query["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -4268,8 +4393,6 @@ class AsyncElasticsearch(BaseClient):
             __query["offsets"] = offsets
         if payloads is not None:
             __query["payloads"] = payloads
-        if per_field_analyzer is not None:
-            __body["per_field_analyzer"] = per_field_analyzer
         if positions is not None:
             __query["positions"] = positions
         if preference is not None:
@@ -4287,6 +4410,13 @@ class AsyncElasticsearch(BaseClient):
         if version_type is not None:
             __query["version_type"] = version_type
         if not __body:
+            if doc is not None:
+                __body["doc"] = doc
+            if filter is not None:
+                __body["filter"] = filter
+            if per_field_analyzer is not None:
+                __body["per_field_analyzer"] = per_field_analyzer
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -4296,7 +4426,15 @@ class AsyncElasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "detect_noop",
+            "doc",
+            "doc_as_upsert",
+            "script",
+            "scripted_upsert",
+            "source",
+            "upsert",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -4334,6 +4472,7 @@ class AsyncElasticsearch(BaseClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates a document with a script or partial document.
@@ -4381,14 +4520,8 @@ class AsyncElasticsearch(BaseClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/{_quote(index)}/_update/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if detect_noop is not None:
-            __body["detect_noop"] = detect_noop
-        if doc is not None:
-            __body["doc"] = doc
-        if doc_as_upsert is not None:
-            __body["doc_as_upsert"] = doc_as_upsert
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -4411,29 +4544,36 @@ class AsyncElasticsearch(BaseClient):
             __query["retry_on_conflict"] = retry_on_conflict
         if routing is not None:
             __query["routing"] = routing
-        if script is not None:
-            __body["script"] = script
-        if scripted_upsert is not None:
-            __body["scripted_upsert"] = scripted_upsert
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
         if timeout is not None:
             __query["timeout"] = timeout
-        if upsert is not None:
-            __body["upsert"] = upsert
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if detect_noop is not None:
+                __body["detect_noop"] = detect_noop
+            if doc is not None:
+                __body["doc"] = doc
+            if doc_as_upsert is not None:
+                __body["doc_as_upsert"] = doc_as_upsert
+            if script is not None:
+                __body["script"] = script
+            if scripted_upsert is not None:
+                __body["scripted_upsert"] = scripted_upsert
+            if source is not None:
+                __body["_source"] = source
+            if upsert is not None:
+                __body["upsert"] = upsert
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("conflicts", "max_docs", "query", "script", "slice"),
         parameter_aliases={"from": "from_"},
     )
     async def update_by_query(
@@ -4490,6 +4630,7 @@ class AsyncElasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs an update on every document in the index without changing the source,
@@ -4571,7 +4712,7 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_update_by_query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -4589,8 +4730,6 @@ class AsyncElasticsearch(BaseClient):
             __query["analyze_wildcard"] = analyze_wildcard
         if analyzer is not None:
             __query["analyzer"] = analyzer
-        if conflicts is not None:
-            __body["conflicts"] = conflicts
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
@@ -4609,16 +4748,12 @@ class AsyncElasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if lenient is not None:
             __query["lenient"] = lenient
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if pipeline is not None:
             __query["pipeline"] = pipeline
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if refresh is not None:
             __query["refresh"] = refresh
         if request_cache is not None:
@@ -4627,8 +4762,6 @@ class AsyncElasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         if routing is not None:
             __query["routing"] = routing
-        if script is not None:
-            __body["script"] = script
         if scroll is not None:
             __query["scroll"] = scroll
         if scroll_size is not None:
@@ -4637,8 +4770,6 @@ class AsyncElasticsearch(BaseClient):
             __query["search_timeout"] = search_timeout
         if search_type is not None:
             __query["search_type"] = search_type
-        if slice is not None:
-            __body["slice"] = slice
         if slices is not None:
             __query["slices"] = slices
         if sort is not None:
@@ -4657,6 +4788,17 @@ class AsyncElasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if conflicts is not None:
+                __body["conflicts"] = conflicts
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if query is not None:
+                __body["query"] = query
+            if script is not None:
+                __body["script"] = script
+            if slice is not None:
+                __body["slice"] = slice
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -155,7 +155,41 @@ class AsyncSearchClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "knn",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -260,6 +294,7 @@ class AsyncSearchClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a search request asynchronously.
@@ -396,8 +431,8 @@ class AsyncSearchClient(NamespacedClient):
             __path = f"/{_quote(index)}/_async_search"
         else:
             __path = "/_async_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -409,10 +444,6 @@ class AsyncSearchClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -425,106 +456,54 @@ class AsyncSearchClient(NamespacedClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
         if keep_on_completion is not None:
             __query["keep_on_completion"] = keep_on_completion
-        if knn is not None:
-            __body["knn"] = knn
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -533,20 +512,77 @@ class AsyncSearchClient(NamespacedClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
         if wait_for_completion_timeout is not None:
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if knn is not None:
+                __body["knn"] = knn
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/autoscaling.py
+++ b/elasticsearch/_async/client/autoscaling.py
@@ -131,7 +131,8 @@ class AutoscalingClient(NamespacedClient):
         self,
         *,
         name: str,
-        policy: t.Mapping[str, t.Any],
+        policy: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -148,8 +149,12 @@ class AutoscalingClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if policy is None:
-            raise ValueError("Empty value passed for parameter 'policy'")
+        if policy is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'policy' and 'body', one of them should be set."
+            )
+        elif policy is not None and body is not None:
+            raise ValueError("Cannot set both 'policy' and 'body'")
         __path = f"/_autoscaling/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -160,7 +165,7 @@ class AutoscalingClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = policy
+        __body = policy if policy is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -59,7 +59,20 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "leader_index",
+            "max_outstanding_read_requests",
+            "max_outstanding_write_requests",
+            "max_read_request_operation_count",
+            "max_read_request_size",
+            "max_retry_delay",
+            "max_write_buffer_count",
+            "max_write_buffer_size",
+            "max_write_request_operation_count",
+            "max_write_request_size",
+            "read_poll_timeout",
+            "remote_cluster",
+        ),
     )
     async def follow(
         self,
@@ -88,6 +101,7 @@ class CcrClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new follower index configured to follow the referenced leader index.
@@ -116,45 +130,48 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_ccr/follow"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if leader_index is not None:
-            __body["leader_index"] = leader_index
-        if max_outstanding_read_requests is not None:
-            __body["max_outstanding_read_requests"] = max_outstanding_read_requests
-        if max_outstanding_write_requests is not None:
-            __body["max_outstanding_write_requests"] = max_outstanding_write_requests
-        if max_read_request_operation_count is not None:
-            __body[
-                "max_read_request_operation_count"
-            ] = max_read_request_operation_count
-        if max_read_request_size is not None:
-            __body["max_read_request_size"] = max_read_request_size
-        if max_retry_delay is not None:
-            __body["max_retry_delay"] = max_retry_delay
-        if max_write_buffer_count is not None:
-            __body["max_write_buffer_count"] = max_write_buffer_count
-        if max_write_buffer_size is not None:
-            __body["max_write_buffer_size"] = max_write_buffer_size
-        if max_write_request_operation_count is not None:
-            __body[
-                "max_write_request_operation_count"
-            ] = max_write_request_operation_count
-        if max_write_request_size is not None:
-            __body["max_write_request_size"] = max_write_request_size
         if pretty is not None:
             __query["pretty"] = pretty
-        if read_poll_timeout is not None:
-            __body["read_poll_timeout"] = read_poll_timeout
-        if remote_cluster is not None:
-            __body["remote_cluster"] = remote_cluster
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if leader_index is not None:
+                __body["leader_index"] = leader_index
+            if max_outstanding_read_requests is not None:
+                __body["max_outstanding_read_requests"] = max_outstanding_read_requests
+            if max_outstanding_write_requests is not None:
+                __body[
+                    "max_outstanding_write_requests"
+                ] = max_outstanding_write_requests
+            if max_read_request_operation_count is not None:
+                __body[
+                    "max_read_request_operation_count"
+                ] = max_read_request_operation_count
+            if max_read_request_size is not None:
+                __body["max_read_request_size"] = max_read_request_size
+            if max_retry_delay is not None:
+                __body["max_retry_delay"] = max_retry_delay
+            if max_write_buffer_count is not None:
+                __body["max_write_buffer_count"] = max_write_buffer_count
+            if max_write_buffer_size is not None:
+                __body["max_write_buffer_size"] = max_write_buffer_size
+            if max_write_request_operation_count is not None:
+                __body[
+                    "max_write_request_operation_count"
+                ] = max_write_request_operation_count
+            if max_write_request_size is not None:
+                __body["max_write_request_size"] = max_write_request_size
+            if read_poll_timeout is not None:
+                __body["read_poll_timeout"] = read_poll_timeout
+            if remote_cluster is not None:
+                __body["remote_cluster"] = remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -233,7 +250,12 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "follower_cluster",
+            "follower_index",
+            "follower_index_uuid",
+            "leader_remote_cluster",
+        ),
     )
     async def forget_follower(
         self,
@@ -247,6 +269,7 @@ class CcrClient(NamespacedClient):
         human: t.Optional[bool] = None,
         leader_remote_cluster: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Removes the follower retention leases from the leader.
@@ -264,23 +287,24 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_ccr/forget_follower"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if follower_cluster is not None:
-            __body["follower_cluster"] = follower_cluster
-        if follower_index is not None:
-            __body["follower_index"] = follower_index
-        if follower_index_uuid is not None:
-            __body["follower_index_uuid"] = follower_index_uuid
         if human is not None:
             __query["human"] = human
-        if leader_remote_cluster is not None:
-            __body["leader_remote_cluster"] = leader_remote_cluster
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if follower_cluster is not None:
+                __body["follower_cluster"] = follower_cluster
+            if follower_index is not None:
+                __body["follower_index"] = follower_index
+            if follower_index_uuid is not None:
+                __body["follower_index_uuid"] = follower_index_uuid
+            if leader_remote_cluster is not None:
+                __body["leader_remote_cluster"] = leader_remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -395,13 +419,29 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "remote_cluster",
+            "follow_index_pattern",
+            "leader_index_exclusion_patterns",
+            "leader_index_patterns",
+            "max_outstanding_read_requests",
+            "max_outstanding_write_requests",
+            "max_read_request_operation_count",
+            "max_read_request_size",
+            "max_retry_delay",
+            "max_write_buffer_count",
+            "max_write_buffer_size",
+            "max_write_request_operation_count",
+            "max_write_request_size",
+            "read_poll_timeout",
+            "settings",
+        ),
     )
     async def put_auto_follow_pattern(
         self,
         *,
         name: str,
-        remote_cluster: str,
+        remote_cluster: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         follow_index_pattern: t.Optional[str] = None,
@@ -424,6 +464,7 @@ class CcrClient(NamespacedClient):
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new named collection of auto-follow patterns against a specified remote
@@ -477,53 +518,58 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if remote_cluster is None:
+        if remote_cluster is None and body is None:
             raise ValueError("Empty value passed for parameter 'remote_cluster'")
         __path = f"/_ccr/auto_follow/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if remote_cluster is not None:
-            __body["remote_cluster"] = remote_cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if follow_index_pattern is not None:
-            __body["follow_index_pattern"] = follow_index_pattern
         if human is not None:
             __query["human"] = human
-        if leader_index_exclusion_patterns is not None:
-            __body["leader_index_exclusion_patterns"] = leader_index_exclusion_patterns
-        if leader_index_patterns is not None:
-            __body["leader_index_patterns"] = leader_index_patterns
-        if max_outstanding_read_requests is not None:
-            __body["max_outstanding_read_requests"] = max_outstanding_read_requests
-        if max_outstanding_write_requests is not None:
-            __body["max_outstanding_write_requests"] = max_outstanding_write_requests
-        if max_read_request_operation_count is not None:
-            __body[
-                "max_read_request_operation_count"
-            ] = max_read_request_operation_count
-        if max_read_request_size is not None:
-            __body["max_read_request_size"] = max_read_request_size
-        if max_retry_delay is not None:
-            __body["max_retry_delay"] = max_retry_delay
-        if max_write_buffer_count is not None:
-            __body["max_write_buffer_count"] = max_write_buffer_count
-        if max_write_buffer_size is not None:
-            __body["max_write_buffer_size"] = max_write_buffer_size
-        if max_write_request_operation_count is not None:
-            __body[
-                "max_write_request_operation_count"
-            ] = max_write_request_operation_count
-        if max_write_request_size is not None:
-            __body["max_write_request_size"] = max_write_request_size
         if pretty is not None:
             __query["pretty"] = pretty
-        if read_poll_timeout is not None:
-            __body["read_poll_timeout"] = read_poll_timeout
-        if settings is not None:
-            __body["settings"] = settings
+        if not __body:
+            if remote_cluster is not None:
+                __body["remote_cluster"] = remote_cluster
+            if follow_index_pattern is not None:
+                __body["follow_index_pattern"] = follow_index_pattern
+            if leader_index_exclusion_patterns is not None:
+                __body[
+                    "leader_index_exclusion_patterns"
+                ] = leader_index_exclusion_patterns
+            if leader_index_patterns is not None:
+                __body["leader_index_patterns"] = leader_index_patterns
+            if max_outstanding_read_requests is not None:
+                __body["max_outstanding_read_requests"] = max_outstanding_read_requests
+            if max_outstanding_write_requests is not None:
+                __body[
+                    "max_outstanding_write_requests"
+                ] = max_outstanding_write_requests
+            if max_read_request_operation_count is not None:
+                __body[
+                    "max_read_request_operation_count"
+                ] = max_read_request_operation_count
+            if max_read_request_size is not None:
+                __body["max_read_request_size"] = max_read_request_size
+            if max_retry_delay is not None:
+                __body["max_retry_delay"] = max_retry_delay
+            if max_write_buffer_count is not None:
+                __body["max_write_buffer_count"] = max_write_buffer_count
+            if max_write_buffer_size is not None:
+                __body["max_write_buffer_size"] = max_write_buffer_size
+            if max_write_request_operation_count is not None:
+                __body[
+                    "max_write_request_operation_count"
+                ] = max_write_request_operation_count
+            if max_write_request_size is not None:
+                __body["max_write_request_size"] = max_write_request_size
+            if read_poll_timeout is not None:
+                __body["read_poll_timeout"] = read_poll_timeout
+            if settings is not None:
+                __body["settings"] = settings
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -565,7 +611,18 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "max_outstanding_read_requests",
+            "max_outstanding_write_requests",
+            "max_read_request_operation_count",
+            "max_read_request_size",
+            "max_retry_delay",
+            "max_write_buffer_count",
+            "max_write_buffer_size",
+            "max_write_request_operation_count",
+            "max_write_request_size",
+            "read_poll_timeout",
+        ),
     )
     async def resume_follow(
         self,
@@ -589,6 +646,7 @@ class CcrClient(NamespacedClient):
         read_poll_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Resumes a follower index that has been paused
@@ -611,39 +669,42 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_ccr/resume_follow"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_outstanding_read_requests is not None:
-            __body["max_outstanding_read_requests"] = max_outstanding_read_requests
-        if max_outstanding_write_requests is not None:
-            __body["max_outstanding_write_requests"] = max_outstanding_write_requests
-        if max_read_request_operation_count is not None:
-            __body[
-                "max_read_request_operation_count"
-            ] = max_read_request_operation_count
-        if max_read_request_size is not None:
-            __body["max_read_request_size"] = max_read_request_size
-        if max_retry_delay is not None:
-            __body["max_retry_delay"] = max_retry_delay
-        if max_write_buffer_count is not None:
-            __body["max_write_buffer_count"] = max_write_buffer_count
-        if max_write_buffer_size is not None:
-            __body["max_write_buffer_size"] = max_write_buffer_size
-        if max_write_request_operation_count is not None:
-            __body[
-                "max_write_request_operation_count"
-            ] = max_write_request_operation_count
-        if max_write_request_size is not None:
-            __body["max_write_request_size"] = max_write_request_size
         if pretty is not None:
             __query["pretty"] = pretty
-        if read_poll_timeout is not None:
-            __body["read_poll_timeout"] = read_poll_timeout
+        if not __body:
+            if max_outstanding_read_requests is not None:
+                __body["max_outstanding_read_requests"] = max_outstanding_read_requests
+            if max_outstanding_write_requests is not None:
+                __body[
+                    "max_outstanding_write_requests"
+                ] = max_outstanding_write_requests
+            if max_read_request_operation_count is not None:
+                __body[
+                    "max_read_request_operation_count"
+                ] = max_read_request_operation_count
+            if max_read_request_size is not None:
+                __body["max_read_request_size"] = max_read_request_size
+            if max_retry_delay is not None:
+                __body["max_retry_delay"] = max_retry_delay
+            if max_write_buffer_count is not None:
+                __body["max_write_buffer_count"] = max_write_buffer_count
+            if max_write_buffer_size is not None:
+                __body["max_write_buffer_size"] = max_write_buffer_size
+            if max_write_request_operation_count is not None:
+                __body[
+                    "max_write_request_operation_count"
+                ] = max_write_request_operation_count
+            if max_write_request_size is not None:
+                __body["max_write_request_size"] = max_write_request_size
+            if read_poll_timeout is not None:
+                __body["read_poll_timeout"] = read_poll_timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -25,7 +25,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class ClusterClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("current_node", "index", "primary", "shard"),
     )
     async def allocation_explain(
         self,
@@ -40,6 +40,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         primary: t.Optional[bool] = None,
         shard: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Provides explanations for shard allocations in the cluster.
@@ -59,10 +60,8 @@ class ClusterClient(NamespacedClient):
             for.
         """
         __path = "/_cluster/allocation/explain"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if current_node is not None:
-            __body["current_node"] = current_node
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -73,14 +72,17 @@ class ClusterClient(NamespacedClient):
             __query["include_disk_info"] = include_disk_info
         if include_yes_decisions is not None:
             __query["include_yes_decisions"] = include_yes_decisions
-        if index is not None:
-            __body["index"] = index
         if pretty is not None:
             __query["pretty"] = pretty
-        if primary is not None:
-            __body["primary"] = primary
-        if shard is not None:
-            __body["shard"] = shard
+        if not __body:
+            if current_node is not None:
+                __body["current_node"] = current_node
+            if index is not None:
+                __body["index"] = index
+            if primary is not None:
+                __body["primary"] = primary
+            if shard is not None:
+                __body["shard"] = shard
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -593,14 +595,14 @@ class ClusterClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("template", "allow_auto_create", "meta", "version"),
         parameter_aliases={"_meta": "meta"},
     )
     async def put_component_template(
         self,
         *,
         name: str,
-        template: t.Mapping[str, t.Any],
+        template: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_auto_create: t.Optional[bool] = None,
         create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -612,6 +614,7 @@ class ClusterClient(NamespacedClient):
         meta: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a component template
@@ -649,15 +652,11 @@ class ClusterClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if template is None:
+        if template is None and body is None:
             raise ValueError("Empty value passed for parameter 'template'")
         __path = f"/_component_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if template is not None:
-            __body["template"] = template
-        if allow_auto_create is not None:
-            __body["allow_auto_create"] = allow_auto_create
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
         if error_trace is not None:
@@ -668,19 +667,24 @@ class ClusterClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if template is not None:
+                __body["template"] = template
+            if allow_auto_create is not None:
+                __body["allow_auto_create"] = allow_auto_create
+            if meta is not None:
+                __body["_meta"] = meta
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("persistent", "transient"),
     )
     async def put_settings(
         self,
@@ -696,6 +700,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         transient: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the cluster settings.
@@ -710,7 +715,7 @@ class ClusterClient(NamespacedClient):
         """
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -721,14 +726,15 @@ class ClusterClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if persistent is not None:
-            __body["persistent"] = persistent
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        if transient is not None:
-            __body["transient"] = transient
+        if not __body:
+            if persistent is not None:
+                __body["persistent"] = persistent
+            if transient is not None:
+                __body["transient"] = transient
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -764,7 +770,7 @@ class ClusterClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("commands",),
     )
     async def reroute(
         self,
@@ -782,6 +788,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         retry_failed: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to manually change the allocation of individual shards in the cluster.
@@ -803,10 +810,8 @@ class ClusterClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         """
         __path = "/_cluster/reroute"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if commands is not None:
-            __body["commands"] = commands
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -827,6 +832,9 @@ class ClusterClient(NamespacedClient):
             __query["retry_failed"] = retry_failed
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if commands is not None:
+                __body["commands"] = commands
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/enrich.py
+++ b/elasticsearch/_async/client/enrich.py
@@ -134,7 +134,7 @@ class EnrichClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("geo_match", "match", "range"),
     )
     async def put_policy(
         self,
@@ -147,6 +147,7 @@ class EnrichClient(NamespacedClient):
         match: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         range: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new enrich policy.
@@ -164,21 +165,22 @@ class EnrichClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_enrich/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if geo_match is not None:
-            __body["geo_match"] = geo_match
         if human is not None:
             __query["human"] = human
-        if match is not None:
-            __body["match"] = match
         if pretty is not None:
             __query["pretty"] = pretty
-        if range is not None:
-            __body["range"] = range
+        if not __body:
+            if geo_match is not None:
+                __body["geo_match"] = geo_match
+            if match is not None:
+                __body["match"] = match
+            if range is not None:
+                __body["range"] = range
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/eql.py
+++ b/elasticsearch/_async/client/eql.py
@@ -145,13 +145,28 @@ class EqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "query",
+            "case_sensitive",
+            "event_category_field",
+            "fetch_size",
+            "fields",
+            "filter",
+            "keep_alive",
+            "keep_on_completion",
+            "result_position",
+            "runtime_mappings",
+            "size",
+            "tiebreaker_field",
+            "timestamp_field",
+            "wait_for_completion_timeout",
+        ),
     )
     async def search(
         self,
         *,
         index: t.Union[str, t.Sequence[str]],
-        query: str,
+        query: t.Optional[str] = None,
         allow_no_indices: t.Optional[bool] = None,
         case_sensitive: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -185,6 +200,7 @@ class EqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns results matching a query expressed in Event Query Language (EQL)
@@ -219,53 +235,54 @@ class EqlClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = f"/{_quote(index)}/_eql/search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if case_sensitive is not None:
-            __body["case_sensitive"] = case_sensitive
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if event_category_field is not None:
-            __body["event_category_field"] = event_category_field
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if fields is not None:
-            __body["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
         if pretty is not None:
             __query["pretty"] = pretty
-        if result_position is not None:
-            __body["result_position"] = result_position
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if size is not None:
-            __body["size"] = size
-        if tiebreaker_field is not None:
-            __body["tiebreaker_field"] = tiebreaker_field
-        if timestamp_field is not None:
-            __body["timestamp_field"] = timestamp_field
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if case_sensitive is not None:
+                __body["case_sensitive"] = case_sensitive
+            if event_category_field is not None:
+                __body["event_category_field"] = event_category_field
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if fields is not None:
+                __body["fields"] = fields
+            if filter is not None:
+                __body["filter"] = filter
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if result_position is not None:
+                __body["result_position"] = result_position
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if size is not None:
+                __body["size"] = size
+            if tiebreaker_field is not None:
+                __body["tiebreaker_field"] = tiebreaker_field
+            if timestamp_field is not None:
+                __body["timestamp_field"] = timestamp_field
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/fleet.py
+++ b/elasticsearch/_async/client/fleet.py
@@ -87,7 +87,8 @@ class FleetClient(NamespacedClient):
     async def msearch(
         self,
         *,
-        searches: t.Sequence[t.Mapping[str, t.Any]],
+        searches: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[str] = None,
         allow_no_indices: t.Optional[bool] = None,
         allow_partial_search_results: t.Optional[bool] = None,
@@ -163,8 +164,12 @@ class FleetClient(NamespacedClient):
             has become visible for search. Defaults to an empty list which will cause
             Elasticsearch to immediately execute the search.
         """
-        if searches is None:
-            raise ValueError("Empty value passed for parameter 'searches'")
+        if searches is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'searches' and 'body', one of them should be set."
+            )
+        elif searches is not None and body is not None:
+            raise ValueError("Cannot set both 'searches' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_fleet/_fleet_msearch"
         else:
@@ -204,7 +209,7 @@ class FleetClient(NamespacedClient):
             __query["typed_keys"] = typed_keys
         if wait_for_checkpoints is not None:
             __query["wait_for_checkpoints"] = wait_for_checkpoints
-        __body = searches
+        __body = searches if searches is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -214,7 +219,40 @@ class FleetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -312,6 +350,7 @@ class FleetClient(NamespacedClient):
         typed_keys: t.Optional[bool] = None,
         version: t.Optional[bool] = None,
         wait_for_checkpoints: t.Optional[t.Sequence[int]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Search API where the search will only be executed after specified checkpoints
@@ -421,8 +460,8 @@ class FleetClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_fleet/_fleet_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -434,10 +473,6 @@ class FleetClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -450,100 +485,50 @@ class FleetClient(NamespacedClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -552,20 +537,75 @@ class FleetClient(NamespacedClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
         if wait_for_checkpoints is not None:
             __query["wait_for_checkpoints"] = wait_for_checkpoints
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/graph.py
+++ b/elasticsearch/_async/client/graph.py
@@ -25,7 +25,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class GraphClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("connections", "controls", "query", "vertices"),
     )
     async def explore(
         self,
@@ -41,6 +41,7 @@ class GraphClient(NamespacedClient):
         routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         vertices: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explore extracted and summarized information about the documents and terms in
@@ -64,12 +65,8 @@ class GraphClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_graph/explore"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if connections is not None:
-            __body["connections"] = connections
-        if controls is not None:
-            __body["controls"] = controls
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -78,14 +75,19 @@ class GraphClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if timeout is not None:
             __query["timeout"] = timeout
-        if vertices is not None:
-            __body["vertices"] = vertices
+        if not __body:
+            if connections is not None:
+                __body["connections"] = connections
+            if controls is not None:
+                __body["controls"] = controls
+            if query is not None:
+                __body["query"] = query
+            if vertices is not None:
+                __body["vertices"] = vertices
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/ilm.py
+++ b/elasticsearch/_async/client/ilm.py
@@ -212,7 +212,7 @@ class IlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("legacy_template_to_delete", "node_attribute"),
     )
     async def migrate_to_data_tiers(
         self,
@@ -224,6 +224,7 @@ class IlmClient(NamespacedClient):
         legacy_template_to_delete: t.Optional[str] = None,
         node_attribute: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Migrates the indices and ILM policies away from custom node attribute allocation
@@ -239,7 +240,7 @@ class IlmClient(NamespacedClient):
         """
         __path = "/_ilm/migrate_to_data_tiers"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -248,12 +249,13 @@ class IlmClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if legacy_template_to_delete is not None:
-            __body["legacy_template_to_delete"] = legacy_template_to_delete
-        if node_attribute is not None:
-            __body["node_attribute"] = node_attribute
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if legacy_template_to_delete is not None:
+                __body["legacy_template_to_delete"] = legacy_template_to_delete
+            if node_attribute is not None:
+                __body["node_attribute"] = node_attribute
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -264,7 +266,7 @@ class IlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("current_step", "next_step"),
     )
     async def move_to_step(
         self,
@@ -276,6 +278,7 @@ class IlmClient(NamespacedClient):
         human: t.Optional[bool] = None,
         next_step: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Manually moves an index into the specified step and executes that step.
@@ -289,20 +292,21 @@ class IlmClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/_ilm/move/{_quote(index)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if current_step is not None:
-            __body["current_step"] = current_step
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if next_step is not None:
-            __body["next_step"] = next_step
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if current_step is not None:
+                __body["current_step"] = current_step
+            if next_step is not None:
+                __body["next_step"] = next_step
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -313,7 +317,7 @@ class IlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("policy",),
     )
     async def put_lifecycle(
         self,
@@ -328,6 +332,7 @@ class IlmClient(NamespacedClient):
         policy: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a lifecycle policy
@@ -346,7 +351,7 @@ class IlmClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_ilm/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -355,12 +360,13 @@ class IlmClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if policy is not None:
-            __body["policy"] = policy
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if policy is not None:
+                __body["policy"] = policy
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -96,7 +96,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analyzer",
+            "attributes",
+            "char_filter",
+            "explain",
+            "field",
+            "filter",
+            "normalizer",
+            "text",
+            "tokenizer",
+        ),
     )
     async def analyze(
         self,
@@ -115,6 +125,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         text: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         tokenizer: t.Optional[t.Union[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs the analysis process on a text and return the tokens breakdown of the
@@ -147,34 +158,35 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(index)}/_analyze"
         else:
             __path = "/_analyze"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analyzer is not None:
-            __body["analyzer"] = analyzer
-        if attributes is not None:
-            __body["attributes"] = attributes
-        if char_filter is not None:
-            __body["char_filter"] = char_filter
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if explain is not None:
-            __body["explain"] = explain
-        if field is not None:
-            __body["field"] = field
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if normalizer is not None:
-            __body["normalizer"] = normalizer
         if pretty is not None:
             __query["pretty"] = pretty
-        if text is not None:
-            __body["text"] = text
-        if tokenizer is not None:
-            __body["tokenizer"] = tokenizer
+        if not __body:
+            if analyzer is not None:
+                __body["analyzer"] = analyzer
+            if attributes is not None:
+                __body["attributes"] = attributes
+            if char_filter is not None:
+                __body["char_filter"] = char_filter
+            if explain is not None:
+                __body["explain"] = explain
+            if field is not None:
+                __body["field"] = field
+            if filter is not None:
+                __body["filter"] = filter
+            if normalizer is not None:
+                __body["normalizer"] = normalizer
+            if text is not None:
+                __body["text"] = text
+            if tokenizer is not None:
+                __body["tokenizer"] = tokenizer
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -265,7 +277,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "settings"),
     )
     async def clone(
         self,
@@ -285,6 +297,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clones an index
@@ -309,10 +322,8 @@ class IndicesClient(NamespacedClient):
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
         __path = f"/{_quote(index)}/_clone/{_quote(target)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -323,12 +334,15 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -420,7 +434,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "mappings", "settings"),
     )
     async def create(
         self,
@@ -440,6 +454,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an index with optional settings and mappings.
@@ -463,28 +478,29 @@ class IndicesClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -991,7 +1007,8 @@ class IndicesClient(NamespacedClient):
         *,
         index: str,
         target_index: str,
-        config: t.Mapping[str, t.Any],
+        config: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -1010,8 +1027,12 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target_index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target_index'")
-        if config is None:
-            raise ValueError("Empty value passed for parameter 'config'")
+        if config is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'config' and 'body', one of them should be set."
+            )
+        elif config is not None and body is not None:
+            raise ValueError("Cannot set both 'config' and 'body'")
         __path = f"/{_quote(index)}/_downsample/{_quote(target_index)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1022,7 +1043,7 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = config
+        __body = config if config is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2220,16 +2241,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     async def modify_data_stream(
         self,
         *,
-        actions: t.Sequence[t.Mapping[str, t.Any]],
+        actions: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Modifies a data stream
@@ -2238,13 +2260,11 @@ class IndicesClient(NamespacedClient):
 
         :param actions: Actions to perform.
         """
-        if actions is None:
+        if actions is None and body is None:
             raise ValueError("Empty value passed for parameter 'actions'")
         __path = "/_data_stream/_modify"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2253,6 +2273,9 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2379,7 +2402,13 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "filter",
+            "index_routing",
+            "is_write_index",
+            "routing",
+            "search_routing",
+        ),
     )
     async def put_alias(
         self,
@@ -2399,6 +2428,7 @@ class IndicesClient(NamespacedClient):
         routing: t.Optional[str] = None,
         search_routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an alias.
@@ -2437,29 +2467,30 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/{_quote(index)}/_alias/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_routing is not None:
-            __body["index_routing"] = index_routing
-        if is_write_index is not None:
-            __body["is_write_index"] = is_write_index
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if routing is not None:
-            __body["routing"] = routing
-        if search_routing is not None:
-            __body["search_routing"] = search_routing
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if filter is not None:
+                __body["filter"] = filter
+            if index_routing is not None:
+                __body["index_routing"] = index_routing
+            if is_write_index is not None:
+                __body["is_write_index"] = is_write_index
+            if routing is not None:
+                __body["routing"] = routing
+            if search_routing is not None:
+                __body["search_routing"] = search_routing
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2470,7 +2501,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data_retention", "downsampling"),
     )
     async def put_data_lifecycle(
         self,
@@ -2496,6 +2527,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the data stream lifecycle of the selected data streams.
@@ -2523,12 +2555,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_data_stream/{_quote(name)}/_lifecycle"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data_retention is not None:
-            __body["data_retention"] = data_retention
-        if downsampling is not None:
-            __body["downsampling"] = downsampling
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
@@ -2544,6 +2572,11 @@ class IndicesClient(NamespacedClient):
         if timeout is not None:
             __query["timeout"] = timeout
         if not __body:
+            if data_retention is not None:
+                __body["data_retention"] = data_retention
+            if downsampling is not None:
+                __body["downsampling"] = downsampling
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -2553,7 +2586,15 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "composed_of",
+            "data_stream",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def put_index_template(
@@ -2572,6 +2613,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -2603,39 +2645,52 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_index_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "date_detection",
+            "dynamic",
+            "dynamic_date_formats",
+            "dynamic_templates",
+            "field_names",
+            "meta",
+            "numeric_detection",
+            "properties",
+            "routing",
+            "runtime",
+            "source",
+        ),
         parameter_aliases={
             "_field_names": "field_names",
             "_meta": "meta",
@@ -2684,6 +2739,7 @@ class IndicesClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         write_index_only: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the index mappings.
@@ -2730,23 +2786,13 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_mapping"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if date_detection is not None:
-            __body["date_detection"] = date_detection
-        if dynamic is not None:
-            __body["dynamic"] = dynamic
-        if dynamic_date_formats is not None:
-            __body["dynamic_date_formats"] = dynamic_date_formats
-        if dynamic_templates is not None:
-            __body["dynamic_templates"] = dynamic_templates
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if field_names is not None:
-            __body["_field_names"] = field_names
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -2755,24 +2801,35 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if numeric_detection is not None:
-            __body["numeric_detection"] = numeric_detection
         if pretty is not None:
             __query["pretty"] = pretty
-        if properties is not None:
-            __body["properties"] = properties
-        if routing is not None:
-            __body["_routing"] = routing
-        if runtime is not None:
-            __body["runtime"] = runtime
-        if source is not None:
-            __body["_source"] = source
         if timeout is not None:
             __query["timeout"] = timeout
         if write_index_only is not None:
             __query["write_index_only"] = write_index_only
+        if not __body:
+            if date_detection is not None:
+                __body["date_detection"] = date_detection
+            if dynamic is not None:
+                __body["dynamic"] = dynamic
+            if dynamic_date_formats is not None:
+                __body["dynamic_date_formats"] = dynamic_date_formats
+            if dynamic_templates is not None:
+                __body["dynamic_templates"] = dynamic_templates
+            if field_names is not None:
+                __body["_field_names"] = field_names
+            if meta is not None:
+                __body["_meta"] = meta
+            if numeric_detection is not None:
+                __body["numeric_detection"] = numeric_detection
+            if properties is not None:
+                __body["properties"] = properties
+            if routing is not None:
+                __body["_routing"] = routing
+            if runtime is not None:
+                __body["runtime"] = runtime
+            if source is not None:
+                __body["_source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2784,7 +2841,8 @@ class IndicesClient(NamespacedClient):
     async def put_settings(
         self,
         *,
-        settings: t.Mapping[str, t.Any],
+        settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2834,8 +2892,12 @@ class IndicesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
-        if settings is None:
-            raise ValueError("Empty value passed for parameter 'settings'")
+        if settings is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'settings' and 'body', one of them should be set."
+            )
+        elif settings is not None and body is not None:
+            raise ValueError("Cannot set both 'settings' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_settings"
         else:
@@ -2863,14 +2925,21 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        __body = settings
+        __body = settings if settings is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aliases",
+            "index_patterns",
+            "mappings",
+            "order",
+            "settings",
+            "version",
+        ),
     )
     async def put_template(
         self,
@@ -2892,6 +2961,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -2922,10 +2992,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
         if error_trace is not None:
@@ -2936,22 +3004,25 @@ class IndicesClient(NamespacedClient):
             __query["flat_settings"] = flat_settings
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if order is not None:
-            __body["order"] = order
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if order is not None:
+                __body["order"] = order
+            if settings is not None:
+                __body["settings"] = settings
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -3173,7 +3244,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "conditions", "mappings", "settings"),
     )
     async def rollover(
         self,
@@ -3196,6 +3267,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates an alias to point to a new index when the existing index is considered
@@ -3237,12 +3309,8 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(alias)}/_rollover"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
-        if conditions is not None:
-            __body["conditions"] = conditions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -3251,18 +3319,23 @@ class IndicesClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if conditions is not None:
+                __body["conditions"] = conditions
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3407,7 +3480,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "settings"),
     )
     async def shrink(
         self,
@@ -3427,6 +3500,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allow to shrink an existing index into a new index with fewer primary shards.
@@ -3451,10 +3525,8 @@ class IndicesClient(NamespacedClient):
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
         __path = f"/{_quote(index)}/_shrink/{_quote(target)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3465,12 +3537,15 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3481,7 +3556,16 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_auto_create",
+            "composed_of",
+            "data_stream",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def simulate_index_template(
@@ -3505,6 +3589,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Simulate matching the given index name against the index templates in the system
@@ -3550,16 +3635,10 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_index_template/_simulate_index/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_auto_create is not None:
-            __body["allow_auto_create"] = allow_auto_create
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3568,20 +3647,27 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if include_defaults is not None:
             __query["include_defaults"] = include_defaults
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if allow_auto_create is not None:
+                __body["allow_auto_create"] = allow_auto_create
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3608,6 +3694,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Simulate resolving the given template name or body
@@ -3628,6 +3715,12 @@ class IndicesClient(NamespacedClient):
             returns an error.
         :param template:
         """
+        if template is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'template' and 'body', one of them should be set."
+            )
+        elif template is not None and body is not None:
+            raise ValueError("Cannot set both 'template' and 'body'")
         if name not in SKIP_IN_PATH:
             __path = f"/_index_template/_simulate/{_quote(name)}"
         else:
@@ -3647,7 +3740,7 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = template
+        __body = template if template is not None else body
         if not __body:
             __body = None
         __headers = {"accept": "application/json"}
@@ -3658,7 +3751,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "settings"),
     )
     async def split(
         self,
@@ -3678,6 +3771,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows you to split an existing index into a new index with more primary shards.
@@ -3702,10 +3796,8 @@ class IndicesClient(NamespacedClient):
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
         __path = f"/{_quote(index)}/_split/{_quote(target)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3716,12 +3808,15 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3910,7 +4005,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     async def update_aliases(
         self,
@@ -3924,6 +4019,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates index aliases.
@@ -3938,10 +4034,8 @@ class IndicesClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         """
         __path = "/_aliases"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3954,13 +4048,16 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
     )
     async def validate_query(
         self,
@@ -3990,6 +4087,7 @@ class IndicesClient(NamespacedClient):
         q: t.Optional[str] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         rewrite: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows a user to validate a potentially expensive query without executing it.
@@ -4032,7 +4130,7 @@ class IndicesClient(NamespacedClient):
         else:
             __path = "/_validate/query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if all_shards is not None:
             __query["all_shards"] = all_shards
         if allow_no_indices is not None:
@@ -4063,10 +4161,11 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if rewrite is not None:
             __query["rewrite"] = rewrite
+        if not __body:
+            if query is not None:
+                __body["query"] = query
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/ingest.py
+++ b/elasticsearch/_async/client/ingest.py
@@ -179,7 +179,7 @@ class IngestClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "meta", "on_failure", "processors", "version"),
         parameter_aliases={"_meta": "meta"},
     )
     async def put_pipeline(
@@ -200,6 +200,7 @@ class IngestClient(NamespacedClient):
         processors: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a pipeline.
@@ -232,10 +233,8 @@ class IngestClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ingest/pipeline/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -246,25 +245,28 @@ class IngestClient(NamespacedClient):
             __query["if_version"] = if_version
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if on_failure is not None:
-            __body["on_failure"] = on_failure
         if pretty is not None:
             __query["pretty"] = pretty
-        if processors is not None:
-            __body["processors"] = processors
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if meta is not None:
+                __body["_meta"] = meta
+            if on_failure is not None:
+                __body["on_failure"] = on_failure
+            if processors is not None:
+                __body["processors"] = processors
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "pipeline"),
     )
     async def simulate(
         self,
@@ -277,6 +279,7 @@ class IngestClient(NamespacedClient):
         pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         verbose: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to simulate a pipeline with example documents.
@@ -296,22 +299,23 @@ class IngestClient(NamespacedClient):
             __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"
         else:
             __path = "/_ingest/pipeline/_simulate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if pipeline is not None:
-            __body["pipeline"] = pipeline
         if pretty is not None:
             __query["pretty"] = pretty
         if verbose is not None:
             __query["verbose"] = verbose
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if pipeline is not None:
+                __body["pipeline"] = pipeline
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -154,7 +154,7 @@ class LicenseClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("license", "licenses"),
     )
     async def post(
         self,
@@ -166,6 +166,7 @@ class LicenseClient(NamespacedClient):
         license: t.Optional[t.Mapping[str, t.Any]] = None,
         licenses: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the license for the cluster.
@@ -179,7 +180,7 @@ class LicenseClient(NamespacedClient):
         """
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if acknowledge is not None:
             __query["acknowledge"] = acknowledge
         if error_trace is not None:
@@ -188,12 +189,13 @@ class LicenseClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if license is not None:
-            __body["license"] = license
-        if licenses is not None:
-            __body["licenses"] = licenses
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if license is not None:
+                __body["license"] = license
+            if licenses is not None:
+                __body["licenses"] = licenses
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/logstash.py
+++ b/elasticsearch/_async/client/logstash.py
@@ -100,7 +100,8 @@ class LogstashClient(NamespacedClient):
         self,
         *,
         id: str,
-        pipeline: t.Mapping[str, t.Any],
+        pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -116,8 +117,12 @@ class LogstashClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if pipeline is None:
-            raise ValueError("Empty value passed for parameter 'pipeline'")
+        if pipeline is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'pipeline' and 'body', one of them should be set."
+            )
+        elif pipeline is not None and body is not None:
+            raise ValueError("Cannot set both 'pipeline' and 'body'")
         __path = f"/_logstash/pipeline/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -128,7 +133,7 @@ class LogstashClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = pipeline
+        __body = pipeline if pipeline is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -59,7 +59,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     async def close_job(
         self,
@@ -72,6 +72,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed multiple
@@ -92,22 +93,23 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -315,7 +317,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("requests_per_second", "timeout"),
     )
     async def delete_expired_data(
         self,
@@ -327,6 +329,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         requests_per_second: t.Optional[float] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Deletes expired and unused machine learning data.
@@ -345,7 +348,7 @@ class MlClient(NamespacedClient):
         else:
             __path = "/_ml/_delete_expired_data"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -354,10 +357,11 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if requests_per_second is not None:
-            __body["requests_per_second"] = requests_per_second
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if requests_per_second is not None:
+                __body["requests_per_second"] = requests_per_second
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -624,7 +628,11 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "max_bucket_cardinality",
+            "overall_cardinality",
+        ),
     )
     async def estimate_model_memory(
         self,
@@ -636,6 +644,7 @@ class MlClient(NamespacedClient):
         max_bucket_cardinality: t.Optional[t.Mapping[str, int]] = None,
         overall_cardinality: t.Optional[t.Mapping[str, int]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Estimates the model memory
@@ -658,40 +667,42 @@ class MlClient(NamespacedClient):
             or `partition_field_name`.
         """
         __path = "/_ml/anomaly_detectors/_estimate_model_memory"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_bucket_cardinality is not None:
-            __body["max_bucket_cardinality"] = max_bucket_cardinality
-        if overall_cardinality is not None:
-            __body["overall_cardinality"] = overall_cardinality
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if max_bucket_cardinality is not None:
+                __body["max_bucket_cardinality"] = max_bucket_cardinality
+            if overall_cardinality is not None:
+                __body["overall_cardinality"] = overall_cardinality
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("evaluation", "index", "query"),
     )
     async def evaluate_data_frame(
         self,
         *,
-        evaluation: t.Mapping[str, t.Any],
-        index: str,
+        evaluation: t.Optional[t.Mapping[str, t.Any]] = None,
+        index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluates the data frame analytics for an annotated index.
@@ -703,17 +714,13 @@ class MlClient(NamespacedClient):
         :param query: A query clause that retrieves a subset of data from the source
             index.
         """
-        if evaluation is None:
+        if evaluation is None and body is None:
             raise ValueError("Empty value passed for parameter 'evaluation'")
-        if index is None:
+        if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = "/_ml/data_frame/_evaluate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if evaluation is not None:
-            __body["evaluation"] = evaluation
-        if index is not None:
-            __body["index"] = index
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -722,15 +729,29 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
+        if not __body:
+            if evaluation is not None:
+                __body["evaluation"] = evaluation
+            if index is not None:
+                __body["index"] = index
+            if query is not None:
+                __body["query"] = query
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_start",
+            "analysis",
+            "analyzed_fields",
+            "description",
+            "dest",
+            "max_num_threads",
+            "model_memory_limit",
+            "source",
+        ),
     )
     async def explain_data_frame_analytics(
         self,
@@ -748,6 +769,7 @@ class MlClient(NamespacedClient):
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         source: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explains a data frame analytics config.
@@ -786,32 +808,33 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/data_frame/analytics/{_quote(id)}/_explain"
         else:
             __path = "/_ml/data_frame/analytics/_explain"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if analysis is not None:
-            __body["analysis"] = analysis
-        if analyzed_fields is not None:
-            __body["analyzed_fields"] = analyzed_fields
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
-        if source is not None:
-            __body["source"] = source
+        if not __body:
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if analysis is not None:
+                __body["analysis"] = analysis
+            if analyzed_fields is not None:
+                __body["analyzed_fields"] = analyzed_fields
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
+            if source is not None:
+                __body["source"] = source
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -822,7 +845,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("advance_time", "calc_interim", "end", "skip_time", "start"),
     )
     async def flush_job(
         self,
@@ -837,6 +860,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         skip_time: t.Optional[t.Union[str, t.Any]] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Forces any buffered data to be processed by the job.
@@ -853,14 +877,8 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_flush"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if advance_time is not None:
-            __body["advance_time"] = advance_time
-        if calc_interim is not None:
-            __body["calc_interim"] = calc_interim
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -869,10 +887,17 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if skip_time is not None:
-            __body["skip_time"] = skip_time
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if advance_time is not None:
+                __body["advance_time"] = advance_time
+            if calc_interim is not None:
+                __body["calc_interim"] = calc_interim
+            if end is not None:
+                __body["end"] = end
+            if skip_time is not None:
+                __body["skip_time"] = skip_time
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -883,7 +908,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("duration", "expires_in", "max_model_memory"),
     )
     async def forecast(
         self,
@@ -896,6 +921,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         max_model_memory: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Predicts the future behavior of a time series by using its historical behavior.
@@ -912,22 +938,23 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if duration is not None:
-            __body["duration"] = duration
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expires_in is not None:
-            __body["expires_in"] = expires_in
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_model_memory is not None:
-            __body["max_model_memory"] = max_model_memory
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if duration is not None:
+                __body["duration"] = duration
+            if expires_in is not None:
+                __body["expires_in"] = expires_in
+            if max_model_memory is not None:
+                __body["max_model_memory"] = max_model_memory
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -938,7 +965,16 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "anomaly_score",
+            "desc",
+            "end",
+            "exclude_interim",
+            "expand",
+            "page",
+            "sort",
+            "start",
+        ),
         parameter_aliases={"from": "from_"},
     )
     async def get_buckets(
@@ -960,6 +996,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly detection job results for one or more buckets.
@@ -990,36 +1027,37 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/buckets"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if anomaly_score is not None:
-            __body["anomaly_score"] = anomaly_score
-        if desc is not None:
-            __body["desc"] = desc
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
-        if expand is not None:
-            __body["expand"] = expand
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if from_ is not None:
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if anomaly_score is not None:
+                __body["anomaly_score"] = anomaly_score
+            if desc is not None:
+                __body["desc"] = desc
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if expand is not None:
+                __body["expand"] = expand
+            if page is not None:
+                __body["page"] = page
+            if sort is not None:
+                __body["sort"] = sort
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1090,7 +1128,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     async def get_calendars(
@@ -1104,6 +1142,7 @@ class MlClient(NamespacedClient):
         page: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves configuration information for calendars.
@@ -1125,7 +1164,7 @@ class MlClient(NamespacedClient):
         else:
             __path = "/_ml/calendars"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1134,12 +1173,13 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1150,7 +1190,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     async def get_categories(
@@ -1166,6 +1206,7 @@ class MlClient(NamespacedClient):
         partition_field_value: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly detection job results for one or more categories.
@@ -1192,7 +1233,7 @@ class MlClient(NamespacedClient):
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1201,14 +1242,15 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if partition_field_value is not None:
             __query["partition_field_value"] = partition_field_value
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1490,7 +1532,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     async def get_influencers(
@@ -1510,6 +1552,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly detection job results for one or more influencers.
@@ -1537,7 +1580,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/influencers"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if desc is not None:
             __query["desc"] = desc
         if end is not None:
@@ -1554,8 +1597,6 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if influencer_score is not None:
             __query["influencer_score"] = influencer_score
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
@@ -1564,6 +1605,9 @@ class MlClient(NamespacedClient):
             __query["sort"] = sort
         if start is not None:
             __query["start"] = start
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1776,7 +1820,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("desc", "end", "page", "sort", "start"),
         parameter_aliases={"from": "from_"},
     )
     async def get_model_snapshots(
@@ -1795,6 +1839,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves information about model snapshots.
@@ -1823,12 +1868,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if desc is not None:
-            __body["desc"] = desc
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1837,16 +1878,21 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if desc is not None:
+                __body["desc"] = desc
+            if end is not None:
+                __body["end"] = end
+            if page is not None:
+                __body["page"] = page
+            if sort is not None:
+                __body["sort"] = sort
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1857,7 +1903,15 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_no_match",
+            "bucket_span",
+            "end",
+            "exclude_interim",
+            "overall_score",
+            "start",
+            "top_n",
+        ),
     )
     async def get_overall_buckets(
         self,
@@ -1874,6 +1928,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         top_n: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves overall bucket results that summarize the bucket results of multiple
@@ -1899,30 +1954,31 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/overall_buckets"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
-        if bucket_span is not None:
-            __body["bucket_span"] = bucket_span
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if overall_score is not None:
-            __body["overall_score"] = overall_score
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if top_n is not None:
-            __body["top_n"] = top_n
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if bucket_span is not None:
+                __body["bucket_span"] = bucket_span
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if overall_score is not None:
+                __body["overall_score"] = overall_score
+            if start is not None:
+                __body["start"] = start
+            if top_n is not None:
+                __body["top_n"] = top_n
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1933,7 +1989,15 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "desc",
+            "end",
+            "exclude_interim",
+            "page",
+            "record_score",
+            "sort",
+            "start",
+        ),
         parameter_aliases={"from": "from_"},
     )
     async def get_records(
@@ -1953,6 +2017,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly records for an anomaly detection job.
@@ -1974,34 +2039,35 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/records"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if desc is not None:
-            __body["desc"] = desc
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if from_ is not None:
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
-        if record_score is not None:
-            __body["record_score"] = record_score
         if size is not None:
             __query["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if desc is not None:
+                __body["desc"] = desc
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if page is not None:
+                __body["page"] = page
+            if record_score is not None:
+                __body["record_score"] = record_score
+            if sort is not None:
+                __body["sort"] = sort
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2147,19 +2213,20 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "inference_config"),
     )
     async def infer_trained_model(
         self,
         *,
         model_id: str,
-        docs: t.Sequence[t.Mapping[str, t.Any]],
+        docs: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         inference_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluate a trained model.
@@ -2177,25 +2244,26 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if docs is None:
+        if docs is None and body is None:
             raise ValueError("Empty value passed for parameter 'docs'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/_infer"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2231,7 +2299,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("timeout",),
     )
     async def open_job(
         self,
@@ -2242,6 +2310,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Opens one or more anomaly detection jobs.
@@ -2255,7 +2324,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_open"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2264,8 +2333,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2276,17 +2346,18 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("events",),
     )
     async def post_calendar_events(
         self,
         *,
         calendar_id: str,
-        events: t.Sequence[t.Mapping[str, t.Any]],
+        events: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Posts scheduled events in a calendar.
@@ -2300,13 +2371,11 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        if events is None:
+        if events is None and body is None:
             raise ValueError("Empty value passed for parameter 'events'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if events is not None:
-            __body["events"] = events
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2315,6 +2384,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if events is not None:
+                __body["events"] = events
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2327,7 +2399,8 @@ class MlClient(NamespacedClient):
         self,
         *,
         job_id: str,
-        data: t.Sequence[t.Any],
+        data: t.Optional[t.Sequence[t.Any]] = None,
+        body: t.Optional[t.Sequence[t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -2348,8 +2421,12 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        if data is None:
-            raise ValueError("Empty value passed for parameter 'data'")
+        if data is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'data' and 'body', one of them should be set."
+            )
+        elif data is not None and body is not None:
+            raise ValueError("Cannot set both 'data' and 'body'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_data"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2364,7 +2441,7 @@ class MlClient(NamespacedClient):
             __query["reset_end"] = reset_end
         if reset_start is not None:
             __query["reset_start"] = reset_start
-        __body = data
+        __body = data if data is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2374,7 +2451,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("config",),
     )
     async def preview_data_frame_analytics(
         self,
@@ -2385,6 +2462,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews that will be analyzed given a data frame analytics config.
@@ -2400,10 +2478,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/data_frame/analytics/{_quote(id)}/_preview"
         else:
             __path = "/_ml/data_frame/analytics/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if config is not None:
-            __body["config"] = config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2412,6 +2488,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if config is not None:
+                __body["config"] = config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2422,7 +2501,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("datafeed_config", "job_config"),
     )
     async def preview_datafeed(
         self,
@@ -2436,6 +2515,7 @@ class MlClient(NamespacedClient):
         job_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a datafeed.
@@ -2461,10 +2541,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_preview"
         else:
             __path = "/_ml/datafeeds/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if end is not None:
             __query["end"] = end
         if error_trace is not None:
@@ -2473,12 +2551,15 @@ class MlClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_config is not None:
-            __body["job_config"] = job_config
         if pretty is not None:
             __query["pretty"] = pretty
         if start is not None:
             __query["start"] = start
+        if not __body:
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if job_config is not None:
+                __body["job_config"] = job_config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2489,7 +2570,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "job_ids"),
     )
     async def put_calendar(
         self,
@@ -2501,6 +2582,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         job_ids: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a calendar.
@@ -2514,20 +2596,21 @@ class MlClient(NamespacedClient):
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_ids is not None:
-            __body["job_ids"] = job_ids
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if job_ids is not None:
+                __body["job_ids"] = job_ids
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2577,16 +2660,27 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis",
+            "dest",
+            "source",
+            "allow_lazy_start",
+            "analyzed_fields",
+            "description",
+            "headers",
+            "max_num_threads",
+            "model_memory_limit",
+            "version",
+        ),
         ignore_deprecated_options={"headers"},
     )
     async def put_data_frame_analytics(
         self,
         *,
         id: str,
-        analysis: t.Mapping[str, t.Any],
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        analysis: t.Optional[t.Mapping[str, t.Any]] = None,
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_start: t.Optional[bool] = None,
         analyzed_fields: t.Optional[t.Mapping[str, t.Any]] = None,
         description: t.Optional[str] = None,
@@ -2598,6 +2692,7 @@ class MlClient(NamespacedClient):
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         version: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a data frame analytics job.
@@ -2661,50 +2756,67 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if analysis is None:
+        if analysis is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis is not None:
-            __body["analysis"] = analysis
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if analyzed_fields is not None:
-            __body["analyzed_fields"] = analyzed_fields
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if analysis is not None:
+                __body["analysis"] = analysis
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if analyzed_fields is not None:
+                __body["analyzed_fields"] = analyzed_fields
+            if description is not None:
+                __body["description"] = description
+            if headers is not None:
+                __body["headers"] = headers
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "headers",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
         ignore_deprecated_options={"headers"},
     )
     async def put_datafeed(
@@ -2741,6 +2853,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a datafeed.
@@ -2819,61 +2932,62 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if headers is not None:
+                __body["headers"] = headers
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "items"),
     )
     async def put_filter(
         self,
@@ -2885,6 +2999,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         items: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a filter.
@@ -2899,34 +3014,51 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if items is not None:
-            __body["items"] = items
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if items is not None:
+                __body["items"] = items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "data_description",
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "datafeed_config",
+            "description",
+            "groups",
+            "model_plot_config",
+            "model_snapshot_retention_days",
+            "renormalization_window_days",
+            "results_index_name",
+            "results_retention_days",
+        ),
     )
     async def put_job(
         self,
         *,
         job_id: str,
-        analysis_config: t.Mapping[str, t.Any],
-        data_description: t.Mapping[str, t.Any],
+        analysis_config: t.Optional[t.Mapping[str, t.Any]] = None,
+        data_description: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_open: t.Optional[bool] = None,
         analysis_limits: t.Optional[t.Mapping[str, t.Any]] = None,
         background_persist_interval: t.Optional[
@@ -2946,6 +3078,7 @@ class MlClient(NamespacedClient):
         renormalization_window_days: t.Optional[int] = None,
         results_index_name: t.Optional[str] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates an anomaly detection job.
@@ -3027,60 +3160,72 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        if analysis_config is None:
+        if analysis_config is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis_config'")
-        if data_description is None:
+        if data_description is None and body is None:
             raise ValueError("Empty value passed for parameter 'data_description'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
-        if data_description is not None:
-            __body["data_description"] = data_description
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body[
-                "daily_model_snapshot_retention_after_days"
-            ] = daily_model_snapshot_retention_after_days
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_index_name is not None:
-            __body["results_index_name"] = results_index_name
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if data_description is not None:
+                __body["data_description"] = data_description
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body[
+                    "daily_model_snapshot_retention_after_days"
+                ] = daily_model_snapshot_retention_after_days
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if description is not None:
+                __body["description"] = description
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_index_name is not None:
+                __body["results_index_name"] = results_index_name
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "compressed_definition",
+            "definition",
+            "description",
+            "inference_config",
+            "input",
+            "metadata",
+            "model_size_bytes",
+            "model_type",
+            "platform_architecture",
+            "tags",
+        ),
     )
     async def put_trained_model(
         self,
@@ -3103,6 +3248,7 @@ class MlClient(NamespacedClient):
         platform_architecture: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         tags: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an inference trained model.
@@ -3142,38 +3288,39 @@ class MlClient(NamespacedClient):
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
         __path = f"/_ml/trained_models/{_quote(model_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if compressed_definition is not None:
-            __body["compressed_definition"] = compressed_definition
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_definition_decompression is not None:
             __query["defer_definition_decompression"] = defer_definition_decompression
-        if definition is not None:
-            __body["definition"] = definition
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
-        if input is not None:
-            __body["input"] = input
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if model_size_bytes is not None:
-            __body["model_size_bytes"] = model_size_bytes
-        if model_type is not None:
-            __body["model_type"] = model_type
-        if platform_architecture is not None:
-            __body["platform_architecture"] = platform_architecture
         if pretty is not None:
             __query["pretty"] = pretty
-        if tags is not None:
-            __body["tags"] = tags
+        if not __body:
+            if compressed_definition is not None:
+                __body["compressed_definition"] = compressed_definition
+            if definition is not None:
+                __body["definition"] = definition
+            if description is not None:
+                __body["description"] = description
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
+            if input is not None:
+                __body["input"] = input
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if model_size_bytes is not None:
+                __body["model_size_bytes"] = model_size_bytes
+            if model_type is not None:
+                __body["model_type"] = model_type
+            if platform_architecture is not None:
+                __body["platform_architecture"] = platform_architecture
+            if tags is not None:
+                __body["tags"] = tags
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -3225,20 +3372,21 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("definition", "total_definition_length", "total_parts"),
     )
     async def put_trained_model_definition_part(
         self,
         *,
         model_id: str,
         part: int,
-        definition: str,
-        total_definition_length: int,
-        total_parts: int,
+        definition: t.Optional[str] = None,
+        total_definition_length: t.Optional[int] = None,
+        total_parts: t.Optional[int] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates part of a trained model definition
@@ -3260,23 +3408,17 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if part in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'part'")
-        if definition is None:
+        if definition is None and body is None:
             raise ValueError("Empty value passed for parameter 'definition'")
-        if total_definition_length is None:
+        if total_definition_length is None and body is None:
             raise ValueError(
                 "Empty value passed for parameter 'total_definition_length'"
             )
-        if total_parts is None:
+        if total_parts is None and body is None:
             raise ValueError("Empty value passed for parameter 'total_parts'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/definition/{_quote(part)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if definition is not None:
-            __body["definition"] = definition
-        if total_definition_length is not None:
-            __body["total_definition_length"] = total_definition_length
-        if total_parts is not None:
-            __body["total_parts"] = total_parts
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3285,25 +3427,33 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if definition is not None:
+                __body["definition"] = definition
+            if total_definition_length is not None:
+                __body["total_definition_length"] = total_definition_length
+            if total_parts is not None:
+                __body["total_parts"] = total_parts
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("vocabulary", "merges", "scores"),
     )
     async def put_trained_model_vocabulary(
         self,
         *,
         model_id: str,
-        vocabulary: t.Sequence[str],
+        vocabulary: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         merges: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
         scores: t.Optional[t.Sequence[float]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a trained model vocabulary
@@ -3317,25 +3467,26 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if vocabulary is None:
+        if vocabulary is None and body is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if vocabulary is not None:
-            __body["vocabulary"] = vocabulary
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if merges is not None:
-            __body["merges"] = merges
         if pretty is not None:
             __query["pretty"] = pretty
-        if scores is not None:
-            __body["scores"] = scores
+        if not __body:
+            if vocabulary is not None:
+                __body["vocabulary"] = vocabulary
+            if merges is not None:
+                __body["merges"] = merges
+            if scores is not None:
+                __body["scores"] = scores
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -3387,7 +3538,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("delete_intervening_results",),
     )
     async def revert_model_snapshot(
         self,
@@ -3399,6 +3550,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Reverts to a specific snapshot.
@@ -3417,10 +3569,8 @@ class MlClient(NamespacedClient):
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_revert"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if delete_intervening_results is not None:
-            __body["delete_intervening_results"] = delete_intervening_results
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3429,6 +3579,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if delete_intervening_results is not None:
+                __body["delete_intervening_results"] = delete_intervening_results
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3521,7 +3674,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("end", "start", "timeout"),
     )
     async def start_datafeed(
         self,
@@ -3534,6 +3687,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Starts one or more datafeeds.
@@ -3551,10 +3705,8 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_start"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3563,10 +3715,13 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if end is not None:
+                __body["end"] = end
+            if start is not None:
+                __body["start"] = start
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3717,7 +3872,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     async def stop_datafeed(
         self,
@@ -3730,6 +3885,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Stops one or more datafeeds.
@@ -3748,22 +3904,23 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stop"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3823,7 +3980,12 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_start",
+            "description",
+            "max_num_threads",
+            "model_memory_limit",
+        ),
     )
     async def update_data_frame_analytics(
         self,
@@ -3837,6 +3999,7 @@ class MlClient(NamespacedClient):
         max_num_threads: t.Optional[int] = None,
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a data frame analytics job.
@@ -3862,31 +4025,47 @@ class MlClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if description is not None:
+                __body["description"] = description
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
     )
     async def update_datafeed(
         self,
@@ -3921,6 +4100,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a datafeed.
@@ -4010,59 +4190,60 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("add_items", "description", "remove_items"),
     )
     async def update_filter(
         self,
@@ -4075,6 +4256,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         remove_items: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the description of a filter, adds items, or removes items.
@@ -4089,12 +4271,8 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if add_items is not None:
-            __body["add_items"] = add_items
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -4103,15 +4281,36 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if remove_items is not None:
-            __body["remove_items"] = remove_items
+        if not __body:
+            if add_items is not None:
+                __body["add_items"] = add_items
+            if description is not None:
+                __body["description"] = description
+            if remove_items is not None:
+                __body["remove_items"] = remove_items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "categorization_filters",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "description",
+            "detectors",
+            "groups",
+            "model_plot_config",
+            "model_prune_window",
+            "model_snapshot_retention_days",
+            "per_partition_categorization",
+            "renormalization_window_days",
+            "results_retention_days",
+        ),
     )
     async def update_job(
         self,
@@ -4140,6 +4339,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         renormalization_window_days: t.Optional[int] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of an anomaly detection job.
@@ -4198,55 +4398,56 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if categorization_filters is not None:
-            __body["categorization_filters"] = categorization_filters
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body[
-                "daily_model_snapshot_retention_after_days"
-            ] = daily_model_snapshot_retention_after_days
-        if description is not None:
-            __body["description"] = description
-        if detectors is not None:
-            __body["detectors"] = detectors
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_prune_window is not None:
-            __body["model_prune_window"] = model_prune_window
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
-        if per_partition_categorization is not None:
-            __body["per_partition_categorization"] = per_partition_categorization
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if categorization_filters is not None:
+                __body["categorization_filters"] = categorization_filters
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body[
+                    "daily_model_snapshot_retention_after_days"
+                ] = daily_model_snapshot_retention_after_days
+            if description is not None:
+                __body["description"] = description
+            if detectors is not None:
+                __body["detectors"] = detectors
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_prune_window is not None:
+                __body["model_prune_window"] = model_prune_window
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if per_partition_categorization is not None:
+                __body["per_partition_categorization"] = per_partition_categorization
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "retain"),
     )
     async def update_model_snapshot(
         self,
@@ -4259,6 +4460,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         retain: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a snapshot.
@@ -4277,10 +4479,8 @@ class MlClient(NamespacedClient):
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -4289,8 +4489,11 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if retain is not None:
-            __body["retain"] = retain
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if retain is not None:
+                __body["retain"] = retain
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -4346,7 +4549,17 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "analysis_limits",
+            "data_description",
+            "description",
+            "job_id",
+            "model_plot",
+            "model_snapshot_id",
+            "model_snapshot_retention_days",
+            "results_index_name",
+        ),
     )
     async def validate(
         self,
@@ -4364,6 +4577,7 @@ class MlClient(NamespacedClient):
         model_snapshot_retention_days: t.Optional[int] = None,
         pretty: t.Optional[bool] = None,
         results_index_name: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Validates an anomaly detection job.
@@ -4381,34 +4595,35 @@ class MlClient(NamespacedClient):
         :param results_index_name:
         """
         __path = "/_ml/anomaly_detectors/_validate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if data_description is not None:
-            __body["data_description"] = data_description
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if model_plot is not None:
-            __body["model_plot"] = model_plot
-        if model_snapshot_id is not None:
-            __body["model_snapshot_id"] = model_snapshot_id
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
         if pretty is not None:
             __query["pretty"] = pretty
-        if results_index_name is not None:
-            __body["results_index_name"] = results_index_name
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if data_description is not None:
+                __body["data_description"] = data_description
+            if description is not None:
+                __body["description"] = description
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if model_plot is not None:
+                __body["model_plot"] = model_plot
+            if model_snapshot_id is not None:
+                __body["model_snapshot_id"] = model_snapshot_id
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if results_index_name is not None:
+                __body["results_index_name"] = results_index_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -4420,7 +4635,8 @@ class MlClient(NamespacedClient):
     async def validate_detector(
         self,
         *,
-        detector: t.Mapping[str, t.Any],
+        detector: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -4433,8 +4649,12 @@ class MlClient(NamespacedClient):
 
         :param detector:
         """
-        if detector is None:
-            raise ValueError("Empty value passed for parameter 'detector'")
+        if detector is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'detector' and 'body', one of them should be set."
+            )
+        elif detector is not None and body is not None:
+            raise ValueError("Cannot set both 'detector' and 'body'")
         __path = "/_ml/anomaly_detectors/_validate/detector"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -4445,7 +4665,7 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = detector
+        __body = detector if detector is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/monitoring.py
+++ b/elasticsearch/_async/client/monitoring.py
@@ -31,7 +31,8 @@ class MonitoringClient(NamespacedClient):
         self,
         *,
         interval: t.Union["t.Literal[-1]", "t.Literal[0]", str],
-        operations: t.Sequence[t.Mapping[str, t.Any]],
+        operations: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         system_api_version: str,
         system_id: str,
         error_trace: t.Optional[bool] = None,
@@ -51,8 +52,12 @@ class MonitoringClient(NamespacedClient):
         """
         if interval is None:
             raise ValueError("Empty value passed for parameter 'interval'")
-        if operations is None:
-            raise ValueError("Empty value passed for parameter 'operations'")
+        if operations is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'operations' and 'body', one of them should be set."
+            )
+        elif operations is not None and body is not None:
+            raise ValueError("Cannot set both 'operations' and 'body'")
         if system_api_version is None:
             raise ValueError("Empty value passed for parameter 'system_api_version'")
         if system_id is None:
@@ -73,7 +78,7 @@ class MonitoringClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = operations
+        __body = operations if operations is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",

--- a/elasticsearch/_async/client/nodes.py
+++ b/elasticsearch/_async/client/nodes.py
@@ -237,7 +237,7 @@ class NodesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("secure_settings_password",),
     )
     async def reload_secure_settings(
         self,
@@ -249,6 +249,7 @@ class NodesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         secure_settings_password: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Reloads secure settings.
@@ -265,7 +266,7 @@ class NodesClient(NamespacedClient):
         else:
             __path = "/_nodes/reload_secure_settings"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -274,10 +275,11 @@ class NodesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if secure_settings_password is not None:
-            __body["secure_settings_password"] = secure_settings_password
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if secure_settings_password is not None:
+                __body["secure_settings_password"] = secure_settings_password
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/query_ruleset.py
+++ b/elasticsearch/_async/client/query_ruleset.py
@@ -133,17 +133,18 @@ class QueryRulesetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("rules",),
     )
     async def put(
         self,
         *,
         ruleset_id: str,
-        rules: t.Sequence[t.Mapping[str, t.Any]],
+        rules: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a query ruleset.
@@ -156,13 +157,11 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        if rules is None:
+        if rules is None and body is None:
             raise ValueError("Empty value passed for parameter 'rules'")
         __path = f"/_query_rules/{_quote(ruleset_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if rules is not None:
-            __body["rules"] = rules
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -171,6 +170,9 @@ class QueryRulesetClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if rules is not None:
+                __body["rules"] = rules
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/rollup.py
+++ b/elasticsearch/_async/client/rollup.py
@@ -168,18 +168,27 @@ class RollupClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "cron",
+            "groups",
+            "index_pattern",
+            "page_size",
+            "rollup_index",
+            "headers",
+            "metrics",
+            "timeout",
+        ),
         ignore_deprecated_options={"headers"},
     )
     async def put_job(
         self,
         *,
         id: str,
-        cron: str,
-        groups: t.Mapping[str, t.Any],
-        index_pattern: str,
-        page_size: int,
-        rollup_index: str,
+        cron: t.Optional[str] = None,
+        groups: t.Optional[t.Mapping[str, t.Any]] = None,
+        index_pattern: t.Optional[str] = None,
+        page_size: t.Optional[int] = None,
+        rollup_index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         headers: t.Optional[t.Mapping[str, t.Union[str, t.Sequence[str]]]] = None,
@@ -187,6 +196,7 @@ class RollupClient(NamespacedClient):
         metrics: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a rollup job.
@@ -235,50 +245,51 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if cron is None:
+        if cron is None and body is None:
             raise ValueError("Empty value passed for parameter 'cron'")
-        if groups is None:
+        if groups is None and body is None:
             raise ValueError("Empty value passed for parameter 'groups'")
-        if index_pattern is None:
+        if index_pattern is None and body is None:
             raise ValueError("Empty value passed for parameter 'index_pattern'")
-        if page_size is None:
+        if page_size is None and body is None:
             raise ValueError("Empty value passed for parameter 'page_size'")
-        if rollup_index is None:
+        if rollup_index is None and body is None:
             raise ValueError("Empty value passed for parameter 'rollup_index'")
         __path = f"/_rollup/job/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if cron is not None:
-            __body["cron"] = cron
-        if groups is not None:
-            __body["groups"] = groups
-        if index_pattern is not None:
-            __body["index_pattern"] = index_pattern
-        if page_size is not None:
-            __body["page_size"] = page_size
-        if rollup_index is not None:
-            __body["rollup_index"] = rollup_index
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
-        if metrics is not None:
-            __body["metrics"] = metrics
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if cron is not None:
+                __body["cron"] = cron
+            if groups is not None:
+                __body["groups"] = groups
+            if index_pattern is not None:
+                __body["index_pattern"] = index_pattern
+            if page_size is not None:
+                __body["page_size"] = page_size
+            if rollup_index is not None:
+                __body["rollup_index"] = rollup_index
+            if headers is not None:
+                __body["headers"] = headers
+            if metrics is not None:
+                __body["metrics"] = metrics
+            if timeout is not None:
+                __body["timeout"] = timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aggregations", "aggs", "query", "size"),
     )
     async def rollup_search(
         self,
@@ -294,6 +305,7 @@ class RollupClient(NamespacedClient):
         rest_total_hits_as_int: t.Optional[bool] = None,
         size: t.Optional[int] = None,
         typed_keys: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Enables searching rolled-up data using the standard query DSL.
@@ -313,12 +325,8 @@ class RollupClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_rollup_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -327,14 +335,19 @@ class RollupClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
-        if size is not None:
-            __body["size"] = size
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if query is not None:
+                __body["query"] = query
+            if size is not None:
+                __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/search_application.py
+++ b/elasticsearch/_async/client/search_application.py
@@ -212,7 +212,8 @@ class SearchApplicationClient(NamespacedClient):
         self,
         *,
         name: str,
-        search_application: t.Mapping[str, t.Any],
+        search_application: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -231,8 +232,12 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if search_application is None:
-            raise ValueError("Empty value passed for parameter 'search_application'")
+        if search_application is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'search_application' and 'body', one of them should be set."
+            )
+        elif search_application is not None and body is not None:
+            raise ValueError("Cannot set both 'search_application' and 'body'")
         __path = f"/_application/search_application/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
@@ -245,7 +250,7 @@ class SearchApplicationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = search_application
+        __body = search_application if search_application is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -286,7 +291,7 @@ class SearchApplicationClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("params",),
         ignore_deprecated_options={"params"},
     )
     async def search(
@@ -298,6 +303,7 @@ class SearchApplicationClient(NamespacedClient):
         human: t.Optional[bool] = None,
         params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Perform a search against a search application
@@ -312,17 +318,18 @@ class SearchApplicationClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_application/search_application/{_quote(name)}/_search"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if params is not None:
+                __body["params"] = params
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -25,12 +25,14 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class SecurityClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("grant_type", "access_token", "password", "username"),
     )
     async def activate_user_profile(
         self,
         *,
-        grant_type: t.Union["t.Literal['access_token', 'password']", str],
+        grant_type: t.Optional[
+            t.Union["t.Literal['access_token', 'password']", str]
+        ] = None,
         access_token: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -38,6 +40,7 @@ class SecurityClient(NamespacedClient):
         password: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates the user profile on behalf of another user.
@@ -49,27 +52,28 @@ class SecurityClient(NamespacedClient):
         :param password:
         :param username:
         """
-        if grant_type is None:
+        if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
         __path = "/_security/profile/_activate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if grant_type is not None:
-            __body["grant_type"] = grant_type
-        if access_token is not None:
-            __body["access_token"] = access_token
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if password is not None:
-            __body["password"] = password
         if pretty is not None:
             __query["pretty"] = pretty
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if grant_type is not None:
+                __body["grant_type"] = grant_type
+            if access_token is not None:
+                __body["access_token"] = access_token
+            if password is not None:
+                __body["password"] = password
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -106,7 +110,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("password", "password_hash"),
     )
     async def change_password(
         self,
@@ -121,6 +125,7 @@ class SecurityClient(NamespacedClient):
         refresh: t.Optional[
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Changes the passwords of users in the native realm and built-in users.
@@ -144,21 +149,22 @@ class SecurityClient(NamespacedClient):
         else:
             __path = "/_security/user/_password"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if password is not None:
-            __body["password"] = password
-        if password_hash is not None:
-            __body["password_hash"] = password_hash
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
+        if not __body:
+            if password is not None:
+                __body["password"] = password
+            if password_hash is not None:
+                __body["password_hash"] = password_hash
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -349,7 +355,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("expiration", "metadata", "name", "role_descriptors"),
     )
     async def create_api_key(
         self,
@@ -365,6 +371,7 @@ class SecurityClient(NamespacedClient):
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an API key for access without requiring basic authentication.
@@ -391,25 +398,26 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expiration is not None:
-            __body["expiration"] = expiration
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if expiration is not None:
+                __body["expiration"] = expiration
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if name is not None:
+                __body["name"] = name
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -1212,7 +1220,14 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "grant_type",
+            "kerberos_ticket",
+            "password",
+            "refresh_token",
+            "scope",
+            "username",
+        ),
     )
     async def get_token(
         self,
@@ -1232,6 +1247,7 @@ class SecurityClient(NamespacedClient):
         refresh_token: t.Optional[str] = None,
         scope: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a bearer token for access without requiring basic authentication.
@@ -1247,27 +1263,28 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if grant_type is not None:
-            __body["grant_type"] = grant_type
         if human is not None:
             __query["human"] = human
-        if kerberos_ticket is not None:
-            __body["kerberos_ticket"] = kerberos_ticket
-        if password is not None:
-            __body["password"] = password
         if pretty is not None:
             __query["pretty"] = pretty
-        if refresh_token is not None:
-            __body["refresh_token"] = refresh_token
-        if scope is not None:
-            __body["scope"] = scope
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if grant_type is not None:
+                __body["grant_type"] = grant_type
+            if kerberos_ticket is not None:
+                __body["kerberos_ticket"] = kerberos_ticket
+            if password is not None:
+                __body["password"] = password
+            if refresh_token is not None:
+                __body["refresh_token"] = refresh_token
+            if scope is not None:
+                __body["scope"] = scope
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -1402,14 +1419,23 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "api_key",
+            "grant_type",
+            "access_token",
+            "password",
+            "run_as",
+            "username",
+        ),
         ignore_deprecated_options={"api_key"},
     )
     async def grant_api_key(
         self,
         *,
-        api_key: t.Mapping[str, t.Any],
-        grant_type: t.Union["t.Literal['access_token', 'password']", str],
+        api_key: t.Optional[t.Mapping[str, t.Any]] = None,
+        grant_type: t.Optional[
+            t.Union["t.Literal['access_token', 'password']", str]
+        ] = None,
         access_token: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -1418,6 +1444,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         run_as: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an API key on behalf of another user.
@@ -1437,40 +1464,41 @@ class SecurityClient(NamespacedClient):
             grant type, this parameter is required. It is not valid with other grant
             types.
         """
-        if api_key is None:
+        if api_key is None and body is None:
             raise ValueError("Empty value passed for parameter 'api_key'")
-        if grant_type is None:
+        if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
         __path = "/_security/api_key/grant"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if api_key is not None:
-            __body["api_key"] = api_key
-        if grant_type is not None:
-            __body["grant_type"] = grant_type
-        if access_token is not None:
-            __body["access_token"] = access_token
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if password is not None:
-            __body["password"] = password
         if pretty is not None:
             __query["pretty"] = pretty
-        if run_as is not None:
-            __body["run_as"] = run_as
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if api_key is not None:
+                __body["api_key"] = api_key
+            if grant_type is not None:
+                __body["grant_type"] = grant_type
+            if access_token is not None:
+                __body["access_token"] = access_token
+            if password is not None:
+                __body["password"] = password
+            if run_as is not None:
+                __body["run_as"] = run_as
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("application", "cluster", "index"),
     )
     async def has_privileges(
         self,
@@ -1490,6 +1518,7 @@ class SecurityClient(NamespacedClient):
         human: t.Optional[bool] = None,
         index: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Determines whether the specified user has a specified list of privileges.
@@ -1505,39 +1534,41 @@ class SecurityClient(NamespacedClient):
             __path = f"/_security/user/{_quote(user)}/_has_privileges"
         else:
             __path = "/_security/user/_has_privileges"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if application is not None:
-            __body["application"] = application
-        if cluster is not None:
-            __body["cluster"] = cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index is not None:
-            __body["index"] = index
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if application is not None:
+                __body["application"] = application
+            if cluster is not None:
+                __body["cluster"] = cluster
+            if index is not None:
+                __body["index"] = index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("privileges", "uids"),
     )
     async def has_privileges_user_profile(
         self,
         *,
-        privileges: t.Mapping[str, t.Any],
-        uids: t.Sequence[str],
+        privileges: t.Optional[t.Mapping[str, t.Any]] = None,
+        uids: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Determines whether the users associated with the specified profile IDs have all
@@ -1549,17 +1580,13 @@ class SecurityClient(NamespacedClient):
         :param uids: A list of profile IDs. The privileges are checked for associated
             users of the profiles.
         """
-        if privileges is None:
+        if privileges is None and body is None:
             raise ValueError("Empty value passed for parameter 'privileges'")
-        if uids is None:
+        if uids is None and body is None:
             raise ValueError("Empty value passed for parameter 'uids'")
         __path = "/_security/profile/_has_privileges"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if privileges is not None:
-            __body["privileges"] = privileges
-        if uids is not None:
-            __body["uids"] = uids
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1568,13 +1595,18 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if privileges is not None:
+                __body["privileges"] = privileges
+            if uids is not None:
+                __body["uids"] = uids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("id", "ids", "name", "owner", "realm_name", "username"),
     )
     async def invalidate_api_key(
         self,
@@ -1589,6 +1621,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         realm_name: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates one or more API keys.
@@ -1611,34 +1644,35 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if id is not None:
-            __body["id"] = id
-        if ids is not None:
-            __body["ids"] = ids
-        if name is not None:
-            __body["name"] = name
-        if owner is not None:
-            __body["owner"] = owner
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm_name is not None:
-            __body["realm_name"] = realm_name
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if id is not None:
+                __body["id"] = id
+            if ids is not None:
+                __body["ids"] = ids
+            if name is not None:
+                __body["name"] = name
+            if owner is not None:
+                __body["owner"] = owner
+            if realm_name is not None:
+                __body["realm_name"] = realm_name
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("realm_name", "refresh_token", "token", "username"),
     )
     async def invalidate_token(
         self,
@@ -1651,6 +1685,7 @@ class SecurityClient(NamespacedClient):
         refresh_token: t.Optional[str] = None,
         token: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates one or more access tokens or refresh tokens.
@@ -1664,7 +1699,7 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1673,14 +1708,15 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm_name is not None:
-            __body["realm_name"] = realm_name
-        if refresh_token is not None:
-            __body["refresh_token"] = refresh_token
-        if token is not None:
-            __body["token"] = token
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if realm_name is not None:
+                __body["realm_name"] = realm_name
+            if refresh_token is not None:
+                __body["refresh_token"] = refresh_token
+            if token is not None:
+                __body["token"] = token
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers, body=__body
@@ -1692,7 +1728,10 @@ class SecurityClient(NamespacedClient):
     async def put_privileges(
         self,
         *,
-        privileges: t.Mapping[str, t.Mapping[str, t.Mapping[str, t.Any]]],
+        privileges: t.Optional[
+            t.Mapping[str, t.Mapping[str, t.Mapping[str, t.Any]]]
+        ] = None,
+        body: t.Optional[t.Mapping[str, t.Mapping[str, t.Mapping[str, t.Any]]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -1711,8 +1750,12 @@ class SecurityClient(NamespacedClient):
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
         """
-        if privileges is None:
-            raise ValueError("Empty value passed for parameter 'privileges'")
+        if privileges is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'privileges' and 'body', one of them should be set."
+            )
+        elif privileges is not None and body is not None:
+            raise ValueError("Cannot set both 'privileges' and 'body'")
         __path = "/_security/privilege"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1725,14 +1768,22 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        __body = privileges
+        __body = privileges if privileges is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "applications",
+            "cluster",
+            "global_",
+            "indices",
+            "metadata",
+            "run_as",
+            "transient_metadata",
+        ),
         parameter_aliases={"global": "global_"},
     )
     async def put_role(
@@ -1760,6 +1811,7 @@ class SecurityClient(NamespacedClient):
         ] = None,
         run_as: t.Optional[t.Sequence[str]] = None,
         transient_metadata: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Adds and updates roles in the native realm.
@@ -1790,39 +1842,40 @@ class SecurityClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_security/role/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if applications is not None:
-            __body["applications"] = applications
-        if cluster is not None:
-            __body["cluster"] = cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if global_ is not None:
-            __body["global"] = global_
         if human is not None:
             __query["human"] = human
-        if indices is not None:
-            __body["indices"] = indices
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if run_as is not None:
-            __body["run_as"] = run_as
-        if transient_metadata is not None:
-            __body["transient_metadata"] = transient_metadata
+        if not __body:
+            if applications is not None:
+                __body["applications"] = applications
+            if cluster is not None:
+                __body["cluster"] = cluster
+            if global_ is not None:
+                __body["global"] = global_
+            if indices is not None:
+                __body["indices"] = indices
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if run_as is not None:
+                __body["run_as"] = run_as
+            if transient_metadata is not None:
+                __body["transient_metadata"] = transient_metadata
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("enabled", "metadata", "roles", "rules", "run_as"),
     )
     async def put_role_mapping(
         self,
@@ -1840,6 +1893,7 @@ class SecurityClient(NamespacedClient):
         roles: t.Optional[t.Sequence[str]] = None,
         rules: t.Optional[t.Mapping[str, t.Any]] = None,
         run_as: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates and updates role mappings.
@@ -1859,35 +1913,44 @@ class SecurityClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_security/role_mapping/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if enabled is not None:
-            __body["enabled"] = enabled
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if roles is not None:
-            __body["roles"] = roles
-        if rules is not None:
-            __body["rules"] = rules
-        if run_as is not None:
-            __body["run_as"] = run_as
+        if not __body:
+            if enabled is not None:
+                __body["enabled"] = enabled
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if roles is not None:
+                __body["roles"] = roles
+            if rules is not None:
+                __body["rules"] = rules
+            if run_as is not None:
+                __body["run_as"] = run_as
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "email",
+            "enabled",
+            "full_name",
+            "metadata",
+            "password",
+            "password_hash",
+            "roles",
+        ),
     )
     async def put_user(
         self,
@@ -1907,6 +1970,7 @@ class SecurityClient(NamespacedClient):
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
         roles: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Adds and updates users in the native realm. These users are commonly referred
@@ -1929,39 +1993,40 @@ class SecurityClient(NamespacedClient):
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
         __path = f"/_security/user/{_quote(username)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if email is not None:
-            __body["email"] = email
-        if enabled is not None:
-            __body["enabled"] = enabled
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if full_name is not None:
-            __body["full_name"] = full_name
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if password is not None:
-            __body["password"] = password
-        if password_hash is not None:
-            __body["password_hash"] = password_hash
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if roles is not None:
-            __body["roles"] = roles
+        if not __body:
+            if email is not None:
+                __body["email"] = email
+            if enabled is not None:
+                __body["enabled"] = enabled
+            if full_name is not None:
+                __body["full_name"] = full_name
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if password is not None:
+                __body["password"] = password
+            if password_hash is not None:
+                __body["password_hash"] = password_hash
+            if roles is not None:
+                __body["roles"] = roles
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("from_", "query", "search_after", "size", "sort"),
         parameter_aliases={"from": "from_"},
     )
     async def query_api_keys(
@@ -1984,6 +2049,7 @@ class SecurityClient(NamespacedClient):
             ]
         ] = None,
         with_limited_by: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves information for API keys using a subset of query DSL
@@ -2010,7 +2076,7 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/_query/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -2026,22 +2092,23 @@ class SecurityClient(NamespacedClient):
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
         if with_limited_by is not None:
             __query["with_limited_by"] = with_limited_by
+        if not __body:
+            if from_ is not None:
+                __body["from"] = from_
+            if query is not None:
+                __body["query"] = query
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2052,18 +2119,19 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("content", "ids", "realm"),
     )
     async def saml_authenticate(
         self,
         *,
-        content: str,
-        ids: t.Union[str, t.Sequence[str]],
+        content: t.Optional[str] = None,
+        ids: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         realm: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Exchanges a SAML Response message for an Elasticsearch access token and refresh
@@ -2078,17 +2146,13 @@ class SecurityClient(NamespacedClient):
         :param realm: The name of the realm that should authenticate the SAML response.
             Useful in cases where many SAML realms are defined.
         """
-        if content is None:
+        if content is None and body is None:
             raise ValueError("Empty value passed for parameter 'content'")
-        if ids is None:
+        if ids is None and body is None:
             raise ValueError("Empty value passed for parameter 'ids'")
         __path = "/_security/saml/authenticate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if content is not None:
-            __body["content"] = content
-        if ids is not None:
-            __body["ids"] = ids
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2097,27 +2161,33 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm is not None:
-            __body["realm"] = realm
+        if not __body:
+            if content is not None:
+                __body["content"] = content
+            if ids is not None:
+                __body["ids"] = ids
+            if realm is not None:
+                __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("ids", "realm", "content", "query_string"),
     )
     async def saml_complete_logout(
         self,
         *,
-        ids: t.Union[str, t.Sequence[str]],
-        realm: str,
+        ids: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        realm: t.Optional[str] = None,
         content: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         query_string: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Verifies the logout response sent from the SAML IdP
@@ -2134,19 +2204,13 @@ class SecurityClient(NamespacedClient):
         :param query_string: If the SAML IdP sends the logout response with the HTTP-Redirect
             binding, this field must be set to the query string of the redirect URI.
         """
-        if ids is None:
+        if ids is None and body is None:
             raise ValueError("Empty value passed for parameter 'ids'")
-        if realm is None:
+        if realm is None and body is None:
             raise ValueError("Empty value passed for parameter 'realm'")
         __path = "/_security/saml/complete_logout"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if ids is not None:
-            __body["ids"] = ids
-        if realm is not None:
-            __body["realm"] = realm
-        if content is not None:
-            __body["content"] = content
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2155,26 +2219,34 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query_string is not None:
-            __body["query_string"] = query_string
+        if not __body:
+            if ids is not None:
+                __body["ids"] = ids
+            if realm is not None:
+                __body["realm"] = realm
+            if content is not None:
+                __body["content"] = content
+            if query_string is not None:
+                __body["query_string"] = query_string
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query_string", "acs", "realm"),
     )
     async def saml_invalidate(
         self,
         *,
-        query_string: str,
+        query_string: t.Optional[str] = None,
         acs: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         realm: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Consumes a SAML LogoutRequest
@@ -2197,15 +2269,11 @@ class SecurityClient(NamespacedClient):
         :param realm: The name of the SAML realm in Elasticsearch the configuration.
             You must specify either this parameter or the acs parameter.
         """
-        if query_string is None:
+        if query_string is None and body is None:
             raise ValueError("Empty value passed for parameter 'query_string'")
         __path = "/_security/saml/invalidate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query_string is not None:
-            __body["query_string"] = query_string
-        if acs is not None:
-            __body["acs"] = acs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2214,25 +2282,31 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm is not None:
-            __body["realm"] = realm
+        if not __body:
+            if query_string is not None:
+                __body["query_string"] = query_string
+            if acs is not None:
+                __body["acs"] = acs
+            if realm is not None:
+                __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("token", "refresh_token"),
     )
     async def saml_logout(
         self,
         *,
-        token: str,
+        token: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         refresh_token: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates an access token and a refresh token that were generated via the SAML
@@ -2247,13 +2321,11 @@ class SecurityClient(NamespacedClient):
             the SAML authenticate API. Alternatively, the most recent refresh token that
             was received after refreshing the original access token.
         """
-        if token is None:
+        if token is None and body is None:
             raise ValueError("Empty value passed for parameter 'token'")
         __path = "/_security/saml/logout"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if token is not None:
-            __body["token"] = token
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2262,15 +2334,18 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if refresh_token is not None:
-            __body["refresh_token"] = refresh_token
+        if not __body:
+            if token is not None:
+                __body["token"] = token
+            if refresh_token is not None:
+                __body["refresh_token"] = refresh_token
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("acs", "realm", "relay_state"),
     )
     async def saml_prepare_authentication(
         self,
@@ -2282,6 +2357,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         realm: t.Optional[str] = None,
         relay_state: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a SAML authentication request
@@ -2299,10 +2375,8 @@ class SecurityClient(NamespacedClient):
             is signed, this value is used as part of the signature computation.
         """
         __path = "/_security/saml/prepare"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if acs is not None:
-            __body["acs"] = acs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2311,10 +2385,13 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm is not None:
-            __body["realm"] = realm
-        if relay_state is not None:
-            __body["relay_state"] = relay_state
+        if not __body:
+            if acs is not None:
+                __body["acs"] = acs
+            if realm is not None:
+                __body["realm"] = realm
+            if relay_state is not None:
+                __body["relay_state"] = relay_state
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2355,7 +2432,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data", "hint", "name", "size"),
     )
     async def suggest_user_profiles(
         self,
@@ -2368,6 +2445,7 @@ class SecurityClient(NamespacedClient):
         name: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Get suggestions for user profiles that match specified search criteria.
@@ -2387,24 +2465,25 @@ class SecurityClient(NamespacedClient):
         :param size: Number of profiles to return.
         """
         __path = "/_security/profile/_suggest"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data is not None:
-            __body["data"] = data
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if hint is not None:
-            __body["hint"] = hint
         if human is not None:
             __query["human"] = human
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
-        if size is not None:
-            __body["size"] = size
+        if not __body:
+            if data is not None:
+                __body["data"] = data
+            if hint is not None:
+                __body["hint"] = hint
+            if name is not None:
+                __body["name"] = name
+            if size is not None:
+                __body["size"] = size
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2415,7 +2494,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("metadata", "role_descriptors"),
     )
     async def update_api_key(
         self,
@@ -2427,6 +2506,7 @@ class SecurityClient(NamespacedClient):
         metadata: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates attributes of an existing API key.
@@ -2450,19 +2530,20 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_security/api_key/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2473,7 +2554,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data", "labels"),
     )
     async def update_user_profile_data(
         self,
@@ -2490,6 +2571,7 @@ class SecurityClient(NamespacedClient):
         refresh: t.Optional[
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Update application specific data for the user profile of the given unique ID.
@@ -2512,10 +2594,8 @@ class SecurityClient(NamespacedClient):
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
         __path = f"/_security/profile/{_quote(uid)}/_data"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data is not None:
-            __body["data"] = data
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2526,12 +2606,15 @@ class SecurityClient(NamespacedClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
-        if labels is not None:
-            __body["labels"] = labels
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
+        if not __body:
+            if data is not None:
+                __body["data"] = data
+            if labels is not None:
+                __body["labels"] = labels
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/shutdown.py
+++ b/elasticsearch/_async/client/shutdown.py
@@ -126,14 +126,16 @@ class ShutdownClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("reason", "type", "allocation_delay", "target_node_name"),
     )
     async def put_node(
         self,
         *,
         node_id: str,
-        reason: str,
-        type: t.Union["t.Literal['remove', 'replace', 'restart']", str],
+        reason: t.Optional[str] = None,
+        type: t.Optional[
+            t.Union["t.Literal['remove', 'replace', 'restart']", str]
+        ] = None,
         allocation_delay: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -146,6 +148,7 @@ class ShutdownClient(NamespacedClient):
         timeout: t.Optional[
             t.Union["t.Literal['d', 'h', 'm', 'micros', 'ms', 'nanos', 's']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Adds a node to be shut down. Designed for indirect use by ECE/ESS and ECK. Direct
@@ -188,19 +191,13 @@ class ShutdownClient(NamespacedClient):
         """
         if node_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'node_id'")
-        if reason is None:
+        if reason is None and body is None:
             raise ValueError("Empty value passed for parameter 'reason'")
-        if type is None:
+        if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
         __path = f"/_nodes/{_quote(node_id)}/shutdown"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if reason is not None:
-            __body["reason"] = reason
-        if type is not None:
-            __body["type"] = type
-        if allocation_delay is not None:
-            __body["allocation_delay"] = allocation_delay
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -211,10 +208,17 @@ class ShutdownClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if target_node_name is not None:
-            __body["target_node_name"] = target_node_name
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if reason is not None:
+                __body["reason"] = reason
+            if type is not None:
+                __body["type"] = type
+            if allocation_delay is not None:
+                __body["allocation_delay"] = allocation_delay
+            if target_node_name is not None:
+                __body["target_node_name"] = target_node_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/slm.py
+++ b/elasticsearch/_async/client/slm.py
@@ -218,7 +218,7 @@ class SlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("config", "name", "repository", "retention", "schedule"),
     )
     async def put_lifecycle(
         self,
@@ -237,6 +237,7 @@ class SlmClient(NamespacedClient):
         retention: t.Optional[t.Mapping[str, t.Any]] = None,
         schedule: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a snapshot lifecycle policy.
@@ -265,10 +266,8 @@ class SlmClient(NamespacedClient):
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
         __path = f"/_slm/policy/{_quote(policy_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if config is not None:
-            __body["config"] = config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -277,18 +276,21 @@ class SlmClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
-        if repository is not None:
-            __body["repository"] = repository
-        if retention is not None:
-            __body["retention"] = retention
-        if schedule is not None:
-            __body["schedule"] = schedule
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if config is not None:
+                __body["config"] = config
+            if name is not None:
+                __body["name"] = name
+            if repository is not None:
+                __body["repository"] = repository
+            if retention is not None:
+                __body["retention"] = retention
+            if schedule is not None:
+                __body["schedule"] = schedule
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -69,7 +69,7 @@ class SnapshotClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("indices",),
     )
     async def clone(
         self,
@@ -77,7 +77,7 @@ class SnapshotClient(NamespacedClient):
         repository: str,
         snapshot: str,
         target_snapshot: str,
-        indices: str,
+        indices: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -86,6 +86,7 @@ class SnapshotClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clones indices from one snapshot into another snapshot in the same repository.
@@ -105,13 +106,11 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         if target_snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target_snapshot'")
-        if indices is None:
+        if indices is None and body is None:
             raise ValueError("Empty value passed for parameter 'indices'")
         __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_clone/{_quote(target_snapshot)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if indices is not None:
-            __body["indices"] = indices
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -124,13 +123,23 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if indices is not None:
+                __body["indices"] = indices
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "feature_states",
+            "ignore_unavailable",
+            "include_global_state",
+            "indices",
+            "metadata",
+            "partial",
+        ),
     )
     async def create(
         self,
@@ -151,6 +160,7 @@ class SnapshotClient(NamespacedClient):
         partial: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a snapshot in a repository.
@@ -194,31 +204,32 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if feature_states is not None:
-            __body["feature_states"] = feature_states
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_unavailable is not None:
-            __body["ignore_unavailable"] = ignore_unavailable
-        if include_global_state is not None:
-            __body["include_global_state"] = include_global_state
-        if indices is not None:
-            __body["indices"] = indices
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if partial is not None:
-            __body["partial"] = partial
         if pretty is not None:
             __query["pretty"] = pretty
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if feature_states is not None:
+                __body["feature_states"] = feature_states
+            if ignore_unavailable is not None:
+                __body["ignore_unavailable"] = ignore_unavailable
+            if include_global_state is not None:
+                __body["include_global_state"] = include_global_state
+            if indices is not None:
+                __body["indices"] = indices
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if partial is not None:
+                __body["partial"] = partial
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -229,14 +240,14 @@ class SnapshotClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("settings", "type", "repository"),
     )
     async def create_repository(
         self,
         *,
         name: str,
-        settings: t.Mapping[str, t.Any],
-        type: str,
+        settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        type: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -247,6 +258,7 @@ class SnapshotClient(NamespacedClient):
         repository: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         verify: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a repository.
@@ -263,17 +275,13 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if settings is None:
+        if settings is None and body is None:
             raise ValueError("Empty value passed for parameter 'settings'")
-        if type is None:
+        if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
         __path = f"/_snapshot/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if settings is not None:
-            __body["settings"] = settings
-        if type is not None:
-            __body["type"] = type
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -284,12 +292,17 @@ class SnapshotClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if repository is not None:
-            __body["repository"] = repository
         if timeout is not None:
             __query["timeout"] = timeout
         if verify is not None:
             __query["verify"] = verify
+        if not __body:
+            if settings is not None:
+                __body["settings"] = settings
+            if type is not None:
+                __body["type"] = type
+            if repository is not None:
+                __body["repository"] = repository
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -553,7 +566,18 @@ class SnapshotClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "feature_states",
+            "ignore_index_settings",
+            "ignore_unavailable",
+            "include_aliases",
+            "include_global_state",
+            "index_settings",
+            "indices",
+            "partial",
+            "rename_pattern",
+            "rename_replacement",
+        ),
     )
     async def restore(
         self,
@@ -578,6 +602,7 @@ class SnapshotClient(NamespacedClient):
         rename_pattern: t.Optional[str] = None,
         rename_replacement: t.Optional[str] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Restores a snapshot.
@@ -606,39 +631,40 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_restore"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if feature_states is not None:
-            __body["feature_states"] = feature_states
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_index_settings is not None:
-            __body["ignore_index_settings"] = ignore_index_settings
-        if ignore_unavailable is not None:
-            __body["ignore_unavailable"] = ignore_unavailable
-        if include_aliases is not None:
-            __body["include_aliases"] = include_aliases
-        if include_global_state is not None:
-            __body["include_global_state"] = include_global_state
-        if index_settings is not None:
-            __body["index_settings"] = index_settings
-        if indices is not None:
-            __body["indices"] = indices
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if partial is not None:
-            __body["partial"] = partial
         if pretty is not None:
             __query["pretty"] = pretty
-        if rename_pattern is not None:
-            __body["rename_pattern"] = rename_pattern
-        if rename_replacement is not None:
-            __body["rename_replacement"] = rename_replacement
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if feature_states is not None:
+                __body["feature_states"] = feature_states
+            if ignore_index_settings is not None:
+                __body["ignore_index_settings"] = ignore_index_settings
+            if ignore_unavailable is not None:
+                __body["ignore_unavailable"] = ignore_unavailable
+            if include_aliases is not None:
+                __body["include_aliases"] = include_aliases
+            if include_global_state is not None:
+                __body["include_global_state"] = include_global_state
+            if index_settings is not None:
+                __body["index_settings"] = index_settings
+            if indices is not None:
+                __body["indices"] = indices
+            if partial is not None:
+                __body["partial"] = partial
+            if rename_pattern is not None:
+                __body["rename_pattern"] = rename_pattern
+            if rename_replacement is not None:
+                __body["rename_replacement"] = rename_replacement
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -25,16 +25,17 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class SqlClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("cursor",),
     )
     async def clear_cursor(
         self,
         *,
-        cursor: str,
+        cursor: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clears the SQL cursor
@@ -43,13 +44,11 @@ class SqlClient(NamespacedClient):
 
         :param cursor: Cursor to clear.
         """
-        if cursor is None:
+        if cursor is None and body is None:
             raise ValueError("Empty value passed for parameter 'cursor'")
         __path = "/_sql/close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -58,6 +57,9 @@ class SqlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if cursor is not None:
+                __body["cursor"] = cursor
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -192,7 +194,24 @@ class SqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "catalog",
+            "columnar",
+            "cursor",
+            "fetch_size",
+            "field_multi_value_leniency",
+            "filter",
+            "index_using_frozen",
+            "keep_alive",
+            "keep_on_completion",
+            "page_timeout",
+            "params",
+            "query",
+            "request_timeout",
+            "runtime_mappings",
+            "time_zone",
+            "wait_for_completion_timeout",
+        ),
         ignore_deprecated_options={"params", "request_timeout"},
     )
     async def query(
@@ -223,6 +242,7 @@ class SqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a SQL request
@@ -261,62 +281,63 @@ class SqlClient(NamespacedClient):
             the search doesn’t finish within this period, the search becomes async.
         """
         __path = "/_sql"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if catalog is not None:
-            __body["catalog"] = catalog
-        if columnar is not None:
-            __body["columnar"] = columnar
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if field_multi_value_leniency is not None:
-            __body["field_multi_value_leniency"] = field_multi_value_leniency
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if format is not None:
             __query["format"] = format
         if human is not None:
             __query["human"] = human
-        if index_using_frozen is not None:
-            __body["index_using_frozen"] = index_using_frozen
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
-        if page_timeout is not None:
-            __body["page_timeout"] = page_timeout
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if request_timeout is not None:
-            __body["request_timeout"] = request_timeout
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if catalog is not None:
+                __body["catalog"] = catalog
+            if columnar is not None:
+                __body["columnar"] = columnar
+            if cursor is not None:
+                __body["cursor"] = cursor
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if field_multi_value_leniency is not None:
+                __body["field_multi_value_leniency"] = field_multi_value_leniency
+            if filter is not None:
+                __body["filter"] = filter
+            if index_using_frozen is not None:
+                __body["index_using_frozen"] = index_using_frozen
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if page_timeout is not None:
+                __body["page_timeout"] = page_timeout
+            if params is not None:
+                __body["params"] = params
+            if query is not None:
+                __body["query"] = query
+            if request_timeout is not None:
+                __body["request_timeout"] = request_timeout
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query", "fetch_size", "filter", "time_zone"),
     )
     async def translate(
         self,
         *,
-        query: str,
+        query: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         fetch_size: t.Optional[int] = None,
         filter: t.Optional[t.Mapping[str, t.Any]] = None,
@@ -324,6 +345,7 @@ class SqlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         time_zone: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Translates SQL into Elasticsearch queries
@@ -335,27 +357,28 @@ class SqlClient(NamespacedClient):
         :param filter: Elasticsearch query DSL for additional filtering.
         :param time_zone: ISO-8601 time zone ID for the search.
         """
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = "/_sql/translate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if filter is not None:
+                __body["filter"] = filter
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/synonyms.py
+++ b/elasticsearch/_async/client/synonyms.py
@@ -219,17 +219,18 @@ class SynonymsClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms_set",),
     )
     async def put_synonym(
         self,
         *,
         id: str,
-        synonyms_set: t.Sequence[t.Mapping[str, t.Any]],
+        synonyms_set: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonyms set
@@ -241,13 +242,11 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if synonyms_set is None:
+        if synonyms_set is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms_set'")
         __path = f"/_synonyms/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms_set is not None:
-            __body["synonyms_set"] = synonyms_set
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -256,24 +255,28 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms_set is not None:
+                __body["synonyms_set"] = synonyms_set
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms",),
     )
     async def put_synonym_rule(
         self,
         *,
         set_id: str,
         rule_id: str,
-        synonyms: t.Sequence[str],
+        synonyms: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonym rule in a synonym set
@@ -288,13 +291,11 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        if synonyms is None:
+        if synonyms is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms'")
         __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms is not None:
-            __body["synonyms"] = synonyms
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -303,6 +304,9 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms is not None:
+                __body["synonyms"] = synonyms
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/text_structure.py
+++ b/elasticsearch/_async/client/text_structure.py
@@ -30,7 +30,8 @@ class TextStructureClient(NamespacedClient):
     async def find_structure(
         self,
         *,
-        text_files: t.Sequence[t.Any],
+        text_files: t.Optional[t.Sequence[t.Any]] = None,
+        body: t.Optional[t.Sequence[t.Any]] = None,
         charset: t.Optional[str] = None,
         column_names: t.Optional[str] = None,
         delimiter: t.Optional[str] = None,
@@ -116,8 +117,12 @@ class TextStructureClient(NamespacedClient):
             the file
         :param timestamp_format: The Java time format of the timestamp field in the text.
         """
-        if text_files is None:
-            raise ValueError("Empty value passed for parameter 'text_files'")
+        if text_files is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'text_files' and 'body', one of them should be set."
+            )
+        elif text_files is not None and body is not None:
+            raise ValueError("Cannot set both 'text_files' and 'body'")
         __path = "/_text_structure/find_structure"
         __query: t.Dict[str, t.Any] = {}
         if charset is not None:
@@ -148,7 +153,7 @@ class TextStructureClient(NamespacedClient):
             __query["timestamp_field"] = timestamp_field
         if timestamp_format is not None:
             __query["timestamp_format"] = timestamp_format
-        __body = text_files
+        __body = text_files if text_files is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -195,7 +195,17 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "latest",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
     )
     async def preview_transform(
         self,
@@ -215,6 +225,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a transform.
@@ -247,36 +258,37 @@ class TransformClient(NamespacedClient):
             __path = f"/_transform/{_quote(transform_id)}/_preview"
         else:
             __path = "/_transform/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -287,15 +299,26 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "dest",
+            "source",
+            "description",
+            "frequency",
+            "latest",
+            "meta",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def put_transform(
         self,
         *,
         transform_id: str,
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         defer_validation: t.Optional[bool] = None,
         description: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -310,6 +333,7 @@ class TransformClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a transform.
@@ -348,45 +372,46 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_transform/{_quote(transform_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if meta is not None:
-            __body["_meta"] = meta
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if description is not None:
+                __body["description"] = description
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if meta is not None:
+                __body["_meta"] = meta
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -589,7 +614,16 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "meta",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def update_transform(
@@ -610,6 +644,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a transform.
@@ -639,35 +674,36 @@ class TransformClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'transform_id'")
         __path = f"/_transform/{_quote(transform_id)}/_update"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if meta is not None:
+                __body["_meta"] = meta
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -168,7 +168,15 @@ class WatcherClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "action_modes",
+            "alternative_input",
+            "ignore_condition",
+            "record_execution",
+            "simulated_actions",
+            "trigger_data",
+            "watch",
+        ),
     )
     async def execute_watch(
         self,
@@ -194,6 +202,7 @@ class WatcherClient(NamespacedClient):
         simulated_actions: t.Optional[t.Mapping[str, t.Any]] = None,
         trigger_data: t.Optional[t.Mapping[str, t.Any]] = None,
         watch: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Forces the execution of a stored watch.
@@ -223,12 +232,8 @@ class WatcherClient(NamespacedClient):
             __path = f"/_watcher/watch/{_quote(id)}/_execute"
         else:
             __path = "/_watcher/watch/_execute"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if action_modes is not None:
-            __body["action_modes"] = action_modes
-        if alternative_input is not None:
-            __body["alternative_input"] = alternative_input
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if debug is not None:
             __query["debug"] = debug
         if error_trace is not None:
@@ -237,18 +242,23 @@ class WatcherClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_condition is not None:
-            __body["ignore_condition"] = ignore_condition
         if pretty is not None:
             __query["pretty"] = pretty
-        if record_execution is not None:
-            __body["record_execution"] = record_execution
-        if simulated_actions is not None:
-            __body["simulated_actions"] = simulated_actions
-        if trigger_data is not None:
-            __body["trigger_data"] = trigger_data
-        if watch is not None:
-            __body["watch"] = watch
+        if not __body:
+            if action_modes is not None:
+                __body["action_modes"] = action_modes
+            if alternative_input is not None:
+                __body["alternative_input"] = alternative_input
+            if ignore_condition is not None:
+                __body["ignore_condition"] = ignore_condition
+            if record_execution is not None:
+                __body["record_execution"] = record_execution
+            if simulated_actions is not None:
+                __body["simulated_actions"] = simulated_actions
+            if trigger_data is not None:
+                __body["trigger_data"] = trigger_data
+            if watch is not None:
+                __body["watch"] = watch
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -293,7 +303,15 @@ class WatcherClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "actions",
+            "condition",
+            "input",
+            "metadata",
+            "throttle_period",
+            "transform",
+            "trigger",
+        ),
     )
     async def put_watch(
         self,
@@ -314,6 +332,7 @@ class WatcherClient(NamespacedClient):
         transform: t.Optional[t.Mapping[str, t.Any]] = None,
         trigger: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new watch, or updates an existing one.
@@ -338,14 +357,10 @@ class WatcherClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_watcher/watch/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if active is not None:
             __query["active"] = active
-        if condition is not None:
-            __body["condition"] = condition
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -356,20 +371,25 @@ class WatcherClient(NamespacedClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
-        if input is not None:
-            __body["input"] = input
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
-        if throttle_period is not None:
-            __body["throttle_period"] = throttle_period
-        if transform is not None:
-            __body["transform"] = transform
-        if trigger is not None:
-            __body["trigger"] = trigger
         if version is not None:
             __query["version"] = version
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
+            if condition is not None:
+                __body["condition"] = condition
+            if input is not None:
+                __body["input"] = input
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if throttle_period is not None:
+                __body["throttle_period"] = throttle_period
+            if transform is not None:
+                __body["transform"] = transform
+            if trigger is not None:
+                __body["trigger"] = trigger
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -380,7 +400,7 @@ class WatcherClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("from_", "query", "search_after", "size", "sort"),
         parameter_aliases={"from": "from_"},
     )
     async def query_watches(
@@ -402,6 +422,7 @@ class WatcherClient(NamespacedClient):
                 t.Union[str, t.Mapping[str, t.Any]],
             ]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves stored watches.
@@ -417,7 +438,7 @@ class WatcherClient(NamespacedClient):
         """
         __path = "/_watcher/_query/watches"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -433,20 +454,21 @@ class WatcherClient(NamespacedClient):
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
+        if not __body:
+            if from_ is not None:
+                __body["from"] = from_
+            if query is not None:
+                __body["query"] = query
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -445,7 +445,7 @@ async def async_scan(
         search_kwargs = kwargs.copy()
         search_kwargs["scroll"] = scroll
         search_kwargs["size"] = size
-        resp = await client.search(body=query, **search_kwargs)  # type: ignore[call-arg]
+        resp = await client.search(body=query, **search_kwargs)
 
     scroll_id: Optional[str] = resp.get("_scroll_id")
     scroll_transport_kwargs = pop_transport_kwargs(scroll_kwargs)

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -610,7 +610,8 @@ class Elasticsearch(BaseClient):
     def bulk(
         self,
         *,
-        operations: t.Sequence[t.Mapping[str, t.Any]],
+        operations: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -661,8 +662,12 @@ class Elasticsearch(BaseClient):
             before proceeding with the operation. Set to all or any positive integer
             up to the total number of shards in the index (`number_of_replicas+1`).
         """
-        if operations is None:
-            raise ValueError("Empty value passed for parameter 'operations'")
+        if operations is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'operations' and 'body', one of them should be set."
+            )
+        elif operations is not None and body is not None:
+            raise ValueError("Cannot set both 'operations' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_bulk"
         else:
@@ -694,7 +699,7 @@ class Elasticsearch(BaseClient):
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = operations
+        __body = operations if operations is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -704,7 +709,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("scroll_id",),
     )
     def clear_scroll(
         self,
@@ -714,6 +719,7 @@ class Elasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         scroll_id: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explicitly clears the search context for a scroll.
@@ -724,7 +730,7 @@ class Elasticsearch(BaseClient):
         """
         __path = "/_search/scroll"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -733,8 +739,9 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if scroll_id is not None:
-            __body["scroll_id"] = scroll_id
+        if not __body:
+            if scroll_id is not None:
+                __body["scroll_id"] = scroll_id
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -745,16 +752,17 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("id",),
     )
     def close_point_in_time(
         self,
         *,
-        id: str,
+        id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Close a point in time
@@ -763,13 +771,11 @@ class Elasticsearch(BaseClient):
 
         :param id: The ID of the point-in-time.
         """
-        if id is None:
+        if id is None and body is None:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = "/_pit"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if id is not None:
-            __body["id"] = id
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -778,6 +784,9 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if id is not None:
+                __body["id"] = id
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -788,7 +797,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
     )
     def count(
         self,
@@ -820,6 +829,7 @@ class Elasticsearch(BaseClient):
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         routing: t.Optional[str] = None,
         terminate_after: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns number of documents matching a query.
@@ -868,7 +878,7 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_count"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if analyze_wildcard is not None:
@@ -901,12 +911,13 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if terminate_after is not None:
             __query["terminate_after"] = terminate_after
+        if not __body:
+            if query is not None:
+                __body["query"] = query
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -924,7 +935,8 @@ class Elasticsearch(BaseClient):
         *,
         index: str,
         id: str,
-        document: t.Mapping[str, t.Any],
+        document: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -980,8 +992,12 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if document is None:
-            raise ValueError("Empty value passed for parameter 'document'")
+        if document is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'document' and 'body', one of them should be set."
+            )
+        elif document is not None and body is not None:
+            raise ValueError("Cannot set both 'document' and 'body'")
         __path = f"/{_quote(index)}/_create/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1006,7 +1022,7 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = document
+        __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -1098,7 +1114,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("max_docs", "query", "slice"),
         parameter_aliases={"from": "from_"},
     )
     def delete_by_query(
@@ -1153,6 +1169,7 @@ class Elasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Deletes documents matching the provided query.
@@ -1226,7 +1243,7 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_delete_by_query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -1264,16 +1281,12 @@ class Elasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if lenient is not None:
             __query["lenient"] = lenient
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if refresh is not None:
             __query["refresh"] = refresh
         if request_cache is not None:
@@ -1290,8 +1303,6 @@ class Elasticsearch(BaseClient):
             __query["search_timeout"] = search_timeout
         if search_type is not None:
             __query["search_type"] = search_type
-        if slice is not None:
-            __body["slice"] = slice
         if slices is not None:
             __query["slices"] = slices
         if sort is not None:
@@ -1308,6 +1319,13 @@ class Elasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if query is not None:
+                __body["query"] = query
+            if slice is not None:
+                __body["slice"] = slice
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -1586,7 +1604,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -1615,6 +1633,7 @@ class Elasticsearch(BaseClient):
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns information about why a specific matches (or doesn't match) a query.
@@ -1653,7 +1672,7 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/{_quote(index)}/_explain/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if analyze_wildcard is not None:
             __query["analyze_wildcard"] = analyze_wildcard
         if analyzer is not None:
@@ -1676,8 +1695,6 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if source is not None:
@@ -1689,6 +1706,9 @@ class Elasticsearch(BaseClient):
         if stored_fields is not None:
             __query["stored_fields"] = stored_fields
         if not __body:
+            if query is not None:
+                __body["query"] = query
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -1698,7 +1718,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("fields", "index_filter", "runtime_mappings"),
     )
     def field_caps(
         self,
@@ -1724,6 +1744,7 @@ class Elasticsearch(BaseClient):
         pretty: t.Optional[bool] = None,
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         types: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns the information about the capabilities of fields among multiple indices.
@@ -1762,15 +1783,13 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_field_caps"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if filters is not None:
@@ -1781,14 +1800,17 @@ class Elasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if include_unmapped is not None:
             __query["include_unmapped"] = include_unmapped
-        if index_filter is not None:
-            __body["index_filter"] = index_filter
         if pretty is not None:
             __query["pretty"] = pretty
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
         if types is not None:
             __query["types"] = types
+        if not __body:
+            if fields is not None:
+                __body["fields"] = fields
+            if index_filter is not None:
+                __body["index_filter"] = index_filter
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2139,7 +2161,8 @@ class Elasticsearch(BaseClient):
         self,
         *,
         index: str,
-        document: t.Mapping[str, t.Any],
+        document: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2203,8 +2226,12 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if document is None:
-            raise ValueError("Empty value passed for parameter 'document'")
+        if document is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'document' and 'body', one of them should be set."
+            )
+        elif document is not None and body is not None:
+            raise ValueError("Cannot set both 'document' and 'body'")
         if index not in SKIP_IN_PATH and id not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_doc/{_quote(id)}"
             __method = "PUT"
@@ -2244,7 +2271,7 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = document
+        __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             __method, __path, params=__query, headers=__headers, body=__body
@@ -2280,14 +2307,21 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "knn",
+            "docvalue_fields",
+            "fields",
+            "filter",
+            "source",
+            "stored_fields",
+        ),
         parameter_aliases={"_source": "source"},
     )
     def knn_search(
         self,
         *,
         index: t.Union[str, t.Sequence[str]],
-        knn: t.Mapping[str, t.Any],
+        knn: t.Optional[t.Mapping[str, t.Any]] = None,
         docvalue_fields: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2300,6 +2334,7 @@ class Elasticsearch(BaseClient):
         routing: t.Optional[str] = None,
         source: t.Optional[t.Union[bool, t.Mapping[str, t.Any]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs a kNN search.
@@ -2329,21 +2364,13 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if knn is None:
+        if knn is None and body is None:
             raise ValueError("Empty value passed for parameter 'knn'")
         __path = f"/{_quote(index)}/_knn_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if knn is not None:
-            __body["knn"] = knn
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fields is not None:
-            __body["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -2352,10 +2379,19 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if routing is not None:
             __query["routing"] = routing
-        if source is not None:
-            __body["_source"] = source
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
+        if not __body:
+            if knn is not None:
+                __body["knn"] = knn
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if fields is not None:
+                __body["fields"] = fields
+            if filter is not None:
+                __body["filter"] = filter
+            if source is not None:
+                __body["_source"] = source
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2366,7 +2402,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "ids"),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -2391,6 +2427,7 @@ class Elasticsearch(BaseClient):
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to get multiple documents in one request.
@@ -2426,18 +2463,14 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_mget"
         else:
             __path = "/_mget"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ids is not None:
-            __body["ids"] = ids
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
@@ -2456,6 +2489,11 @@ class Elasticsearch(BaseClient):
             __query["_source_includes"] = source_includes
         if stored_fields is not None:
             __query["stored_fields"] = stored_fields
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if ids is not None:
+                __body["ids"] = ids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2467,7 +2505,8 @@ class Elasticsearch(BaseClient):
     def msearch(
         self,
         *,
-        searches: t.Sequence[t.Mapping[str, t.Any]],
+        searches: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         ccs_minimize_roundtrips: t.Optional[bool] = None,
@@ -2536,8 +2575,12 @@ class Elasticsearch(BaseClient):
         :param typed_keys: Specifies whether aggregation and suggester names should be
             prefixed by their respective types in the response.
         """
-        if searches is None:
-            raise ValueError("Empty value passed for parameter 'searches'")
+        if searches is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'searches' and 'body', one of them should be set."
+            )
+        elif searches is not None and body is not None:
+            raise ValueError("Cannot set both 'searches' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_msearch"
         else:
@@ -2575,7 +2618,7 @@ class Elasticsearch(BaseClient):
             __query["search_type"] = search_type
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        __body = searches
+        __body = searches if searches is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2590,7 +2633,8 @@ class Elasticsearch(BaseClient):
     def msearch_template(
         self,
         *,
-        search_templates: t.Sequence[t.Mapping[str, t.Any]],
+        search_templates: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         ccs_minimize_roundtrips: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2624,8 +2668,12 @@ class Elasticsearch(BaseClient):
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
-        if search_templates is None:
-            raise ValueError("Empty value passed for parameter 'search_templates'")
+        if search_templates is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'search_templates' and 'body', one of them should be set."
+            )
+        elif search_templates is not None and body is not None:
+            raise ValueError("Cannot set both 'search_templates' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_msearch/template"
         else:
@@ -2649,7 +2697,7 @@ class Elasticsearch(BaseClient):
             __query["search_type"] = search_type
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        __body = search_templates
+        __body = search_templates if search_templates is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2659,7 +2707,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "ids"),
     )
     def mtermvectors(
         self,
@@ -2684,6 +2732,7 @@ class Elasticsearch(BaseClient):
         version_type: t.Optional[
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns multiple termvectors in one request.
@@ -2715,10 +2764,8 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_mtermvectors"
         else:
             __path = "/_mtermvectors"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if field_statistics is not None:
@@ -2729,8 +2776,6 @@ class Elasticsearch(BaseClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ids is not None:
-            __body["ids"] = ids
         if offsets is not None:
             __query["offsets"] = offsets
         if payloads is not None:
@@ -2751,6 +2796,11 @@ class Elasticsearch(BaseClient):
             __query["version"] = version
         if version_type is not None:
             __query["version_type"] = version_type
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if ids is not None:
+                __body["ids"] = ids
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2830,13 +2880,13 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("script",),
     )
     def put_script(
         self,
         *,
         id: str,
-        script: t.Mapping[str, t.Any],
+        script: t.Optional[t.Mapping[str, t.Any]] = None,
         context: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2846,6 +2896,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a script.
@@ -2867,7 +2918,7 @@ class Elasticsearch(BaseClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if script is None:
+        if script is None and body is None:
             raise ValueError("Empty value passed for parameter 'script'")
         if id not in SKIP_IN_PATH and context not in SKIP_IN_PATH:
             __path = f"/_scripts/{_quote(id)}/{_quote(context)}"
@@ -2875,10 +2926,8 @@ class Elasticsearch(BaseClient):
             __path = f"/_scripts/{_quote(id)}"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if script is not None:
-            __body["script"] = script
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2891,18 +2940,21 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if script is not None:
+                __body["script"] = script
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("requests", "metric"),
     )
     def rank_eval(
         self,
         *,
-        requests: t.Sequence[t.Mapping[str, t.Any]],
+        requests: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2920,6 +2972,7 @@ class Elasticsearch(BaseClient):
         metric: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         search_type: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to evaluate the quality of ranked search results over a set of typical
@@ -2945,16 +2998,14 @@ class Elasticsearch(BaseClient):
         :param metric: Definition of the evaluation metric to calculate.
         :param search_type: Search operation type
         """
-        if requests is None:
+        if requests is None and body is None:
             raise ValueError("Empty value passed for parameter 'requests'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_rank_eval"
         else:
             __path = "/_rank_eval"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if requests is not None:
-            __body["requests"] = requests
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if error_trace is not None:
@@ -2967,25 +3018,28 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if metric is not None:
-            __body["metric"] = metric
         if pretty is not None:
             __query["pretty"] = pretty
         if search_type is not None:
             __query["search_type"] = search_type
+        if not __body:
+            if requests is not None:
+                __body["requests"] = requests
+            if metric is not None:
+                __body["metric"] = metric
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("dest", "source", "conflicts", "max_docs", "script", "size"),
     )
     def reindex(
         self,
         *,
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         conflicts: t.Optional[t.Union["t.Literal['abort', 'proceed']", str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -3004,6 +3058,7 @@ class Elasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to copy documents from one index to another, optionally filtering the
@@ -3036,27 +3091,19 @@ class Elasticsearch(BaseClient):
         :param wait_for_completion: If `true`, the request blocks until the operation
             is complete.
         """
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = "/_reindex"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
-        if conflicts is not None:
-            __body["conflicts"] = conflicts
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
@@ -3065,12 +3112,8 @@ class Elasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         if require_alias is not None:
             __query["require_alias"] = require_alias
-        if script is not None:
-            __body["script"] = script
         if scroll is not None:
             __query["scroll"] = scroll
-        if size is not None:
-            __body["size"] = size
         if slices is not None:
             __query["slices"] = slices
         if timeout is not None:
@@ -3079,6 +3122,19 @@ class Elasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if conflicts is not None:
+                __body["conflicts"] = conflicts
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if script is not None:
+                __body["script"] = script
+            if size is not None:
+                __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -3124,7 +3180,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("file", "params", "source"),
         ignore_deprecated_options={"params"},
     )
     def render_search_template(
@@ -3138,6 +3194,7 @@ class Elasticsearch(BaseClient):
         params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         source: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to use the Mustache language to pre-render a search definition.
@@ -3158,21 +3215,22 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_render/template"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if file is not None:
-            __body["file"] = file
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if source is not None:
-            __body["source"] = source
+        if not __body:
+            if file is not None:
+                __body["file"] = file
+            if params is not None:
+                __body["params"] = params
+            if source is not None:
+                __body["source"] = source
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3183,7 +3241,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("context", "context_setup", "script"),
     )
     def scripts_painless_execute(
         self,
@@ -3195,6 +3253,7 @@ class Elasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         script: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows an arbitrary script to be executed and a result to be returned
@@ -3206,12 +3265,8 @@ class Elasticsearch(BaseClient):
         :param script: The Painless script to execute.
         """
         __path = "/_scripts/painless/_execute"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if context is not None:
-            __body["context"] = context
-        if context_setup is not None:
-            __body["context_setup"] = context_setup
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3220,8 +3275,13 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if script is not None:
-            __body["script"] = script
+        if not __body:
+            if context is not None:
+                __body["context"] = context
+            if context_setup is not None:
+                __body["context_setup"] = context_setup
+            if script is not None:
+                __body["script"] = script
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3232,18 +3292,19 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("scroll_id", "scroll"),
     )
     def scroll(
         self,
         *,
-        scroll_id: str,
+        scroll_id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         rest_total_hits_as_int: t.Optional[bool] = None,
         scroll: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to retrieve a large numbers of results from a single search request.
@@ -3256,13 +3317,11 @@ class Elasticsearch(BaseClient):
             is returned as an object.
         :param scroll: Period to retain the search context for scrolling.
         """
-        if scroll_id is None:
+        if scroll_id is None and body is None:
             raise ValueError("Empty value passed for parameter 'scroll_id'")
         __path = "/_search/scroll"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if scroll_id is not None:
-            __body["scroll_id"] = scroll_id
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3273,8 +3332,11 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
-        if scroll is not None:
-            __body["scroll"] = scroll
+        if not __body:
+            if scroll_id is not None:
+                __body["scroll_id"] = scroll_id
+            if scroll is not None:
+                __body["scroll"] = scroll
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3285,7 +3347,42 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "knn",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rank",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -3386,6 +3483,7 @@ class Elasticsearch(BaseClient):
         track_total_hits: t.Optional[t.Union[bool, int]] = None,
         typed_keys: t.Optional[bool] = None,
         version: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns results matching a query.
@@ -3578,8 +3676,8 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_search"
         else:
             __path = "/_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -3591,10 +3689,6 @@ class Elasticsearch(BaseClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -3607,104 +3701,50 @@ class Elasticsearch(BaseClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
-        if knn is not None:
-            __body["knn"] = knn
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
-        if rank is not None:
-            __body["rank"] = rank
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -3713,18 +3753,77 @@ class Elasticsearch(BaseClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if knn is not None:
+                __body["knn"] = knn
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rank is not None:
+                __body["rank"] = rank
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3735,7 +3834,22 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggs",
+            "buffer",
+            "exact_bounds",
+            "extent",
+            "fields",
+            "grid_agg",
+            "grid_precision",
+            "grid_type",
+            "query",
+            "runtime_mappings",
+            "size",
+            "sort",
+            "track_total_hits",
+            "with_labels",
+        ),
     )
     def search_mvt(
         self,
@@ -3770,6 +3884,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         track_total_hits: t.Optional[t.Union[bool, int]] = None,
         with_labels: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> BinaryApiResponse:
         """
         Searches a vector tile for geospatial values. Returns results as a binary Mapbox
@@ -3831,8 +3946,8 @@ class Elasticsearch(BaseClient):
         if y in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'y'")
         __path = f"/{_quote(index)}/_mvt/{_quote(field)}/{_quote(zoom)}/{_quote(x)}/{_quote(y)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -3844,42 +3959,43 @@ class Elasticsearch(BaseClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggs is not None:
-            __body["aggs"] = aggs
-        if buffer is not None:
-            __body["buffer"] = buffer
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exact_bounds is not None:
-            __body["exact_bounds"] = exact_bounds
-        if extent is not None:
-            __body["extent"] = extent
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if grid_agg is not None:
-            __body["grid_agg"] = grid_agg
-        if grid_precision is not None:
-            __body["grid_precision"] = grid_precision
-        if grid_type is not None:
-            __body["grid_type"] = grid_type
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
-        if with_labels is not None:
-            __body["with_labels"] = with_labels
+        if not __body:
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if buffer is not None:
+                __body["buffer"] = buffer
+            if exact_bounds is not None:
+                __body["exact_bounds"] = exact_bounds
+            if extent is not None:
+                __body["extent"] = extent
+            if fields is not None:
+                __body["fields"] = fields
+            if grid_agg is not None:
+                __body["grid_agg"] = grid_agg
+            if grid_precision is not None:
+                __body["grid_precision"] = grid_precision
+            if grid_type is not None:
+                __body["grid_type"] = grid_type
+            if query is not None:
+                __body["query"] = query
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if with_labels is not None:
+                __body["with_labels"] = with_labels
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/vnd.mapbox-vector-tile"}
@@ -3968,7 +4084,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("explain", "id", "params", "profile", "source"),
         ignore_deprecated_options={"params"},
     )
     def search_template(
@@ -4004,6 +4120,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         source: t.Optional[str] = None,
         typed_keys: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to use the Mustache language to pre-render a search definition.
@@ -4053,7 +4170,7 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_search/template"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if ccs_minimize_roundtrips is not None:
@@ -4062,26 +4179,18 @@ class Elasticsearch(BaseClient):
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if id is not None:
-            __body["id"] = id
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if params is not None:
-            __body["params"] = params
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
@@ -4090,23 +4199,40 @@ class Elasticsearch(BaseClient):
             __query["scroll"] = scroll
         if search_type is not None:
             __query["search_type"] = search_type
-        if source is not None:
-            __body["source"] = source
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
+        if not __body:
+            if explain is not None:
+                __body["explain"] = explain
+            if id is not None:
+                __body["id"] = id
+            if params is not None:
+                __body["params"] = params
+            if profile is not None:
+                __body["profile"] = profile
+            if source is not None:
+                __body["source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "field",
+            "case_insensitive",
+            "index_filter",
+            "search_after",
+            "size",
+            "string",
+            "timeout",
+        ),
     )
     def terms_enum(
         self,
         *,
         index: str,
-        field: str,
+        field: t.Optional[str] = None,
         case_insensitive: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -4117,6 +4243,7 @@ class Elasticsearch(BaseClient):
         size: t.Optional[int] = None,
         string: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         The terms enum API can be used to discover terms in the index that begin with
@@ -4144,33 +4271,34 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if field is None:
+        if field is None and body is None:
             raise ValueError("Empty value passed for parameter 'field'")
         __path = f"/{_quote(index)}/_terms_enum"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if field is not None:
-            __body["field"] = field
-        if case_insensitive is not None:
-            __body["case_insensitive"] = case_insensitive
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_filter is not None:
-            __body["index_filter"] = index_filter
         if pretty is not None:
             __query["pretty"] = pretty
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if string is not None:
-            __body["string"] = string
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if field is not None:
+                __body["field"] = field
+            if case_insensitive is not None:
+                __body["case_insensitive"] = case_insensitive
+            if index_filter is not None:
+                __body["index_filter"] = index_filter
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if string is not None:
+                __body["string"] = string
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -4181,7 +4309,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("doc", "filter", "per_field_analyzer"),
     )
     def termvectors(
         self,
@@ -4208,6 +4336,7 @@ class Elasticsearch(BaseClient):
         version_type: t.Optional[
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns information and statistics about terms in the fields of a particular
@@ -4246,18 +4375,14 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_termvectors"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if doc is not None:
-            __body["doc"] = doc
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if field_statistics is not None:
             __query["field_statistics"] = field_statistics
         if fields is not None:
             __query["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -4266,8 +4391,6 @@ class Elasticsearch(BaseClient):
             __query["offsets"] = offsets
         if payloads is not None:
             __query["payloads"] = payloads
-        if per_field_analyzer is not None:
-            __body["per_field_analyzer"] = per_field_analyzer
         if positions is not None:
             __query["positions"] = positions
         if preference is not None:
@@ -4285,6 +4408,13 @@ class Elasticsearch(BaseClient):
         if version_type is not None:
             __query["version_type"] = version_type
         if not __body:
+            if doc is not None:
+                __body["doc"] = doc
+            if filter is not None:
+                __body["filter"] = filter
+            if per_field_analyzer is not None:
+                __body["per_field_analyzer"] = per_field_analyzer
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -4294,7 +4424,15 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "detect_noop",
+            "doc",
+            "doc_as_upsert",
+            "script",
+            "scripted_upsert",
+            "source",
+            "upsert",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -4332,6 +4470,7 @@ class Elasticsearch(BaseClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates a document with a script or partial document.
@@ -4379,14 +4518,8 @@ class Elasticsearch(BaseClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/{_quote(index)}/_update/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if detect_noop is not None:
-            __body["detect_noop"] = detect_noop
-        if doc is not None:
-            __body["doc"] = doc
-        if doc_as_upsert is not None:
-            __body["doc_as_upsert"] = doc_as_upsert
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -4409,29 +4542,36 @@ class Elasticsearch(BaseClient):
             __query["retry_on_conflict"] = retry_on_conflict
         if routing is not None:
             __query["routing"] = routing
-        if script is not None:
-            __body["script"] = script
-        if scripted_upsert is not None:
-            __body["scripted_upsert"] = scripted_upsert
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
         if timeout is not None:
             __query["timeout"] = timeout
-        if upsert is not None:
-            __body["upsert"] = upsert
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if detect_noop is not None:
+                __body["detect_noop"] = detect_noop
+            if doc is not None:
+                __body["doc"] = doc
+            if doc_as_upsert is not None:
+                __body["doc_as_upsert"] = doc_as_upsert
+            if script is not None:
+                __body["script"] = script
+            if scripted_upsert is not None:
+                __body["scripted_upsert"] = scripted_upsert
+            if source is not None:
+                __body["_source"] = source
+            if upsert is not None:
+                __body["upsert"] = upsert
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("conflicts", "max_docs", "query", "script", "slice"),
         parameter_aliases={"from": "from_"},
     )
     def update_by_query(
@@ -4488,6 +4628,7 @@ class Elasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs an update on every document in the index without changing the source,
@@ -4569,7 +4710,7 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_update_by_query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -4587,8 +4728,6 @@ class Elasticsearch(BaseClient):
             __query["analyze_wildcard"] = analyze_wildcard
         if analyzer is not None:
             __query["analyzer"] = analyzer
-        if conflicts is not None:
-            __body["conflicts"] = conflicts
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
@@ -4607,16 +4746,12 @@ class Elasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if lenient is not None:
             __query["lenient"] = lenient
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if pipeline is not None:
             __query["pipeline"] = pipeline
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if refresh is not None:
             __query["refresh"] = refresh
         if request_cache is not None:
@@ -4625,8 +4760,6 @@ class Elasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         if routing is not None:
             __query["routing"] = routing
-        if script is not None:
-            __body["script"] = script
         if scroll is not None:
             __query["scroll"] = scroll
         if scroll_size is not None:
@@ -4635,8 +4768,6 @@ class Elasticsearch(BaseClient):
             __query["search_timeout"] = search_timeout
         if search_type is not None:
             __query["search_type"] = search_type
-        if slice is not None:
-            __body["slice"] = slice
         if slices is not None:
             __query["slices"] = slices
         if sort is not None:
@@ -4655,6 +4786,17 @@ class Elasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if conflicts is not None:
+                __body["conflicts"] = conflicts
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if query is not None:
+                __body["query"] = query
+            if script is not None:
+                __body["script"] = script
+            if slice is not None:
+                __body["slice"] = slice
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/async_search.py
+++ b/elasticsearch/_sync/client/async_search.py
@@ -155,7 +155,41 @@ class AsyncSearchClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "knn",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -260,6 +294,7 @@ class AsyncSearchClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a search request asynchronously.
@@ -396,8 +431,8 @@ class AsyncSearchClient(NamespacedClient):
             __path = f"/{_quote(index)}/_async_search"
         else:
             __path = "/_async_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -409,10 +444,6 @@ class AsyncSearchClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -425,106 +456,54 @@ class AsyncSearchClient(NamespacedClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
         if keep_on_completion is not None:
             __query["keep_on_completion"] = keep_on_completion
-        if knn is not None:
-            __body["knn"] = knn
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -533,20 +512,77 @@ class AsyncSearchClient(NamespacedClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
         if wait_for_completion_timeout is not None:
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if knn is not None:
+                __body["knn"] = knn
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/autoscaling.py
+++ b/elasticsearch/_sync/client/autoscaling.py
@@ -131,7 +131,8 @@ class AutoscalingClient(NamespacedClient):
         self,
         *,
         name: str,
-        policy: t.Mapping[str, t.Any],
+        policy: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -148,8 +149,12 @@ class AutoscalingClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if policy is None:
-            raise ValueError("Empty value passed for parameter 'policy'")
+        if policy is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'policy' and 'body', one of them should be set."
+            )
+        elif policy is not None and body is not None:
+            raise ValueError("Cannot set both 'policy' and 'body'")
         __path = f"/_autoscaling/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -160,7 +165,7 @@ class AutoscalingClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = policy
+        __body = policy if policy is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/ccr.py
+++ b/elasticsearch/_sync/client/ccr.py
@@ -59,7 +59,20 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "leader_index",
+            "max_outstanding_read_requests",
+            "max_outstanding_write_requests",
+            "max_read_request_operation_count",
+            "max_read_request_size",
+            "max_retry_delay",
+            "max_write_buffer_count",
+            "max_write_buffer_size",
+            "max_write_request_operation_count",
+            "max_write_request_size",
+            "read_poll_timeout",
+            "remote_cluster",
+        ),
     )
     def follow(
         self,
@@ -88,6 +101,7 @@ class CcrClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new follower index configured to follow the referenced leader index.
@@ -116,45 +130,48 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_ccr/follow"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if leader_index is not None:
-            __body["leader_index"] = leader_index
-        if max_outstanding_read_requests is not None:
-            __body["max_outstanding_read_requests"] = max_outstanding_read_requests
-        if max_outstanding_write_requests is not None:
-            __body["max_outstanding_write_requests"] = max_outstanding_write_requests
-        if max_read_request_operation_count is not None:
-            __body[
-                "max_read_request_operation_count"
-            ] = max_read_request_operation_count
-        if max_read_request_size is not None:
-            __body["max_read_request_size"] = max_read_request_size
-        if max_retry_delay is not None:
-            __body["max_retry_delay"] = max_retry_delay
-        if max_write_buffer_count is not None:
-            __body["max_write_buffer_count"] = max_write_buffer_count
-        if max_write_buffer_size is not None:
-            __body["max_write_buffer_size"] = max_write_buffer_size
-        if max_write_request_operation_count is not None:
-            __body[
-                "max_write_request_operation_count"
-            ] = max_write_request_operation_count
-        if max_write_request_size is not None:
-            __body["max_write_request_size"] = max_write_request_size
         if pretty is not None:
             __query["pretty"] = pretty
-        if read_poll_timeout is not None:
-            __body["read_poll_timeout"] = read_poll_timeout
-        if remote_cluster is not None:
-            __body["remote_cluster"] = remote_cluster
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if leader_index is not None:
+                __body["leader_index"] = leader_index
+            if max_outstanding_read_requests is not None:
+                __body["max_outstanding_read_requests"] = max_outstanding_read_requests
+            if max_outstanding_write_requests is not None:
+                __body[
+                    "max_outstanding_write_requests"
+                ] = max_outstanding_write_requests
+            if max_read_request_operation_count is not None:
+                __body[
+                    "max_read_request_operation_count"
+                ] = max_read_request_operation_count
+            if max_read_request_size is not None:
+                __body["max_read_request_size"] = max_read_request_size
+            if max_retry_delay is not None:
+                __body["max_retry_delay"] = max_retry_delay
+            if max_write_buffer_count is not None:
+                __body["max_write_buffer_count"] = max_write_buffer_count
+            if max_write_buffer_size is not None:
+                __body["max_write_buffer_size"] = max_write_buffer_size
+            if max_write_request_operation_count is not None:
+                __body[
+                    "max_write_request_operation_count"
+                ] = max_write_request_operation_count
+            if max_write_request_size is not None:
+                __body["max_write_request_size"] = max_write_request_size
+            if read_poll_timeout is not None:
+                __body["read_poll_timeout"] = read_poll_timeout
+            if remote_cluster is not None:
+                __body["remote_cluster"] = remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -233,7 +250,12 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "follower_cluster",
+            "follower_index",
+            "follower_index_uuid",
+            "leader_remote_cluster",
+        ),
     )
     def forget_follower(
         self,
@@ -247,6 +269,7 @@ class CcrClient(NamespacedClient):
         human: t.Optional[bool] = None,
         leader_remote_cluster: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Removes the follower retention leases from the leader.
@@ -264,23 +287,24 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_ccr/forget_follower"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if follower_cluster is not None:
-            __body["follower_cluster"] = follower_cluster
-        if follower_index is not None:
-            __body["follower_index"] = follower_index
-        if follower_index_uuid is not None:
-            __body["follower_index_uuid"] = follower_index_uuid
         if human is not None:
             __query["human"] = human
-        if leader_remote_cluster is not None:
-            __body["leader_remote_cluster"] = leader_remote_cluster
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if follower_cluster is not None:
+                __body["follower_cluster"] = follower_cluster
+            if follower_index is not None:
+                __body["follower_index"] = follower_index
+            if follower_index_uuid is not None:
+                __body["follower_index_uuid"] = follower_index_uuid
+            if leader_remote_cluster is not None:
+                __body["leader_remote_cluster"] = leader_remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -395,13 +419,29 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "remote_cluster",
+            "follow_index_pattern",
+            "leader_index_exclusion_patterns",
+            "leader_index_patterns",
+            "max_outstanding_read_requests",
+            "max_outstanding_write_requests",
+            "max_read_request_operation_count",
+            "max_read_request_size",
+            "max_retry_delay",
+            "max_write_buffer_count",
+            "max_write_buffer_size",
+            "max_write_request_operation_count",
+            "max_write_request_size",
+            "read_poll_timeout",
+            "settings",
+        ),
     )
     def put_auto_follow_pattern(
         self,
         *,
         name: str,
-        remote_cluster: str,
+        remote_cluster: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         follow_index_pattern: t.Optional[str] = None,
@@ -424,6 +464,7 @@ class CcrClient(NamespacedClient):
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new named collection of auto-follow patterns against a specified remote
@@ -477,53 +518,58 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if remote_cluster is None:
+        if remote_cluster is None and body is None:
             raise ValueError("Empty value passed for parameter 'remote_cluster'")
         __path = f"/_ccr/auto_follow/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if remote_cluster is not None:
-            __body["remote_cluster"] = remote_cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if follow_index_pattern is not None:
-            __body["follow_index_pattern"] = follow_index_pattern
         if human is not None:
             __query["human"] = human
-        if leader_index_exclusion_patterns is not None:
-            __body["leader_index_exclusion_patterns"] = leader_index_exclusion_patterns
-        if leader_index_patterns is not None:
-            __body["leader_index_patterns"] = leader_index_patterns
-        if max_outstanding_read_requests is not None:
-            __body["max_outstanding_read_requests"] = max_outstanding_read_requests
-        if max_outstanding_write_requests is not None:
-            __body["max_outstanding_write_requests"] = max_outstanding_write_requests
-        if max_read_request_operation_count is not None:
-            __body[
-                "max_read_request_operation_count"
-            ] = max_read_request_operation_count
-        if max_read_request_size is not None:
-            __body["max_read_request_size"] = max_read_request_size
-        if max_retry_delay is not None:
-            __body["max_retry_delay"] = max_retry_delay
-        if max_write_buffer_count is not None:
-            __body["max_write_buffer_count"] = max_write_buffer_count
-        if max_write_buffer_size is not None:
-            __body["max_write_buffer_size"] = max_write_buffer_size
-        if max_write_request_operation_count is not None:
-            __body[
-                "max_write_request_operation_count"
-            ] = max_write_request_operation_count
-        if max_write_request_size is not None:
-            __body["max_write_request_size"] = max_write_request_size
         if pretty is not None:
             __query["pretty"] = pretty
-        if read_poll_timeout is not None:
-            __body["read_poll_timeout"] = read_poll_timeout
-        if settings is not None:
-            __body["settings"] = settings
+        if not __body:
+            if remote_cluster is not None:
+                __body["remote_cluster"] = remote_cluster
+            if follow_index_pattern is not None:
+                __body["follow_index_pattern"] = follow_index_pattern
+            if leader_index_exclusion_patterns is not None:
+                __body[
+                    "leader_index_exclusion_patterns"
+                ] = leader_index_exclusion_patterns
+            if leader_index_patterns is not None:
+                __body["leader_index_patterns"] = leader_index_patterns
+            if max_outstanding_read_requests is not None:
+                __body["max_outstanding_read_requests"] = max_outstanding_read_requests
+            if max_outstanding_write_requests is not None:
+                __body[
+                    "max_outstanding_write_requests"
+                ] = max_outstanding_write_requests
+            if max_read_request_operation_count is not None:
+                __body[
+                    "max_read_request_operation_count"
+                ] = max_read_request_operation_count
+            if max_read_request_size is not None:
+                __body["max_read_request_size"] = max_read_request_size
+            if max_retry_delay is not None:
+                __body["max_retry_delay"] = max_retry_delay
+            if max_write_buffer_count is not None:
+                __body["max_write_buffer_count"] = max_write_buffer_count
+            if max_write_buffer_size is not None:
+                __body["max_write_buffer_size"] = max_write_buffer_size
+            if max_write_request_operation_count is not None:
+                __body[
+                    "max_write_request_operation_count"
+                ] = max_write_request_operation_count
+            if max_write_request_size is not None:
+                __body["max_write_request_size"] = max_write_request_size
+            if read_poll_timeout is not None:
+                __body["read_poll_timeout"] = read_poll_timeout
+            if settings is not None:
+                __body["settings"] = settings
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -565,7 +611,18 @@ class CcrClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "max_outstanding_read_requests",
+            "max_outstanding_write_requests",
+            "max_read_request_operation_count",
+            "max_read_request_size",
+            "max_retry_delay",
+            "max_write_buffer_count",
+            "max_write_buffer_size",
+            "max_write_request_operation_count",
+            "max_write_request_size",
+            "read_poll_timeout",
+        ),
     )
     def resume_follow(
         self,
@@ -589,6 +646,7 @@ class CcrClient(NamespacedClient):
         read_poll_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Resumes a follower index that has been paused
@@ -611,39 +669,42 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_ccr/resume_follow"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_outstanding_read_requests is not None:
-            __body["max_outstanding_read_requests"] = max_outstanding_read_requests
-        if max_outstanding_write_requests is not None:
-            __body["max_outstanding_write_requests"] = max_outstanding_write_requests
-        if max_read_request_operation_count is not None:
-            __body[
-                "max_read_request_operation_count"
-            ] = max_read_request_operation_count
-        if max_read_request_size is not None:
-            __body["max_read_request_size"] = max_read_request_size
-        if max_retry_delay is not None:
-            __body["max_retry_delay"] = max_retry_delay
-        if max_write_buffer_count is not None:
-            __body["max_write_buffer_count"] = max_write_buffer_count
-        if max_write_buffer_size is not None:
-            __body["max_write_buffer_size"] = max_write_buffer_size
-        if max_write_request_operation_count is not None:
-            __body[
-                "max_write_request_operation_count"
-            ] = max_write_request_operation_count
-        if max_write_request_size is not None:
-            __body["max_write_request_size"] = max_write_request_size
         if pretty is not None:
             __query["pretty"] = pretty
-        if read_poll_timeout is not None:
-            __body["read_poll_timeout"] = read_poll_timeout
+        if not __body:
+            if max_outstanding_read_requests is not None:
+                __body["max_outstanding_read_requests"] = max_outstanding_read_requests
+            if max_outstanding_write_requests is not None:
+                __body[
+                    "max_outstanding_write_requests"
+                ] = max_outstanding_write_requests
+            if max_read_request_operation_count is not None:
+                __body[
+                    "max_read_request_operation_count"
+                ] = max_read_request_operation_count
+            if max_read_request_size is not None:
+                __body["max_read_request_size"] = max_read_request_size
+            if max_retry_delay is not None:
+                __body["max_retry_delay"] = max_retry_delay
+            if max_write_buffer_count is not None:
+                __body["max_write_buffer_count"] = max_write_buffer_count
+            if max_write_buffer_size is not None:
+                __body["max_write_buffer_size"] = max_write_buffer_size
+            if max_write_request_operation_count is not None:
+                __body[
+                    "max_write_request_operation_count"
+                ] = max_write_request_operation_count
+            if max_write_request_size is not None:
+                __body["max_write_request_size"] = max_write_request_size
+            if read_poll_timeout is not None:
+                __body["read_poll_timeout"] = read_poll_timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/cluster.py
+++ b/elasticsearch/_sync/client/cluster.py
@@ -25,7 +25,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class ClusterClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("current_node", "index", "primary", "shard"),
     )
     def allocation_explain(
         self,
@@ -40,6 +40,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         primary: t.Optional[bool] = None,
         shard: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Provides explanations for shard allocations in the cluster.
@@ -59,10 +60,8 @@ class ClusterClient(NamespacedClient):
             for.
         """
         __path = "/_cluster/allocation/explain"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if current_node is not None:
-            __body["current_node"] = current_node
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -73,14 +72,17 @@ class ClusterClient(NamespacedClient):
             __query["include_disk_info"] = include_disk_info
         if include_yes_decisions is not None:
             __query["include_yes_decisions"] = include_yes_decisions
-        if index is not None:
-            __body["index"] = index
         if pretty is not None:
             __query["pretty"] = pretty
-        if primary is not None:
-            __body["primary"] = primary
-        if shard is not None:
-            __body["shard"] = shard
+        if not __body:
+            if current_node is not None:
+                __body["current_node"] = current_node
+            if index is not None:
+                __body["index"] = index
+            if primary is not None:
+                __body["primary"] = primary
+            if shard is not None:
+                __body["shard"] = shard
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -593,14 +595,14 @@ class ClusterClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("template", "allow_auto_create", "meta", "version"),
         parameter_aliases={"_meta": "meta"},
     )
     def put_component_template(
         self,
         *,
         name: str,
-        template: t.Mapping[str, t.Any],
+        template: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_auto_create: t.Optional[bool] = None,
         create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -612,6 +614,7 @@ class ClusterClient(NamespacedClient):
         meta: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a component template
@@ -649,15 +652,11 @@ class ClusterClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if template is None:
+        if template is None and body is None:
             raise ValueError("Empty value passed for parameter 'template'")
         __path = f"/_component_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if template is not None:
-            __body["template"] = template
-        if allow_auto_create is not None:
-            __body["allow_auto_create"] = allow_auto_create
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
         if error_trace is not None:
@@ -668,19 +667,24 @@ class ClusterClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if template is not None:
+                __body["template"] = template
+            if allow_auto_create is not None:
+                __body["allow_auto_create"] = allow_auto_create
+            if meta is not None:
+                __body["_meta"] = meta
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("persistent", "transient"),
     )
     def put_settings(
         self,
@@ -696,6 +700,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         transient: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the cluster settings.
@@ -710,7 +715,7 @@ class ClusterClient(NamespacedClient):
         """
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -721,14 +726,15 @@ class ClusterClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if persistent is not None:
-            __body["persistent"] = persistent
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        if transient is not None:
-            __body["transient"] = transient
+        if not __body:
+            if persistent is not None:
+                __body["persistent"] = persistent
+            if transient is not None:
+                __body["transient"] = transient
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -764,7 +770,7 @@ class ClusterClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("commands",),
     )
     def reroute(
         self,
@@ -782,6 +788,7 @@ class ClusterClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         retry_failed: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to manually change the allocation of individual shards in the cluster.
@@ -803,10 +810,8 @@ class ClusterClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         """
         __path = "/_cluster/reroute"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if commands is not None:
-            __body["commands"] = commands
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -827,6 +832,9 @@ class ClusterClient(NamespacedClient):
             __query["retry_failed"] = retry_failed
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if commands is not None:
+                __body["commands"] = commands
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/enrich.py
+++ b/elasticsearch/_sync/client/enrich.py
@@ -134,7 +134,7 @@ class EnrichClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("geo_match", "match", "range"),
     )
     def put_policy(
         self,
@@ -147,6 +147,7 @@ class EnrichClient(NamespacedClient):
         match: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         range: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new enrich policy.
@@ -164,21 +165,22 @@ class EnrichClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_enrich/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if geo_match is not None:
-            __body["geo_match"] = geo_match
         if human is not None:
             __query["human"] = human
-        if match is not None:
-            __body["match"] = match
         if pretty is not None:
             __query["pretty"] = pretty
-        if range is not None:
-            __body["range"] = range
+        if not __body:
+            if geo_match is not None:
+                __body["geo_match"] = geo_match
+            if match is not None:
+                __body["match"] = match
+            if range is not None:
+                __body["range"] = range
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/eql.py
+++ b/elasticsearch/_sync/client/eql.py
@@ -145,13 +145,28 @@ class EqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "query",
+            "case_sensitive",
+            "event_category_field",
+            "fetch_size",
+            "fields",
+            "filter",
+            "keep_alive",
+            "keep_on_completion",
+            "result_position",
+            "runtime_mappings",
+            "size",
+            "tiebreaker_field",
+            "timestamp_field",
+            "wait_for_completion_timeout",
+        ),
     )
     def search(
         self,
         *,
         index: t.Union[str, t.Sequence[str]],
-        query: str,
+        query: t.Optional[str] = None,
         allow_no_indices: t.Optional[bool] = None,
         case_sensitive: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -185,6 +200,7 @@ class EqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns results matching a query expressed in Event Query Language (EQL)
@@ -219,53 +235,54 @@ class EqlClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = f"/{_quote(index)}/_eql/search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if case_sensitive is not None:
-            __body["case_sensitive"] = case_sensitive
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if event_category_field is not None:
-            __body["event_category_field"] = event_category_field
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if fields is not None:
-            __body["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
         if pretty is not None:
             __query["pretty"] = pretty
-        if result_position is not None:
-            __body["result_position"] = result_position
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if size is not None:
-            __body["size"] = size
-        if tiebreaker_field is not None:
-            __body["tiebreaker_field"] = tiebreaker_field
-        if timestamp_field is not None:
-            __body["timestamp_field"] = timestamp_field
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if case_sensitive is not None:
+                __body["case_sensitive"] = case_sensitive
+            if event_category_field is not None:
+                __body["event_category_field"] = event_category_field
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if fields is not None:
+                __body["fields"] = fields
+            if filter is not None:
+                __body["filter"] = filter
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if result_position is not None:
+                __body["result_position"] = result_position
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if size is not None:
+                __body["size"] = size
+            if tiebreaker_field is not None:
+                __body["tiebreaker_field"] = tiebreaker_field
+            if timestamp_field is not None:
+                __body["timestamp_field"] = timestamp_field
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/fleet.py
+++ b/elasticsearch/_sync/client/fleet.py
@@ -87,7 +87,8 @@ class FleetClient(NamespacedClient):
     def msearch(
         self,
         *,
-        searches: t.Sequence[t.Mapping[str, t.Any]],
+        searches: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[str] = None,
         allow_no_indices: t.Optional[bool] = None,
         allow_partial_search_results: t.Optional[bool] = None,
@@ -163,8 +164,12 @@ class FleetClient(NamespacedClient):
             has become visible for search. Defaults to an empty list which will cause
             Elasticsearch to immediately execute the search.
         """
-        if searches is None:
-            raise ValueError("Empty value passed for parameter 'searches'")
+        if searches is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'searches' and 'body', one of them should be set."
+            )
+        elif searches is not None and body is not None:
+            raise ValueError("Cannot set both 'searches' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_fleet/_fleet_msearch"
         else:
@@ -204,7 +209,7 @@ class FleetClient(NamespacedClient):
             __query["typed_keys"] = typed_keys
         if wait_for_checkpoints is not None:
             __query["wait_for_checkpoints"] = wait_for_checkpoints
-        __body = searches
+        __body = searches if searches is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -214,7 +219,40 @@ class FleetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -312,6 +350,7 @@ class FleetClient(NamespacedClient):
         typed_keys: t.Optional[bool] = None,
         version: t.Optional[bool] = None,
         wait_for_checkpoints: t.Optional[t.Sequence[int]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Search API where the search will only be executed after specified checkpoints
@@ -421,8 +460,8 @@ class FleetClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_fleet/_fleet_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -434,10 +473,6 @@ class FleetClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -450,100 +485,50 @@ class FleetClient(NamespacedClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -552,20 +537,75 @@ class FleetClient(NamespacedClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
         if wait_for_checkpoints is not None:
             __query["wait_for_checkpoints"] = wait_for_checkpoints
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/graph.py
+++ b/elasticsearch/_sync/client/graph.py
@@ -25,7 +25,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class GraphClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("connections", "controls", "query", "vertices"),
     )
     def explore(
         self,
@@ -41,6 +41,7 @@ class GraphClient(NamespacedClient):
         routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         vertices: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explore extracted and summarized information about the documents and terms in
@@ -64,12 +65,8 @@ class GraphClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_graph/explore"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if connections is not None:
-            __body["connections"] = connections
-        if controls is not None:
-            __body["controls"] = controls
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -78,14 +75,19 @@ class GraphClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if timeout is not None:
             __query["timeout"] = timeout
-        if vertices is not None:
-            __body["vertices"] = vertices
+        if not __body:
+            if connections is not None:
+                __body["connections"] = connections
+            if controls is not None:
+                __body["controls"] = controls
+            if query is not None:
+                __body["query"] = query
+            if vertices is not None:
+                __body["vertices"] = vertices
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/ilm.py
+++ b/elasticsearch/_sync/client/ilm.py
@@ -212,7 +212,7 @@ class IlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("legacy_template_to_delete", "node_attribute"),
     )
     def migrate_to_data_tiers(
         self,
@@ -224,6 +224,7 @@ class IlmClient(NamespacedClient):
         legacy_template_to_delete: t.Optional[str] = None,
         node_attribute: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Migrates the indices and ILM policies away from custom node attribute allocation
@@ -239,7 +240,7 @@ class IlmClient(NamespacedClient):
         """
         __path = "/_ilm/migrate_to_data_tiers"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -248,12 +249,13 @@ class IlmClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if legacy_template_to_delete is not None:
-            __body["legacy_template_to_delete"] = legacy_template_to_delete
-        if node_attribute is not None:
-            __body["node_attribute"] = node_attribute
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if legacy_template_to_delete is not None:
+                __body["legacy_template_to_delete"] = legacy_template_to_delete
+            if node_attribute is not None:
+                __body["node_attribute"] = node_attribute
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -264,7 +266,7 @@ class IlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("current_step", "next_step"),
     )
     def move_to_step(
         self,
@@ -276,6 +278,7 @@ class IlmClient(NamespacedClient):
         human: t.Optional[bool] = None,
         next_step: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Manually moves an index into the specified step and executes that step.
@@ -289,20 +292,21 @@ class IlmClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/_ilm/move/{_quote(index)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if current_step is not None:
-            __body["current_step"] = current_step
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if next_step is not None:
-            __body["next_step"] = next_step
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if current_step is not None:
+                __body["current_step"] = current_step
+            if next_step is not None:
+                __body["next_step"] = next_step
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -313,7 +317,7 @@ class IlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("policy",),
     )
     def put_lifecycle(
         self,
@@ -328,6 +332,7 @@ class IlmClient(NamespacedClient):
         policy: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a lifecycle policy
@@ -346,7 +351,7 @@ class IlmClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_ilm/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -355,12 +360,13 @@ class IlmClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if policy is not None:
-            __body["policy"] = policy
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if policy is not None:
+                __body["policy"] = policy
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/indices.py
+++ b/elasticsearch/_sync/client/indices.py
@@ -96,7 +96,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analyzer",
+            "attributes",
+            "char_filter",
+            "explain",
+            "field",
+            "filter",
+            "normalizer",
+            "text",
+            "tokenizer",
+        ),
     )
     def analyze(
         self,
@@ -115,6 +125,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         text: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         tokenizer: t.Optional[t.Union[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs the analysis process on a text and return the tokens breakdown of the
@@ -147,34 +158,35 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(index)}/_analyze"
         else:
             __path = "/_analyze"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analyzer is not None:
-            __body["analyzer"] = analyzer
-        if attributes is not None:
-            __body["attributes"] = attributes
-        if char_filter is not None:
-            __body["char_filter"] = char_filter
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if explain is not None:
-            __body["explain"] = explain
-        if field is not None:
-            __body["field"] = field
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if normalizer is not None:
-            __body["normalizer"] = normalizer
         if pretty is not None:
             __query["pretty"] = pretty
-        if text is not None:
-            __body["text"] = text
-        if tokenizer is not None:
-            __body["tokenizer"] = tokenizer
+        if not __body:
+            if analyzer is not None:
+                __body["analyzer"] = analyzer
+            if attributes is not None:
+                __body["attributes"] = attributes
+            if char_filter is not None:
+                __body["char_filter"] = char_filter
+            if explain is not None:
+                __body["explain"] = explain
+            if field is not None:
+                __body["field"] = field
+            if filter is not None:
+                __body["filter"] = filter
+            if normalizer is not None:
+                __body["normalizer"] = normalizer
+            if text is not None:
+                __body["text"] = text
+            if tokenizer is not None:
+                __body["tokenizer"] = tokenizer
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -265,7 +277,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "settings"),
     )
     def clone(
         self,
@@ -285,6 +297,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clones an index
@@ -309,10 +322,8 @@ class IndicesClient(NamespacedClient):
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
         __path = f"/{_quote(index)}/_clone/{_quote(target)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -323,12 +334,15 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -420,7 +434,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "mappings", "settings"),
     )
     def create(
         self,
@@ -440,6 +454,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an index with optional settings and mappings.
@@ -463,28 +478,29 @@ class IndicesClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -991,7 +1007,8 @@ class IndicesClient(NamespacedClient):
         *,
         index: str,
         target_index: str,
-        config: t.Mapping[str, t.Any],
+        config: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -1010,8 +1027,12 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target_index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target_index'")
-        if config is None:
-            raise ValueError("Empty value passed for parameter 'config'")
+        if config is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'config' and 'body', one of them should be set."
+            )
+        elif config is not None and body is not None:
+            raise ValueError("Cannot set both 'config' and 'body'")
         __path = f"/{_quote(index)}/_downsample/{_quote(target_index)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1022,7 +1043,7 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = config
+        __body = config if config is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2220,16 +2241,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     def modify_data_stream(
         self,
         *,
-        actions: t.Sequence[t.Mapping[str, t.Any]],
+        actions: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Modifies a data stream
@@ -2238,13 +2260,11 @@ class IndicesClient(NamespacedClient):
 
         :param actions: Actions to perform.
         """
-        if actions is None:
+        if actions is None and body is None:
             raise ValueError("Empty value passed for parameter 'actions'")
         __path = "/_data_stream/_modify"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2253,6 +2273,9 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2379,7 +2402,13 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "filter",
+            "index_routing",
+            "is_write_index",
+            "routing",
+            "search_routing",
+        ),
     )
     def put_alias(
         self,
@@ -2399,6 +2428,7 @@ class IndicesClient(NamespacedClient):
         routing: t.Optional[str] = None,
         search_routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an alias.
@@ -2437,29 +2467,30 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/{_quote(index)}/_alias/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_routing is not None:
-            __body["index_routing"] = index_routing
-        if is_write_index is not None:
-            __body["is_write_index"] = is_write_index
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if routing is not None:
-            __body["routing"] = routing
-        if search_routing is not None:
-            __body["search_routing"] = search_routing
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if filter is not None:
+                __body["filter"] = filter
+            if index_routing is not None:
+                __body["index_routing"] = index_routing
+            if is_write_index is not None:
+                __body["is_write_index"] = is_write_index
+            if routing is not None:
+                __body["routing"] = routing
+            if search_routing is not None:
+                __body["search_routing"] = search_routing
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2470,7 +2501,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data_retention", "downsampling"),
     )
     def put_data_lifecycle(
         self,
@@ -2496,6 +2527,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the data stream lifecycle of the selected data streams.
@@ -2523,12 +2555,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_data_stream/{_quote(name)}/_lifecycle"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data_retention is not None:
-            __body["data_retention"] = data_retention
-        if downsampling is not None:
-            __body["downsampling"] = downsampling
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
@@ -2544,6 +2572,11 @@ class IndicesClient(NamespacedClient):
         if timeout is not None:
             __query["timeout"] = timeout
         if not __body:
+            if data_retention is not None:
+                __body["data_retention"] = data_retention
+            if downsampling is not None:
+                __body["downsampling"] = downsampling
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -2553,7 +2586,15 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "composed_of",
+            "data_stream",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def put_index_template(
@@ -2572,6 +2613,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -2603,39 +2645,52 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_index_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "date_detection",
+            "dynamic",
+            "dynamic_date_formats",
+            "dynamic_templates",
+            "field_names",
+            "meta",
+            "numeric_detection",
+            "properties",
+            "routing",
+            "runtime",
+            "source",
+        ),
         parameter_aliases={
             "_field_names": "field_names",
             "_meta": "meta",
@@ -2684,6 +2739,7 @@ class IndicesClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         write_index_only: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the index mappings.
@@ -2730,23 +2786,13 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_mapping"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if date_detection is not None:
-            __body["date_detection"] = date_detection
-        if dynamic is not None:
-            __body["dynamic"] = dynamic
-        if dynamic_date_formats is not None:
-            __body["dynamic_date_formats"] = dynamic_date_formats
-        if dynamic_templates is not None:
-            __body["dynamic_templates"] = dynamic_templates
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if field_names is not None:
-            __body["_field_names"] = field_names
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -2755,24 +2801,35 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if numeric_detection is not None:
-            __body["numeric_detection"] = numeric_detection
         if pretty is not None:
             __query["pretty"] = pretty
-        if properties is not None:
-            __body["properties"] = properties
-        if routing is not None:
-            __body["_routing"] = routing
-        if runtime is not None:
-            __body["runtime"] = runtime
-        if source is not None:
-            __body["_source"] = source
         if timeout is not None:
             __query["timeout"] = timeout
         if write_index_only is not None:
             __query["write_index_only"] = write_index_only
+        if not __body:
+            if date_detection is not None:
+                __body["date_detection"] = date_detection
+            if dynamic is not None:
+                __body["dynamic"] = dynamic
+            if dynamic_date_formats is not None:
+                __body["dynamic_date_formats"] = dynamic_date_formats
+            if dynamic_templates is not None:
+                __body["dynamic_templates"] = dynamic_templates
+            if field_names is not None:
+                __body["_field_names"] = field_names
+            if meta is not None:
+                __body["_meta"] = meta
+            if numeric_detection is not None:
+                __body["numeric_detection"] = numeric_detection
+            if properties is not None:
+                __body["properties"] = properties
+            if routing is not None:
+                __body["_routing"] = routing
+            if runtime is not None:
+                __body["runtime"] = runtime
+            if source is not None:
+                __body["_source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2784,7 +2841,8 @@ class IndicesClient(NamespacedClient):
     def put_settings(
         self,
         *,
-        settings: t.Mapping[str, t.Any],
+        settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2834,8 +2892,12 @@ class IndicesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
-        if settings is None:
-            raise ValueError("Empty value passed for parameter 'settings'")
+        if settings is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'settings' and 'body', one of them should be set."
+            )
+        elif settings is not None and body is not None:
+            raise ValueError("Cannot set both 'settings' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_settings"
         else:
@@ -2863,14 +2925,21 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        __body = settings
+        __body = settings if settings is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aliases",
+            "index_patterns",
+            "mappings",
+            "order",
+            "settings",
+            "version",
+        ),
     )
     def put_template(
         self,
@@ -2892,6 +2961,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -2922,10 +2992,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
         if error_trace is not None:
@@ -2936,22 +3004,25 @@ class IndicesClient(NamespacedClient):
             __query["flat_settings"] = flat_settings
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if order is not None:
-            __body["order"] = order
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if order is not None:
+                __body["order"] = order
+            if settings is not None:
+                __body["settings"] = settings
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -3173,7 +3244,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "conditions", "mappings", "settings"),
     )
     def rollover(
         self,
@@ -3196,6 +3267,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates an alias to point to a new index when the existing index is considered
@@ -3237,12 +3309,8 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(alias)}/_rollover"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
-        if conditions is not None:
-            __body["conditions"] = conditions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -3251,18 +3319,23 @@ class IndicesClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if conditions is not None:
+                __body["conditions"] = conditions
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3407,7 +3480,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "settings"),
     )
     def shrink(
         self,
@@ -3427,6 +3500,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allow to shrink an existing index into a new index with fewer primary shards.
@@ -3451,10 +3525,8 @@ class IndicesClient(NamespacedClient):
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
         __path = f"/{_quote(index)}/_shrink/{_quote(target)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3465,12 +3537,15 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3481,7 +3556,16 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_auto_create",
+            "composed_of",
+            "data_stream",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def simulate_index_template(
@@ -3505,6 +3589,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Simulate matching the given index name against the index templates in the system
@@ -3550,16 +3635,10 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_index_template/_simulate_index/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_auto_create is not None:
-            __body["allow_auto_create"] = allow_auto_create
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3568,20 +3647,27 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if include_defaults is not None:
             __query["include_defaults"] = include_defaults
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if allow_auto_create is not None:
+                __body["allow_auto_create"] = allow_auto_create
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3608,6 +3694,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Simulate resolving the given template name or body
@@ -3628,6 +3715,12 @@ class IndicesClient(NamespacedClient):
             returns an error.
         :param template:
         """
+        if template is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'template' and 'body', one of them should be set."
+            )
+        elif template is not None and body is not None:
+            raise ValueError("Cannot set both 'template' and 'body'")
         if name not in SKIP_IN_PATH:
             __path = f"/_index_template/_simulate/{_quote(name)}"
         else:
@@ -3647,7 +3740,7 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = template
+        __body = template if template is not None else body
         if not __body:
             __body = None
         __headers = {"accept": "application/json"}
@@ -3658,7 +3751,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "settings"),
     )
     def split(
         self,
@@ -3678,6 +3771,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows you to split an existing index into a new index with more primary shards.
@@ -3702,10 +3796,8 @@ class IndicesClient(NamespacedClient):
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
         __path = f"/{_quote(index)}/_split/{_quote(target)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3716,12 +3808,15 @@ class IndicesClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3910,7 +4005,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     def update_aliases(
         self,
@@ -3924,6 +4019,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates index aliases.
@@ -3938,10 +4034,8 @@ class IndicesClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         """
         __path = "/_aliases"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3954,13 +4048,16 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
     )
     def validate_query(
         self,
@@ -3990,6 +4087,7 @@ class IndicesClient(NamespacedClient):
         q: t.Optional[str] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         rewrite: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows a user to validate a potentially expensive query without executing it.
@@ -4032,7 +4130,7 @@ class IndicesClient(NamespacedClient):
         else:
             __path = "/_validate/query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if all_shards is not None:
             __query["all_shards"] = all_shards
         if allow_no_indices is not None:
@@ -4063,10 +4161,11 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if rewrite is not None:
             __query["rewrite"] = rewrite
+        if not __body:
+            if query is not None:
+                __body["query"] = query
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/ingest.py
+++ b/elasticsearch/_sync/client/ingest.py
@@ -179,7 +179,7 @@ class IngestClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "meta", "on_failure", "processors", "version"),
         parameter_aliases={"_meta": "meta"},
     )
     def put_pipeline(
@@ -200,6 +200,7 @@ class IngestClient(NamespacedClient):
         processors: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a pipeline.
@@ -232,10 +233,8 @@ class IngestClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ingest/pipeline/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -246,25 +245,28 @@ class IngestClient(NamespacedClient):
             __query["if_version"] = if_version
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if on_failure is not None:
-            __body["on_failure"] = on_failure
         if pretty is not None:
             __query["pretty"] = pretty
-        if processors is not None:
-            __body["processors"] = processors
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if meta is not None:
+                __body["_meta"] = meta
+            if on_failure is not None:
+                __body["on_failure"] = on_failure
+            if processors is not None:
+                __body["processors"] = processors
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "pipeline"),
     )
     def simulate(
         self,
@@ -277,6 +279,7 @@ class IngestClient(NamespacedClient):
         pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         verbose: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to simulate a pipeline with example documents.
@@ -296,22 +299,23 @@ class IngestClient(NamespacedClient):
             __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"
         else:
             __path = "/_ingest/pipeline/_simulate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if pipeline is not None:
-            __body["pipeline"] = pipeline
         if pretty is not None:
             __query["pretty"] = pretty
         if verbose is not None:
             __query["verbose"] = verbose
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if pipeline is not None:
+                __body["pipeline"] = pipeline
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/license.py
+++ b/elasticsearch/_sync/client/license.py
@@ -154,7 +154,7 @@ class LicenseClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("license", "licenses"),
     )
     def post(
         self,
@@ -166,6 +166,7 @@ class LicenseClient(NamespacedClient):
         license: t.Optional[t.Mapping[str, t.Any]] = None,
         licenses: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the license for the cluster.
@@ -179,7 +180,7 @@ class LicenseClient(NamespacedClient):
         """
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if acknowledge is not None:
             __query["acknowledge"] = acknowledge
         if error_trace is not None:
@@ -188,12 +189,13 @@ class LicenseClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if license is not None:
-            __body["license"] = license
-        if licenses is not None:
-            __body["licenses"] = licenses
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if license is not None:
+                __body["license"] = license
+            if licenses is not None:
+                __body["licenses"] = licenses
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/logstash.py
+++ b/elasticsearch/_sync/client/logstash.py
@@ -100,7 +100,8 @@ class LogstashClient(NamespacedClient):
         self,
         *,
         id: str,
-        pipeline: t.Mapping[str, t.Any],
+        pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -116,8 +117,12 @@ class LogstashClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if pipeline is None:
-            raise ValueError("Empty value passed for parameter 'pipeline'")
+        if pipeline is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'pipeline' and 'body', one of them should be set."
+            )
+        elif pipeline is not None and body is not None:
+            raise ValueError("Cannot set both 'pipeline' and 'body'")
         __path = f"/_logstash/pipeline/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -128,7 +133,7 @@ class LogstashClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = pipeline
+        __body = pipeline if pipeline is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -59,7 +59,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     def close_job(
         self,
@@ -72,6 +72,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed multiple
@@ -92,22 +93,23 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -315,7 +317,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("requests_per_second", "timeout"),
     )
     def delete_expired_data(
         self,
@@ -327,6 +329,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         requests_per_second: t.Optional[float] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Deletes expired and unused machine learning data.
@@ -345,7 +348,7 @@ class MlClient(NamespacedClient):
         else:
             __path = "/_ml/_delete_expired_data"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -354,10 +357,11 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if requests_per_second is not None:
-            __body["requests_per_second"] = requests_per_second
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if requests_per_second is not None:
+                __body["requests_per_second"] = requests_per_second
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -624,7 +628,11 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "max_bucket_cardinality",
+            "overall_cardinality",
+        ),
     )
     def estimate_model_memory(
         self,
@@ -636,6 +644,7 @@ class MlClient(NamespacedClient):
         max_bucket_cardinality: t.Optional[t.Mapping[str, int]] = None,
         overall_cardinality: t.Optional[t.Mapping[str, int]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Estimates the model memory
@@ -658,40 +667,42 @@ class MlClient(NamespacedClient):
             or `partition_field_name`.
         """
         __path = "/_ml/anomaly_detectors/_estimate_model_memory"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_bucket_cardinality is not None:
-            __body["max_bucket_cardinality"] = max_bucket_cardinality
-        if overall_cardinality is not None:
-            __body["overall_cardinality"] = overall_cardinality
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if max_bucket_cardinality is not None:
+                __body["max_bucket_cardinality"] = max_bucket_cardinality
+            if overall_cardinality is not None:
+                __body["overall_cardinality"] = overall_cardinality
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("evaluation", "index", "query"),
     )
     def evaluate_data_frame(
         self,
         *,
-        evaluation: t.Mapping[str, t.Any],
-        index: str,
+        evaluation: t.Optional[t.Mapping[str, t.Any]] = None,
+        index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluates the data frame analytics for an annotated index.
@@ -703,17 +714,13 @@ class MlClient(NamespacedClient):
         :param query: A query clause that retrieves a subset of data from the source
             index.
         """
-        if evaluation is None:
+        if evaluation is None and body is None:
             raise ValueError("Empty value passed for parameter 'evaluation'")
-        if index is None:
+        if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = "/_ml/data_frame/_evaluate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if evaluation is not None:
-            __body["evaluation"] = evaluation
-        if index is not None:
-            __body["index"] = index
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -722,15 +729,29 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
+        if not __body:
+            if evaluation is not None:
+                __body["evaluation"] = evaluation
+            if index is not None:
+                __body["index"] = index
+            if query is not None:
+                __body["query"] = query
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_start",
+            "analysis",
+            "analyzed_fields",
+            "description",
+            "dest",
+            "max_num_threads",
+            "model_memory_limit",
+            "source",
+        ),
     )
     def explain_data_frame_analytics(
         self,
@@ -748,6 +769,7 @@ class MlClient(NamespacedClient):
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         source: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explains a data frame analytics config.
@@ -786,32 +808,33 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/data_frame/analytics/{_quote(id)}/_explain"
         else:
             __path = "/_ml/data_frame/analytics/_explain"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if analysis is not None:
-            __body["analysis"] = analysis
-        if analyzed_fields is not None:
-            __body["analyzed_fields"] = analyzed_fields
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
-        if source is not None:
-            __body["source"] = source
+        if not __body:
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if analysis is not None:
+                __body["analysis"] = analysis
+            if analyzed_fields is not None:
+                __body["analyzed_fields"] = analyzed_fields
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
+            if source is not None:
+                __body["source"] = source
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -822,7 +845,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("advance_time", "calc_interim", "end", "skip_time", "start"),
     )
     def flush_job(
         self,
@@ -837,6 +860,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         skip_time: t.Optional[t.Union[str, t.Any]] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Forces any buffered data to be processed by the job.
@@ -853,14 +877,8 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_flush"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if advance_time is not None:
-            __body["advance_time"] = advance_time
-        if calc_interim is not None:
-            __body["calc_interim"] = calc_interim
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -869,10 +887,17 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if skip_time is not None:
-            __body["skip_time"] = skip_time
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if advance_time is not None:
+                __body["advance_time"] = advance_time
+            if calc_interim is not None:
+                __body["calc_interim"] = calc_interim
+            if end is not None:
+                __body["end"] = end
+            if skip_time is not None:
+                __body["skip_time"] = skip_time
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -883,7 +908,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("duration", "expires_in", "max_model_memory"),
     )
     def forecast(
         self,
@@ -896,6 +921,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         max_model_memory: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Predicts the future behavior of a time series by using its historical behavior.
@@ -912,22 +938,23 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if duration is not None:
-            __body["duration"] = duration
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expires_in is not None:
-            __body["expires_in"] = expires_in
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_model_memory is not None:
-            __body["max_model_memory"] = max_model_memory
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if duration is not None:
+                __body["duration"] = duration
+            if expires_in is not None:
+                __body["expires_in"] = expires_in
+            if max_model_memory is not None:
+                __body["max_model_memory"] = max_model_memory
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -938,7 +965,16 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "anomaly_score",
+            "desc",
+            "end",
+            "exclude_interim",
+            "expand",
+            "page",
+            "sort",
+            "start",
+        ),
         parameter_aliases={"from": "from_"},
     )
     def get_buckets(
@@ -960,6 +996,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly detection job results for one or more buckets.
@@ -990,36 +1027,37 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/buckets"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if anomaly_score is not None:
-            __body["anomaly_score"] = anomaly_score
-        if desc is not None:
-            __body["desc"] = desc
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
-        if expand is not None:
-            __body["expand"] = expand
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if from_ is not None:
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if anomaly_score is not None:
+                __body["anomaly_score"] = anomaly_score
+            if desc is not None:
+                __body["desc"] = desc
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if expand is not None:
+                __body["expand"] = expand
+            if page is not None:
+                __body["page"] = page
+            if sort is not None:
+                __body["sort"] = sort
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1090,7 +1128,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     def get_calendars(
@@ -1104,6 +1142,7 @@ class MlClient(NamespacedClient):
         page: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves configuration information for calendars.
@@ -1125,7 +1164,7 @@ class MlClient(NamespacedClient):
         else:
             __path = "/_ml/calendars"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1134,12 +1173,13 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1150,7 +1190,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     def get_categories(
@@ -1166,6 +1206,7 @@ class MlClient(NamespacedClient):
         partition_field_value: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly detection job results for one or more categories.
@@ -1192,7 +1233,7 @@ class MlClient(NamespacedClient):
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1201,14 +1242,15 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if partition_field_value is not None:
             __query["partition_field_value"] = partition_field_value
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1490,7 +1532,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     def get_influencers(
@@ -1510,6 +1552,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly detection job results for one or more influencers.
@@ -1537,7 +1580,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/influencers"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if desc is not None:
             __query["desc"] = desc
         if end is not None:
@@ -1554,8 +1597,6 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if influencer_score is not None:
             __query["influencer_score"] = influencer_score
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
@@ -1564,6 +1605,9 @@ class MlClient(NamespacedClient):
             __query["sort"] = sort
         if start is not None:
             __query["start"] = start
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1776,7 +1820,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("desc", "end", "page", "sort", "start"),
         parameter_aliases={"from": "from_"},
     )
     def get_model_snapshots(
@@ -1795,6 +1839,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves information about model snapshots.
@@ -1823,12 +1868,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if desc is not None:
-            __body["desc"] = desc
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1837,16 +1878,21 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if desc is not None:
+                __body["desc"] = desc
+            if end is not None:
+                __body["end"] = end
+            if page is not None:
+                __body["page"] = page
+            if sort is not None:
+                __body["sort"] = sort
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1857,7 +1903,15 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_no_match",
+            "bucket_span",
+            "end",
+            "exclude_interim",
+            "overall_score",
+            "start",
+            "top_n",
+        ),
     )
     def get_overall_buckets(
         self,
@@ -1874,6 +1928,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         top_n: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves overall bucket results that summarize the bucket results of multiple
@@ -1899,30 +1954,31 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/overall_buckets"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
-        if bucket_span is not None:
-            __body["bucket_span"] = bucket_span
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if overall_score is not None:
-            __body["overall_score"] = overall_score
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if top_n is not None:
-            __body["top_n"] = top_n
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if bucket_span is not None:
+                __body["bucket_span"] = bucket_span
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if overall_score is not None:
+                __body["overall_score"] = overall_score
+            if start is not None:
+                __body["start"] = start
+            if top_n is not None:
+                __body["top_n"] = top_n
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1933,7 +1989,15 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "desc",
+            "end",
+            "exclude_interim",
+            "page",
+            "record_score",
+            "sort",
+            "start",
+        ),
         parameter_aliases={"from": "from_"},
     )
     def get_records(
@@ -1953,6 +2017,7 @@ class MlClient(NamespacedClient):
         size: t.Optional[int] = None,
         sort: t.Optional[str] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves anomaly records for an anomaly detection job.
@@ -1974,34 +2039,35 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/records"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if desc is not None:
-            __body["desc"] = desc
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if from_ is not None:
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
-        if record_score is not None:
-            __body["record_score"] = record_score
         if size is not None:
             __query["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if desc is not None:
+                __body["desc"] = desc
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if page is not None:
+                __body["page"] = page
+            if record_score is not None:
+                __body["record_score"] = record_score
+            if sort is not None:
+                __body["sort"] = sort
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2147,19 +2213,20 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "inference_config"),
     )
     def infer_trained_model(
         self,
         *,
         model_id: str,
-        docs: t.Sequence[t.Mapping[str, t.Any]],
+        docs: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         inference_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluate a trained model.
@@ -2177,25 +2244,26 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if docs is None:
+        if docs is None and body is None:
             raise ValueError("Empty value passed for parameter 'docs'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/_infer"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2231,7 +2299,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("timeout",),
     )
     def open_job(
         self,
@@ -2242,6 +2310,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Opens one or more anomaly detection jobs.
@@ -2255,7 +2324,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_open"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2264,8 +2333,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2276,17 +2346,18 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("events",),
     )
     def post_calendar_events(
         self,
         *,
         calendar_id: str,
-        events: t.Sequence[t.Mapping[str, t.Any]],
+        events: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Posts scheduled events in a calendar.
@@ -2300,13 +2371,11 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        if events is None:
+        if events is None and body is None:
             raise ValueError("Empty value passed for parameter 'events'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if events is not None:
-            __body["events"] = events
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2315,6 +2384,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if events is not None:
+                __body["events"] = events
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2327,7 +2399,8 @@ class MlClient(NamespacedClient):
         self,
         *,
         job_id: str,
-        data: t.Sequence[t.Any],
+        data: t.Optional[t.Sequence[t.Any]] = None,
+        body: t.Optional[t.Sequence[t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -2348,8 +2421,12 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        if data is None:
-            raise ValueError("Empty value passed for parameter 'data'")
+        if data is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'data' and 'body', one of them should be set."
+            )
+        elif data is not None and body is not None:
+            raise ValueError("Cannot set both 'data' and 'body'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_data"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2364,7 +2441,7 @@ class MlClient(NamespacedClient):
             __query["reset_end"] = reset_end
         if reset_start is not None:
             __query["reset_start"] = reset_start
-        __body = data
+        __body = data if data is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2374,7 +2451,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("config",),
     )
     def preview_data_frame_analytics(
         self,
@@ -2385,6 +2462,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews that will be analyzed given a data frame analytics config.
@@ -2400,10 +2478,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/data_frame/analytics/{_quote(id)}/_preview"
         else:
             __path = "/_ml/data_frame/analytics/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if config is not None:
-            __body["config"] = config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2412,6 +2488,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if config is not None:
+                __body["config"] = config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2422,7 +2501,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("datafeed_config", "job_config"),
     )
     def preview_datafeed(
         self,
@@ -2436,6 +2515,7 @@ class MlClient(NamespacedClient):
         job_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a datafeed.
@@ -2461,10 +2541,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_preview"
         else:
             __path = "/_ml/datafeeds/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if end is not None:
             __query["end"] = end
         if error_trace is not None:
@@ -2473,12 +2551,15 @@ class MlClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_config is not None:
-            __body["job_config"] = job_config
         if pretty is not None:
             __query["pretty"] = pretty
         if start is not None:
             __query["start"] = start
+        if not __body:
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if job_config is not None:
+                __body["job_config"] = job_config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2489,7 +2570,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "job_ids"),
     )
     def put_calendar(
         self,
@@ -2501,6 +2582,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         job_ids: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a calendar.
@@ -2514,20 +2596,21 @@ class MlClient(NamespacedClient):
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_ids is not None:
-            __body["job_ids"] = job_ids
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if job_ids is not None:
+                __body["job_ids"] = job_ids
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2577,16 +2660,27 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis",
+            "dest",
+            "source",
+            "allow_lazy_start",
+            "analyzed_fields",
+            "description",
+            "headers",
+            "max_num_threads",
+            "model_memory_limit",
+            "version",
+        ),
         ignore_deprecated_options={"headers"},
     )
     def put_data_frame_analytics(
         self,
         *,
         id: str,
-        analysis: t.Mapping[str, t.Any],
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        analysis: t.Optional[t.Mapping[str, t.Any]] = None,
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_start: t.Optional[bool] = None,
         analyzed_fields: t.Optional[t.Mapping[str, t.Any]] = None,
         description: t.Optional[str] = None,
@@ -2598,6 +2692,7 @@ class MlClient(NamespacedClient):
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         version: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a data frame analytics job.
@@ -2661,50 +2756,67 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if analysis is None:
+        if analysis is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis is not None:
-            __body["analysis"] = analysis
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if analyzed_fields is not None:
-            __body["analyzed_fields"] = analyzed_fields
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if analysis is not None:
+                __body["analysis"] = analysis
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if analyzed_fields is not None:
+                __body["analyzed_fields"] = analyzed_fields
+            if description is not None:
+                __body["description"] = description
+            if headers is not None:
+                __body["headers"] = headers
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "headers",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
         ignore_deprecated_options={"headers"},
     )
     def put_datafeed(
@@ -2741,6 +2853,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a datafeed.
@@ -2819,61 +2932,62 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if headers is not None:
+                __body["headers"] = headers
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "items"),
     )
     def put_filter(
         self,
@@ -2885,6 +2999,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         items: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a filter.
@@ -2899,34 +3014,51 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if items is not None:
-            __body["items"] = items
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if items is not None:
+                __body["items"] = items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "data_description",
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "datafeed_config",
+            "description",
+            "groups",
+            "model_plot_config",
+            "model_snapshot_retention_days",
+            "renormalization_window_days",
+            "results_index_name",
+            "results_retention_days",
+        ),
     )
     def put_job(
         self,
         *,
         job_id: str,
-        analysis_config: t.Mapping[str, t.Any],
-        data_description: t.Mapping[str, t.Any],
+        analysis_config: t.Optional[t.Mapping[str, t.Any]] = None,
+        data_description: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_open: t.Optional[bool] = None,
         analysis_limits: t.Optional[t.Mapping[str, t.Any]] = None,
         background_persist_interval: t.Optional[
@@ -2946,6 +3078,7 @@ class MlClient(NamespacedClient):
         renormalization_window_days: t.Optional[int] = None,
         results_index_name: t.Optional[str] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates an anomaly detection job.
@@ -3027,60 +3160,72 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        if analysis_config is None:
+        if analysis_config is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis_config'")
-        if data_description is None:
+        if data_description is None and body is None:
             raise ValueError("Empty value passed for parameter 'data_description'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
-        if data_description is not None:
-            __body["data_description"] = data_description
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body[
-                "daily_model_snapshot_retention_after_days"
-            ] = daily_model_snapshot_retention_after_days
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_index_name is not None:
-            __body["results_index_name"] = results_index_name
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if data_description is not None:
+                __body["data_description"] = data_description
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body[
+                    "daily_model_snapshot_retention_after_days"
+                ] = daily_model_snapshot_retention_after_days
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if description is not None:
+                __body["description"] = description
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_index_name is not None:
+                __body["results_index_name"] = results_index_name
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "compressed_definition",
+            "definition",
+            "description",
+            "inference_config",
+            "input",
+            "metadata",
+            "model_size_bytes",
+            "model_type",
+            "platform_architecture",
+            "tags",
+        ),
     )
     def put_trained_model(
         self,
@@ -3103,6 +3248,7 @@ class MlClient(NamespacedClient):
         platform_architecture: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         tags: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an inference trained model.
@@ -3142,38 +3288,39 @@ class MlClient(NamespacedClient):
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
         __path = f"/_ml/trained_models/{_quote(model_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if compressed_definition is not None:
-            __body["compressed_definition"] = compressed_definition
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_definition_decompression is not None:
             __query["defer_definition_decompression"] = defer_definition_decompression
-        if definition is not None:
-            __body["definition"] = definition
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
-        if input is not None:
-            __body["input"] = input
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if model_size_bytes is not None:
-            __body["model_size_bytes"] = model_size_bytes
-        if model_type is not None:
-            __body["model_type"] = model_type
-        if platform_architecture is not None:
-            __body["platform_architecture"] = platform_architecture
         if pretty is not None:
             __query["pretty"] = pretty
-        if tags is not None:
-            __body["tags"] = tags
+        if not __body:
+            if compressed_definition is not None:
+                __body["compressed_definition"] = compressed_definition
+            if definition is not None:
+                __body["definition"] = definition
+            if description is not None:
+                __body["description"] = description
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
+            if input is not None:
+                __body["input"] = input
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if model_size_bytes is not None:
+                __body["model_size_bytes"] = model_size_bytes
+            if model_type is not None:
+                __body["model_type"] = model_type
+            if platform_architecture is not None:
+                __body["platform_architecture"] = platform_architecture
+            if tags is not None:
+                __body["tags"] = tags
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -3225,20 +3372,21 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("definition", "total_definition_length", "total_parts"),
     )
     def put_trained_model_definition_part(
         self,
         *,
         model_id: str,
         part: int,
-        definition: str,
-        total_definition_length: int,
-        total_parts: int,
+        definition: t.Optional[str] = None,
+        total_definition_length: t.Optional[int] = None,
+        total_parts: t.Optional[int] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates part of a trained model definition
@@ -3260,23 +3408,17 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if part in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'part'")
-        if definition is None:
+        if definition is None and body is None:
             raise ValueError("Empty value passed for parameter 'definition'")
-        if total_definition_length is None:
+        if total_definition_length is None and body is None:
             raise ValueError(
                 "Empty value passed for parameter 'total_definition_length'"
             )
-        if total_parts is None:
+        if total_parts is None and body is None:
             raise ValueError("Empty value passed for parameter 'total_parts'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/definition/{_quote(part)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if definition is not None:
-            __body["definition"] = definition
-        if total_definition_length is not None:
-            __body["total_definition_length"] = total_definition_length
-        if total_parts is not None:
-            __body["total_parts"] = total_parts
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3285,25 +3427,33 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if definition is not None:
+                __body["definition"] = definition
+            if total_definition_length is not None:
+                __body["total_definition_length"] = total_definition_length
+            if total_parts is not None:
+                __body["total_parts"] = total_parts
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("vocabulary", "merges", "scores"),
     )
     def put_trained_model_vocabulary(
         self,
         *,
         model_id: str,
-        vocabulary: t.Sequence[str],
+        vocabulary: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         merges: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
         scores: t.Optional[t.Sequence[float]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a trained model vocabulary
@@ -3317,25 +3467,26 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if vocabulary is None:
+        if vocabulary is None and body is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if vocabulary is not None:
-            __body["vocabulary"] = vocabulary
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if merges is not None:
-            __body["merges"] = merges
         if pretty is not None:
             __query["pretty"] = pretty
-        if scores is not None:
-            __body["scores"] = scores
+        if not __body:
+            if vocabulary is not None:
+                __body["vocabulary"] = vocabulary
+            if merges is not None:
+                __body["merges"] = merges
+            if scores is not None:
+                __body["scores"] = scores
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -3387,7 +3538,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("delete_intervening_results",),
     )
     def revert_model_snapshot(
         self,
@@ -3399,6 +3550,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Reverts to a specific snapshot.
@@ -3417,10 +3569,8 @@ class MlClient(NamespacedClient):
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_revert"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if delete_intervening_results is not None:
-            __body["delete_intervening_results"] = delete_intervening_results
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3429,6 +3579,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if delete_intervening_results is not None:
+                __body["delete_intervening_results"] = delete_intervening_results
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3521,7 +3674,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("end", "start", "timeout"),
     )
     def start_datafeed(
         self,
@@ -3534,6 +3687,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Starts one or more datafeeds.
@@ -3551,10 +3705,8 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_start"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3563,10 +3715,13 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if end is not None:
+                __body["end"] = end
+            if start is not None:
+                __body["start"] = start
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3717,7 +3872,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     def stop_datafeed(
         self,
@@ -3730,6 +3885,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Stops one or more datafeeds.
@@ -3748,22 +3904,23 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stop"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3823,7 +3980,12 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_start",
+            "description",
+            "max_num_threads",
+            "model_memory_limit",
+        ),
     )
     def update_data_frame_analytics(
         self,
@@ -3837,6 +3999,7 @@ class MlClient(NamespacedClient):
         max_num_threads: t.Optional[int] = None,
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a data frame analytics job.
@@ -3862,31 +4025,47 @@ class MlClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if description is not None:
+                __body["description"] = description
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
     )
     def update_datafeed(
         self,
@@ -3921,6 +4100,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a datafeed.
@@ -4010,59 +4190,60 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("add_items", "description", "remove_items"),
     )
     def update_filter(
         self,
@@ -4075,6 +4256,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         remove_items: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the description of a filter, adds items, or removes items.
@@ -4089,12 +4271,8 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if add_items is not None:
-            __body["add_items"] = add_items
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -4103,15 +4281,36 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if remove_items is not None:
-            __body["remove_items"] = remove_items
+        if not __body:
+            if add_items is not None:
+                __body["add_items"] = add_items
+            if description is not None:
+                __body["description"] = description
+            if remove_items is not None:
+                __body["remove_items"] = remove_items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "categorization_filters",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "description",
+            "detectors",
+            "groups",
+            "model_plot_config",
+            "model_prune_window",
+            "model_snapshot_retention_days",
+            "per_partition_categorization",
+            "renormalization_window_days",
+            "results_retention_days",
+        ),
     )
     def update_job(
         self,
@@ -4140,6 +4339,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         renormalization_window_days: t.Optional[int] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of an anomaly detection job.
@@ -4198,55 +4398,56 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if categorization_filters is not None:
-            __body["categorization_filters"] = categorization_filters
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body[
-                "daily_model_snapshot_retention_after_days"
-            ] = daily_model_snapshot_retention_after_days
-        if description is not None:
-            __body["description"] = description
-        if detectors is not None:
-            __body["detectors"] = detectors
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_prune_window is not None:
-            __body["model_prune_window"] = model_prune_window
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
-        if per_partition_categorization is not None:
-            __body["per_partition_categorization"] = per_partition_categorization
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if categorization_filters is not None:
+                __body["categorization_filters"] = categorization_filters
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body[
+                    "daily_model_snapshot_retention_after_days"
+                ] = daily_model_snapshot_retention_after_days
+            if description is not None:
+                __body["description"] = description
+            if detectors is not None:
+                __body["detectors"] = detectors
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_prune_window is not None:
+                __body["model_prune_window"] = model_prune_window
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if per_partition_categorization is not None:
+                __body["per_partition_categorization"] = per_partition_categorization
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "retain"),
     )
     def update_model_snapshot(
         self,
@@ -4259,6 +4460,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         retain: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a snapshot.
@@ -4277,10 +4479,8 @@ class MlClient(NamespacedClient):
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -4289,8 +4489,11 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if retain is not None:
-            __body["retain"] = retain
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if retain is not None:
+                __body["retain"] = retain
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -4346,7 +4549,17 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "analysis_limits",
+            "data_description",
+            "description",
+            "job_id",
+            "model_plot",
+            "model_snapshot_id",
+            "model_snapshot_retention_days",
+            "results_index_name",
+        ),
     )
     def validate(
         self,
@@ -4364,6 +4577,7 @@ class MlClient(NamespacedClient):
         model_snapshot_retention_days: t.Optional[int] = None,
         pretty: t.Optional[bool] = None,
         results_index_name: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Validates an anomaly detection job.
@@ -4381,34 +4595,35 @@ class MlClient(NamespacedClient):
         :param results_index_name:
         """
         __path = "/_ml/anomaly_detectors/_validate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if data_description is not None:
-            __body["data_description"] = data_description
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if model_plot is not None:
-            __body["model_plot"] = model_plot
-        if model_snapshot_id is not None:
-            __body["model_snapshot_id"] = model_snapshot_id
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
         if pretty is not None:
             __query["pretty"] = pretty
-        if results_index_name is not None:
-            __body["results_index_name"] = results_index_name
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if data_description is not None:
+                __body["data_description"] = data_description
+            if description is not None:
+                __body["description"] = description
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if model_plot is not None:
+                __body["model_plot"] = model_plot
+            if model_snapshot_id is not None:
+                __body["model_snapshot_id"] = model_snapshot_id
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if results_index_name is not None:
+                __body["results_index_name"] = results_index_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -4420,7 +4635,8 @@ class MlClient(NamespacedClient):
     def validate_detector(
         self,
         *,
-        detector: t.Mapping[str, t.Any],
+        detector: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -4433,8 +4649,12 @@ class MlClient(NamespacedClient):
 
         :param detector:
         """
-        if detector is None:
-            raise ValueError("Empty value passed for parameter 'detector'")
+        if detector is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'detector' and 'body', one of them should be set."
+            )
+        elif detector is not None and body is not None:
+            raise ValueError("Cannot set both 'detector' and 'body'")
         __path = "/_ml/anomaly_detectors/_validate/detector"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -4445,7 +4665,7 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = detector
+        __body = detector if detector is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/monitoring.py
+++ b/elasticsearch/_sync/client/monitoring.py
@@ -31,7 +31,8 @@ class MonitoringClient(NamespacedClient):
         self,
         *,
         interval: t.Union["t.Literal[-1]", "t.Literal[0]", str],
-        operations: t.Sequence[t.Mapping[str, t.Any]],
+        operations: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         system_api_version: str,
         system_id: str,
         error_trace: t.Optional[bool] = None,
@@ -51,8 +52,12 @@ class MonitoringClient(NamespacedClient):
         """
         if interval is None:
             raise ValueError("Empty value passed for parameter 'interval'")
-        if operations is None:
-            raise ValueError("Empty value passed for parameter 'operations'")
+        if operations is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'operations' and 'body', one of them should be set."
+            )
+        elif operations is not None and body is not None:
+            raise ValueError("Cannot set both 'operations' and 'body'")
         if system_api_version is None:
             raise ValueError("Empty value passed for parameter 'system_api_version'")
         if system_id is None:
@@ -73,7 +78,7 @@ class MonitoringClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = operations
+        __body = operations if operations is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",

--- a/elasticsearch/_sync/client/nodes.py
+++ b/elasticsearch/_sync/client/nodes.py
@@ -237,7 +237,7 @@ class NodesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("secure_settings_password",),
     )
     def reload_secure_settings(
         self,
@@ -249,6 +249,7 @@ class NodesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         secure_settings_password: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Reloads secure settings.
@@ -265,7 +266,7 @@ class NodesClient(NamespacedClient):
         else:
             __path = "/_nodes/reload_secure_settings"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -274,10 +275,11 @@ class NodesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if secure_settings_password is not None:
-            __body["secure_settings_password"] = secure_settings_password
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if secure_settings_password is not None:
+                __body["secure_settings_password"] = secure_settings_password
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/query_ruleset.py
+++ b/elasticsearch/_sync/client/query_ruleset.py
@@ -133,17 +133,18 @@ class QueryRulesetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("rules",),
     )
     def put(
         self,
         *,
         ruleset_id: str,
-        rules: t.Sequence[t.Mapping[str, t.Any]],
+        rules: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a query ruleset.
@@ -156,13 +157,11 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        if rules is None:
+        if rules is None and body is None:
             raise ValueError("Empty value passed for parameter 'rules'")
         __path = f"/_query_rules/{_quote(ruleset_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if rules is not None:
-            __body["rules"] = rules
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -171,6 +170,9 @@ class QueryRulesetClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if rules is not None:
+                __body["rules"] = rules
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/rollup.py
+++ b/elasticsearch/_sync/client/rollup.py
@@ -168,18 +168,27 @@ class RollupClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "cron",
+            "groups",
+            "index_pattern",
+            "page_size",
+            "rollup_index",
+            "headers",
+            "metrics",
+            "timeout",
+        ),
         ignore_deprecated_options={"headers"},
     )
     def put_job(
         self,
         *,
         id: str,
-        cron: str,
-        groups: t.Mapping[str, t.Any],
-        index_pattern: str,
-        page_size: int,
-        rollup_index: str,
+        cron: t.Optional[str] = None,
+        groups: t.Optional[t.Mapping[str, t.Any]] = None,
+        index_pattern: t.Optional[str] = None,
+        page_size: t.Optional[int] = None,
+        rollup_index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         headers: t.Optional[t.Mapping[str, t.Union[str, t.Sequence[str]]]] = None,
@@ -187,6 +196,7 @@ class RollupClient(NamespacedClient):
         metrics: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a rollup job.
@@ -235,50 +245,51 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if cron is None:
+        if cron is None and body is None:
             raise ValueError("Empty value passed for parameter 'cron'")
-        if groups is None:
+        if groups is None and body is None:
             raise ValueError("Empty value passed for parameter 'groups'")
-        if index_pattern is None:
+        if index_pattern is None and body is None:
             raise ValueError("Empty value passed for parameter 'index_pattern'")
-        if page_size is None:
+        if page_size is None and body is None:
             raise ValueError("Empty value passed for parameter 'page_size'")
-        if rollup_index is None:
+        if rollup_index is None and body is None:
             raise ValueError("Empty value passed for parameter 'rollup_index'")
         __path = f"/_rollup/job/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if cron is not None:
-            __body["cron"] = cron
-        if groups is not None:
-            __body["groups"] = groups
-        if index_pattern is not None:
-            __body["index_pattern"] = index_pattern
-        if page_size is not None:
-            __body["page_size"] = page_size
-        if rollup_index is not None:
-            __body["rollup_index"] = rollup_index
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
-        if metrics is not None:
-            __body["metrics"] = metrics
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if cron is not None:
+                __body["cron"] = cron
+            if groups is not None:
+                __body["groups"] = groups
+            if index_pattern is not None:
+                __body["index_pattern"] = index_pattern
+            if page_size is not None:
+                __body["page_size"] = page_size
+            if rollup_index is not None:
+                __body["rollup_index"] = rollup_index
+            if headers is not None:
+                __body["headers"] = headers
+            if metrics is not None:
+                __body["metrics"] = metrics
+            if timeout is not None:
+                __body["timeout"] = timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aggregations", "aggs", "query", "size"),
     )
     def rollup_search(
         self,
@@ -294,6 +305,7 @@ class RollupClient(NamespacedClient):
         rest_total_hits_as_int: t.Optional[bool] = None,
         size: t.Optional[int] = None,
         typed_keys: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Enables searching rolled-up data using the standard query DSL.
@@ -313,12 +325,8 @@ class RollupClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_rollup_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -327,14 +335,19 @@ class RollupClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
-        if size is not None:
-            __body["size"] = size
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if query is not None:
+                __body["query"] = query
+            if size is not None:
+                __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/search_application.py
+++ b/elasticsearch/_sync/client/search_application.py
@@ -212,7 +212,8 @@ class SearchApplicationClient(NamespacedClient):
         self,
         *,
         name: str,
-        search_application: t.Mapping[str, t.Any],
+        search_application: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -231,8 +232,12 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if search_application is None:
-            raise ValueError("Empty value passed for parameter 'search_application'")
+        if search_application is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'search_application' and 'body', one of them should be set."
+            )
+        elif search_application is not None and body is not None:
+            raise ValueError("Cannot set both 'search_application' and 'body'")
         __path = f"/_application/search_application/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
@@ -245,7 +250,7 @@ class SearchApplicationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = search_application
+        __body = search_application if search_application is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -286,7 +291,7 @@ class SearchApplicationClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("params",),
         ignore_deprecated_options={"params"},
     )
     def search(
@@ -298,6 +303,7 @@ class SearchApplicationClient(NamespacedClient):
         human: t.Optional[bool] = None,
         params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Perform a search against a search application
@@ -312,17 +318,18 @@ class SearchApplicationClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_application/search_application/{_quote(name)}/_search"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if params is not None:
+                __body["params"] = params
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/searchable_snapshots.py
+++ b/elasticsearch/_sync/client/searchable_snapshots.py
@@ -126,14 +126,19 @@ class SearchableSnapshotsClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "index",
+            "ignore_index_settings",
+            "index_settings",
+            "renamed_index",
+        ),
     )
     def mount(
         self,
         *,
         repository: str,
         snapshot: str,
-        index: str,
+        index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -146,6 +151,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         renamed_index: t.Optional[str] = None,
         storage: t.Optional[str] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Mount a snapshot as a searchable index.
@@ -169,33 +175,34 @@ class SearchableSnapshotsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        if index is None:
+        if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_mount"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if index is not None:
-            __body["index"] = index
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_index_settings is not None:
-            __body["ignore_index_settings"] = ignore_index_settings
-        if index_settings is not None:
-            __body["index_settings"] = index_settings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if renamed_index is not None:
-            __body["renamed_index"] = renamed_index
         if storage is not None:
             __query["storage"] = storage
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if index is not None:
+                __body["index"] = index
+            if ignore_index_settings is not None:
+                __body["ignore_index_settings"] = ignore_index_settings
+            if index_settings is not None:
+                __body["index_settings"] = index_settings
+            if renamed_index is not None:
+                __body["renamed_index"] = renamed_index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/security.py
+++ b/elasticsearch/_sync/client/security.py
@@ -25,12 +25,14 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class SecurityClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("grant_type", "access_token", "password", "username"),
     )
     def activate_user_profile(
         self,
         *,
-        grant_type: t.Union["t.Literal['access_token', 'password']", str],
+        grant_type: t.Optional[
+            t.Union["t.Literal['access_token', 'password']", str]
+        ] = None,
         access_token: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -38,6 +40,7 @@ class SecurityClient(NamespacedClient):
         password: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates the user profile on behalf of another user.
@@ -49,27 +52,28 @@ class SecurityClient(NamespacedClient):
         :param password:
         :param username:
         """
-        if grant_type is None:
+        if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
         __path = "/_security/profile/_activate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if grant_type is not None:
-            __body["grant_type"] = grant_type
-        if access_token is not None:
-            __body["access_token"] = access_token
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if password is not None:
-            __body["password"] = password
         if pretty is not None:
             __query["pretty"] = pretty
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if grant_type is not None:
+                __body["grant_type"] = grant_type
+            if access_token is not None:
+                __body["access_token"] = access_token
+            if password is not None:
+                __body["password"] = password
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -106,7 +110,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("password", "password_hash"),
     )
     def change_password(
         self,
@@ -121,6 +125,7 @@ class SecurityClient(NamespacedClient):
         refresh: t.Optional[
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Changes the passwords of users in the native realm and built-in users.
@@ -144,21 +149,22 @@ class SecurityClient(NamespacedClient):
         else:
             __path = "/_security/user/_password"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if password is not None:
-            __body["password"] = password
-        if password_hash is not None:
-            __body["password_hash"] = password_hash
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
+        if not __body:
+            if password is not None:
+                __body["password"] = password
+            if password_hash is not None:
+                __body["password_hash"] = password_hash
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -349,7 +355,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("expiration", "metadata", "name", "role_descriptors"),
     )
     def create_api_key(
         self,
@@ -365,6 +371,7 @@ class SecurityClient(NamespacedClient):
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an API key for access without requiring basic authentication.
@@ -391,25 +398,26 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expiration is not None:
-            __body["expiration"] = expiration
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if expiration is not None:
+                __body["expiration"] = expiration
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if name is not None:
+                __body["name"] = name
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -1212,7 +1220,14 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "grant_type",
+            "kerberos_ticket",
+            "password",
+            "refresh_token",
+            "scope",
+            "username",
+        ),
     )
     def get_token(
         self,
@@ -1232,6 +1247,7 @@ class SecurityClient(NamespacedClient):
         refresh_token: t.Optional[str] = None,
         scope: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a bearer token for access without requiring basic authentication.
@@ -1247,27 +1263,28 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if grant_type is not None:
-            __body["grant_type"] = grant_type
         if human is not None:
             __query["human"] = human
-        if kerberos_ticket is not None:
-            __body["kerberos_ticket"] = kerberos_ticket
-        if password is not None:
-            __body["password"] = password
         if pretty is not None:
             __query["pretty"] = pretty
-        if refresh_token is not None:
-            __body["refresh_token"] = refresh_token
-        if scope is not None:
-            __body["scope"] = scope
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if grant_type is not None:
+                __body["grant_type"] = grant_type
+            if kerberos_ticket is not None:
+                __body["kerberos_ticket"] = kerberos_ticket
+            if password is not None:
+                __body["password"] = password
+            if refresh_token is not None:
+                __body["refresh_token"] = refresh_token
+            if scope is not None:
+                __body["scope"] = scope
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -1402,14 +1419,23 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "api_key",
+            "grant_type",
+            "access_token",
+            "password",
+            "run_as",
+            "username",
+        ),
         ignore_deprecated_options={"api_key"},
     )
     def grant_api_key(
         self,
         *,
-        api_key: t.Mapping[str, t.Any],
-        grant_type: t.Union["t.Literal['access_token', 'password']", str],
+        api_key: t.Optional[t.Mapping[str, t.Any]] = None,
+        grant_type: t.Optional[
+            t.Union["t.Literal['access_token', 'password']", str]
+        ] = None,
         access_token: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -1418,6 +1444,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         run_as: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an API key on behalf of another user.
@@ -1437,40 +1464,41 @@ class SecurityClient(NamespacedClient):
             grant type, this parameter is required. It is not valid with other grant
             types.
         """
-        if api_key is None:
+        if api_key is None and body is None:
             raise ValueError("Empty value passed for parameter 'api_key'")
-        if grant_type is None:
+        if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
         __path = "/_security/api_key/grant"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if api_key is not None:
-            __body["api_key"] = api_key
-        if grant_type is not None:
-            __body["grant_type"] = grant_type
-        if access_token is not None:
-            __body["access_token"] = access_token
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if password is not None:
-            __body["password"] = password
         if pretty is not None:
             __query["pretty"] = pretty
-        if run_as is not None:
-            __body["run_as"] = run_as
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if api_key is not None:
+                __body["api_key"] = api_key
+            if grant_type is not None:
+                __body["grant_type"] = grant_type
+            if access_token is not None:
+                __body["access_token"] = access_token
+            if password is not None:
+                __body["password"] = password
+            if run_as is not None:
+                __body["run_as"] = run_as
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("application", "cluster", "index"),
     )
     def has_privileges(
         self,
@@ -1490,6 +1518,7 @@ class SecurityClient(NamespacedClient):
         human: t.Optional[bool] = None,
         index: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Determines whether the specified user has a specified list of privileges.
@@ -1505,39 +1534,41 @@ class SecurityClient(NamespacedClient):
             __path = f"/_security/user/{_quote(user)}/_has_privileges"
         else:
             __path = "/_security/user/_has_privileges"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if application is not None:
-            __body["application"] = application
-        if cluster is not None:
-            __body["cluster"] = cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index is not None:
-            __body["index"] = index
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if application is not None:
+                __body["application"] = application
+            if cluster is not None:
+                __body["cluster"] = cluster
+            if index is not None:
+                __body["index"] = index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("privileges", "uids"),
     )
     def has_privileges_user_profile(
         self,
         *,
-        privileges: t.Mapping[str, t.Any],
-        uids: t.Sequence[str],
+        privileges: t.Optional[t.Mapping[str, t.Any]] = None,
+        uids: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Determines whether the users associated with the specified profile IDs have all
@@ -1549,17 +1580,13 @@ class SecurityClient(NamespacedClient):
         :param uids: A list of profile IDs. The privileges are checked for associated
             users of the profiles.
         """
-        if privileges is None:
+        if privileges is None and body is None:
             raise ValueError("Empty value passed for parameter 'privileges'")
-        if uids is None:
+        if uids is None and body is None:
             raise ValueError("Empty value passed for parameter 'uids'")
         __path = "/_security/profile/_has_privileges"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if privileges is not None:
-            __body["privileges"] = privileges
-        if uids is not None:
-            __body["uids"] = uids
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1568,13 +1595,18 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if privileges is not None:
+                __body["privileges"] = privileges
+            if uids is not None:
+                __body["uids"] = uids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("id", "ids", "name", "owner", "realm_name", "username"),
     )
     def invalidate_api_key(
         self,
@@ -1589,6 +1621,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         realm_name: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates one or more API keys.
@@ -1611,34 +1644,35 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if id is not None:
-            __body["id"] = id
-        if ids is not None:
-            __body["ids"] = ids
-        if name is not None:
-            __body["name"] = name
-        if owner is not None:
-            __body["owner"] = owner
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm_name is not None:
-            __body["realm_name"] = realm_name
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if id is not None:
+                __body["id"] = id
+            if ids is not None:
+                __body["ids"] = ids
+            if name is not None:
+                __body["name"] = name
+            if owner is not None:
+                __body["owner"] = owner
+            if realm_name is not None:
+                __body["realm_name"] = realm_name
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("realm_name", "refresh_token", "token", "username"),
     )
     def invalidate_token(
         self,
@@ -1651,6 +1685,7 @@ class SecurityClient(NamespacedClient):
         refresh_token: t.Optional[str] = None,
         token: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates one or more access tokens or refresh tokens.
@@ -1664,7 +1699,7 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1673,14 +1708,15 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm_name is not None:
-            __body["realm_name"] = realm_name
-        if refresh_token is not None:
-            __body["refresh_token"] = refresh_token
-        if token is not None:
-            __body["token"] = token
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if realm_name is not None:
+                __body["realm_name"] = realm_name
+            if refresh_token is not None:
+                __body["refresh_token"] = refresh_token
+            if token is not None:
+                __body["token"] = token
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers, body=__body
@@ -1692,7 +1728,10 @@ class SecurityClient(NamespacedClient):
     def put_privileges(
         self,
         *,
-        privileges: t.Mapping[str, t.Mapping[str, t.Mapping[str, t.Any]]],
+        privileges: t.Optional[
+            t.Mapping[str, t.Mapping[str, t.Mapping[str, t.Any]]]
+        ] = None,
+        body: t.Optional[t.Mapping[str, t.Mapping[str, t.Mapping[str, t.Any]]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -1711,8 +1750,12 @@ class SecurityClient(NamespacedClient):
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
         """
-        if privileges is None:
-            raise ValueError("Empty value passed for parameter 'privileges'")
+        if privileges is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'privileges' and 'body', one of them should be set."
+            )
+        elif privileges is not None and body is not None:
+            raise ValueError("Cannot set both 'privileges' and 'body'")
         __path = "/_security/privilege"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1725,14 +1768,22 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        __body = privileges
+        __body = privileges if privileges is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "applications",
+            "cluster",
+            "global_",
+            "indices",
+            "metadata",
+            "run_as",
+            "transient_metadata",
+        ),
         parameter_aliases={"global": "global_"},
     )
     def put_role(
@@ -1760,6 +1811,7 @@ class SecurityClient(NamespacedClient):
         ] = None,
         run_as: t.Optional[t.Sequence[str]] = None,
         transient_metadata: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Adds and updates roles in the native realm.
@@ -1790,39 +1842,40 @@ class SecurityClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_security/role/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if applications is not None:
-            __body["applications"] = applications
-        if cluster is not None:
-            __body["cluster"] = cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if global_ is not None:
-            __body["global"] = global_
         if human is not None:
             __query["human"] = human
-        if indices is not None:
-            __body["indices"] = indices
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if run_as is not None:
-            __body["run_as"] = run_as
-        if transient_metadata is not None:
-            __body["transient_metadata"] = transient_metadata
+        if not __body:
+            if applications is not None:
+                __body["applications"] = applications
+            if cluster is not None:
+                __body["cluster"] = cluster
+            if global_ is not None:
+                __body["global"] = global_
+            if indices is not None:
+                __body["indices"] = indices
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if run_as is not None:
+                __body["run_as"] = run_as
+            if transient_metadata is not None:
+                __body["transient_metadata"] = transient_metadata
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("enabled", "metadata", "roles", "rules", "run_as"),
     )
     def put_role_mapping(
         self,
@@ -1840,6 +1893,7 @@ class SecurityClient(NamespacedClient):
         roles: t.Optional[t.Sequence[str]] = None,
         rules: t.Optional[t.Mapping[str, t.Any]] = None,
         run_as: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates and updates role mappings.
@@ -1859,35 +1913,44 @@ class SecurityClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_security/role_mapping/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if enabled is not None:
-            __body["enabled"] = enabled
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if roles is not None:
-            __body["roles"] = roles
-        if rules is not None:
-            __body["rules"] = rules
-        if run_as is not None:
-            __body["run_as"] = run_as
+        if not __body:
+            if enabled is not None:
+                __body["enabled"] = enabled
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if roles is not None:
+                __body["roles"] = roles
+            if rules is not None:
+                __body["rules"] = rules
+            if run_as is not None:
+                __body["run_as"] = run_as
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "email",
+            "enabled",
+            "full_name",
+            "metadata",
+            "password",
+            "password_hash",
+            "roles",
+        ),
     )
     def put_user(
         self,
@@ -1907,6 +1970,7 @@ class SecurityClient(NamespacedClient):
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
         roles: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Adds and updates users in the native realm. These users are commonly referred
@@ -1929,39 +1993,40 @@ class SecurityClient(NamespacedClient):
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
         __path = f"/_security/user/{_quote(username)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if email is not None:
-            __body["email"] = email
-        if enabled is not None:
-            __body["enabled"] = enabled
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if full_name is not None:
-            __body["full_name"] = full_name
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if password is not None:
-            __body["password"] = password
-        if password_hash is not None:
-            __body["password_hash"] = password_hash
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if roles is not None:
-            __body["roles"] = roles
+        if not __body:
+            if email is not None:
+                __body["email"] = email
+            if enabled is not None:
+                __body["enabled"] = enabled
+            if full_name is not None:
+                __body["full_name"] = full_name
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if password is not None:
+                __body["password"] = password
+            if password_hash is not None:
+                __body["password_hash"] = password_hash
+            if roles is not None:
+                __body["roles"] = roles
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("from_", "query", "search_after", "size", "sort"),
         parameter_aliases={"from": "from_"},
     )
     def query_api_keys(
@@ -1984,6 +2049,7 @@ class SecurityClient(NamespacedClient):
             ]
         ] = None,
         with_limited_by: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves information for API keys using a subset of query DSL
@@ -2010,7 +2076,7 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/_query/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -2026,22 +2092,23 @@ class SecurityClient(NamespacedClient):
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
         if with_limited_by is not None:
             __query["with_limited_by"] = with_limited_by
+        if not __body:
+            if from_ is not None:
+                __body["from"] = from_
+            if query is not None:
+                __body["query"] = query
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2052,18 +2119,19 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("content", "ids", "realm"),
     )
     def saml_authenticate(
         self,
         *,
-        content: str,
-        ids: t.Union[str, t.Sequence[str]],
+        content: t.Optional[str] = None,
+        ids: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         realm: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Exchanges a SAML Response message for an Elasticsearch access token and refresh
@@ -2078,17 +2146,13 @@ class SecurityClient(NamespacedClient):
         :param realm: The name of the realm that should authenticate the SAML response.
             Useful in cases where many SAML realms are defined.
         """
-        if content is None:
+        if content is None and body is None:
             raise ValueError("Empty value passed for parameter 'content'")
-        if ids is None:
+        if ids is None and body is None:
             raise ValueError("Empty value passed for parameter 'ids'")
         __path = "/_security/saml/authenticate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if content is not None:
-            __body["content"] = content
-        if ids is not None:
-            __body["ids"] = ids
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2097,27 +2161,33 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm is not None:
-            __body["realm"] = realm
+        if not __body:
+            if content is not None:
+                __body["content"] = content
+            if ids is not None:
+                __body["ids"] = ids
+            if realm is not None:
+                __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("ids", "realm", "content", "query_string"),
     )
     def saml_complete_logout(
         self,
         *,
-        ids: t.Union[str, t.Sequence[str]],
-        realm: str,
+        ids: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        realm: t.Optional[str] = None,
         content: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         query_string: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Verifies the logout response sent from the SAML IdP
@@ -2134,19 +2204,13 @@ class SecurityClient(NamespacedClient):
         :param query_string: If the SAML IdP sends the logout response with the HTTP-Redirect
             binding, this field must be set to the query string of the redirect URI.
         """
-        if ids is None:
+        if ids is None and body is None:
             raise ValueError("Empty value passed for parameter 'ids'")
-        if realm is None:
+        if realm is None and body is None:
             raise ValueError("Empty value passed for parameter 'realm'")
         __path = "/_security/saml/complete_logout"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if ids is not None:
-            __body["ids"] = ids
-        if realm is not None:
-            __body["realm"] = realm
-        if content is not None:
-            __body["content"] = content
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2155,26 +2219,34 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query_string is not None:
-            __body["query_string"] = query_string
+        if not __body:
+            if ids is not None:
+                __body["ids"] = ids
+            if realm is not None:
+                __body["realm"] = realm
+            if content is not None:
+                __body["content"] = content
+            if query_string is not None:
+                __body["query_string"] = query_string
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query_string", "acs", "realm"),
     )
     def saml_invalidate(
         self,
         *,
-        query_string: str,
+        query_string: t.Optional[str] = None,
         acs: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         realm: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Consumes a SAML LogoutRequest
@@ -2197,15 +2269,11 @@ class SecurityClient(NamespacedClient):
         :param realm: The name of the SAML realm in Elasticsearch the configuration.
             You must specify either this parameter or the acs parameter.
         """
-        if query_string is None:
+        if query_string is None and body is None:
             raise ValueError("Empty value passed for parameter 'query_string'")
         __path = "/_security/saml/invalidate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query_string is not None:
-            __body["query_string"] = query_string
-        if acs is not None:
-            __body["acs"] = acs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2214,25 +2282,31 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm is not None:
-            __body["realm"] = realm
+        if not __body:
+            if query_string is not None:
+                __body["query_string"] = query_string
+            if acs is not None:
+                __body["acs"] = acs
+            if realm is not None:
+                __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("token", "refresh_token"),
     )
     def saml_logout(
         self,
         *,
-        token: str,
+        token: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         refresh_token: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates an access token and a refresh token that were generated via the SAML
@@ -2247,13 +2321,11 @@ class SecurityClient(NamespacedClient):
             the SAML authenticate API. Alternatively, the most recent refresh token that
             was received after refreshing the original access token.
         """
-        if token is None:
+        if token is None and body is None:
             raise ValueError("Empty value passed for parameter 'token'")
         __path = "/_security/saml/logout"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if token is not None:
-            __body["token"] = token
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2262,15 +2334,18 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if refresh_token is not None:
-            __body["refresh_token"] = refresh_token
+        if not __body:
+            if token is not None:
+                __body["token"] = token
+            if refresh_token is not None:
+                __body["refresh_token"] = refresh_token
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("acs", "realm", "relay_state"),
     )
     def saml_prepare_authentication(
         self,
@@ -2282,6 +2357,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         realm: t.Optional[str] = None,
         relay_state: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a SAML authentication request
@@ -2299,10 +2375,8 @@ class SecurityClient(NamespacedClient):
             is signed, this value is used as part of the signature computation.
         """
         __path = "/_security/saml/prepare"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if acs is not None:
-            __body["acs"] = acs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2311,10 +2385,13 @@ class SecurityClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm is not None:
-            __body["realm"] = realm
-        if relay_state is not None:
-            __body["relay_state"] = relay_state
+        if not __body:
+            if acs is not None:
+                __body["acs"] = acs
+            if realm is not None:
+                __body["realm"] = realm
+            if relay_state is not None:
+                __body["relay_state"] = relay_state
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2355,7 +2432,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data", "hint", "name", "size"),
     )
     def suggest_user_profiles(
         self,
@@ -2368,6 +2445,7 @@ class SecurityClient(NamespacedClient):
         name: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Get suggestions for user profiles that match specified search criteria.
@@ -2387,24 +2465,25 @@ class SecurityClient(NamespacedClient):
         :param size: Number of profiles to return.
         """
         __path = "/_security/profile/_suggest"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data is not None:
-            __body["data"] = data
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if hint is not None:
-            __body["hint"] = hint
         if human is not None:
             __query["human"] = human
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
-        if size is not None:
-            __body["size"] = size
+        if not __body:
+            if data is not None:
+                __body["data"] = data
+            if hint is not None:
+                __body["hint"] = hint
+            if name is not None:
+                __body["name"] = name
+            if size is not None:
+                __body["size"] = size
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2415,7 +2494,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("metadata", "role_descriptors"),
     )
     def update_api_key(
         self,
@@ -2427,6 +2506,7 @@ class SecurityClient(NamespacedClient):
         metadata: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates attributes of an existing API key.
@@ -2450,19 +2530,20 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_security/api_key/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2473,7 +2554,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data", "labels"),
     )
     def update_user_profile_data(
         self,
@@ -2490,6 +2571,7 @@ class SecurityClient(NamespacedClient):
         refresh: t.Optional[
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Update application specific data for the user profile of the given unique ID.
@@ -2512,10 +2594,8 @@ class SecurityClient(NamespacedClient):
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
         __path = f"/_security/profile/{_quote(uid)}/_data"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data is not None:
-            __body["data"] = data
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2526,12 +2606,15 @@ class SecurityClient(NamespacedClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
-        if labels is not None:
-            __body["labels"] = labels
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
+        if not __body:
+            if data is not None:
+                __body["data"] = data
+            if labels is not None:
+                __body["labels"] = labels
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/shutdown.py
+++ b/elasticsearch/_sync/client/shutdown.py
@@ -126,14 +126,16 @@ class ShutdownClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("reason", "type", "allocation_delay", "target_node_name"),
     )
     def put_node(
         self,
         *,
         node_id: str,
-        reason: str,
-        type: t.Union["t.Literal['remove', 'replace', 'restart']", str],
+        reason: t.Optional[str] = None,
+        type: t.Optional[
+            t.Union["t.Literal['remove', 'replace', 'restart']", str]
+        ] = None,
         allocation_delay: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -146,6 +148,7 @@ class ShutdownClient(NamespacedClient):
         timeout: t.Optional[
             t.Union["t.Literal['d', 'h', 'm', 'micros', 'ms', 'nanos', 's']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Adds a node to be shut down. Designed for indirect use by ECE/ESS and ECK. Direct
@@ -188,19 +191,13 @@ class ShutdownClient(NamespacedClient):
         """
         if node_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'node_id'")
-        if reason is None:
+        if reason is None and body is None:
             raise ValueError("Empty value passed for parameter 'reason'")
-        if type is None:
+        if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
         __path = f"/_nodes/{_quote(node_id)}/shutdown"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if reason is not None:
-            __body["reason"] = reason
-        if type is not None:
-            __body["type"] = type
-        if allocation_delay is not None:
-            __body["allocation_delay"] = allocation_delay
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -211,10 +208,17 @@ class ShutdownClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if target_node_name is not None:
-            __body["target_node_name"] = target_node_name
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if reason is not None:
+                __body["reason"] = reason
+            if type is not None:
+                __body["type"] = type
+            if allocation_delay is not None:
+                __body["allocation_delay"] = allocation_delay
+            if target_node_name is not None:
+                __body["target_node_name"] = target_node_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/slm.py
+++ b/elasticsearch/_sync/client/slm.py
@@ -218,7 +218,7 @@ class SlmClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("config", "name", "repository", "retention", "schedule"),
     )
     def put_lifecycle(
         self,
@@ -237,6 +237,7 @@ class SlmClient(NamespacedClient):
         retention: t.Optional[t.Mapping[str, t.Any]] = None,
         schedule: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a snapshot lifecycle policy.
@@ -265,10 +266,8 @@ class SlmClient(NamespacedClient):
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
         __path = f"/_slm/policy/{_quote(policy_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if config is not None:
-            __body["config"] = config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -277,18 +276,21 @@ class SlmClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
-        if repository is not None:
-            __body["repository"] = repository
-        if retention is not None:
-            __body["retention"] = retention
-        if schedule is not None:
-            __body["schedule"] = schedule
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if config is not None:
+                __body["config"] = config
+            if name is not None:
+                __body["name"] = name
+            if repository is not None:
+                __body["repository"] = repository
+            if retention is not None:
+                __body["retention"] = retention
+            if schedule is not None:
+                __body["schedule"] = schedule
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/snapshot.py
+++ b/elasticsearch/_sync/client/snapshot.py
@@ -69,7 +69,7 @@ class SnapshotClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("indices",),
     )
     def clone(
         self,
@@ -77,7 +77,7 @@ class SnapshotClient(NamespacedClient):
         repository: str,
         snapshot: str,
         target_snapshot: str,
-        indices: str,
+        indices: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -86,6 +86,7 @@ class SnapshotClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clones indices from one snapshot into another snapshot in the same repository.
@@ -105,13 +106,11 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         if target_snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target_snapshot'")
-        if indices is None:
+        if indices is None and body is None:
             raise ValueError("Empty value passed for parameter 'indices'")
         __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_clone/{_quote(target_snapshot)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if indices is not None:
-            __body["indices"] = indices
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -124,13 +123,23 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if indices is not None:
+                __body["indices"] = indices
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "feature_states",
+            "ignore_unavailable",
+            "include_global_state",
+            "indices",
+            "metadata",
+            "partial",
+        ),
     )
     def create(
         self,
@@ -151,6 +160,7 @@ class SnapshotClient(NamespacedClient):
         partial: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a snapshot in a repository.
@@ -194,31 +204,32 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if feature_states is not None:
-            __body["feature_states"] = feature_states
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_unavailable is not None:
-            __body["ignore_unavailable"] = ignore_unavailable
-        if include_global_state is not None:
-            __body["include_global_state"] = include_global_state
-        if indices is not None:
-            __body["indices"] = indices
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if partial is not None:
-            __body["partial"] = partial
         if pretty is not None:
             __query["pretty"] = pretty
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if feature_states is not None:
+                __body["feature_states"] = feature_states
+            if ignore_unavailable is not None:
+                __body["ignore_unavailable"] = ignore_unavailable
+            if include_global_state is not None:
+                __body["include_global_state"] = include_global_state
+            if indices is not None:
+                __body["indices"] = indices
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if partial is not None:
+                __body["partial"] = partial
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -229,14 +240,14 @@ class SnapshotClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("settings", "type", "repository"),
     )
     def create_repository(
         self,
         *,
         name: str,
-        settings: t.Mapping[str, t.Any],
-        type: str,
+        settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        type: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -247,6 +258,7 @@ class SnapshotClient(NamespacedClient):
         repository: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         verify: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a repository.
@@ -263,17 +275,13 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if settings is None:
+        if settings is None and body is None:
             raise ValueError("Empty value passed for parameter 'settings'")
-        if type is None:
+        if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
         __path = f"/_snapshot/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if settings is not None:
-            __body["settings"] = settings
-        if type is not None:
-            __body["type"] = type
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -284,12 +292,17 @@ class SnapshotClient(NamespacedClient):
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if repository is not None:
-            __body["repository"] = repository
         if timeout is not None:
             __query["timeout"] = timeout
         if verify is not None:
             __query["verify"] = verify
+        if not __body:
+            if settings is not None:
+                __body["settings"] = settings
+            if type is not None:
+                __body["type"] = type
+            if repository is not None:
+                __body["repository"] = repository
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -553,7 +566,18 @@ class SnapshotClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "feature_states",
+            "ignore_index_settings",
+            "ignore_unavailable",
+            "include_aliases",
+            "include_global_state",
+            "index_settings",
+            "indices",
+            "partial",
+            "rename_pattern",
+            "rename_replacement",
+        ),
     )
     def restore(
         self,
@@ -578,6 +602,7 @@ class SnapshotClient(NamespacedClient):
         rename_pattern: t.Optional[str] = None,
         rename_replacement: t.Optional[str] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Restores a snapshot.
@@ -606,39 +631,40 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_restore"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if feature_states is not None:
-            __body["feature_states"] = feature_states
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_index_settings is not None:
-            __body["ignore_index_settings"] = ignore_index_settings
-        if ignore_unavailable is not None:
-            __body["ignore_unavailable"] = ignore_unavailable
-        if include_aliases is not None:
-            __body["include_aliases"] = include_aliases
-        if include_global_state is not None:
-            __body["include_global_state"] = include_global_state
-        if index_settings is not None:
-            __body["index_settings"] = index_settings
-        if indices is not None:
-            __body["indices"] = indices
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if partial is not None:
-            __body["partial"] = partial
         if pretty is not None:
             __query["pretty"] = pretty
-        if rename_pattern is not None:
-            __body["rename_pattern"] = rename_pattern
-        if rename_replacement is not None:
-            __body["rename_replacement"] = rename_replacement
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if feature_states is not None:
+                __body["feature_states"] = feature_states
+            if ignore_index_settings is not None:
+                __body["ignore_index_settings"] = ignore_index_settings
+            if ignore_unavailable is not None:
+                __body["ignore_unavailable"] = ignore_unavailable
+            if include_aliases is not None:
+                __body["include_aliases"] = include_aliases
+            if include_global_state is not None:
+                __body["include_global_state"] = include_global_state
+            if index_settings is not None:
+                __body["index_settings"] = index_settings
+            if indices is not None:
+                __body["indices"] = indices
+            if partial is not None:
+                __body["partial"] = partial
+            if rename_pattern is not None:
+                __body["rename_pattern"] = rename_pattern
+            if rename_replacement is not None:
+                __body["rename_replacement"] = rename_replacement
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/_sync/client/sql.py
+++ b/elasticsearch/_sync/client/sql.py
@@ -25,16 +25,17 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 class SqlClient(NamespacedClient):
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("cursor",),
     )
     def clear_cursor(
         self,
         *,
-        cursor: str,
+        cursor: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clears the SQL cursor
@@ -43,13 +44,11 @@ class SqlClient(NamespacedClient):
 
         :param cursor: Cursor to clear.
         """
-        if cursor is None:
+        if cursor is None and body is None:
             raise ValueError("Empty value passed for parameter 'cursor'")
         __path = "/_sql/close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -58,6 +57,9 @@ class SqlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if cursor is not None:
+                __body["cursor"] = cursor
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -192,7 +194,24 @@ class SqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "catalog",
+            "columnar",
+            "cursor",
+            "fetch_size",
+            "field_multi_value_leniency",
+            "filter",
+            "index_using_frozen",
+            "keep_alive",
+            "keep_on_completion",
+            "page_timeout",
+            "params",
+            "query",
+            "request_timeout",
+            "runtime_mappings",
+            "time_zone",
+            "wait_for_completion_timeout",
+        ),
         ignore_deprecated_options={"params", "request_timeout"},
     )
     def query(
@@ -223,6 +242,7 @@ class SqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a SQL request
@@ -261,62 +281,63 @@ class SqlClient(NamespacedClient):
             the search doesn’t finish within this period, the search becomes async.
         """
         __path = "/_sql"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if catalog is not None:
-            __body["catalog"] = catalog
-        if columnar is not None:
-            __body["columnar"] = columnar
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if field_multi_value_leniency is not None:
-            __body["field_multi_value_leniency"] = field_multi_value_leniency
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if format is not None:
             __query["format"] = format
         if human is not None:
             __query["human"] = human
-        if index_using_frozen is not None:
-            __body["index_using_frozen"] = index_using_frozen
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
-        if page_timeout is not None:
-            __body["page_timeout"] = page_timeout
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if request_timeout is not None:
-            __body["request_timeout"] = request_timeout
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if catalog is not None:
+                __body["catalog"] = catalog
+            if columnar is not None:
+                __body["columnar"] = columnar
+            if cursor is not None:
+                __body["cursor"] = cursor
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if field_multi_value_leniency is not None:
+                __body["field_multi_value_leniency"] = field_multi_value_leniency
+            if filter is not None:
+                __body["filter"] = filter
+            if index_using_frozen is not None:
+                __body["index_using_frozen"] = index_using_frozen
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if page_timeout is not None:
+                __body["page_timeout"] = page_timeout
+            if params is not None:
+                __body["params"] = params
+            if query is not None:
+                __body["query"] = query
+            if request_timeout is not None:
+                __body["request_timeout"] = request_timeout
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query", "fetch_size", "filter", "time_zone"),
     )
     def translate(
         self,
         *,
-        query: str,
+        query: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         fetch_size: t.Optional[int] = None,
         filter: t.Optional[t.Mapping[str, t.Any]] = None,
@@ -324,6 +345,7 @@ class SqlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         time_zone: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Translates SQL into Elasticsearch queries
@@ -335,27 +357,28 @@ class SqlClient(NamespacedClient):
         :param filter: Elasticsearch query DSL for additional filtering.
         :param time_zone: ISO-8601 time zone ID for the search.
         """
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = "/_sql/translate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if filter is not None:
+                __body["filter"] = filter
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/synonyms.py
+++ b/elasticsearch/_sync/client/synonyms.py
@@ -219,17 +219,18 @@ class SynonymsClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms_set",),
     )
     def put_synonym(
         self,
         *,
         id: str,
-        synonyms_set: t.Sequence[t.Mapping[str, t.Any]],
+        synonyms_set: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonyms set
@@ -241,13 +242,11 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if synonyms_set is None:
+        if synonyms_set is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms_set'")
         __path = f"/_synonyms/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms_set is not None:
-            __body["synonyms_set"] = synonyms_set
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -256,24 +255,28 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms_set is not None:
+                __body["synonyms_set"] = synonyms_set
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms",),
     )
     def put_synonym_rule(
         self,
         *,
         set_id: str,
         rule_id: str,
-        synonyms: t.Sequence[str],
+        synonyms: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonym rule in a synonym set
@@ -288,13 +291,11 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        if synonyms is None:
+        if synonyms is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms'")
         __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms is not None:
-            __body["synonyms"] = synonyms
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -303,6 +304,9 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms is not None:
+                __body["synonyms"] = synonyms
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/text_structure.py
+++ b/elasticsearch/_sync/client/text_structure.py
@@ -30,7 +30,8 @@ class TextStructureClient(NamespacedClient):
     def find_structure(
         self,
         *,
-        text_files: t.Sequence[t.Any],
+        text_files: t.Optional[t.Sequence[t.Any]] = None,
+        body: t.Optional[t.Sequence[t.Any]] = None,
         charset: t.Optional[str] = None,
         column_names: t.Optional[str] = None,
         delimiter: t.Optional[str] = None,
@@ -116,8 +117,12 @@ class TextStructureClient(NamespacedClient):
             the file
         :param timestamp_format: The Java time format of the timestamp field in the text.
         """
-        if text_files is None:
-            raise ValueError("Empty value passed for parameter 'text_files'")
+        if text_files is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'text_files' and 'body', one of them should be set."
+            )
+        elif text_files is not None and body is not None:
+            raise ValueError("Cannot set both 'text_files' and 'body'")
         __path = "/_text_structure/find_structure"
         __query: t.Dict[str, t.Any] = {}
         if charset is not None:
@@ -148,7 +153,7 @@ class TextStructureClient(NamespacedClient):
             __query["timestamp_field"] = timestamp_field
         if timestamp_format is not None:
             __query["timestamp_format"] = timestamp_format
-        __body = text_files
+        __body = text_files if text_files is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -195,7 +195,17 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "latest",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
     )
     def preview_transform(
         self,
@@ -215,6 +225,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a transform.
@@ -247,36 +258,37 @@ class TransformClient(NamespacedClient):
             __path = f"/_transform/{_quote(transform_id)}/_preview"
         else:
             __path = "/_transform/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -287,15 +299,26 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "dest",
+            "source",
+            "description",
+            "frequency",
+            "latest",
+            "meta",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def put_transform(
         self,
         *,
         transform_id: str,
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         defer_validation: t.Optional[bool] = None,
         description: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -310,6 +333,7 @@ class TransformClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a transform.
@@ -348,45 +372,46 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_transform/{_quote(transform_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if meta is not None:
-            __body["_meta"] = meta
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if description is not None:
+                __body["description"] = description
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if meta is not None:
+                __body["_meta"] = meta
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -589,7 +614,16 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "meta",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def update_transform(
@@ -610,6 +644,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a transform.
@@ -639,35 +674,36 @@ class TransformClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'transform_id'")
         __path = f"/_transform/{_quote(transform_id)}/_update"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if meta is not None:
+                __body["_meta"] = meta
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -74,6 +74,8 @@ _TYPE_HOSTS = Union[
     str, Sequence[Union[str, Mapping[str, Union[str, int]], NodeConfig]]
 ]
 
+_TYPE_BODY = Union[bytes, str, Dict[str, Any]]
+
 _TYPE_ASYNC_SNIFF_CALLBACK = Callable[
     [AsyncTransport, SniffOptions], Awaitable[List[NodeConfig]]
 ]
@@ -289,14 +291,40 @@ def _merge_kwargs_no_duplicates(kwargs: Dict[str, Any], values: Dict[str, Any]) 
         if key in kwargs:
             raise ValueError(
                 f"Received multiple values for '{key}', specify parameters "
-                "directly instead of using 'body' or 'params'"
+                "directly instead of using 'params'"
             )
         kwargs[key] = val
 
 
+def _merge_body_fields_no_duplicates(
+    body: _TYPE_BODY, kwargs: Dict[str, Any], body_fields: Tuple[str, ...]
+) -> None:
+    for key in list(kwargs.keys()):
+        if key in body_fields:
+            if isinstance(body, (str, bytes)):
+                raise ValueError(
+                    "Couldn't merge 'body' with other parameters as it wasn't a mapping."
+                )
+
+            if key in body:
+                raise ValueError(
+                    f"Received multiple values for '{key}', specify parameters "
+                    "using either body or parameters, not both."
+                )
+
+            warnings.warn(
+                f"Received '{key}' via a specific parameter in the presence of a "
+                "'body' parameter, which is deprecated and will be removed in a future "
+                "version. Instead, use only 'body' or only specific paremeters.",
+                category=DeprecationWarning,
+                stacklevel=warn_stacklevel(),
+            )
+            body[key] = kwargs.pop(key)
+
+
 def _rewrite_parameters(
     body_name: Optional[str] = None,
-    body_fields: bool = False,
+    body_fields: Optional[Tuple[str, ...]] = None,
     parameter_aliases: Optional[Dict[str, str]] = None,
     ignore_deprecated_options: Optional[Set[str]] = None,
 ) -> Callable[[F], F]:
@@ -372,7 +400,7 @@ def _rewrite_parameters(
             if "body" in kwargs and (
                 not ignore_deprecated_options or "body" not in ignore_deprecated_options
             ):
-                body = kwargs.pop("body")
+                body: Optional[_TYPE_BODY] = kwargs.pop("body")
                 if body is not None:
                     if body_name:
                         if body_name in kwargs:
@@ -384,13 +412,9 @@ def _rewrite_parameters(
                             )
                         kwargs[body_name] = body
 
-                    elif body_fields:
-                        if not hasattr(body, "items"):
-                            raise ValueError(
-                                "Couldn't merge 'body' with other parameters as it wasn't a mapping. "
-                                "Instead of using 'body' use individual API parameters"
-                            )
-                        _merge_kwargs_no_duplicates(kwargs, body)
+                    elif body_fields is not None:
+                        _merge_body_fields_no_duplicates(body, kwargs, body_fields)
+                        kwargs["body"] = body
 
             if parameter_aliases:
                 for alias, rename_to in parameter_aliases.items():

--- a/elasticsearch/_sync/client/watcher.py
+++ b/elasticsearch/_sync/client/watcher.py
@@ -168,7 +168,15 @@ class WatcherClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "action_modes",
+            "alternative_input",
+            "ignore_condition",
+            "record_execution",
+            "simulated_actions",
+            "trigger_data",
+            "watch",
+        ),
     )
     def execute_watch(
         self,
@@ -194,6 +202,7 @@ class WatcherClient(NamespacedClient):
         simulated_actions: t.Optional[t.Mapping[str, t.Any]] = None,
         trigger_data: t.Optional[t.Mapping[str, t.Any]] = None,
         watch: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Forces the execution of a stored watch.
@@ -223,12 +232,8 @@ class WatcherClient(NamespacedClient):
             __path = f"/_watcher/watch/{_quote(id)}/_execute"
         else:
             __path = "/_watcher/watch/_execute"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if action_modes is not None:
-            __body["action_modes"] = action_modes
-        if alternative_input is not None:
-            __body["alternative_input"] = alternative_input
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if debug is not None:
             __query["debug"] = debug
         if error_trace is not None:
@@ -237,18 +242,23 @@ class WatcherClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_condition is not None:
-            __body["ignore_condition"] = ignore_condition
         if pretty is not None:
             __query["pretty"] = pretty
-        if record_execution is not None:
-            __body["record_execution"] = record_execution
-        if simulated_actions is not None:
-            __body["simulated_actions"] = simulated_actions
-        if trigger_data is not None:
-            __body["trigger_data"] = trigger_data
-        if watch is not None:
-            __body["watch"] = watch
+        if not __body:
+            if action_modes is not None:
+                __body["action_modes"] = action_modes
+            if alternative_input is not None:
+                __body["alternative_input"] = alternative_input
+            if ignore_condition is not None:
+                __body["ignore_condition"] = ignore_condition
+            if record_execution is not None:
+                __body["record_execution"] = record_execution
+            if simulated_actions is not None:
+                __body["simulated_actions"] = simulated_actions
+            if trigger_data is not None:
+                __body["trigger_data"] = trigger_data
+            if watch is not None:
+                __body["watch"] = watch
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -293,7 +303,15 @@ class WatcherClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "actions",
+            "condition",
+            "input",
+            "metadata",
+            "throttle_period",
+            "transform",
+            "trigger",
+        ),
     )
     def put_watch(
         self,
@@ -314,6 +332,7 @@ class WatcherClient(NamespacedClient):
         transform: t.Optional[t.Mapping[str, t.Any]] = None,
         trigger: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new watch, or updates an existing one.
@@ -338,14 +357,10 @@ class WatcherClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_watcher/watch/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if active is not None:
             __query["active"] = active
-        if condition is not None:
-            __body["condition"] = condition
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -356,20 +371,25 @@ class WatcherClient(NamespacedClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
-        if input is not None:
-            __body["input"] = input
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
-        if throttle_period is not None:
-            __body["throttle_period"] = throttle_period
-        if transform is not None:
-            __body["transform"] = transform
-        if trigger is not None:
-            __body["trigger"] = trigger
         if version is not None:
             __query["version"] = version
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
+            if condition is not None:
+                __body["condition"] = condition
+            if input is not None:
+                __body["input"] = input
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if throttle_period is not None:
+                __body["throttle_period"] = throttle_period
+            if transform is not None:
+                __body["transform"] = transform
+            if trigger is not None:
+                __body["trigger"] = trigger
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -380,7 +400,7 @@ class WatcherClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("from_", "query", "search_after", "size", "sort"),
         parameter_aliases={"from": "from_"},
     )
     def query_watches(
@@ -402,6 +422,7 @@ class WatcherClient(NamespacedClient):
                 t.Union[str, t.Mapping[str, t.Any]],
             ]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves stored watches.
@@ -417,7 +438,7 @@ class WatcherClient(NamespacedClient):
         """
         __path = "/_watcher/_query/watches"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -433,20 +454,21 @@ class WatcherClient(NamespacedClient):
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
+        if not __body:
+            if from_ is not None:
+                __body["from"] = from_
+            if query is not None:
+                __body["query"] = query
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -714,7 +714,7 @@ def scan(
         search_kwargs = kwargs.copy()
         search_kwargs["scroll"] = scroll
         search_kwargs["size"] = size
-        resp = client.search(body=query, **search_kwargs)  # type: ignore[call-arg]
+        resp = client.search(body=query, **search_kwargs)
 
     scroll_id = resp.get("_scroll_id")
     scroll_transport_kwargs = pop_transport_kwargs(scroll_kwargs)

--- a/test_elasticsearch/test_client/test_rewrite_parameters.py
+++ b/test_elasticsearch/test_client/test_rewrite_parameters.py
@@ -42,17 +42,19 @@ class TestRewriteParameters:
     def wrapped_func_body_name(self, *args, **kwargs):
         self.calls.append((args, kwargs))
 
-    @_rewrite_parameters(body_fields=True)
+    @_rewrite_parameters(body_fields=("query", "source"))
     def wrapped_func_body_fields(self, *args, **kwargs):
         self.calls.append((args, kwargs))
 
     @_rewrite_parameters(
-        body_fields=True, ignore_deprecated_options={"api_key", "body", "params"}
+        body_fields=("query",), ignore_deprecated_options={"api_key", "body", "params"}
     )
     def wrapped_func_ignore(self, *args, **kwargs):
         self.calls.append((args, kwargs))
 
-    @_rewrite_parameters(body_fields=True, parameter_aliases={"_source": "source"})
+    @_rewrite_parameters(
+        body_fields=("source",), parameter_aliases={"_source": "source"}
+    )
     def wrapped_func_aliases(self, *args, **kwargs):
         self.calls.append((args, kwargs))
 
@@ -80,6 +82,16 @@ class TestRewriteParameters:
             ((), {"api_key": ("id", "api_key"), "ignore_status": 404}),
             ((), {"query": {"match_all": {}}, "key": "value"}),
         ]
+
+    def test_default_params_conflict(self):
+        with pytest.raises(ValueError) as e:
+            self.wrapped_func_default(
+                query={"match_all": {}},
+                params={"query": {"match_all": {}}},
+            )
+        assert str(e.value) == (
+            "Received multiple values for 'query', specify parameters directly instead of using 'params'"
+        )
 
     def test_body_name_using_body(self):
         with warnings.catch_warnings(record=True) as w:
@@ -142,18 +154,21 @@ class TestRewriteParameters:
 
         assert self.calls == [
             ((), {"api_key": ("id", "api_key")}),
-            ((), {"query": {"match_all": {}}}),
+            ((), {"body": {"query": {"match_all": {}}}}),
         ]
 
     @pytest.mark.parametrize(
-        "body", ['{"query": {"match_all": {}}}', b'{"query": {"match_all": {}}}']
+        "body, kwargs",
+        [
+            ('{"query": {"match_all": {}}}', {"query": {"match_all": {}}}),
+            (b'{"query": {"match_all": {}}}', {"query": {"match_all": {}}}),
+        ],
     )
-    def test_error_on_body_merge(self, body):
+    def test_error_on_body_merge(self, body, kwargs):
         with pytest.raises(ValueError) as e:
-            self.wrapped_func_body_fields(body=body)
+            self.wrapped_func_body_fields(body=body, **kwargs)
         assert str(e.value) == (
-            "Couldn't merge 'body' with other parameters as it wasn't a mapping. Instead of "
-            "using 'body' use individual API parameters"
+            "Couldn't merge 'body' with other parameters as it wasn't a mapping."
         )
 
     @pytest.mark.parametrize(
@@ -165,6 +180,25 @@ class TestRewriteParameters:
         assert str(e.value) == (
             "Couldn't merge 'params' with other parameters as it wasn't a mapping. Instead of "
             "using 'params' use individual API parameters"
+        )
+
+    def test_body_fields_merge(self):
+        with warnings.catch_warnings(record=True) as w:
+            self.wrapped_func_body_fields(source=False, body={"query": {}})
+
+        assert len(w) == 1
+        assert w[0].category == DeprecationWarning
+        assert str(w[0].message) == (
+            "Received 'source' via a specific parameter in the presence of a "
+            "'body' parameter, which is deprecated and will be removed in a future "
+            "version. Instead, use only 'body' or only specific paremeters."
+        )
+
+    def test_body_fields_conflict(self):
+        with pytest.raises(ValueError) as e:
+            self.wrapped_func_body_fields(query={"match_all": {}}, body={"query": {}})
+        assert str(e.value) == (
+            "Received multiple values for 'query', specify parameters using either body or parameters, not both."
         )
 
     def test_ignore_deprecated_options(self):


### PR DESCRIPTION
Closes #2181 

Allows using the `body` parameter again, not only to allow performance optimizations and use cases where the elasticsearch-specification is not up to date, but also to facilitate migration from 7.x. See #2181 for a detailed discussion. This will be released as part of the next minor release of elasticsearch-py 8.x, likely early next year.

The following rules apply:

 * if the query does not accept body parameters, nothing changes
 * if the body and required body parameter(s) are unset (such as `query` for `search`), the query fails with a `ValueError` about the required parameter(s) (as we can't rely on typing or the default `TypeError` anymore)
 * if only the body is set, then it will be used without validation:
   * as is if already encoded as a string or bytes
   * or serialized to JSON if it's a mapping
 * if both the body and specific parameter(s) are set:
   * if at least one key is the same, the query fails with a `ValueError` exception because we don't know which one to use
   * if the keys are all different, the specific parameters are merged in the body, with a deprecation warning (while this could be an useful way to only use body for parameters missing from elasticsearch-specification, it's confusing and will be removed in a future version)

Note that the above was carefully written to take into account the case where:

 *  a single parameter is used as a body:

    ```python
    # those calls were already working
    es.index(index="test_index", document={"foo": "bar"})
    es.index(index="test_index", document=json.dumps({"foo": "bar"}))
    es.index(index="test_index", document=orjson.dumps({"foo": "bar"}))
    # and those are now possible
    es.index(index="test_index", body={"foo": "bar"})
    es.index(index="test_index", body=json.dumps({"foo": "bar"}))
    es.index(index="test_index", body=orjson.dumps({"foo": "bar"}))
    ```

* multiple parameters are used to reconstruct the body:

    ```python
    # this currently fails as `ignore_missing_component_templates` is not in the specification
    es.indices.put_index_template(
        name="my_template0",
        index_patterns=["my_index*"],
        data_stream={},
        composed_of=["my_data_stream", "my_data_stream_2"],
        ignore_missing_component_templates=["my_data_stream", "my_data_stream_2"],
        priority=1000,
    )
    # this works but the body isn't validated (passing as string and bytes as above works too)
    es.indices.put_index_template(
        name="my_template1",
        body={
            "index_patterns": ["my_index*"],
            "data_stream": {},
            "composed_of": ["my_data_stream", "my_data_stream_2"],
            "ignore_missing_component_templates": ["my_data_stream", "my_data_stream_2"],
            "priority": 1000,
        },
    )
    # using body *and* parameters works but is deprecated:
    es.indices.put_index_template(
        name="my_template2",
        body={"ignore_missing_component_templates": ["my_data_stream", "my_data_stream_2"]},
        index_patterns=["my_index*"],
        data_stream={},
        composed_of=["my_data_stream", "my_data_stream_2"],
        priority=1002,
    )
    ```

The useful commit to review is https://github.com/elastic/elasticsearch-py/pull/2383/commits/7bae67e1b8cf1bf97a4ff7de40fc6e79d80519b0, as the other only updates the generated code.