### PR TITLE
Add Elasticsearch quickstart examples

### DIFF
--- a/docs/examples/36b86b97feedcf5632824eefc251d6ed.asciidoc
+++ b/docs/examples/36b86b97feedcf5632824eefc251d6ed.asciidoc
@@ -1,0 +1,10 @@
+// getting-started.asciidoc:245
+
+[source, python]
+----
+resp = client.search(
+    index="books",
+    body={"query": {"match": {"name": "brave"}}},
+)
+print(resp)
+----

--- a/docs/examples/8575c966b004fb124c7afd6bb5827b50.asciidoc
+++ b/docs/examples/8575c966b004fb124c7afd6bb5827b50.asciidoc
@@ -1,0 +1,15 @@
+// getting-started.asciidoc:65
+
+[source, python]
+----
+resp = client.index(
+    index="books",
+    body={
+        "name": "Snow Crash",
+        "author": "Neal Stephenson",
+        "release_date": "1992-06-01",
+        "page_count": 470,
+    },
+)
+print(resp)
+----

--- a/docs/examples/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
+++ b/docs/examples/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
@@ -1,0 +1,9 @@
+// getting-started.asciidoc:228
+
+[source, python]
+----
+resp = client.search(
+    index="books",
+)
+print(resp)
+----

--- a/docs/examples/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
+++ b/docs/examples/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
@@ -1,0 +1,45 @@
+// getting-started.asciidoc:104
+
+[source, python]
+----
+resp = client.bulk(
+    body=[
+        {"index": {"_index": "books"}},
+        {
+            "name": "Revelation Space",
+            "author": "Alastair Reynolds",
+            "release_date": "2000-03-15",
+            "page_count": 585,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "1984",
+            "author": "George Orwell",
+            "release_date": "1985-06-01",
+            "page_count": 328,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "Fahrenheit 451",
+            "author": "Ray Bradbury",
+            "release_date": "1953-10-15",
+            "page_count": 227,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "Brave New World",
+            "author": "Aldous Huxley",
+            "release_date": "1932-06-01",
+            "page_count": 268,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "The Handmaids Tale",
+            "author": "Margaret Atwood",
+            "release_date": "1985-06-01",
+            "page_count": 311,
+        },
+    ],
+)
+print(resp)
+----


### PR DESCRIPTION
We learned in this [test PR](https://github.com/elastic/elasticsearch-py/pull/2392/files) that examples generation workflow isn't working as expected.

This PR:

- adds a subset of examples generated during that test which we know are correct
- the four samples come from this [quickstart](https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started.html)