### PR TITLE
Add GH action for posting docs preview

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,20 @@
+---
+name: docs-preview
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  doc-preview-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/docs/.github/actions/docs-preview@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.event.repository.name }}
+          preview-path: 'guide/en/elasticsearch/client/python-api/index.html'
+          pr: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Should be merged after https://github.com/elastic/docs/pull/2843/files and it looks as below (when docs PR are opened):

![image](https://github.com/elastic/elasticsearch-py/assets/124953/ad3c8c2b-13b5-4104-8e76-6b1913843b38)
