### PR TITLE
[TEST][Docs] Test updating examples generation script

### DIFF
--- a/docs/examples/08f20902821a4f7a73ce7b959c5bdbdc.asciidoc
+++ b/docs/examples/08f20902821a4f7a73ce7b959c5bdbdc.asciidoc
@@ -1,0 +1,21 @@
+// query-dsl/regexp-query.asciidoc:23
+
+[source, python]
+----
+resp = client.search(
+    body={
+        "query": {
+            "regexp": {
+                "user.id": {
+                    "value": "k.*y",
+                    "flags": "ALL",
+                    "case_insensitive": True,
+                    "max_determinized_states": 10000,
+                    "rewrite": "constant_score_blended",
+                }
+            }
+        }
+    },
+)
+print(resp)
+----

--- a/docs/examples/13d90ba227131aefbf4fcfd5992e662a.asciidoc
+++ b/docs/examples/13d90ba227131aefbf4fcfd5992e662a.asciidoc
@@ -1,4 +1,4 @@
-// query-dsl/bool-query.asciidoc:153
+// query-dsl/bool-query.asciidoc:156
 
 [source, python]
 ----

--- a/docs/examples/178c920d5e8ec0071f77290fa059802c.asciidoc
+++ b/docs/examples/178c920d5e8ec0071f77290fa059802c.asciidoc
@@ -1,4 +1,4 @@
-// indices/update-settings.asciidoc:122
+// indices/update-settings.asciidoc:132
 
 [source, python]
 ----

--- a/docs/examples/1aa91d3d48140d6367b6cabca8737b8f.asciidoc
+++ b/docs/examples/1aa91d3d48140d6367b6cabca8737b8f.asciidoc
@@ -1,4 +1,4 @@
-// docs/bulk.asciidoc:625
+// docs/bulk.asciidoc:634
 
 [source, python]
 ----

--- a/docs/examples/20005d8a6555b259b299d862cd218701.asciidoc
+++ b/docs/examples/20005d8a6555b259b299d862cd218701.asciidoc
@@ -1,4 +1,4 @@
-// query-dsl/match-query.asciidoc:175
+// query-dsl/match-query.asciidoc:186
 
 [source, python]
 ----

--- a/docs/examples/2fea3e324939cc7e9c396964aeee7111.asciidoc
+++ b/docs/examples/2fea3e324939cc7e9c396964aeee7111.asciidoc
@@ -1,4 +1,4 @@
-// query-dsl/match-query.asciidoc:241
+// query-dsl/match-query.asciidoc:252
 
 [source, python]
 ----

--- a/docs/examples/36b86b97feedcf5632824eefc251d6ed.asciidoc
+++ b/docs/examples/36b86b97feedcf5632824eefc251d6ed.asciidoc
@@ -1,0 +1,10 @@
+// getting-started.asciidoc:245
+
+[source, python]
+----
+resp = client.search(
+    index="books",
+    body={"query": {"match": {"name": "brave"}}},
+)
+print(resp)
+----

--- a/docs/examples/39ce44333d28ed2b833722d3e3cb06f3.asciidoc
+++ b/docs/examples/39ce44333d28ed2b833722d3e3cb06f3.asciidoc
@@ -1,4 +1,4 @@
-// query-dsl/bool-query.asciidoc:181
+// query-dsl/bool-query.asciidoc:184
 
 [source, python]
 ----

--- a/docs/examples/6b0288acb739c4667d41339e5100c327.asciidoc
+++ b/docs/examples/6b0288acb739c4667d41339e5100c327.asciidoc
@@ -1,4 +1,4 @@
-// query-dsl/match-query.asciidoc:219
+// query-dsl/match-query.asciidoc:230
 
 [source, python]
 ----

