### PR TITLE
Fix example asciidoc syntax

### DIFF
--- a/docs/examples/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
+++ b/docs/examples/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
@@ -1,4 +1,7 @@
 // tab-widgets/api-call.asciidoc:13
 
+[source, python]
+----
 resp = es.info()
 print(resp)
+----


### PR DESCRIPTION
Missing code block broke docs build  😬 