### PR TITLE
Removing the from parameter per issue #2385

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -3541,9 +3541,6 @@ class AsyncElasticsearch(BaseClient):
         :param fields: Array of wildcard (`*`) patterns. The request returns values for
             field names matching these patterns in the `hits.fields` property of the
             response.
-        :param from_: Starting document offset. Needs to be non-negative. By default,
-            you cannot page through more than 10,000 hits using the `from` and `size`
-            parameters. To page through more hits, use the `search_after` parameter.
         :param highlight: Specifies the highlighter to use for retrieving highlighted
             snippets from one or more fields in your search results.
         :param ignore_throttled: If `true`, concrete, expanded or aliased indices will

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -333,9 +333,6 @@ class AsyncSearchClient(NamespacedClient):
         :param ext: Configuration of search extensions defined by Elasticsearch plugins.
         :param fields: Array of wildcard (*) patterns. The request returns values for
             field names matching these patterns in the hits.fields property of the response.
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the search_after parameter.
         :param highlight:
         :param ignore_throttled: Whether specified concrete, expanded or aliased indices
             should be ignored when throttled

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -3539,9 +3539,6 @@ class Elasticsearch(BaseClient):
         :param fields: Array of wildcard (`*`) patterns. The request returns values for
             field names matching these patterns in the `hits.fields` property of the
             response.
-        :param from_: Starting document offset. Needs to be non-negative. By default,
-            you cannot page through more than 10,000 hits using the `from` and `size`
-            parameters. To page through more hits, use the `search_after` parameter.
         :param highlight: Specifies the highlighter to use for retrieving highlighted
             snippets from one or more fields in your search results.
         :param ignore_throttled: If `true`, concrete, expanded or aliased indices will

--- a/elasticsearch/_sync/client/async_search.py
+++ b/elasticsearch/_sync/client/async_search.py
@@ -333,9 +333,6 @@ class AsyncSearchClient(NamespacedClient):
         :param ext: Configuration of search extensions defined by Elasticsearch plugins.
         :param fields: Array of wildcard (*) patterns. The request returns values for
             field names matching these patterns in the hits.fields property of the response.
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the search_after parameter.
         :param highlight:
         :param ignore_throttled: Whether specified concrete, expanded or aliased indices
             should be ignored when throttled


### PR DESCRIPTION
I removed the from parameter to fix the bug in the documentation reported [here](https://github.com/elastic/elasticsearch-py/issues/2385). 

I also wanted to know if you knew of a good spot to add back to the description.