--- a/docs/examples/7c862a20772467e0f5beebbd1b80c4cb.asciidoc
+++ b/docs/examples/7c862a20772467e0f5beebbd1b80c4cb.asciidoc
@@ -1,0 +1,28 @@
+// docs/reindex.asciidoc:1095
+
+[source, python]
+----
+resp = client.reindex(
+    body=
+{
+  "source": {
+    "remote": {
+      "host": "http://otherhost:9200",
+      ...,
+      "socket_timeout": "1m",
+      "connect_timeout": "10s"
+    },
+    "index": "source",
+    "query": {
+      "match": {
+        "test": "data"
+      }
+    }
+  },
+  "dest": {
+    "index": "dest"
+  }
+},
+)
+print(resp)
+----

--- a/docs/examples/7cd3d8388c51a9f6ee3f730cdaddbb89.asciidoc
+++ b/docs/examples/7cd3d8388c51a9f6ee3f730cdaddbb89.asciidoc
@@ -1,4 +1,4 @@
-// indices/update-settings.asciidoc:81
+// indices/update-settings.asciidoc:91
 
 [source, python]
 ----

--- a/docs/examples/7f56755fb6c42f7e6203339a6d0cb6e6.asciidoc
+++ b/docs/examples/7f56755fb6c42f7e6203339a6d0cb6e6.asciidoc
@@ -1,4 +1,4 @@
-// query-dsl/match-query.asciidoc:268
+// query-dsl/match-query.asciidoc:279
 
 [source, python]
 ----

--- a/docs/examples/8575c966b004fb124c7afd6bb5827b50.asciidoc
+++ b/docs/examples/8575c966b004fb124c7afd6bb5827b50.asciidoc
@@ -1,0 +1,15 @@
+// getting-started.asciidoc:65
+
+[source, python]
+----
+resp = client.index(
+    index="books",
+    body={
+        "name": "Snow Crash",
+        "author": "Neal Stephenson",
+        "release_date": "1992-06-01",
+        "page_count": 470,
+    },
+)
+print(resp)
+----

--- a/docs/examples/8cd00a3aba7c3c158277bc032aac2830.asciidoc
+++ b/docs/examples/8cd00a3aba7c3c158277bc032aac2830.asciidoc
@@ -1,4 +1,4 @@
-// docs/bulk.asciidoc:603
+// docs/bulk.asciidoc:612
 
 [source, python]
 ----

--- a/docs/examples/ac497917ef707538198a8458ae3d5c6b.asciidoc
+++ b/docs/examples/ac497917ef707538198a8458ae3d5c6b.asciidoc
@@ -1,4 +1,4 @@
-// query-dsl/match-query.asciidoc:150
+// query-dsl/match-query.asciidoc:161
 
 [source, python]
 ----

--- a/docs/examples/ae9ccfaa146731ab9176df90670db1c2.asciidoc
+++ b/docs/examples/ae9ccfaa146731ab9176df90670db1c2.asciidoc
@@ -1,4 +1,4 @@
-// docs/bulk.asciidoc:492
+// docs/bulk.asciidoc:501
 
 [source, python]
 ----

--- a/docs/examples/b52951b78cd5fb2f9353d1c7e6d37070.asciidoc
+++ b/docs/examples/b52951b78cd5fb2f9353d1c7e6d37070.asciidoc
@@ -1,0 +1,19 @@
+// query-dsl/wildcard-query.asciidoc:21
+
+[source, python]
+----
+resp = client.search(
+    body={
+        "query": {
+            "wildcard": {
+                "user.id": {
+                    "value": "ki*y",
+                    "boost": 1,
+                    "rewrite": "constant_score_blended",
+                }
+            }
+        }
+    },
+)
+print(resp)
+----

--- a/docs/examples/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
+++ b/docs/examples/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
@@ -1,0 +1,9 @@
+// getting-started.asciidoc:228
+
+[source, python]
+----
+resp = client.search(
+    index="books",
+)
+print(resp)
+----

