### PR TITLE
Add mappings and bulk to quickstart page

### DIFF
--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -104,20 +104,7 @@ This indexes a document with the index API:
         },
     )
 
-You can also index multiple documents at once with the bulk API:
-
-.. code-block:: python
-
-    def generate_operations(documents, index_name):
-      operations = []
-      for i, document in enumerate(documents):
-          operations.append({"index": {"_index": index_name, "_id": i}})
-          operations.append(document)
-      return operations
-
-    client.bulk(index=index_name, operations=generate_operations(books, index_name), refresh=True)
-
-Alternatively, you can use one of the helper functions:
+You can also index multiple documents at once with the bulk helper function:
 
 .. code-block:: python
 
@@ -128,6 +115,8 @@ Alternatively, you can use one of the helper functions:
             yield dict(_index=index_name, _id=f"{i}", _source=document)
     
     helpers.bulk(client, generate_docs(books, index_name))
+
+These helpers are the recommended simple and streamlined way to abstract otherwise complicated and verbose functions such as `client.bulk`.
 
 Getting documents
 ^^^^^^^^^^^^^^^^^

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -54,18 +54,10 @@ Time to use Elasticsearch! This section walks you through the most important
 operations of Elasticsearch. The following examples assume that the Python 
 client was instantiated as above.
 
-Creating an index
-^^^^^^^^^^^^^^^^^
+Create an index with mappings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is how you create the `my_index` index:
-
-.. code-block:: python
-
-    client.indices.create(index="my_index")
-
-Create a mapping for your index
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+This is how you create the `my_index` index.
 Optionally, you can first define the expected types of your features with a custom mapping.
 
 .. code-block:: python
@@ -85,7 +77,7 @@ Optionally, you can first define the expected types of your features with a cust
         }
     }
 
-    client.indices.create(index="my_index", mappings = mappings)
+    client.indices.create(index="my_index", mappings=mappings)
 
 Indexing documents
 ^^^^^^^^^^^^^^^^^^

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -54,30 +54,6 @@ Time to use Elasticsearch! This section walks you through the most important
 operations of Elasticsearch. The following examples assume that the Python 
 client was instantiated as above.
 
-Create a mapping for your index
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Set the expected types of your features.
-
-.. code-block:: python
-
-    mappings = {
-        "properties": {
-            "foo": {
-                "type" : "text"
-            },
-            "bar" : {
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                  "type" : "keyword",
-                  "ignore_above" : 256
-                  }
-                 }
-            }
-        }
-    }
-
 Creating an index
 ^^^^^^^^^^^^^^^^^
 
@@ -85,8 +61,31 @@ This is how you create the `my_index` index:
 
 .. code-block:: python
 
-    client.indices.create(index="my_index", mappings = mappings)
+    client.indices.create(index="my_index")
 
+Create a mapping for your index
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optionally, you can first define the expected types of your features with a custom mapping.
+
+.. code-block:: python
+
+    mappings = {
+        "properties": {
+            "foo": {"type": "text"},
+            "bar": {
+                "type": "text",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                    }
+                },
+            },
+        }
+    }
+
+    client.indices.create(index="my_index", mappings = mappings)
 
 Indexing documents
 ^^^^^^^^^^^^^^^^^^
@@ -110,13 +109,17 @@ You can also index multiple documents at once with the bulk helper function:
 
     from elasticsearch import helpers
 
-    def generate_docs(documents, index_name):
-        for i, document in enumerate(documents):
-            yield dict(_index=index_name, _id=f"{i}", _source=document)
-    
-    helpers.bulk(client, generate_docs(books, index_name))
+    def generate_docs():
+        for i in range(10):
+            yield {
+                "_index": "my_index",
+                "foo": f"foo {i}",
+                "bar": "bar",
+            }
+            
+    helpers.bulk(client, generate_docs())
 
-These helpers are the recommended simple and streamlined way to abstract otherwise complicated and verbose functions such as `client.bulk`.
+These helpers are the recommended way to perform bulk ingestion. While it is also possible to perform bulk ingestion using ``client.bulk`` directly, the helpers handle retries, ingesting chunk by chunk and more. See the :ref:`helpers` page for more details.
 
 Getting documents
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Added a few more examples including dealing with mappings and indexing multiple documents at once (in two alternative ways).
These changes have also been added to the 00 notebook in search-labs, that is also linked to under `interactive examples`.

Response to issue #2139 requesting changes to documentation