### PR TITLE
Add quickstart example from api call widget

### DIFF
--- a/docs/examples/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
+++ b/docs/examples/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
@@ -1,0 +1,4 @@
+// tab-widgets/api-call.asciidoc:13
+
+resp = es.info()
+print(resp)


### PR DESCRIPTION
This [snippet](https://github.com/elastic/elasticsearch/blob/main/docs/reference/tab-widgets/api-call.asciidoc?plain=1#L13) was missing 

@pquentin can you check the [backport](https://github.com/elastic/elasticsearch-py/pull/2397) on original PR when you have a second? :)