--- a/docs/examples/bfdad8a928ea30d7cf60d0a0a6bc6e2e.asciidoc
+++ b/docs/examples/bfdad8a928ea30d7cf60d0a0a6bc6e2e.asciidoc
@@ -1,4 +1,4 @@
-// docs/bulk.asciidoc:704
+// docs/bulk.asciidoc:713
 
 [source, python]
 ----

--- a/docs/examples/c0ebaa33e750b87555dc352073f692e8.asciidoc
+++ b/docs/examples/c0ebaa33e750b87555dc352073f692e8.asciidoc
@@ -1,4 +1,4 @@
-// indices/update-settings.asciidoc:171
+// indices/update-settings.asciidoc:181
 
 [source, python]
 ----

--- a/docs/examples/c9c396b94bb88098477e2b08b55a12ee.asciidoc
+++ b/docs/examples/c9c396b94bb88098477e2b08b55a12ee.asciidoc
@@ -1,4 +1,4 @@
-// docs/bulk.asciidoc:757
+// docs/bulk.asciidoc:766
 
 [source, python]
 ----

--- a/docs/examples/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
+++ b/docs/examples/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
@@ -1,0 +1,45 @@
+// getting-started.asciidoc:104
+
+[source, python]
+----
+resp = client.bulk(
+    body=[
+        {"index": {"_index": "books"}},
+        {
+            "name": "Revelation Space",
+            "author": "Alastair Reynolds",
+            "release_date": "2000-03-15",
+            "page_count": 585,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "1984",
+            "author": "George Orwell",
+            "release_date": "1985-06-01",
+            "page_count": 328,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "Fahrenheit 451",
+            "author": "Ray Bradbury",
+            "release_date": "1953-10-15",
+            "page_count": 227,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "Brave New World",
+            "author": "Aldous Huxley",
+            "release_date": "1932-06-01",
+            "page_count": 268,
+        },
+        {"index": {"_index": "books"}},
+        {
+            "name": "The Handmaids Tale",
+            "author": "Margaret Atwood",
+            "release_date": "1985-06-01",
+            "page_count": 311,
+        },
+    ],
+)
+print(resp)
+----

--- a/docs/examples/dbc50b8c934171e94604575a8b36f349.asciidoc
+++ b/docs/examples/dbc50b8c934171e94604575a8b36f349.asciidoc
@@ -1,4 +1,4 @@
-// indices/update-settings.asciidoc:135
+// indices/update-settings.asciidoc:145
 
 [source, python]
 ----

--- a/docs/examples/e9ae959608d128202921b174f4faa7a8.asciidoc
+++ b/docs/examples/e9ae959608d128202921b174f4faa7a8.asciidoc
@@ -1,0 +1,27 @@
+// docs/reindex.asciidoc:1062
+
+[source, python]
+----
+resp = client.reindex(
+    body=
+{
+  "source": {
+    "remote": {
+      "host": "http://otherhost:9200",
+      ...
+    },
+    "index": "source",
+    "size": 10,
+    "query": {
+      "match": {
+        "test": "data"
+      }
+    }
+  },
+  "dest": {
+    "index": "dest"
+  }
+},
+)
+print(resp)
+----

--- a/docs/examples/f4f557716049b23f8840d58d71e748f0.asciidoc
+++ b/docs/examples/f4f557716049b23f8840d58d71e748f0.asciidoc
@@ -1,4 +1,4 @@
-// indices/update-settings.asciidoc:105
+// indices/update-settings.asciidoc:115
 
 [source, python]
 ----

--- a/utils/generate-examples.py
+++ b/utils/generate-examples.py
@@ -141,7 +141,6 @@ def main():
                 print(f"Error deleting file {filepath}: {e}")
 
     # Rest of the script processes the report to regenerate files.
-    # ...
 
     t = jinja_env.get_template("example")
 


### PR DESCRIPTION
Assumes the JSON report includes all necessary file information, meaning the hardcoded [`files_to_generate`](https://github.com/elastic/elasticsearch-py/blob/main/utils/generate-examples.py#L42C1-L43C21) list can be ignored. 