### PR TITLE
Run Buildkite docs step on organization pull requests

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -4,6 +4,11 @@
       "enabled": true,
       "pipeline_slug": "elasticsearch-py-integration-tests",
       "allow_org_users": true
+    },
+    {
+      "enabled": true,
+      "pipeline_slug": "docs-build-pr",
+      "allow_org_users": true
     }
   ]
 }


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch-py/pull/2389

This should avoid typing `buildkite test this please` on pull requests by member of the @elastic organization using their own forks. But we will still need it for community contributions, unfortunately.