### PR TITLE
Pass endpoint_id and path_parts to transport

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-elastic-transport>=8.0.0b1, <9
+# TODO switch back to elastic-transport>=8,<9 between elastic-transport release and elasticsearch-py release
+elastic-transport @ git+https://github.com/elastic/elastic-transport-python
 requests>=2, <3
 aiohttp
 pytest

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -674,9 +674,12 @@ class AsyncElasticsearch(BaseClient):
             )
         elif operations is not None and body is not None:
             raise ValueError("Cannot set both 'operations' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_bulk"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_bulk'
         else:
+            __path_parts = {}
             __path = "/_bulk"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -711,7 +714,13 @@ class AsyncElasticsearch(BaseClient):
             "content-type": "application/x-ndjson",
         }
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="bulk",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -734,6 +743,8 @@ class AsyncElasticsearch(BaseClient):
 
         :param scroll_id: Scroll IDs to clear. To clear all scroll IDs, use `_all`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_search/scroll"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -754,7 +765,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="clear_scroll",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -779,6 +796,8 @@ class AsyncElasticsearch(BaseClient):
         """
         if id is None and body is None:
             raise ValueError("Empty value passed for parameter 'id'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_pit"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -799,7 +818,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="close_point_in_time",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -879,9 +904,12 @@ class AsyncElasticsearch(BaseClient):
             If a query reaches this limit, Elasticsearch terminates the query early.
             Elasticsearch collects documents before sorting.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_count"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_count'
         else:
+            __path_parts = {}
             __path = "/_count"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -930,7 +958,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="count",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1004,7 +1038,9 @@ class AsyncElasticsearch(BaseClient):
             )
         elif document is not None and body is not None:
             raise ValueError("Cannot set both 'document' and 'body'")
-        __path = f"/{_quote(index)}/_create/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_create/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1031,7 +1067,13 @@ class AsyncElasticsearch(BaseClient):
         __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="create",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1088,7 +1130,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1116,7 +1160,12 @@ class AsyncElasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1247,7 +1296,9 @@ class AsyncElasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_delete_by_query"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_delete_by_query'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -1334,7 +1385,13 @@ class AsyncElasticsearch(BaseClient):
                 __body["slice"] = slice
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="delete_by_query",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1359,7 +1416,9 @@ class AsyncElasticsearch(BaseClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_delete_by_query/{_quote(task_id)}/_rethrottle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_delete_by_query/{__path_parts["task_id"]}/_rethrottle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1373,7 +1432,12 @@ class AsyncElasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="delete_by_query_rethrottle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1404,7 +1468,9 @@ class AsyncElasticsearch(BaseClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_scripts/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_scripts/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1420,7 +1486,12 @@ class AsyncElasticsearch(BaseClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="delete_script",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1484,7 +1555,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1516,7 +1589,12 @@ class AsyncElasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="exists",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1576,7 +1654,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_source/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_source/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1606,7 +1686,12 @@ class AsyncElasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="exists_source",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1676,7 +1761,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_explain/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_explain/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if analyze_wildcard is not None:
@@ -1720,7 +1807,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="explain",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1786,9 +1879,12 @@ class AsyncElasticsearch(BaseClient):
         :param types: Only return results for fields that have one of the types in the
             list
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_field_caps"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_field_caps'
         else:
+            __path_parts = {}
             __path = "/_field_caps"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1827,7 +1923,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="field_caps",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1890,7 +1992,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1922,7 +2026,12 @@ class AsyncElasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1948,7 +2057,9 @@ class AsyncElasticsearch(BaseClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_scripts/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_scripts/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1962,7 +2073,12 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_script",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1979,6 +2095,8 @@ class AsyncElasticsearch(BaseClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_script_context"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1991,7 +2109,12 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_script_context",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2008,6 +2131,8 @@ class AsyncElasticsearch(BaseClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_script_language"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2020,7 +2145,12 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_script_languages",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2081,7 +2211,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_source/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_source/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2113,7 +2245,12 @@ class AsyncElasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_source",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2140,9 +2277,12 @@ class AsyncElasticsearch(BaseClient):
         :param timeout: Explicit operation timeout.
         :param verbose: Opt-in for more information about the health of the system.
         """
+        __path_parts: t.Dict[str, str]
         if feature not in SKIP_IN_PATH:
-            __path = f"/_health_report/{_quote(feature)}"
+            __path_parts = {"feature": _quote(feature)}
+            __path = f'/_health_report/{__path_parts["feature"]}'
         else:
+            __path_parts = {}
             __path = "/_health_report"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2161,7 +2301,12 @@ class AsyncElasticsearch(BaseClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="health_report",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2242,11 +2387,14 @@ class AsyncElasticsearch(BaseClient):
             )
         elif document is not None and body is not None:
             raise ValueError("Cannot set both 'document' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and id not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+            __path_parts = {"index": _quote(index), "id": _quote(id)}
+            __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
             __method = "PUT"
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_doc"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_doc'
             __method = "POST"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
@@ -2284,7 +2432,13 @@ class AsyncElasticsearch(BaseClient):
         __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            __method, __path, params=__query, headers=__headers, body=__body
+            __method,
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2301,6 +2455,8 @@ class AsyncElasticsearch(BaseClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2313,7 +2469,12 @@ class AsyncElasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2376,7 +2537,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if knn is None and body is None:
             raise ValueError("Empty value passed for parameter 'knn'")
-        __path = f"/{_quote(index)}/_knn_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_knn_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2408,7 +2571,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="knn_search",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2469,9 +2638,12 @@ class AsyncElasticsearch(BaseClient):
         :param stored_fields: If `true`, retrieves the document fields stored in the
             index rather than the document `_source`.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mget"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_mget'
         else:
+            __path_parts = {}
             __path = "/_mget"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2506,7 +2678,13 @@ class AsyncElasticsearch(BaseClient):
                 __body["ids"] = ids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="mget",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2591,9 +2769,12 @@ class AsyncElasticsearch(BaseClient):
             )
         elif searches is not None and body is not None:
             raise ValueError("Cannot set both 'searches' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_msearch"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_msearch'
         else:
+            __path_parts = {}
             __path = "/_msearch"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2634,7 +2815,13 @@ class AsyncElasticsearch(BaseClient):
             "content-type": "application/x-ndjson",
         }
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="msearch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2684,9 +2871,12 @@ class AsyncElasticsearch(BaseClient):
             )
         elif search_templates is not None and body is not None:
             raise ValueError("Cannot set both 'search_templates' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_msearch/template"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_msearch/template'
         else:
+            __path_parts = {}
             __path = "/_msearch/template"
         __query: t.Dict[str, t.Any] = {}
         if ccs_minimize_roundtrips is not None:
@@ -2713,7 +2903,13 @@ class AsyncElasticsearch(BaseClient):
             "content-type": "application/x-ndjson",
         }
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="msearch_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2770,9 +2966,12 @@ class AsyncElasticsearch(BaseClient):
         :param version: If `true`, returns the document version as part of a hit.
         :param version_type: Specific version type.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mtermvectors"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_mtermvectors'
         else:
+            __path_parts = {}
             __path = "/_mtermvectors"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2817,7 +3016,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="mtermvectors",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2864,7 +3069,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if keep_alive is None:
             raise ValueError("Empty value passed for parameter 'keep_alive'")
-        __path = f"/{_quote(index)}/_pit"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_pit'
         __query: t.Dict[str, t.Any] = {}
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
@@ -2886,7 +3093,12 @@ class AsyncElasticsearch(BaseClient):
             __query["routing"] = routing
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="open_point_in_time",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2930,10 +3142,13 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'id'")
         if script is None and body is None:
             raise ValueError("Empty value passed for parameter 'script'")
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH and context not in SKIP_IN_PATH:
-            __path = f"/_scripts/{_quote(id)}/{_quote(context)}"
+            __path_parts = {"id": _quote(id), "context": _quote(context)}
+            __path = f'/_scripts/{__path_parts["id"]}/{__path_parts["context"]}'
         elif id not in SKIP_IN_PATH:
-            __path = f"/_scripts/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_scripts/{__path_parts["id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -2955,7 +3170,13 @@ class AsyncElasticsearch(BaseClient):
                 __body["script"] = script
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="put_script",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3010,9 +3231,12 @@ class AsyncElasticsearch(BaseClient):
         """
         if requests is None and body is None:
             raise ValueError("Empty value passed for parameter 'requests'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_rank_eval"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_rank_eval'
         else:
+            __path_parts = {}
             __path = "/_rank_eval"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3039,7 +3263,13 @@ class AsyncElasticsearch(BaseClient):
                 __body["metric"] = metric
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="rank_eval",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3105,6 +3335,8 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'dest'")
         if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_reindex"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3147,7 +3379,13 @@ class AsyncElasticsearch(BaseClient):
                 __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="reindex",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3172,7 +3410,9 @@ class AsyncElasticsearch(BaseClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_reindex/{_quote(task_id)}/_rethrottle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_reindex/{__path_parts["task_id"]}/_rethrottle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3186,7 +3426,12 @@ class AsyncElasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="reindex_rethrottle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3220,9 +3465,12 @@ class AsyncElasticsearch(BaseClient):
             search API's request body. These parameters also support Mustache variables.
             If no `id` or `<templated-id>` is specified, this parameter is required.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_render/template/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_render/template/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_render/template"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3247,7 +3495,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="render_search_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3274,6 +3528,8 @@ class AsyncElasticsearch(BaseClient):
         :param context_setup: Additional parameters for the `context`.
         :param script: The Painless script to execute.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_scripts/painless/_execute"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3298,7 +3554,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="scripts_painless_execute",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3329,6 +3591,8 @@ class AsyncElasticsearch(BaseClient):
         """
         if scroll_id is None and body is None:
             raise ValueError("Empty value passed for parameter 'scroll_id'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_search/scroll"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3353,7 +3617,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="scroll",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3682,9 +3952,12 @@ class AsyncElasticsearch(BaseClient):
             by their respective types in the response.
         :param version: If true, returns document version as part of a hit.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_search"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_search'
         else:
+            __path_parts = {}
             __path = "/_search"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3840,7 +4113,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3955,7 +4234,15 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'x'")
         if y in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'y'")
-        __path = f"/{_quote(index)}/_mvt/{_quote(field)}/{_quote(zoom)}/{_quote(x)}/{_quote(y)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "index": _quote(index),
+            "field": _quote(field),
+            "zoom": _quote(zoom),
+            "x": _quote(x),
+            "y": _quote(y),
+        }
+        __path = f'/{__path_parts["index"]}/_mvt/{__path_parts["field"]}/{__path_parts["zoom"]}/{__path_parts["x"]}/{__path_parts["y"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -4012,7 +4299,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_mvt",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4063,9 +4356,12 @@ class AsyncElasticsearch(BaseClient):
             on. Random by default.
         :param routing: Custom value used to route operations to a specific shard.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_search_shards"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_search_shards'
         else:
+            __path_parts = {}
             __path = "/_search_shards"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -4090,7 +4386,12 @@ class AsyncElasticsearch(BaseClient):
             __query["routing"] = routing
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_shards",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4175,9 +4476,12 @@ class AsyncElasticsearch(BaseClient):
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_search/template"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_search/template'
         else:
+            __path_parts = {}
             __path = "/_search/template"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4224,7 +4528,13 @@ class AsyncElasticsearch(BaseClient):
                 __body["source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4283,7 +4593,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if field is None and body is None:
             raise ValueError("Empty value passed for parameter 'field'")
-        __path = f"/{_quote(index)}/_terms_enum"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_terms_enum'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4315,7 +4627,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="terms_enum",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4379,10 +4697,13 @@ class AsyncElasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and id not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_termvectors/{_quote(id)}"
+            __path_parts = {"index": _quote(index), "id": _quote(id)}
+            __path = f'/{__path_parts["index"]}/_termvectors/{__path_parts["id"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_termvectors"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_termvectors'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -4430,7 +4751,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="termvectors",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4527,7 +4854,9 @@ class AsyncElasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_update/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_update/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4577,7 +4906,13 @@ class AsyncElasticsearch(BaseClient):
                 __body["upsert"] = upsert
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="update",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4719,7 +5054,9 @@ class AsyncElasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_update_by_query"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_update_by_query'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -4814,7 +5151,13 @@ class AsyncElasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="update_by_query",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4839,7 +5182,9 @@ class AsyncElasticsearch(BaseClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_update_by_query/{_quote(task_id)}/_rethrottle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_update_by_query/{__path_parts["task_id"]}/_rethrottle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -4853,5 +5198,10 @@ class AsyncElasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="update_by_query_rethrottle",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/_base.py
+++ b/elasticsearch/_async/client/_base.py
@@ -257,6 +257,8 @@ class BaseClient:
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
+        endpoint_id: Union[DefaultType, str] = DEFAULT,
+        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
     ) -> ApiResponse[Any]:
         if headers:
             request_headers = self._headers.copy()
@@ -292,6 +294,8 @@ class BaseClient:
             retry_on_status=self._retry_on_status,
             retry_on_timeout=self._retry_on_timeout,
             client_meta=self._client_meta,
+            endpoint_id=endpoint_id,
+            path_parts=path_parts,
         )
 
         # HEAD with a 404 is returned as a normal response
@@ -383,9 +387,17 @@ class NamespacedClient(BaseClient):
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
+        endpoint_id: Union[DefaultType, str] = DEFAULT,
+        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
     ) -> ApiResponse[Any]:
         # Use the internal clients .perform_request() implementation
         # so we take advantage of their transport options.
         return await self._client.perform_request(
-            method, path, params=params, headers=headers, body=body
+            method,
+            path,
+            params=params,
+            headers=headers,
+            body=body,
+            endpoint_id=endpoint_id,
+            path_parts=path_parts,
         )

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -45,7 +45,9 @@ class AsyncSearchClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_async_search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_async_search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -57,7 +59,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="async_search.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -99,7 +106,9 @@ class AsyncSearchClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_async_search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_async_search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -117,7 +126,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="async_search.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -140,7 +154,9 @@ class AsyncSearchClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_async_search/status/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_async_search/status/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -152,7 +168,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="async_search.status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -428,9 +449,12 @@ class AsyncSearchClient(NamespacedClient):
             up to a certain timeout. When the async search completes within the timeout,
             the response won’t include the ID as the results are not stored in the cluster.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_async_search"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_async_search'
         else:
+            __path_parts = {}
             __path = "/_async_search"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -590,5 +614,11 @@ class AsyncSearchClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="async_search.submit",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/autoscaling.py
+++ b/elasticsearch/_async/client/autoscaling.py
@@ -45,7 +45,9 @@ class AutoscalingClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_autoscaling/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -57,7 +59,12 @@ class AutoscalingClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="autoscaling.delete_autoscaling_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -75,6 +82,8 @@ class AutoscalingClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_autoscaling/capacity"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -87,7 +96,12 @@ class AutoscalingClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="autoscaling.get_autoscaling_capacity",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -110,7 +124,9 @@ class AutoscalingClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_autoscaling/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -122,7 +138,12 @@ class AutoscalingClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="autoscaling.get_autoscaling_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -156,7 +177,9 @@ class AutoscalingClient(NamespacedClient):
             )
         elif policy is not None and body is not None:
             raise ValueError("Cannot set both 'policy' and 'body'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_autoscaling/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -169,5 +192,11 @@ class AutoscalingClient(NamespacedClient):
         __body = policy if policy is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="autoscaling.put_autoscaling_policy",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/cat.py
+++ b/elasticsearch/_async/client/cat.py
@@ -77,9 +77,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_cat/aliases/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_cat/aliases/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/aliases"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -108,7 +111,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.aliases",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -157,9 +165,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_cat/allocation/{_quote(node_id)}"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_cat/allocation/{__path_parts["node_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/allocation"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -188,7 +199,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.allocation",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -232,9 +248,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_cat/component_templates/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_cat/component_templates/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/component_templates"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -261,7 +280,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.component_templates",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -307,9 +331,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/count/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/count/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/count"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -336,7 +363,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.count",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -385,9 +417,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if fields not in SKIP_IN_PATH:
-            __path = f"/_cat/fielddata/{_quote(fields)}"
+            __path_parts = {"fields": _quote(fields)}
+            __path = f'/_cat/fielddata/{__path_parts["fields"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/fielddata"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -416,7 +451,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.fielddata",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -463,6 +503,8 @@ class CatClient(NamespacedClient):
         :param ts: If true, returns `HH:MM:SS` and Unix epoch timestamps.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/health"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -493,7 +535,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.health",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -534,6 +581,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -560,7 +609,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.help",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -631,9 +685,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/indices/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/indices/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/indices"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -672,7 +729,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.indices",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -713,6 +775,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/master"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -739,7 +803,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.master",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -816,9 +885,12 @@ class CatClient(NamespacedClient):
         :param time: Unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/data_frame/analytics/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_cat/ml/data_frame/analytics/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/data_frame/analytics"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -851,7 +923,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -932,9 +1009,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/datafeeds/{_quote(datafeed_id)}"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_cat/ml/datafeeds/{__path_parts["datafeed_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/datafeeds"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -965,7 +1045,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_datafeeds",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1049,9 +1134,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/anomaly_detectors/{_quote(job_id)}"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_cat/ml/anomaly_detectors/{__path_parts["job_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/anomaly_detectors"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1084,7 +1172,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_jobs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1170,9 +1263,12 @@ class CatClient(NamespacedClient):
         :param size: The maximum number of transforms to display.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if model_id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/trained_models/{_quote(model_id)}"
+            __path_parts = {"model_id": _quote(model_id)}
+            __path = f'/_cat/ml/trained_models/{__path_parts["model_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/trained_models"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1207,7 +1303,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_trained_models",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1248,6 +1349,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/nodeattrs"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1274,7 +1377,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.nodeattrs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1325,6 +1433,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/nodes"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -1357,7 +1467,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.nodes",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1398,6 +1513,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/pending_tasks"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1424,7 +1541,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.pending_tasks",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1465,6 +1587,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/plugins"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1491,7 +1615,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.plugins",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1545,9 +1674,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/recovery/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/recovery/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/recovery"
         __query: t.Dict[str, t.Any] = {}
         if active_only is not None:
@@ -1580,7 +1712,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.recovery",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1621,6 +1758,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/repositories"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1647,7 +1786,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.repositories",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1696,9 +1840,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/segments/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/segments/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/segments"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -1727,7 +1874,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.segments",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1776,9 +1928,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/shards/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/shards/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/shards"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -1807,7 +1962,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.shards",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1855,9 +2015,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if repository not in SKIP_IN_PATH:
-            __path = f"/_cat/snapshots/{_quote(repository)}"
+            __path_parts = {"repository": _quote(repository)}
+            __path = f'/_cat/snapshots/{__path_parts["repository"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/snapshots"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1886,7 +2049,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.snapshots",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1938,6 +2106,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/tasks"
         __query: t.Dict[str, t.Any] = {}
         if actions is not None:
@@ -1972,7 +2142,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.tasks",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2016,9 +2191,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_cat/templates/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_cat/templates/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/templates"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2045,7 +2223,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.templates",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2094,9 +2277,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if thread_pool_patterns not in SKIP_IN_PATH:
-            __path = f"/_cat/thread_pool/{_quote(thread_pool_patterns)}"
+            __path_parts = {"thread_pool_patterns": _quote(thread_pool_patterns)}
+            __path = f'/_cat/thread_pool/{__path_parts["thread_pool_patterns"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/thread_pool"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2125,7 +2311,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.thread_pool",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2213,9 +2404,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if transform_id not in SKIP_IN_PATH:
-            __path = f"/_cat/transforms/{_quote(transform_id)}"
+            __path_parts = {"transform_id": _quote(transform_id)}
+            __path = f'/_cat/transforms/{__path_parts["transform_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/transforms"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -2250,5 +2444,10 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.transforms",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -44,7 +44,9 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.delete_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -129,7 +136,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/follow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/follow'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -175,7 +184,13 @@ class CcrClient(NamespacedClient):
                 __body["remote_cluster"] = remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.follow",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -199,7 +214,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/info"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/info'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -211,7 +228,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.follow_info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -235,7 +257,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/stats'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -247,7 +271,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.follow_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -286,7 +315,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/forget_follower"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/forget_follower'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -308,7 +339,13 @@ class CcrClient(NamespacedClient):
                 __body["leader_remote_cluster"] = leader_remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.forget_follower",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -330,9 +367,12 @@ class CcrClient(NamespacedClient):
         :param name: Specifies the auto-follow pattern collection that you want to retrieve.
             If you do not specify a name, the API returns information for all collections.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_ccr/auto_follow/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_ccr/auto_follow/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_ccr/auto_follow"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -345,7 +385,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.get_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -368,7 +413,9 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}/pause"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}/pause'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -380,7 +427,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.pause_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -404,7 +456,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/pause_follow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/pause_follow'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -416,7 +470,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.pause_follow",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -521,7 +580,9 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         if remote_cluster is None and body is None:
             raise ValueError("Empty value passed for parameter 'remote_cluster'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -573,7 +634,13 @@ class CcrClient(NamespacedClient):
                 __body["settings"] = settings
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.put_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -596,7 +663,9 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}/resume"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}/resume'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -608,7 +677,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.resume_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -668,7 +742,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/resume_follow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/resume_follow'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -712,7 +788,13 @@ class CcrClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.resume_follow",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -729,6 +811,8 @@ class CcrClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ccr/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -741,7 +825,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -765,7 +854,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/unfollow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/unfollow'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -777,5 +868,10 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.unfollow",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -60,6 +60,8 @@ class ClusterClient(NamespacedClient):
         :param shard: Specifies the ID of the shard that you would like an explanation
             for.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/allocation/explain"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -90,7 +92,13 @@ class ClusterClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.allocation_explain",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -122,7 +130,9 @@ class ClusterClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_component_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_component_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -138,7 +148,12 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.delete_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -163,6 +178,8 @@ class ClusterClient(NamespacedClient):
             configuration exclusions list is cleared even if some excluded nodes are
             still in the cluster.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/voting_config_exclusions"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -177,7 +194,12 @@ class ClusterClient(NamespacedClient):
             __query["wait_for_removal"] = wait_for_removal
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.delete_voting_config_exclusions",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -210,7 +232,9 @@ class ClusterClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_component_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_component_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -226,7 +250,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.exists_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -261,9 +290,12 @@ class ClusterClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_component_template/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_component_template/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_component_template"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -284,7 +316,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.get_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -316,6 +353,8 @@ class ClusterClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -336,7 +375,12 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.get_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -419,9 +463,12 @@ class ClusterClient(NamespacedClient):
             provided) until the status of the cluster changes to the one provided or
             better, i.e. green > yellow > red. By default, will not wait for any status.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cluster/health/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cluster/health/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cluster/health"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -456,7 +503,12 @@ class ClusterClient(NamespacedClient):
             __query["wait_for_status"] = wait_for_status
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.health",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -488,7 +540,9 @@ class ClusterClient(NamespacedClient):
         """
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/_info/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"target": _quote(target)}
+        __path = f'/_info/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -500,7 +554,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -528,6 +587,8 @@ class ClusterClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/pending_tasks"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -544,7 +605,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.pending_tasks",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -574,6 +640,8 @@ class ClusterClient(NamespacedClient):
             If the timeout expires before the appropriate condition is satisfied, the
             request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/voting_config_exclusions"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -592,7 +660,12 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.post_voting_config_exclusions",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -655,7 +728,9 @@ class ClusterClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         if template is None and body is None:
             raise ValueError("Empty value passed for parameter 'template'")
-        __path = f"/_component_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_component_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -681,7 +756,13 @@ class ClusterClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.put_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -714,6 +795,8 @@ class ClusterClient(NamespacedClient):
         :param timeout: Explicit operation timeout
         :param transient:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -738,7 +821,13 @@ class ClusterClient(NamespacedClient):
                 __body["transient"] = transient
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.put_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -755,6 +844,8 @@ class ClusterClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_remote/info"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -767,7 +858,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.remote_info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -810,6 +906,8 @@ class ClusterClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/reroute"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -842,7 +940,13 @@ class ClusterClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.reroute",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -899,13 +1003,18 @@ class ClusterClient(NamespacedClient):
         :param wait_for_timeout: The maximum time to wait for wait_for_metadata_version
             before timing out
         """
+        __path_parts: t.Dict[str, str]
         if metric not in SKIP_IN_PATH and index not in SKIP_IN_PATH:
-            __path = f"/_cluster/state/{_quote(metric)}/{_quote(index)}"
+            __path_parts = {"metric": _quote(metric), "index": _quote(index)}
+            __path = f'/_cluster/state/{__path_parts["metric"]}/{__path_parts["index"]}'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_cluster/state/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_cluster/state/{__path_parts["metric"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/_cluster/state/_all/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cluster/state/_all/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cluster/state"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -934,7 +1043,12 @@ class ClusterClient(NamespacedClient):
             __query["wait_for_timeout"] = wait_for_timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.state",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -962,9 +1076,12 @@ class ClusterClient(NamespacedClient):
             timed out nodes are included in the response’s `_nodes.failed` property.
             Defaults to no timeout.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_cluster/stats/nodes/{_quote(node_id)}"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_cluster/stats/nodes/{__path_parts["node_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cluster/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -981,5 +1098,10 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.stats",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/dangling_indices.py
+++ b/elasticsearch/_async/client/dangling_indices.py
@@ -55,7 +55,9 @@ class DanglingIndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index_uuid'")
         if accept_data_loss is None:
             raise ValueError("Empty value passed for parameter 'accept_data_loss'")
-        __path = f"/_dangling/{_quote(index_uuid)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index_uuid": _quote(index_uuid)}
+        __path = f'/_dangling/{__path_parts["index_uuid"]}'
         __query: t.Dict[str, t.Any] = {}
         if accept_data_loss is not None:
             __query["accept_data_loss"] = accept_data_loss
@@ -73,7 +75,12 @@ class DanglingIndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="dangling_indices.delete_dangling_index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -106,7 +113,9 @@ class DanglingIndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index_uuid'")
         if accept_data_loss is None:
             raise ValueError("Empty value passed for parameter 'accept_data_loss'")
-        __path = f"/_dangling/{_quote(index_uuid)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index_uuid": _quote(index_uuid)}
+        __path = f'/_dangling/{__path_parts["index_uuid"]}'
         __query: t.Dict[str, t.Any] = {}
         if accept_data_loss is not None:
             __query["accept_data_loss"] = accept_data_loss
@@ -124,7 +133,12 @@ class DanglingIndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="dangling_indices.import_dangling_index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -141,6 +155,8 @@ class DanglingIndicesClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_dangling"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -153,5 +169,10 @@ class DanglingIndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="dangling_indices.list_dangling_indices",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/enrich.py
+++ b/elasticsearch/_async/client/enrich.py
@@ -44,7 +44,9 @@ class EnrichClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_enrich/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_enrich/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class EnrichClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.delete_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -81,7 +88,9 @@ class EnrichClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_enrich/policy/{_quote(name)}/_execute"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_enrich/policy/{__path_parts["name"]}/_execute'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -95,7 +104,12 @@ class EnrichClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.execute_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -116,9 +130,12 @@ class EnrichClient(NamespacedClient):
         :param name: Comma-separated list of enrich policy names used to limit the request.
             To return information for all enrich policies, omit this parameter.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_enrich/policy/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_enrich/policy/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_enrich/policy"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -131,7 +148,12 @@ class EnrichClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.get_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -164,7 +186,9 @@ class EnrichClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_enrich/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_enrich/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -184,7 +208,13 @@ class EnrichClient(NamespacedClient):
                 __body["range"] = range
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="enrich.put_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -202,6 +232,8 @@ class EnrichClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_enrich/_stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -214,5 +246,10 @@ class EnrichClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.stats",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/eql.py
+++ b/elasticsearch/_async/client/eql.py
@@ -47,7 +47,9 @@ class EqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_eql/search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_eql/search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -59,7 +61,12 @@ class EqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="eql.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -91,7 +98,9 @@ class EqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_eql/search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_eql/search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -107,7 +116,12 @@ class EqlClient(NamespacedClient):
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="eql.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -130,7 +144,9 @@ class EqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_eql/search/status/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_eql/search/status/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -142,7 +158,12 @@ class EqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="eql.get_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -238,7 +259,9 @@ class EqlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
-        __path = f"/{_quote(index)}/_eql/search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_eql/search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -286,5 +309,11 @@ class EqlClient(NamespacedClient):
                 __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="eql.search",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/esql.py
+++ b/elasticsearch/_async/client/esql.py
@@ -68,6 +68,8 @@ class EsqlClient(NamespacedClient):
         """
         if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -96,5 +98,11 @@ class EsqlClient(NamespacedClient):
                 __body["params"] = params
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="esql.query",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/features.py
+++ b/elasticsearch/_async/client/features.py
@@ -40,6 +40,8 @@ class FeaturesClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_features"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -52,7 +54,12 @@ class FeaturesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="features.get_features",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -69,6 +76,8 @@ class FeaturesClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_features/_reset"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -81,5 +90,10 @@ class FeaturesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="features.reset_features",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/fleet.py
+++ b/elasticsearch/_async/client/fleet.py
@@ -59,7 +59,9 @@ class FleetClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_fleet/global_checkpoints"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_fleet/global_checkpoints'
         __query: t.Dict[str, t.Any] = {}
         if checkpoints is not None:
             __query["checkpoints"] = checkpoints
@@ -79,7 +81,12 @@ class FleetClient(NamespacedClient):
             __query["wait_for_index"] = wait_for_index
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="fleet.global_checkpoints",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -171,9 +178,12 @@ class FleetClient(NamespacedClient):
             )
         elif searches is not None and body is not None:
             raise ValueError("Cannot set both 'searches' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_fleet/_fleet_msearch"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_fleet/_fleet_msearch'
         else:
+            __path_parts = {}
             __path = "/_fleet/_fleet_msearch"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -216,7 +226,13 @@ class FleetClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="fleet.msearch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -460,7 +476,9 @@ class FleetClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_fleet/_fleet_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_fleet/_fleet_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -613,5 +631,11 @@ class FleetClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="fleet.search",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/graph.py
+++ b/elasticsearch/_async/client/graph.py
@@ -65,7 +65,9 @@ class GraphClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_graph/explore"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_graph/explore'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -95,5 +97,11 @@ class GraphClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="graph.explore",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/ilm.py
+++ b/elasticsearch/_async/client/ilm.py
@@ -54,7 +54,9 @@ class IlmClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ilm/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy": _quote(name)}
+        __path = f'/_ilm/policy/{__path_parts["policy"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -70,7 +72,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.delete_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -111,7 +118,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ilm/explain"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ilm/explain'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -131,7 +140,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.explain_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -161,9 +175,12 @@ class IlmClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_ilm/policy/{_quote(name)}"
+            __path_parts = {"policy": _quote(name)}
+            __path = f'/_ilm/policy/{__path_parts["policy"]}'
         else:
+            __path_parts = {}
             __path = "/_ilm/policy"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -180,7 +197,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.get_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -197,6 +219,8 @@ class IlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -209,7 +233,12 @@ class IlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.get_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -239,6 +268,8 @@ class IlmClient(NamespacedClient):
         :param legacy_template_to_delete:
         :param node_attribute:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/migrate_to_data_tiers"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -263,7 +294,13 @@ class IlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ilm.migrate_to_data_tiers",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -292,7 +329,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/_ilm/move/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/_ilm/move/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -314,7 +353,13 @@ class IlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ilm.move_to_step",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -350,7 +395,9 @@ class IlmClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ilm/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy": _quote(name)}
+        __path = f'/_ilm/policy/{__path_parts["policy"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -374,7 +421,13 @@ class IlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ilm.put_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -396,7 +449,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ilm/remove"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ilm/remove'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -408,7 +463,12 @@ class IlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.remove_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -431,7 +491,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ilm/retry"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ilm/retry'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -443,7 +505,12 @@ class IlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.retry",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -467,6 +534,8 @@ class IlmClient(NamespacedClient):
         :param master_timeout:
         :param timeout:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/start"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -483,7 +552,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.start",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -508,6 +582,8 @@ class IlmClient(NamespacedClient):
         :param master_timeout:
         :param timeout:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/stop"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -524,5 +600,10 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.stop",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -71,7 +71,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if block in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'block'")
-        __path = f"/{_quote(index)}/_block/{_quote(block)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "block": _quote(block)}
+        __path = f'/{__path_parts["index"]}/_block/{__path_parts["block"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -93,7 +95,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.add_block",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -155,9 +162,12 @@ class IndicesClient(NamespacedClient):
             as a multi-value field.
         :param tokenizer: Tokenizer to use to convert text into tokens.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_analyze"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_analyze'
         else:
+            __path_parts = {}
             __path = "/_analyze"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -194,7 +204,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.analyze",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -245,9 +261,12 @@ class IndicesClient(NamespacedClient):
         :param query: If `true`, clears the query cache.
         :param request: If `true`, clears the request cache.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_cache/clear"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_cache/clear'
         else:
+            __path_parts = {}
             __path = "/_cache/clear"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -274,7 +293,12 @@ class IndicesClient(NamespacedClient):
             __query["request"] = request
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.clear_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -322,7 +346,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/{_quote(index)}/_clone/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target": _quote(target)}
+        __path = f'/{__path_parts["index"]}/_clone/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -350,7 +376,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.clone",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -407,7 +439,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_close"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_close'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -431,7 +465,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.close",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -478,7 +517,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -508,7 +549,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.create",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -534,7 +581,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -546,7 +595,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.create_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -578,9 +632,12 @@ class IndicesClient(NamespacedClient):
         :param expand_wildcards: Type of data stream that wildcard patterns can match.
             Supports comma-separated values, such as `open,hidden`.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_data_stream/{_quote(name)}/_stats"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_data_stream/{__path_parts["name"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_data_stream/_stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -595,7 +652,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.data_streams_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -648,7 +710,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -670,7 +734,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -707,7 +776,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "name": _quote(name)}
+        __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -723,7 +794,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -762,7 +838,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}/_lifecycle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -780,7 +858,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -813,7 +896,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -827,7 +912,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -859,7 +949,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -875,7 +967,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -907,7 +1004,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -923,7 +1022,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -975,7 +1079,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_disk_usage"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_disk_usage'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -997,7 +1103,12 @@ class IndicesClient(NamespacedClient):
             __query["run_expensive_tasks"] = run_expensive_tasks
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.disk_usage",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1034,7 +1145,9 @@ class IndicesClient(NamespacedClient):
             )
         elif config is not None and body is not None:
             raise ValueError("Cannot set both 'config' and 'body'")
-        __path = f"/{_quote(index)}/_downsample/{_quote(target_index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target_index": _quote(target_index)}
+        __path = f'/{__path_parts["index"]}/_downsample/{__path_parts["target_index"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1047,7 +1160,13 @@ class IndicesClient(NamespacedClient):
         __body = config if config is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.downsample",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1096,7 +1215,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -1120,7 +1241,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1168,10 +1294,13 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+            __path_parts = {"index": _quote(index), "name": _quote(name)}
+            __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         elif name not in SKIP_IN_PATH:
-            __path = f"/_alias/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_alias/{__path_parts["name"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1193,7 +1322,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1222,7 +1356,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1236,7 +1372,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1267,7 +1408,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1285,7 +1428,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1315,7 +1463,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_lifecycle/explain"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_lifecycle/explain'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1331,7 +1481,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.explain_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1393,7 +1548,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_field_usage_stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_field_usage_stats'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -1419,7 +1576,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.field_usage_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1467,9 +1629,12 @@ class IndicesClient(NamespacedClient):
             when another flush operation is running. If `false`, Elasticsearch returns
             an error if you request a flush when another flush operation is running.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_flush"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_flush'
         else:
+            __path_parts = {}
             __path = "/_flush"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -1492,7 +1657,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_if_ongoing"] = wait_if_ongoing
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.flush",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1542,9 +1712,12 @@ class IndicesClient(NamespacedClient):
         :param wait_for_completion: Should the request wait until the force merge is
             completed.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_forcemerge"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_forcemerge'
         else:
+            __path_parts = {}
             __path = "/_forcemerge"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -1571,7 +1744,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.forcemerge",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1638,7 +1816,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -1666,7 +1846,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1713,13 +1898,18 @@ class IndicesClient(NamespacedClient):
         :param local: If `true`, the request retrieves information from the local node
             only.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+            __path_parts = {"index": _quote(index), "name": _quote(name)}
+            __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_alias"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_alias'
         elif name not in SKIP_IN_PATH:
-            __path = f"/_alias/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_alias/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_alias"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -1740,7 +1930,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1777,7 +1972,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}/_lifecycle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1793,7 +1990,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1828,9 +2030,12 @@ class IndicesClient(NamespacedClient):
         :param include_defaults: If true, returns all relevant default configurations
             for the index template.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_data_stream/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_data_stream/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_data_stream"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1847,7 +2052,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1898,10 +2108,13 @@ class IndicesClient(NamespacedClient):
         """
         if fields in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'fields'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and fields not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mapping/field/{_quote(fields)}"
+            __path_parts = {"index": _quote(index), "fields": _quote(fields)}
+            __path = f'/{__path_parts["index"]}/_mapping/field/{__path_parts["fields"]}'
         elif fields not in SKIP_IN_PATH:
-            __path = f"/_mapping/field/{_quote(fields)}"
+            __path_parts = {"fields": _quote(fields)}
+            __path = f'/_mapping/field/{__path_parts["fields"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1925,7 +2138,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_field_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1961,9 +2179,12 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_index_template/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_index_template/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_index_template"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1984,7 +2205,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2034,9 +2260,12 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mapping"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_mapping'
         else:
+            __path_parts = {}
             __path = "/_mapping"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2059,7 +2288,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2117,13 +2351,18 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_settings/{_quote(name)}"
+            __path_parts = {"index": _quote(index), "name": _quote(name)}
+            __path = f'/{__path_parts["index"]}/_settings/{__path_parts["name"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_settings"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_settings'
         elif name not in SKIP_IN_PATH:
-            __path = f"/_settings/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_settings/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_settings"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2150,7 +2389,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2183,9 +2427,12 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_template/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_template/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_template"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2204,7 +2451,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2226,7 +2478,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/_migrate/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/_migrate/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2238,7 +2492,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.migrate_to_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2263,6 +2522,8 @@ class IndicesClient(NamespacedClient):
         """
         if actions is None and body is None:
             raise ValueError("Empty value passed for parameter 'actions'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_data_stream/_modify"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2279,7 +2540,13 @@ class IndicesClient(NamespacedClient):
                 __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.modify_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2340,7 +2607,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_open"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_open'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -2364,7 +2633,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.open",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2387,7 +2661,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/_promote/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/_promote/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2399,7 +2675,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.promote_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2466,7 +2747,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "name": _quote(name)}
+        __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2498,7 +2781,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2555,7 +2844,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}/_lifecycle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2583,7 +2874,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2645,7 +2942,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -2675,7 +2974,13 @@ class IndicesClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2785,7 +3090,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_mapping"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_mapping'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -2833,7 +3140,13 @@ class IndicesClient(NamespacedClient):
                 __body["_source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2899,9 +3212,12 @@ class IndicesClient(NamespacedClient):
             )
         elif settings is not None and body is not None:
             raise ValueError("Cannot set both 'settings' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_settings"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_settings'
         else:
+            __path_parts = {}
             __path = "/_settings"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2929,7 +3245,13 @@ class IndicesClient(NamespacedClient):
         __body = settings if settings is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2992,7 +3314,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -3026,7 +3350,13 @@ class IndicesClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3053,9 +3383,12 @@ class IndicesClient(NamespacedClient):
         :param detailed: If `true`, the response includes detailed information about
             shard recoveries.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_recovery"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_recovery'
         else:
+            __path_parts = {}
             __path = "/_recovery"
         __query: t.Dict[str, t.Any] = {}
         if active_only is not None:
@@ -3072,7 +3405,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.recovery",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3113,9 +3451,12 @@ class IndicesClient(NamespacedClient):
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_refresh"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_refresh'
         else:
+            __path_parts = {}
             __path = "/_refresh"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -3134,7 +3475,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.refresh",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3173,7 +3519,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_reload_search_analyzers"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_reload_search_analyzers'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -3191,7 +3539,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.reload_search_analyzers",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3240,7 +3593,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_resolve/cluster/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_resolve/cluster/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -3260,7 +3615,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.resolve_cluster",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3296,7 +3656,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_resolve/index/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_resolve/index/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3310,7 +3672,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.resolve_index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3373,10 +3740,13 @@ class IndicesClient(NamespacedClient):
         """
         if alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'alias'")
+        __path_parts: t.Dict[str, str]
         if alias not in SKIP_IN_PATH and new_index not in SKIP_IN_PATH:
-            __path = f"/{_quote(alias)}/_rollover/{_quote(new_index)}"
+            __path_parts = {"alias": _quote(alias), "new_index": _quote(new_index)}
+            __path = f'/{__path_parts["alias"]}/_rollover/{__path_parts["new_index"]}'
         elif alias not in SKIP_IN_PATH:
-            __path = f"/{_quote(alias)}/_rollover"
+            __path_parts = {"alias": _quote(alias)}
+            __path = f'/{__path_parts["alias"]}/_rollover'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -3412,7 +3782,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.rollover",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3455,9 +3831,12 @@ class IndicesClient(NamespacedClient):
             a missing or closed index.
         :param verbose: If `true`, the request returns a verbose response.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_segments"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_segments'
         else:
+            __path_parts = {}
             __path = "/_segments"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -3478,7 +3857,12 @@ class IndicesClient(NamespacedClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.segments",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3523,9 +3907,12 @@ class IndicesClient(NamespacedClient):
             in the response.
         :param status: List of shard health statuses used to limit the request.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_shard_stores"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_shard_stores'
         else:
+            __path_parts = {}
             __path = "/_shard_stores"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -3546,7 +3933,12 @@ class IndicesClient(NamespacedClient):
             __query["status"] = status
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.shard_stores",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3594,7 +3986,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/{_quote(index)}/_shrink/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target": _quote(target)}
+        __path = f'/{__path_parts["index"]}/_shrink/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3622,7 +4016,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.shrink",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3704,7 +4104,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/_simulate_index/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/_simulate_index/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -3744,7 +4146,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.simulate_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3791,9 +4199,12 @@ class IndicesClient(NamespacedClient):
             )
         elif template is not None and body is not None:
             raise ValueError("Cannot set both 'template' and 'body'")
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_index_template/_simulate/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_index_template/_simulate/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_index_template/_simulate"
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
@@ -3817,7 +4228,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.simulate_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3865,7 +4282,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/{_quote(index)}/_split/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target": _quote(target)}
+        __path = f'/{__path_parts["index"]}/_split/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3893,7 +4312,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.split",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3955,13 +4380,18 @@ class IndicesClient(NamespacedClient):
         :param level: Indicates whether statistics are aggregated at the cluster, index,
             or shard level.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_stats/{_quote(metric)}"
+            __path_parts = {"index": _quote(index), "metric": _quote(metric)}
+            __path = f'/{__path_parts["index"]}/_stats/{__path_parts["metric"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_stats"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_stats'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_stats/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_stats/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_stats"
         __query: t.Dict[str, t.Any] = {}
         if completion_fields is not None:
@@ -3992,7 +4422,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4047,7 +4482,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_unfreeze"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_unfreeze'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -4071,7 +4508,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.unfreeze",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4103,6 +4545,8 @@ class IndicesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_aliases"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4123,7 +4567,13 @@ class IndicesClient(NamespacedClient):
                 __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.update_aliases",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4195,9 +4645,12 @@ class IndicesClient(NamespacedClient):
         :param rewrite: If `true`, returns a more detailed explanation showing the actual
             Lucene query that will be executed.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_validate/query"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_validate/query'
         else:
+            __path_parts = {}
             __path = "/_validate/query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4242,5 +4695,11 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.validate_query",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/inference.py
+++ b/elasticsearch/_async/client/inference.py
@@ -48,10 +48,16 @@ class InferenceClient(NamespacedClient):
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -65,7 +71,12 @@ class InferenceClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="inference.delete_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -91,10 +102,16 @@ class InferenceClient(NamespacedClient):
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -108,7 +125,12 @@ class InferenceClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="inference.get_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -143,10 +165,16 @@ class InferenceClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'inference_id'")
         if input is None and body is None:
             raise ValueError("Empty value passed for parameter 'input'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -170,7 +198,13 @@ class InferenceClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.inference",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -207,10 +241,16 @@ class InferenceClient(NamespacedClient):
             )
         elif model_config is not None and body is not None:
             raise ValueError("Cannot set both 'model_config' and 'body'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -229,5 +269,11 @@ class InferenceClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.put_model",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/ingest.py
+++ b/elasticsearch/_async/client/ingest.py
@@ -54,7 +54,9 @@ class IngestClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ingest/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ingest/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -70,7 +72,12 @@ class IngestClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.delete_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -87,6 +94,8 @@ class IngestClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ingest/geoip/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -99,7 +108,12 @@ class IngestClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.geo_ip_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -128,9 +142,12 @@ class IngestClient(NamespacedClient):
             returns an error.
         :param summary: Return pipelines without their definitions (default: false)
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ingest/pipeline/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ingest/pipeline/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_ingest/pipeline"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -147,7 +164,12 @@ class IngestClient(NamespacedClient):
             __query["summary"] = summary
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.get_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -164,6 +186,8 @@ class IngestClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ingest/processor/grok"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -176,7 +200,12 @@ class IngestClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.processor_grok",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -233,7 +262,9 @@ class IngestClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ingest/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ingest/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -263,7 +294,13 @@ class IngestClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ingest.put_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -296,9 +333,12 @@ class IngestClient(NamespacedClient):
         :param verbose: If `true`, the response includes output data for each processor
             in the executed pipeline.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ingest/pipeline/{__path_parts["id"]}/_simulate'
         else:
+            __path_parts = {}
             __path = "/_ingest/pipeline/_simulate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -319,5 +359,11 @@ class IngestClient(NamespacedClient):
                 __body["pipeline"] = pipeline
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ingest.simulate",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -39,6 +39,8 @@ class LicenseClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -51,7 +53,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -77,6 +84,8 @@ class LicenseClient(NamespacedClient):
         :param local: Specifies whether to retrieve local information. The default value
             is `false`, which means the information is retrieved from the master node.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
         if accept_enterprise is not None:
@@ -93,7 +102,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -110,6 +124,8 @@ class LicenseClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/basic_status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -122,7 +138,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.get_basic_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -139,6 +160,8 @@ class LicenseClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/trial_status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -151,7 +174,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.get_trial_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -179,6 +207,8 @@ class LicenseClient(NamespacedClient):
         :param licenses: A sequence of one or more JSON documents containing the license
             information.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -203,7 +233,13 @@ class LicenseClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="license.post",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -224,6 +260,8 @@ class LicenseClient(NamespacedClient):
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/start_basic"
         __query: t.Dict[str, t.Any] = {}
         if acknowledge is not None:
@@ -238,7 +276,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.post_start_basic",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -261,6 +304,8 @@ class LicenseClient(NamespacedClient):
             false)
         :param type_query_string:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/start_trial"
         __query: t.Dict[str, t.Any] = {}
         if acknowledge is not None:
@@ -277,5 +322,10 @@ class LicenseClient(NamespacedClient):
             __query["type_query_string"] = type_query_string
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.post_start_trial",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/logstash.py
+++ b/elasticsearch/_async/client/logstash.py
@@ -44,7 +44,9 @@ class LogstashClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_logstash/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_logstash/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class LogstashClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="logstash.delete_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -76,9 +83,12 @@ class LogstashClient(NamespacedClient):
 
         :param id: Comma-separated list of pipeline identifiers.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_logstash/pipeline/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_logstash/pipeline/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_logstash/pipeline"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -91,7 +101,12 @@ class LogstashClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="logstash.get_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -124,7 +139,9 @@ class LogstashClient(NamespacedClient):
             )
         elif pipeline is not None and body is not None:
             raise ValueError("Cannot set both 'pipeline' and 'body'")
-        __path = f"/_logstash/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_logstash/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -137,5 +154,11 @@ class LogstashClient(NamespacedClient):
         __body = pipeline if pipeline is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="logstash.put_pipeline",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/migration.py
+++ b/elasticsearch/_async/client/migration.py
@@ -45,9 +45,12 @@ class MigrationClient(NamespacedClient):
         :param index: Comma-separate list of data streams or indices to check. Wildcard
             (*) expressions are supported.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_migration/deprecations"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_migration/deprecations'
         else:
+            __path_parts = {}
             __path = "/_migration/deprecations"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -60,7 +63,12 @@ class MigrationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="migration.deprecations",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -77,6 +85,8 @@ class MigrationClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-feature-upgrade.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_migration/system_features"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -89,7 +99,12 @@ class MigrationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="migration.get_feature_upgrade_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -106,6 +121,8 @@ class MigrationClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-feature-upgrade.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_migration/system_features"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -118,5 +135,10 @@ class MigrationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="migration.post_feature_upgrade",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -44,7 +44,11 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/deployment/cache/_clear"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = (
+            f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/cache/_clear'
+        )
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +60,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.clear_trained_model_deployment_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -93,7 +102,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_close"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_close'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -117,7 +128,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.close_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -139,7 +156,9 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -151,7 +170,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_calendar",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -178,7 +202,12 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if event_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'event_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/events/{_quote(event_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "calendar_id": _quote(calendar_id),
+            "event_id": _quote(event_id),
+        }
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/events/{__path_parts["event_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -190,7 +219,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_calendar_event",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -217,7 +251,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/jobs/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id), "job_id": _quote(job_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/jobs/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -229,7 +265,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_calendar_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -256,7 +297,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -272,7 +315,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -300,7 +348,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -314,7 +364,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -344,9 +399,12 @@ class MlClient(NamespacedClient):
         :param timeout: How long can the underlying delete processes run until they are
             canceled.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/_delete_expired_data/{_quote(job_id)}"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/_delete_expired_data/{__path_parts["job_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/_delete_expired_data"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -369,7 +427,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.delete_expired_data",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -391,7 +455,9 @@ class MlClient(NamespacedClient):
         """
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
-        __path = f"/_ml/filters/{_quote(filter_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"filter_id": _quote(filter_id)}
+        __path = f'/_ml/filters/{__path_parts["filter_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -403,7 +469,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_filter",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -438,10 +509,16 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and forecast_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast/{_quote(forecast_id)}"
+            __path_parts = {
+                "job_id": _quote(job_id),
+                "forecast_id": _quote(forecast_id),
+            }
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_forecast/{__path_parts["forecast_id"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_forecast'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -459,7 +536,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_forecast",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -491,7 +573,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if delete_user_annotations is not None:
             __query["delete_user_annotations"] = delete_user_annotations
@@ -509,7 +593,12 @@ class MlClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -535,7 +624,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -547,7 +638,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_model_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -573,7 +669,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -587,7 +685,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_trained_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -613,7 +716,12 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if model_alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_alias'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/model_aliases/{_quote(model_alias)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "model_id": _quote(model_id),
+            "model_alias": _quote(model_alias),
+        }
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/model_aliases/{__path_parts["model_alias"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -625,7 +733,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_trained_model_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -667,6 +780,8 @@ class MlClient(NamespacedClient):
             from the request if no detectors have a `by_field_name`, `over_field_name`
             or `partition_field_name`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/anomaly_detectors/_estimate_model_memory"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -687,7 +802,13 @@ class MlClient(NamespacedClient):
                 __body["overall_cardinality"] = overall_cardinality
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.estimate_model_memory",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -719,6 +840,8 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'evaluation'")
         if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/data_frame/_evaluate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -739,7 +862,13 @@ class MlClient(NamespacedClient):
                 __body["query"] = query
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.evaluate_data_frame",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -805,9 +934,12 @@ class MlClient(NamespacedClient):
         :param source: The configuration of how to source the analysis data. It requires
             an index. Optionally, query and _source may be specified.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}/_explain"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_explain'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics/_explain"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -842,7 +974,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.explain_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -877,7 +1015,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_flush"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_flush'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -905,7 +1045,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.flush_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -938,7 +1084,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_forecast'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -962,7 +1110,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.forecast",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1022,10 +1176,13 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and timestamp not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/buckets/{_quote(timestamp)}"
+            __path_parts = {"job_id": _quote(job_id), "timestamp": _quote(timestamp)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/buckets/{__path_parts["timestamp"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/buckets"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/buckets'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1065,7 +1222,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_buckets",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1103,7 +1266,9 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/events'
         __query: t.Dict[str, t.Any] = {}
         if end is not None:
             __query["end"] = end
@@ -1125,7 +1290,12 @@ class MlClient(NamespacedClient):
             __query["start"] = start
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_calendar_events",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1160,9 +1330,12 @@ class MlClient(NamespacedClient):
         :param size: Specifies the maximum number of calendars to obtain. This parameter
             is supported only when you omit the calendar identifier.
         """
+        __path_parts: t.Dict[str, str]
         if calendar_id not in SKIP_IN_PATH:
-            __path = f"/_ml/calendars/{_quote(calendar_id)}"
+            __path_parts = {"calendar_id": _quote(calendar_id)}
+            __path = f'/_ml/calendars/{__path_parts["calendar_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/calendars"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1187,7 +1360,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_calendars",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1227,10 +1406,18 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and category_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/categories/{_quote(category_id)}"
+            __path_parts = {
+                "job_id": _quote(job_id),
+                "category_id": _quote(category_id),
+            }
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/categories/{__path_parts["category_id"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/categories"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = (
+                f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/categories'
+            )
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1258,7 +1445,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_categories",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1299,9 +1492,12 @@ class MlClient(NamespacedClient):
         :param from_: Skips the specified number of data frame analytics jobs.
         :param size: Specifies the maximum number of data frame analytics jobs to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1322,7 +1518,12 @@ class MlClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1361,9 +1562,12 @@ class MlClient(NamespacedClient):
         :param size: Specifies the maximum number of data frame analytics jobs to obtain.
         :param verbose: Defines whether the stats response should be verbose.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}/_stats"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1384,7 +1588,12 @@ class MlClient(NamespacedClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_data_frame_analytics_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1414,9 +1623,12 @@ class MlClient(NamespacedClient):
             when there are partial matches. If this parameter is `false`, the request
             returns a `404` status code when there are no matches or only partial matches.
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stats"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/datafeeds/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1431,7 +1643,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_datafeed_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1465,9 +1682,12 @@ class MlClient(NamespacedClient):
             the configuration on retrieval. This allows the configuration to be in an
             acceptable format to be retrieved and then added to another cluster.
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/datafeeds"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1484,7 +1704,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_datafeeds",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1510,9 +1735,12 @@ class MlClient(NamespacedClient):
         :param from_: Skips the specified number of filters.
         :param size: Specifies the maximum number of filters to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if filter_id not in SKIP_IN_PATH:
-            __path = f"/_ml/filters/{_quote(filter_id)}"
+            __path_parts = {"filter_id": _quote(filter_id)}
+            __path = f'/_ml/filters/{__path_parts["filter_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/filters"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1529,7 +1757,12 @@ class MlClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_filters",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1579,7 +1812,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/influencers"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/influencers'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if desc is not None:
@@ -1615,7 +1850,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_influencers",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1646,9 +1887,12 @@ class MlClient(NamespacedClient):
             partial matches. If `false`, the API returns a `404` status code when there
             are no matches or only partial matches.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_stats"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/anomaly_detectors/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1663,7 +1907,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_job_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1697,9 +1946,12 @@ class MlClient(NamespacedClient):
             the configuration on retrieval. This allows the configuration to be in an
             acceptable format to be retrieved and then added to another cluster.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/anomaly_detectors"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1716,7 +1968,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_jobs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1746,9 +2003,12 @@ class MlClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_ml/memory/{_quote(node_id)}/_stats"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_ml/memory/{__path_parts["node_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/memory/_stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1765,7 +2025,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_memory_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1803,7 +2068,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_upgrade/_stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_upgrade/_stats'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -1817,7 +2084,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_model_snapshot_upgrade_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1863,10 +2135,16 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and snapshot_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}"
+            __path_parts = {
+                "job_id": _quote(job_id),
+                "snapshot_id": _quote(snapshot_id),
+            }
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1900,7 +2178,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_model_snapshots",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1954,7 +2238,11 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/overall_buckets"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = (
+            f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/overall_buckets'
+        )
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -1986,7 +2274,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_overall_buckets",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2039,7 +2333,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/records"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/records'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2075,7 +2371,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_records",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2127,9 +2429,12 @@ class MlClient(NamespacedClient):
             tags, or none. When supplied, only trained models that contain all the supplied
             tags are returned.
         """
+        __path_parts: t.Dict[str, str]
         if model_id not in SKIP_IN_PATH:
-            __path = f"/_ml/trained_models/{_quote(model_id)}"
+            __path_parts = {"model_id": _quote(model_id)}
+            __path = f'/_ml/trained_models/{__path_parts["model_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/trained_models"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -2156,7 +2461,12 @@ class MlClient(NamespacedClient):
             __query["tags"] = tags
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_trained_models",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2189,9 +2499,12 @@ class MlClient(NamespacedClient):
         :param from_: Skips the specified number of models.
         :param size: Specifies the maximum number of models to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if model_id not in SKIP_IN_PATH:
-            __path = f"/_ml/trained_models/{_quote(model_id)}/_stats"
+            __path_parts = {"model_id": _quote(model_id)}
+            __path = f'/_ml/trained_models/{__path_parts["model_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/trained_models/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -2210,7 +2523,12 @@ class MlClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_trained_models_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2247,7 +2565,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if docs is None and body is None:
             raise ValueError("Empty value passed for parameter 'docs'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/_infer"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/_infer'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2267,7 +2587,13 @@ class MlClient(NamespacedClient):
                 __body["inference_config"] = inference_config
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.infer_trained_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2284,6 +2610,8 @@ class MlClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/info"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2296,7 +2624,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2323,7 +2656,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_open"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_open'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2343,7 +2678,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.open_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2374,7 +2715,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if events is None and body is None:
             raise ValueError("Empty value passed for parameter 'events'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/events'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2390,7 +2733,13 @@ class MlClient(NamespacedClient):
                 __body["events"] = events
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.post_calendar_events",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2428,7 +2777,9 @@ class MlClient(NamespacedClient):
             )
         elif data is not None and body is not None:
             raise ValueError("Cannot set both 'data' and 'body'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_data"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_data'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2448,7 +2799,13 @@ class MlClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.post_data",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2475,9 +2832,12 @@ class MlClient(NamespacedClient):
             analytics jobs. Note that `id` and `dest` don’t need to be provided in the
             context of this API.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}/_preview"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_preview'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics/_preview"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2498,7 +2858,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.preview_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2538,9 +2904,12 @@ class MlClient(NamespacedClient):
             object unless you also supply a `datafeed_config` object.
         :param start: The start time from where the datafeed preview should begin
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_preview"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_preview'
         else:
+            __path_parts = {}
             __path = "/_ml/datafeeds/_preview"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2567,7 +2936,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.preview_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2596,7 +2971,9 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2618,7 +2995,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_calendar",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2645,7 +3028,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/jobs/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id), "job_id": _quote(job_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/jobs/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2657,7 +3042,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.put_calendar_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2763,7 +3153,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'dest'")
         if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2797,7 +3189,13 @@ class MlClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2932,7 +3330,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -2984,7 +3384,13 @@ class MlClient(NamespacedClient):
                 __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3014,7 +3420,9 @@ class MlClient(NamespacedClient):
         """
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
-        __path = f"/_ml/filters/{_quote(filter_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"filter_id": _quote(filter_id)}
+        __path = f'/_ml/filters/{__path_parts["filter_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3032,7 +3440,13 @@ class MlClient(NamespacedClient):
                 __body["items"] = items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_filter",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3165,7 +3579,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'analysis_config'")
         if data_description is None and body is None:
             raise ValueError("Empty value passed for parameter 'data_description'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3211,7 +3627,13 @@ class MlClient(NamespacedClient):
                 __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3288,7 +3710,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_definition_decompression is not None:
@@ -3324,7 +3748,13 @@ class MlClient(NamespacedClient):
                 __body["tags"] = tags
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_trained_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3355,7 +3785,12 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if model_alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_alias'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/model_aliases/{_quote(model_alias)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "model_id": _quote(model_id),
+            "model_alias": _quote(model_alias),
+        }
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/model_aliases/{__path_parts["model_alias"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3369,7 +3804,12 @@ class MlClient(NamespacedClient):
             __query["reassign"] = reassign
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.put_trained_model_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3417,7 +3857,9 @@ class MlClient(NamespacedClient):
             )
         if total_parts is None and body is None:
             raise ValueError("Empty value passed for parameter 'total_parts'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/definition/{_quote(part)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id), "part": _quote(part)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/definition/{__path_parts["part"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3437,7 +3879,13 @@ class MlClient(NamespacedClient):
                 __body["total_parts"] = total_parts
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_trained_model_definition_part",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3470,7 +3918,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if vocabulary is None and body is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/vocabulary'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3490,7 +3940,13 @@ class MlClient(NamespacedClient):
                 __body["scores"] = scores
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_trained_model_vocabulary",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3519,7 +3975,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_reset"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_reset'
         __query: t.Dict[str, t.Any] = {}
         if delete_user_annotations is not None:
             __query["delete_user_annotations"] = delete_user_annotations
@@ -3535,7 +3993,12 @@ class MlClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.reset_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3569,7 +4032,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_revert"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_revert'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3589,7 +4054,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.revert_model_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3614,6 +4085,8 @@ class MlClient(NamespacedClient):
             starting.
         :param timeout: The time to wait for the request to be completed.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/set_upgrade_mode"
         __query: t.Dict[str, t.Any] = {}
         if enabled is not None:
@@ -3630,7 +4103,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.set_upgrade_mode",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3657,7 +4135,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3671,7 +4151,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.start_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3705,7 +4190,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3729,7 +4216,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.start_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3785,7 +4278,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/deployment/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/_start'
         __query: t.Dict[str, t.Any] = {}
         if cache_size is not None:
             __query["cache_size"] = cache_size
@@ -3813,7 +4308,12 @@ class MlClient(NamespacedClient):
             __query["wait_for"] = wait_for
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.start_trained_model_deployment",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3851,7 +4351,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -3869,7 +4371,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.stop_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3904,7 +4411,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3928,7 +4437,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.stop_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3961,7 +4476,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/deployment/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/_stop'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -3977,7 +4494,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.stop_trained_model_deployment",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4025,7 +4547,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4047,7 +4571,13 @@ class MlClient(NamespacedClient):
                 __body["model_memory_limit"] = model_memory_limit
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4190,7 +4720,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -4240,7 +4772,13 @@ class MlClient(NamespacedClient):
                 __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4271,7 +4809,9 @@ class MlClient(NamespacedClient):
         """
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
-        __path = f"/_ml/filters/{_quote(filter_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"filter_id": _quote(filter_id)}
+        __path = f'/_ml/filters/{__path_parts["filter_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4291,7 +4831,13 @@ class MlClient(NamespacedClient):
                 __body["remove_items"] = remove_items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_filter",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4398,7 +4944,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4444,7 +4992,13 @@ class MlClient(NamespacedClient):
                 __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4479,7 +5033,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4497,7 +5053,13 @@ class MlClient(NamespacedClient):
                 __body["retain"] = retain
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_model_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4530,7 +5092,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_upgrade"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_upgrade'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -4546,7 +5110,12 @@ class MlClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.upgrade_job_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4595,6 +5164,8 @@ class MlClient(NamespacedClient):
         :param model_snapshot_retention_days:
         :param results_index_name:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/anomaly_detectors/_validate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4627,7 +5198,13 @@ class MlClient(NamespacedClient):
                 __body["results_index_name"] = results_index_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.validate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4656,6 +5233,8 @@ class MlClient(NamespacedClient):
             )
         elif detector is not None and body is not None:
             raise ValueError("Cannot set both 'detector' and 'body'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/anomaly_detectors/_validate/detector"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -4669,5 +5248,11 @@ class MlClient(NamespacedClient):
         __body = detector if detector is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.validate_detector",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/monitoring.py
+++ b/elasticsearch/_async/client/monitoring.py
@@ -63,6 +63,8 @@ class MonitoringClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'system_api_version'")
         if system_id is None:
             raise ValueError("Empty value passed for parameter 'system_id'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_monitoring/bulk"
         __query: t.Dict[str, t.Any] = {}
         if interval is not None:
@@ -85,5 +87,11 @@ class MonitoringClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="monitoring.bulk",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/nodes.py
+++ b/elasticsearch/_async/client/nodes.py
@@ -50,7 +50,12 @@ class NodesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'node_id'")
         if max_archive_version in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'max_archive_version'")
-        __path = f"/_nodes/{_quote(node_id)}/_repositories_metering/{_quote(max_archive_version)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "node_id": _quote(node_id),
+            "max_archive_version": _quote(max_archive_version),
+        }
+        __path = f'/_nodes/{__path_parts["node_id"]}/_repositories_metering/{__path_parts["max_archive_version"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -62,7 +67,12 @@ class NodesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.clear_repositories_metering_archive",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -85,7 +95,9 @@ class NodesClient(NamespacedClient):
         """
         if node_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'node_id'")
-        __path = f"/_nodes/{_quote(node_id)}/_repositories_metering"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"node_id": _quote(node_id)}
+        __path = f'/_nodes/{__path_parts["node_id"]}/_repositories_metering'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -97,7 +109,12 @@ class NodesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.get_repositories_metering_info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -143,9 +160,12 @@ class NodesClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         :param type: The type to sample.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/hot_threads"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/hot_threads'
         else:
+            __path_parts = {}
             __path = "/_nodes/hot_threads"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -174,7 +194,12 @@ class NodesClient(NamespacedClient):
             __query["type"] = type
         __headers = {"accept": "text/plain"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.hot_threads",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -209,13 +234,18 @@ class NodesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/{_quote(metric)}"
+            __path_parts = {"node_id": _quote(node_id), "metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/{__path_parts["metric"]}'
         elif node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_nodes"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -234,7 +264,12 @@ class NodesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -262,9 +297,12 @@ class NodesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/reload_secure_settings"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/reload_secure_settings'
         else:
+            __path_parts = {}
             __path = "/_nodes/reload_secure_settings"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -287,7 +325,13 @@ class NodesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="nodes.reload_secure_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -350,21 +394,37 @@ class NodesClient(NamespacedClient):
         :param types: A comma-separated list of document types for the indexing index
             metric.
         """
+        __path_parts: t.Dict[str, str]
         if (
             node_id not in SKIP_IN_PATH
             and metric not in SKIP_IN_PATH
             and index_metric not in SKIP_IN_PATH
         ):
-            __path = f"/_nodes/{_quote(node_id)}/stats/{_quote(metric)}/{_quote(index_metric)}"
+            __path_parts = {
+                "node_id": _quote(node_id),
+                "metric": _quote(metric),
+                "index_metric": _quote(index_metric),
+            }
+            __path = f'/_nodes/{__path_parts["node_id"]}/stats/{__path_parts["metric"]}/{__path_parts["index_metric"]}'
         elif node_id not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/stats/{_quote(metric)}"
+            __path_parts = {"node_id": _quote(node_id), "metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/stats/{__path_parts["metric"]}'
         elif metric not in SKIP_IN_PATH and index_metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/stats/{_quote(metric)}/{_quote(index_metric)}"
+            __path_parts = {
+                "metric": _quote(metric),
+                "index_metric": _quote(index_metric),
+            }
+            __path = (
+                f'/_nodes/stats/{__path_parts["metric"]}/{__path_parts["index_metric"]}'
+            )
         elif node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/stats"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/stats'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/stats/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_nodes/stats/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_nodes/stats"
         __query: t.Dict[str, t.Any] = {}
         if completion_fields is not None:
@@ -397,7 +457,12 @@ class NodesClient(NamespacedClient):
             __query["types"] = types
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -425,13 +490,18 @@ class NodesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/usage/{_quote(metric)}"
+            __path_parts = {"node_id": _quote(node_id), "metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/usage/{__path_parts["metric"]}'
         elif node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/usage"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/usage'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/usage/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_nodes/usage/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_nodes/usage"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -446,5 +516,10 @@ class NodesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.usage",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/query_ruleset.py
+++ b/elasticsearch/_async/client/query_ruleset.py
@@ -44,7 +44,9 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ruleset_id": _quote(ruleset_id)}
+        __path = f'/_query_rules/{__path_parts["ruleset_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class QueryRulesetClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="query_ruleset.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -78,7 +85,9 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ruleset_id": _quote(ruleset_id)}
+        __path = f'/_query_rules/{__path_parts["ruleset_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -90,7 +99,12 @@ class QueryRulesetClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="query_ruleset.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -114,6 +128,8 @@ class QueryRulesetClient(NamespacedClient):
         :param from_: Starting offset (default: 0)
         :param size: specifies a max number of results to get
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_query_rules"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -130,7 +146,12 @@ class QueryRulesetClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="query_ruleset.list",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -160,7 +181,9 @@ class QueryRulesetClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
         if rules is None and body is None:
             raise ValueError("Empty value passed for parameter 'rules'")
-        __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ruleset_id": _quote(ruleset_id)}
+        __path = f'/_query_rules/{__path_parts["ruleset_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -176,5 +199,11 @@ class QueryRulesetClient(NamespacedClient):
                 __body["rules"] = rules
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="query_ruleset.put",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/rollup.py
+++ b/elasticsearch/_async/client/rollup.py
@@ -44,7 +44,9 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_rollup/job/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.delete_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -77,9 +84,12 @@ class RollupClient(NamespacedClient):
         :param id: Identifier for the rollup job. If it is `_all` or omitted, the API
             returns all rollup jobs.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_rollup/job/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_rollup/job/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_rollup/job"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -92,7 +102,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.get_jobs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -114,9 +129,12 @@ class RollupClient(NamespacedClient):
         :param id: Index, indices or index-pattern to return rollup capabilities for.
             `_all` may be used to fetch rollup capabilities from all jobs.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_rollup/data/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_rollup/data/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_rollup/data"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -129,7 +147,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.get_rollup_caps",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -153,7 +176,9 @@ class RollupClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_rollup/data"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_rollup/data'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -165,7 +190,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.get_rollup_index_caps",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -256,7 +286,9 @@ class RollupClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'page_size'")
         if rollup_index is None and body is None:
             raise ValueError("Empty value passed for parameter 'rollup_index'")
-        __path = f"/_rollup/job/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -286,7 +318,13 @@ class RollupClient(NamespacedClient):
                 __body["timeout"] = timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="rollup.put_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -325,7 +363,9 @@ class RollupClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_rollup_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_rollup_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -351,7 +391,13 @@ class RollupClient(NamespacedClient):
                 __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="rollup.rollup_search",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -373,7 +419,9 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_rollup/job/{_quote(id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -385,7 +433,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.start_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -415,7 +468,9 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_rollup/job/{_quote(id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -431,5 +486,10 @@ class RollupClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.stop_job",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/search_application.py
+++ b/elasticsearch/_async/client/search_application.py
@@ -44,7 +44,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -78,7 +85,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/analytics/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -90,7 +99,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.delete_behavioral_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -112,7 +126,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -124,7 +140,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -144,9 +165,12 @@ class SearchApplicationClient(NamespacedClient):
 
         :param name: A list of analytics collections to limit the returned information
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_application/analytics/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_application/analytics/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_application/analytics"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -159,7 +183,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.get_behavioral_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -185,6 +214,8 @@ class SearchApplicationClient(NamespacedClient):
         :param q: Query in the Lucene query string syntax.
         :param size: Specifies a max number of results to get.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_application/search_application"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -203,7 +234,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.list",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -239,7 +275,9 @@ class SearchApplicationClient(NamespacedClient):
             )
         elif search_application is not None and body is not None:
             raise ValueError("Cannot set both 'search_application' and 'body'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
             __query["create"] = create
@@ -254,7 +292,13 @@ class SearchApplicationClient(NamespacedClient):
         __body = search_application if search_application is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_application.put",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -276,7 +320,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/analytics/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -288,7 +334,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.put_behavioral_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -317,7 +368,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}/_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}/_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -337,5 +390,11 @@ class SearchApplicationClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_application.search",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/searchable_snapshots.py
+++ b/elasticsearch/_async/client/searchable_snapshots.py
@@ -48,9 +48,12 @@ class SearchableSnapshotsClient(NamespacedClient):
             to, leave empty to get information from all nodes
         :param master_timeout:
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_searchable_snapshots/{_quote(node_id)}/cache/stats"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_searchable_snapshots/{__path_parts["node_id"]}/cache/stats'
         else:
+            __path_parts = {}
             __path = "/_searchable_snapshots/cache/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -65,7 +68,12 @@ class SearchableSnapshotsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="searchable_snapshots.cache_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -102,9 +110,12 @@ class SearchableSnapshotsClient(NamespacedClient):
         :param ignore_unavailable: Whether specified concrete indices should be ignored
             when unavailable (missing or closed)
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_searchable_snapshots/cache/clear"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_searchable_snapshots/cache/clear'
         else:
+            __path_parts = {}
             __path = "/_searchable_snapshots/cache/clear"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -123,7 +134,12 @@ class SearchableSnapshotsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="searchable_snapshots.clear_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -178,7 +194,11 @@ class SearchableSnapshotsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_mount"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = (
+            f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_mount'
+        )
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -206,7 +226,13 @@ class SearchableSnapshotsClient(NamespacedClient):
                 __body["renamed_index"] = renamed_index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="searchable_snapshots.mount",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -230,9 +256,12 @@ class SearchableSnapshotsClient(NamespacedClient):
         :param index: A comma-separated list of index names
         :param level: Return stats aggregated at cluster, index or shard level
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_searchable_snapshots/stats"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_searchable_snapshots/stats'
         else:
+            __path_parts = {}
             __path = "/_searchable_snapshots/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -247,5 +276,10 @@ class SearchableSnapshotsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="searchable_snapshots.stats",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -55,6 +55,8 @@ class SecurityClient(NamespacedClient):
         """
         if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/profile/_activate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -77,7 +79,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.activate_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -95,6 +103,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/_authenticate"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -107,7 +117,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.authenticate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -145,9 +160,12 @@ class SecurityClient(NamespacedClient):
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
         """
+        __path_parts: t.Dict[str, str]
         if username not in SKIP_IN_PATH:
-            __path = f"/_security/user/{_quote(username)}/_password"
+            __path_parts = {"username": _quote(username)}
+            __path = f'/_security/user/{__path_parts["username"]}/_password'
         else:
+            __path_parts = {}
             __path = "/_security/user/_password"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -168,7 +186,13 @@ class SecurityClient(NamespacedClient):
                 __body["password_hash"] = password_hash
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.change_password",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -191,7 +215,9 @@ class SecurityClient(NamespacedClient):
         """
         if ids in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ids'")
-        __path = f"/_security/api_key/{_quote(ids)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ids": _quote(ids)}
+        __path = f'/_security/api_key/{__path_parts["ids"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -203,7 +229,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_api_key_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -225,7 +256,9 @@ class SecurityClient(NamespacedClient):
         """
         if application in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'application'")
-        __path = f"/_security/privilege/{_quote(application)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"application": _quote(application)}
+        __path = f'/_security/privilege/{__path_parts["application"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -237,7 +270,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -262,7 +300,9 @@ class SecurityClient(NamespacedClient):
         """
         if realms in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'realms'")
-        __path = f"/_security/realm/{_quote(realms)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"realms": _quote(realms)}
+        __path = f'/_security/realm/{__path_parts["realms"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -276,7 +316,12 @@ class SecurityClient(NamespacedClient):
             __query["usernames"] = usernames
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_realms",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -298,7 +343,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role/{_quote(name)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role/{__path_parts["name"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -310,7 +357,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_roles",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -340,7 +392,13 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'service'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token/{_quote(name)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "namespace": _quote(namespace),
+            "service": _quote(service),
+            "name": _quote(name),
+        }
+        __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token/{__path_parts["name"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -352,7 +410,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_service_tokens",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -397,6 +460,8 @@ class SecurityClient(NamespacedClient):
             is the same as the request for create role API. For more details, see create
             or update roles API.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -421,7 +486,13 @@ class SecurityClient(NamespacedClient):
                 __body["role_descriptors"] = role_descriptors
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.create_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -455,15 +526,22 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'namespace'")
         if service in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'service'")
+        __path_parts: t.Dict[str, str]
         if (
             namespace not in SKIP_IN_PATH
             and service not in SKIP_IN_PATH
             and name not in SKIP_IN_PATH
         ):
-            __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token/{_quote(name)}"
+            __path_parts = {
+                "namespace": _quote(namespace),
+                "service": _quote(service),
+                "name": _quote(name),
+            }
+            __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token/{__path_parts["name"]}'
             __method = "PUT"
         elif namespace not in SKIP_IN_PATH and service not in SKIP_IN_PATH:
-            __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token"
+            __path_parts = {"namespace": _quote(namespace), "service": _quote(service)}
+            __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token'
             __method = "POST"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
@@ -480,7 +558,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            __method, __path, params=__query, headers=__headers
+            __method,
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.create_service_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -512,7 +595,11 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'application'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/privilege/{_quote(application)}/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"application": _quote(application), "name": _quote(name)}
+        __path = (
+            f'/_security/privilege/{__path_parts["application"]}/{__path_parts["name"]}'
+        )
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -526,7 +613,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -554,7 +646,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -568,7 +662,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_role",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -596,7 +695,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role_mapping/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role_mapping/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -610,7 +711,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_role_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -646,7 +752,13 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'service'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "namespace": _quote(namespace),
+            "service": _quote(service),
+            "name": _quote(name),
+        }
+        __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -660,7 +772,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_service_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -688,7 +805,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -702,7 +821,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -730,7 +854,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}/_disable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}/_disable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -744,7 +870,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.disable_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -772,7 +903,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}/_disable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}/_disable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -786,7 +919,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.disable_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -814,7 +952,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}/_enable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}/_enable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -828,7 +968,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enable_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -856,7 +1001,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}/_enable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}/_enable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -870,7 +1017,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enable_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -888,6 +1040,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/enroll/kibana"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -900,7 +1054,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enroll_kibana",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -917,6 +1076,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/enroll/node"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -929,7 +1090,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enroll_node",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -974,6 +1140,8 @@ class SecurityClient(NamespacedClient):
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
         if active_only is not None:
@@ -1000,7 +1168,12 @@ class SecurityClient(NamespacedClient):
             __query["with_limited_by"] = with_limited_by
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1018,6 +1191,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/privilege/_builtin"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1030,7 +1205,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_builtin_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1052,11 +1232,15 @@ class SecurityClient(NamespacedClient):
         :param application: Application name
         :param name: Privilege name
         """
+        __path_parts: t.Dict[str, str]
         if application not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/_security/privilege/{_quote(application)}/{_quote(name)}"
+            __path_parts = {"application": _quote(application), "name": _quote(name)}
+            __path = f'/_security/privilege/{__path_parts["application"]}/{__path_parts["name"]}'
         elif application not in SKIP_IN_PATH:
-            __path = f"/_security/privilege/{_quote(application)}"
+            __path_parts = {"application": _quote(application)}
+            __path = f'/_security/privilege/{__path_parts["application"]}'
         else:
+            __path_parts = {}
             __path = "/_security/privilege"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1069,7 +1253,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1091,9 +1280,12 @@ class SecurityClient(NamespacedClient):
             list. If you do not specify this parameter, the API returns information about
             all roles.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_security/role/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_security/role/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_security/role"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1106,7 +1298,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_role",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1130,9 +1327,12 @@ class SecurityClient(NamespacedClient):
             mapping names as a comma-separated list. If you do not specify this parameter,
             the API returns information about all role mappings.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_security/role_mapping/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_security/role_mapping/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_security/role_mapping"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1145,7 +1345,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_role_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1170,11 +1375,15 @@ class SecurityClient(NamespacedClient):
         :param service: Name of the service name. Omit this parameter to retrieve information
             about all service accounts that belong to the specified `namespace`.
         """
+        __path_parts: t.Dict[str, str]
         if namespace not in SKIP_IN_PATH and service not in SKIP_IN_PATH:
-            __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}"
+            __path_parts = {"namespace": _quote(namespace), "service": _quote(service)}
+            __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}'
         elif namespace not in SKIP_IN_PATH:
-            __path = f"/_security/service/{_quote(namespace)}"
+            __path_parts = {"namespace": _quote(namespace)}
+            __path = f'/_security/service/{__path_parts["namespace"]}'
         else:
+            __path_parts = {}
             __path = "/_security/service"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1187,7 +1396,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_service_accounts",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1213,7 +1427,9 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'namespace'")
         if service in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'service'")
-        __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"namespace": _quote(namespace), "service": _quote(service)}
+        __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1225,7 +1441,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_service_credentials",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1270,6 +1491,8 @@ class SecurityClient(NamespacedClient):
         :param scope:
         :param username:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1296,7 +1519,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.get_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1321,9 +1550,12 @@ class SecurityClient(NamespacedClient):
         :param with_profile_uid: If true will return the User Profile ID for a user,
             if any.
         """
+        __path_parts: t.Dict[str, str]
         if username not in SKIP_IN_PATH:
-            __path = f"/_security/user/{_quote(username)}"
+            __path_parts = {"username": _quote(username)}
+            __path = f'/_security/user/{__path_parts["username"]}'
         else:
+            __path_parts = {}
             __path = "/_security/user"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1338,7 +1570,12 @@ class SecurityClient(NamespacedClient):
             __query["with_profile_uid"] = with_profile_uid
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1365,6 +1602,8 @@ class SecurityClient(NamespacedClient):
             the API returns information about all privileges for the requested application.
         :param username:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/user/_privileges"
         __query: t.Dict[str, t.Any] = {}
         if application is not None:
@@ -1383,7 +1622,12 @@ class SecurityClient(NamespacedClient):
             __query["username"] = username
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_user_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1410,7 +1654,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}'
         __query: t.Dict[str, t.Any] = {}
         if data is not None:
             __query["data"] = data
@@ -1424,7 +1670,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1477,6 +1728,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'api_key'")
         if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key/grant"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1503,7 +1756,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.grant_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1539,9 +1798,12 @@ class SecurityClient(NamespacedClient):
         :param cluster: A list of the cluster privileges that you want to check.
         :param index:
         """
+        __path_parts: t.Dict[str, str]
         if user not in SKIP_IN_PATH:
-            __path = f"/_security/user/{_quote(user)}/_has_privileges"
+            __path_parts = {"user": _quote(user)}
+            __path = f'/_security/user/{__path_parts["user"]}/_has_privileges'
         else:
+            __path_parts = {}
             __path = "/_security/user/_has_privileges"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1562,7 +1824,13 @@ class SecurityClient(NamespacedClient):
                 __body["index"] = index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.has_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1593,6 +1861,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'privileges'")
         if uids is None and body is None:
             raise ValueError("Empty value passed for parameter 'uids'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/profile/_has_privileges"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1611,7 +1881,13 @@ class SecurityClient(NamespacedClient):
                 __body["uids"] = uids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.has_privileges_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1651,6 +1927,8 @@ class SecurityClient(NamespacedClient):
         :param username: The username of a user. This parameter cannot be used with either
             `ids` or `name`, or when `owner` flag is set to `true`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1677,7 +1955,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.invalidate_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1706,6 +1990,8 @@ class SecurityClient(NamespacedClient):
         :param token:
         :param username:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1728,7 +2014,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.invalidate_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1765,6 +2057,8 @@ class SecurityClient(NamespacedClient):
             )
         elif privileges is not None and body is not None:
             raise ValueError("Cannot set both 'privileges' and 'body'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/privilege"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1780,7 +2074,13 @@ class SecurityClient(NamespacedClient):
         __body = privileges if privileges is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1850,7 +2150,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -1880,7 +2182,13 @@ class SecurityClient(NamespacedClient):
                 __body["transient_metadata"] = transient_metadata
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_role",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1930,7 +2238,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role_mapping/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role_mapping/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -1958,7 +2268,13 @@ class SecurityClient(NamespacedClient):
                 __body["run_as"] = run_as
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_role_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2012,7 +2328,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2042,7 +2360,13 @@ class SecurityClient(NamespacedClient):
                 __body["roles"] = roles
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2094,6 +2418,8 @@ class SecurityClient(NamespacedClient):
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/_query/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2135,7 +2461,13 @@ class SecurityClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.query_api_keys",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2170,6 +2502,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'content'")
         if ids is None and body is None:
             raise ValueError("Empty value passed for parameter 'ids'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/authenticate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2190,7 +2524,13 @@ class SecurityClient(NamespacedClient):
                 __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_authenticate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2228,6 +2568,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'ids'")
         if realm is None and body is None:
             raise ValueError("Empty value passed for parameter 'realm'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/complete_logout"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2250,7 +2592,13 @@ class SecurityClient(NamespacedClient):
                 __body["query_string"] = query_string
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_complete_logout",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2291,6 +2639,8 @@ class SecurityClient(NamespacedClient):
         """
         if query_string is None and body is None:
             raise ValueError("Empty value passed for parameter 'query_string'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/invalidate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2311,7 +2661,13 @@ class SecurityClient(NamespacedClient):
                 __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_invalidate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2343,6 +2699,8 @@ class SecurityClient(NamespacedClient):
         """
         if token is None and body is None:
             raise ValueError("Empty value passed for parameter 'token'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/logout"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2361,7 +2719,13 @@ class SecurityClient(NamespacedClient):
                 __body["refresh_token"] = refresh_token
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_logout",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2394,6 +2758,8 @@ class SecurityClient(NamespacedClient):
             API returns as the RelayState query parameter. If the Authentication Request
             is signed, this value is used as part of the signature computation.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/prepare"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2414,7 +2780,13 @@ class SecurityClient(NamespacedClient):
                 __body["relay_state"] = relay_state
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_prepare_authentication",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2436,7 +2808,9 @@ class SecurityClient(NamespacedClient):
         """
         if realm_name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'realm_name'")
-        __path = f"/_security/saml/metadata/{_quote(realm_name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"realm_name": _quote(realm_name)}
+        __path = f'/_security/saml/metadata/{__path_parts["realm_name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2448,7 +2822,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.saml_service_provider_metadata",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2484,6 +2863,8 @@ class SecurityClient(NamespacedClient):
             Name-related fields are the user's `username`, `full_name`, and `email`.
         :param size: Number of profiles to return.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/profile/_suggest"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2510,7 +2891,13 @@ class SecurityClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.suggest_user_profiles",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2550,7 +2937,9 @@ class SecurityClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_security/api_key/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_security/api_key/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2574,7 +2963,13 @@ class SecurityClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.update_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2617,7 +3012,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}/_data"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}/_data'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2641,5 +3038,11 @@ class SecurityClient(NamespacedClient):
                 __body["labels"] = labels
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.update_user_profile_data",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/shutdown.py
+++ b/elasticsearch/_async/client/shutdown.py
@@ -56,7 +56,9 @@ class ShutdownClient(NamespacedClient):
         """
         if node_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'node_id'")
-        __path = f"/_nodes/{_quote(node_id)}/shutdown"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"node_id": _quote(node_id)}
+        __path = f'/_nodes/{__path_parts["node_id"]}/shutdown'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -72,7 +74,12 @@ class ShutdownClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="shutdown.delete_node",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -104,9 +111,12 @@ class ShutdownClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/shutdown"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/shutdown'
         else:
+            __path_parts = {}
             __path = "/_nodes/shutdown"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -123,7 +133,12 @@ class ShutdownClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="shutdown.get_node",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -196,7 +211,9 @@ class ShutdownClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'reason'")
         if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
-        __path = f"/_nodes/{_quote(node_id)}/shutdown"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"node_id": _quote(node_id)}
+        __path = f'/_nodes/{__path_parts["node_id"]}/shutdown'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -222,5 +239,11 @@ class ShutdownClient(NamespacedClient):
                 __body["target_node_name"] = target_node_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="shutdown.put_node",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/slm.py
+++ b/elasticsearch/_async/client/slm.py
@@ -44,7 +44,9 @@ class SlmClient(NamespacedClient):
         """
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
-        __path = f"/_slm/policy/{_quote(policy_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy_id": _quote(policy_id)}
+        __path = f'/_slm/policy/{__path_parts["policy_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.delete_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -79,7 +86,9 @@ class SlmClient(NamespacedClient):
         """
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
-        __path = f"/_slm/policy/{_quote(policy_id)}/_execute"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy_id": _quote(policy_id)}
+        __path = f'/_slm/policy/{__path_parts["policy_id"]}/_execute'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -91,7 +100,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.execute_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -108,6 +122,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/_execute_retention"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -120,7 +136,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.execute_retention",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -141,9 +162,12 @@ class SlmClient(NamespacedClient):
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         """
+        __path_parts: t.Dict[str, str]
         if policy_id not in SKIP_IN_PATH:
-            __path = f"/_slm/policy/{_quote(policy_id)}"
+            __path_parts = {"policy_id": _quote(policy_id)}
+            __path = f'/_slm/policy/{__path_parts["policy_id"]}'
         else:
+            __path_parts = {}
             __path = "/_slm/policy"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -156,7 +180,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.get_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -174,6 +203,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -186,7 +217,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.get_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -203,6 +239,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -215,7 +253,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.get_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -266,7 +309,9 @@ class SlmClient(NamespacedClient):
         """
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
-        __path = f"/_slm/policy/{_quote(policy_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy_id": _quote(policy_id)}
+        __path = f'/_slm/policy/{__path_parts["policy_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -298,7 +343,13 @@ class SlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="slm.put_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -315,6 +366,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/start"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -327,7 +380,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.start",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -344,6 +402,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/stop"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -356,5 +416,10 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.stop",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -50,7 +50,9 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_snapshot/{_quote(name)}/_cleanup"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/_cleanup'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -66,7 +68,12 @@ class SnapshotClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.cleanup_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -109,7 +116,13 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'target_snapshot'")
         if indices is None and body is None:
             raise ValueError("Empty value passed for parameter 'indices'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_clone/{_quote(target_snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "repository": _quote(repository),
+            "snapshot": _quote(snapshot),
+            "target_snapshot": _quote(target_snapshot),
+        }
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_clone/{__path_parts["target_snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -129,7 +142,13 @@ class SnapshotClient(NamespacedClient):
                 __body["indices"] = indices
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.clone",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -203,7 +222,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -237,7 +258,13 @@ class SnapshotClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.create",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -280,7 +307,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'settings'")
         if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
-        __path = f"/_snapshot/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -306,7 +335,13 @@ class SnapshotClient(NamespacedClient):
                 __body["repository"] = repository
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.create_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -336,7 +371,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -350,7 +387,12 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -379,7 +421,9 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_snapshot/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -395,7 +439,12 @@ class SnapshotClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.delete_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -479,7 +528,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         if after is not None:
             __query["after"] = after
@@ -517,7 +568,12 @@ class SnapshotClient(NamespacedClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -544,9 +600,12 @@ class SnapshotClient(NamespacedClient):
             node (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_snapshot/{_quote(name)}"
+            __path_parts = {"repository": _quote(name)}
+            __path = f'/_snapshot/{__path_parts["repository"]}'
         else:
+            __path_parts = {}
             __path = "/_snapshot"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -563,7 +622,12 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.get_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -630,7 +694,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_restore"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_restore'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -672,7 +738,13 @@ class SnapshotClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.restore",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -701,11 +773,18 @@ class SnapshotClient(NamespacedClient):
             to false which means a SnapshotMissingException is thrown
         :param master_timeout: Explicit operation timeout for connection to master node
         """
+        __path_parts: t.Dict[str, str]
         if repository not in SKIP_IN_PATH and snapshot not in SKIP_IN_PATH:
-            __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_status"
+            __path_parts = {
+                "repository": _quote(repository),
+                "snapshot": _quote(snapshot),
+            }
+            __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_status'
         elif repository not in SKIP_IN_PATH:
-            __path = f"/_snapshot/{_quote(repository)}/_status"
+            __path_parts = {"repository": _quote(repository)}
+            __path = f'/_snapshot/{__path_parts["repository"]}/_status'
         else:
+            __path_parts = {}
             __path = "/_snapshot/_status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -722,7 +801,12 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -750,7 +834,9 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_snapshot/{_quote(name)}/_verify"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/_verify'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -766,5 +852,10 @@ class SnapshotClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.verify_repository",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -47,6 +47,8 @@ class SqlClient(NamespacedClient):
         """
         if cursor is None and body is None:
             raise ValueError("Empty value passed for parameter 'cursor'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_sql/close"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -63,7 +65,13 @@ class SqlClient(NamespacedClient):
                 __body["cursor"] = cursor
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="sql.clear_cursor",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -86,7 +94,9 @@ class SqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_sql/async/delete/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_sql/async/delete/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -98,7 +108,12 @@ class SqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="sql.delete_async",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -136,7 +151,9 @@ class SqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_sql/async/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_sql/async/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if delimiter is not None:
             __query["delimiter"] = delimiter
@@ -156,7 +173,12 @@ class SqlClient(NamespacedClient):
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="sql.get_async",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -179,7 +201,9 @@ class SqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_sql/async/status/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_sql/async/status/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -191,7 +215,12 @@ class SqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="sql.get_async_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -281,6 +310,8 @@ class SqlClient(NamespacedClient):
             to no timeout, meaning the request waits for complete search results. If
             the search doesn’t finish within this period, the search becomes async.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_sql"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -329,7 +360,13 @@ class SqlClient(NamespacedClient):
                 __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="sql.query",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -360,6 +397,8 @@ class SqlClient(NamespacedClient):
         """
         if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_sql/translate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -382,5 +421,11 @@ class SqlClient(NamespacedClient):
                 __body["time_zone"] = time_zone
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="sql.translate",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/ssl.py
+++ b/elasticsearch/_async/client/ssl.py
@@ -40,6 +40,8 @@ class SslClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ssl/certificates"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -52,5 +54,10 @@ class SslClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ssl.certificates",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/synonyms.py
+++ b/elasticsearch/_async/client/synonyms.py
@@ -44,7 +44,9 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_synonyms/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_synonyms/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class SynonymsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.delete_synonym",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -82,7 +89,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"set_id": _quote(set_id), "rule_id": _quote(rule_id)}
+        __path = f'/_synonyms/{__path_parts["set_id"]}/{__path_parts["rule_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -94,7 +103,12 @@ class SynonymsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.delete_synonym_rule",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -122,7 +136,9 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_synonyms/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_synonyms/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -138,7 +154,12 @@ class SynonymsClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.get_synonym",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -164,7 +185,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"set_id": _quote(set_id), "rule_id": _quote(rule_id)}
+        __path = f'/_synonyms/{__path_parts["set_id"]}/{__path_parts["rule_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -176,7 +199,12 @@ class SynonymsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.get_synonym_rule",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -200,6 +228,8 @@ class SynonymsClient(NamespacedClient):
         :param from_: Starting offset
         :param size: specifies a max number of results to get
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_synonyms"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -216,7 +246,12 @@ class SynonymsClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.get_synonyms_sets",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -245,7 +280,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'id'")
         if synonyms_set is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms_set'")
-        __path = f"/_synonyms/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_synonyms/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -261,7 +298,13 @@ class SynonymsClient(NamespacedClient):
                 __body["synonyms_set"] = synonyms_set
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="synonyms.put_synonym",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -294,7 +337,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'rule_id'")
         if synonyms is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms'")
-        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"set_id": _quote(set_id), "rule_id": _quote(rule_id)}
+        __path = f'/_synonyms/{__path_parts["set_id"]}/{__path_parts["rule_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -310,5 +355,11 @@ class SynonymsClient(NamespacedClient):
                 __body["synonyms"] = synonyms
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="synonyms.put_synonym_rule",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/tasks.py
+++ b/elasticsearch/_async/client/tasks.py
@@ -52,9 +52,12 @@ class TasksClient(NamespacedClient):
         :param wait_for_completion: Should the request block until the cancellation of
             the task and its descendant tasks is completed. Defaults to false
         """
+        __path_parts: t.Dict[str, str]
         if task_id not in SKIP_IN_PATH:
-            __path = f"/_tasks/{_quote(task_id)}/_cancel"
+            __path_parts = {"task_id": _quote(task_id)}
+            __path = f'/_tasks/{__path_parts["task_id"]}/_cancel'
         else:
+            __path_parts = {}
             __path = "/_tasks/_cancel"
         __query: t.Dict[str, t.Any] = {}
         if actions is not None:
@@ -75,7 +78,12 @@ class TasksClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="tasks.cancel",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -103,7 +111,9 @@ class TasksClient(NamespacedClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_tasks/{_quote(task_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_tasks/{__path_parts["task_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -119,7 +129,12 @@ class TasksClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="tasks.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -165,6 +180,8 @@ class TasksClient(NamespacedClient):
         :param wait_for_completion: If `true`, the request blocks until the operation
             is complete.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_tasks"
         __query: t.Dict[str, t.Any] = {}
         if actions is not None:
@@ -193,5 +210,10 @@ class TasksClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="tasks.list",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/text_structure.py
+++ b/elasticsearch/_async/client/text_structure.py
@@ -127,6 +127,8 @@ class TextStructureClient(NamespacedClient):
             )
         elif text_files is not None and body is not None:
             raise ValueError("Cannot set both 'text_files' and 'body'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_text_structure/find_structure"
         __query: t.Dict[str, t.Any] = {}
         if charset is not None:
@@ -165,7 +167,13 @@ class TextStructureClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="text_structure.find_structure",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -186,7 +194,7 @@ class TextStructureClient(NamespacedClient):
         """
         Tests a Grok pattern on some text.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-grok-pattern-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-grok-pattern.html>`_
 
         :param grok_pattern: Grok pattern to run on the text.
         :param text: Lines of text to run the Grok pattern on.
@@ -197,6 +205,8 @@ class TextStructureClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'grok_pattern'")
         if text is None and body is None:
             raise ValueError("Empty value passed for parameter 'text'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_text_structure/test_grok_pattern"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -217,5 +227,11 @@ class TextStructureClient(NamespacedClient):
                 __body["text"] = text
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="text_structure.test_grok_pattern",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -55,7 +55,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if delete_dest_index is not None:
             __query["delete_dest_index"] = delete_dest_index
@@ -73,7 +75,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.delete_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -111,9 +118,12 @@ class TransformClient(NamespacedClient):
         :param from_: Skips the specified number of transforms.
         :param size: Specifies the maximum number of transforms to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if transform_id not in SKIP_IN_PATH:
-            __path = f"/_transform/{_quote(transform_id)}"
+            __path_parts = {"transform_id": _quote(transform_id)}
+            __path = f'/_transform/{__path_parts["transform_id"]}'
         else:
+            __path_parts = {}
             __path = "/_transform"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -134,7 +144,12 @@ class TransformClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.get_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -172,7 +187,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_stats'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -192,7 +209,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.get_transform_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -255,9 +277,12 @@ class TransformClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if transform_id not in SKIP_IN_PATH:
-            __path = f"/_transform/{_quote(transform_id)}/_preview"
+            __path_parts = {"transform_id": _quote(transform_id)}
+            __path = f'/_transform/{__path_parts["transform_id"]}/_preview'
         else:
+            __path_parts = {}
             __path = "/_transform/_preview"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -296,7 +321,13 @@ class TransformClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="transform.preview_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -377,7 +408,9 @@ class TransformClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'dest'")
         if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
-        __path = f"/_transform/{_quote(transform_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
@@ -415,7 +448,13 @@ class TransformClient(NamespacedClient):
                 __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="transform.put_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -443,7 +482,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_reset"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_reset'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -457,7 +498,12 @@ class TransformClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.reset_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -481,7 +527,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_schedule_now"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_schedule_now'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -495,7 +543,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.schedule_now_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -526,7 +579,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -542,7 +597,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.start_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -589,7 +649,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -611,7 +673,12 @@ class TransformClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.stop_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -673,7 +740,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
@@ -707,7 +776,13 @@ class TransformClient(NamespacedClient):
                 __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="transform.update_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -730,6 +805,8 @@ class TransformClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_transform/_upgrade"
         __query: t.Dict[str, t.Any] = {}
         if dry_run is not None:
@@ -746,5 +823,10 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.upgrade_transforms",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -46,10 +46,16 @@ class WatcherClient(NamespacedClient):
         """
         if watch_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'watch_id'")
+        __path_parts: t.Dict[str, str]
         if watch_id not in SKIP_IN_PATH and action_id not in SKIP_IN_PATH:
-            __path = f"/_watcher/watch/{_quote(watch_id)}/_ack/{_quote(action_id)}"
+            __path_parts = {
+                "watch_id": _quote(watch_id),
+                "action_id": _quote(action_id),
+            }
+            __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_ack/{__path_parts["action_id"]}'
         elif watch_id not in SKIP_IN_PATH:
-            __path = f"/_watcher/watch/{_quote(watch_id)}/_ack"
+            __path_parts = {"watch_id": _quote(watch_id)}
+            __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_ack'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -63,7 +69,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.ack_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -85,7 +96,9 @@ class WatcherClient(NamespacedClient):
         """
         if watch_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'watch_id'")
-        __path = f"/_watcher/watch/{_quote(watch_id)}/_activate"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"watch_id": _quote(watch_id)}
+        __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_activate'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -97,7 +110,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.activate_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -119,7 +137,9 @@ class WatcherClient(NamespacedClient):
         """
         if watch_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'watch_id'")
-        __path = f"/_watcher/watch/{_quote(watch_id)}/_deactivate"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"watch_id": _quote(watch_id)}
+        __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_deactivate'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -131,7 +151,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.deactivate_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -153,7 +178,9 @@ class WatcherClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_watcher/watch/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_watcher/watch/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -165,7 +192,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.delete_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -229,9 +261,12 @@ class WatcherClient(NamespacedClient):
             the request. This watch is not persisted to the index and record_execution
             cannot be set.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_watcher/watch/{_quote(id)}/_execute"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_watcher/watch/{__path_parts["id"]}/_execute'
         else:
+            __path_parts = {}
             __path = "/_watcher/watch/_execute"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -266,7 +301,13 @@ class WatcherClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="watcher.execute_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -288,7 +329,9 @@ class WatcherClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_watcher/watch/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_watcher/watch/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -300,7 +343,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.get_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -357,7 +405,9 @@ class WatcherClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_watcher/watch/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_watcher/watch/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if active is not None:
@@ -397,7 +447,13 @@ class WatcherClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="watcher.put_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -437,6 +493,8 @@ class WatcherClient(NamespacedClient):
         :param size: The number of hits to return. Needs to be non-negative.
         :param sort: Optional sort definition.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_watcher/_query/watches"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -476,7 +534,13 @@ class WatcherClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="watcher.query_watches",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -493,6 +557,8 @@ class WatcherClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_watcher/_start"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -505,7 +571,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.start",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -541,9 +612,12 @@ class WatcherClient(NamespacedClient):
         :param emit_stacktraces: Defines whether stack traces are generated for each
             watch that is running.
         """
+        __path_parts: t.Dict[str, str]
         if metric not in SKIP_IN_PATH:
-            __path = f"/_watcher/stats/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_watcher/stats/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_watcher/stats"
         __query: t.Dict[str, t.Any] = {}
         if emit_stacktraces is not None:
@@ -558,7 +632,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -575,6 +654,8 @@ class WatcherClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_watcher/_stop"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -587,5 +668,10 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.stop",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_async/client/xpack.py
+++ b/elasticsearch/_async/client/xpack.py
@@ -49,6 +49,8 @@ class XPackClient(NamespacedClient):
         :param categories: A comma-separated list of the information categories to include
             in the response. For example, `build,license,features`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_xpack"
         __query: t.Dict[str, t.Any] = {}
         if accept_enterprise is not None:
@@ -65,7 +67,12 @@ class XPackClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="xpack.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -89,6 +96,8 @@ class XPackClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_xpack/usage"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -103,5 +112,10 @@ class XPackClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="xpack.usage",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -672,9 +672,12 @@ class Elasticsearch(BaseClient):
             )
         elif operations is not None and body is not None:
             raise ValueError("Cannot set both 'operations' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_bulk"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_bulk'
         else:
+            __path_parts = {}
             __path = "/_bulk"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -709,7 +712,13 @@ class Elasticsearch(BaseClient):
             "content-type": "application/x-ndjson",
         }
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="bulk",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -732,6 +741,8 @@ class Elasticsearch(BaseClient):
 
         :param scroll_id: Scroll IDs to clear. To clear all scroll IDs, use `_all`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_search/scroll"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -752,7 +763,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="clear_scroll",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -777,6 +794,8 @@ class Elasticsearch(BaseClient):
         """
         if id is None and body is None:
             raise ValueError("Empty value passed for parameter 'id'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_pit"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -797,7 +816,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="close_point_in_time",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -877,9 +902,12 @@ class Elasticsearch(BaseClient):
             If a query reaches this limit, Elasticsearch terminates the query early.
             Elasticsearch collects documents before sorting.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_count"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_count'
         else:
+            __path_parts = {}
             __path = "/_count"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -928,7 +956,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="count",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1002,7 +1036,9 @@ class Elasticsearch(BaseClient):
             )
         elif document is not None and body is not None:
             raise ValueError("Cannot set both 'document' and 'body'")
-        __path = f"/{_quote(index)}/_create/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_create/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1029,7 +1065,13 @@ class Elasticsearch(BaseClient):
         __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="create",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1086,7 +1128,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1114,7 +1158,12 @@ class Elasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1245,7 +1294,9 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_delete_by_query"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_delete_by_query'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -1332,7 +1383,13 @@ class Elasticsearch(BaseClient):
                 __body["slice"] = slice
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="delete_by_query",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1357,7 +1414,9 @@ class Elasticsearch(BaseClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_delete_by_query/{_quote(task_id)}/_rethrottle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_delete_by_query/{__path_parts["task_id"]}/_rethrottle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1371,7 +1430,12 @@ class Elasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="delete_by_query_rethrottle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1402,7 +1466,9 @@ class Elasticsearch(BaseClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_scripts/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_scripts/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1418,7 +1484,12 @@ class Elasticsearch(BaseClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="delete_script",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1482,7 +1553,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1514,7 +1587,12 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="exists",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1574,7 +1652,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_source/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_source/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1604,7 +1684,12 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="exists_source",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1674,7 +1759,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_explain/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_explain/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if analyze_wildcard is not None:
@@ -1718,7 +1805,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="explain",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1784,9 +1877,12 @@ class Elasticsearch(BaseClient):
         :param types: Only return results for fields that have one of the types in the
             list
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_field_caps"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_field_caps'
         else:
+            __path_parts = {}
             __path = "/_field_caps"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1825,7 +1921,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="field_caps",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1888,7 +1990,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1920,7 +2024,12 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1946,7 +2055,9 @@ class Elasticsearch(BaseClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_scripts/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_scripts/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1960,7 +2071,12 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_script",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1977,6 +2093,8 @@ class Elasticsearch(BaseClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_script_context"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1989,7 +2107,12 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_script_context",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2006,6 +2129,8 @@ class Elasticsearch(BaseClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_script_language"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2018,7 +2143,12 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_script_languages",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2079,7 +2209,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_source/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_source/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2111,7 +2243,12 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="get_source",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2138,9 +2275,12 @@ class Elasticsearch(BaseClient):
         :param timeout: Explicit operation timeout.
         :param verbose: Opt-in for more information about the health of the system.
         """
+        __path_parts: t.Dict[str, str]
         if feature not in SKIP_IN_PATH:
-            __path = f"/_health_report/{_quote(feature)}"
+            __path_parts = {"feature": _quote(feature)}
+            __path = f'/_health_report/{__path_parts["feature"]}'
         else:
+            __path_parts = {}
             __path = "/_health_report"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2159,7 +2299,12 @@ class Elasticsearch(BaseClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="health_report",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2240,11 +2385,14 @@ class Elasticsearch(BaseClient):
             )
         elif document is not None and body is not None:
             raise ValueError("Cannot set both 'document' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and id not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_doc/{_quote(id)}"
+            __path_parts = {"index": _quote(index), "id": _quote(id)}
+            __path = f'/{__path_parts["index"]}/_doc/{__path_parts["id"]}'
             __method = "PUT"
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_doc"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_doc'
             __method = "POST"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
@@ -2282,7 +2430,13 @@ class Elasticsearch(BaseClient):
         __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            __method, __path, params=__query, headers=__headers, body=__body
+            __method,
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2299,6 +2453,8 @@ class Elasticsearch(BaseClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2311,7 +2467,12 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2374,7 +2535,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if knn is None and body is None:
             raise ValueError("Empty value passed for parameter 'knn'")
-        __path = f"/{_quote(index)}/_knn_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_knn_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2406,7 +2569,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="knn_search",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2467,9 +2636,12 @@ class Elasticsearch(BaseClient):
         :param stored_fields: If `true`, retrieves the document fields stored in the
             index rather than the document `_source`.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mget"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_mget'
         else:
+            __path_parts = {}
             __path = "/_mget"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2504,7 +2676,13 @@ class Elasticsearch(BaseClient):
                 __body["ids"] = ids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="mget",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2589,9 +2767,12 @@ class Elasticsearch(BaseClient):
             )
         elif searches is not None and body is not None:
             raise ValueError("Cannot set both 'searches' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_msearch"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_msearch'
         else:
+            __path_parts = {}
             __path = "/_msearch"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2632,7 +2813,13 @@ class Elasticsearch(BaseClient):
             "content-type": "application/x-ndjson",
         }
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="msearch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2682,9 +2869,12 @@ class Elasticsearch(BaseClient):
             )
         elif search_templates is not None and body is not None:
             raise ValueError("Cannot set both 'search_templates' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_msearch/template"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_msearch/template'
         else:
+            __path_parts = {}
             __path = "/_msearch/template"
         __query: t.Dict[str, t.Any] = {}
         if ccs_minimize_roundtrips is not None:
@@ -2711,7 +2901,13 @@ class Elasticsearch(BaseClient):
             "content-type": "application/x-ndjson",
         }
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="msearch_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2768,9 +2964,12 @@ class Elasticsearch(BaseClient):
         :param version: If `true`, returns the document version as part of a hit.
         :param version_type: Specific version type.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mtermvectors"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_mtermvectors'
         else:
+            __path_parts = {}
             __path = "/_mtermvectors"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2815,7 +3014,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="mtermvectors",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2862,7 +3067,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if keep_alive is None:
             raise ValueError("Empty value passed for parameter 'keep_alive'")
-        __path = f"/{_quote(index)}/_pit"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_pit'
         __query: t.Dict[str, t.Any] = {}
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
@@ -2884,7 +3091,12 @@ class Elasticsearch(BaseClient):
             __query["routing"] = routing
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="open_point_in_time",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2928,10 +3140,13 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'id'")
         if script is None and body is None:
             raise ValueError("Empty value passed for parameter 'script'")
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH and context not in SKIP_IN_PATH:
-            __path = f"/_scripts/{_quote(id)}/{_quote(context)}"
+            __path_parts = {"id": _quote(id), "context": _quote(context)}
+            __path = f'/_scripts/{__path_parts["id"]}/{__path_parts["context"]}'
         elif id not in SKIP_IN_PATH:
-            __path = f"/_scripts/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_scripts/{__path_parts["id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -2953,7 +3168,13 @@ class Elasticsearch(BaseClient):
                 __body["script"] = script
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="put_script",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3008,9 +3229,12 @@ class Elasticsearch(BaseClient):
         """
         if requests is None and body is None:
             raise ValueError("Empty value passed for parameter 'requests'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_rank_eval"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_rank_eval'
         else:
+            __path_parts = {}
             __path = "/_rank_eval"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3037,7 +3261,13 @@ class Elasticsearch(BaseClient):
                 __body["metric"] = metric
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="rank_eval",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3103,6 +3333,8 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'dest'")
         if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_reindex"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3145,7 +3377,13 @@ class Elasticsearch(BaseClient):
                 __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="reindex",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3170,7 +3408,9 @@ class Elasticsearch(BaseClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_reindex/{_quote(task_id)}/_rethrottle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_reindex/{__path_parts["task_id"]}/_rethrottle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3184,7 +3424,12 @@ class Elasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="reindex_rethrottle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3218,9 +3463,12 @@ class Elasticsearch(BaseClient):
             search API's request body. These parameters also support Mustache variables.
             If no `id` or `<templated-id>` is specified, this parameter is required.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_render/template/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_render/template/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_render/template"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3245,7 +3493,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="render_search_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3272,6 +3526,8 @@ class Elasticsearch(BaseClient):
         :param context_setup: Additional parameters for the `context`.
         :param script: The Painless script to execute.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_scripts/painless/_execute"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3296,7 +3552,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="scripts_painless_execute",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3327,6 +3589,8 @@ class Elasticsearch(BaseClient):
         """
         if scroll_id is None and body is None:
             raise ValueError("Empty value passed for parameter 'scroll_id'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_search/scroll"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3351,7 +3615,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="scroll",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3680,9 +3950,12 @@ class Elasticsearch(BaseClient):
             by their respective types in the response.
         :param version: If true, returns document version as part of a hit.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_search"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_search'
         else:
+            __path_parts = {}
             __path = "/_search"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -3838,7 +4111,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3953,7 +4232,15 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'x'")
         if y in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'y'")
-        __path = f"/{_quote(index)}/_mvt/{_quote(field)}/{_quote(zoom)}/{_quote(x)}/{_quote(y)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "index": _quote(index),
+            "field": _quote(field),
+            "zoom": _quote(zoom),
+            "x": _quote(x),
+            "y": _quote(y),
+        }
+        __path = f'/{__path_parts["index"]}/_mvt/{__path_parts["field"]}/{__path_parts["zoom"]}/{__path_parts["x"]}/{__path_parts["y"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -4010,7 +4297,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_mvt",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4061,9 +4354,12 @@ class Elasticsearch(BaseClient):
             on. Random by default.
         :param routing: Custom value used to route operations to a specific shard.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_search_shards"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_search_shards'
         else:
+            __path_parts = {}
             __path = "/_search_shards"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -4088,7 +4384,12 @@ class Elasticsearch(BaseClient):
             __query["routing"] = routing
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_shards",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4173,9 +4474,12 @@ class Elasticsearch(BaseClient):
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_search/template"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_search/template'
         else:
+            __path_parts = {}
             __path = "/_search/template"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4222,7 +4526,13 @@ class Elasticsearch(BaseClient):
                 __body["source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4281,7 +4591,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if field is None and body is None:
             raise ValueError("Empty value passed for parameter 'field'")
-        __path = f"/{_quote(index)}/_terms_enum"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_terms_enum'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4313,7 +4625,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="terms_enum",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4377,10 +4695,13 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and id not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_termvectors/{_quote(id)}"
+            __path_parts = {"index": _quote(index), "id": _quote(id)}
+            __path = f'/{__path_parts["index"]}/_termvectors/{__path_parts["id"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_termvectors"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_termvectors'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -4428,7 +4749,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="termvectors",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4525,7 +4852,9 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/{_quote(index)}/_update/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "id": _quote(id)}
+        __path = f'/{__path_parts["index"]}/_update/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4575,7 +4904,13 @@ class Elasticsearch(BaseClient):
                 __body["upsert"] = upsert
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="update",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4717,7 +5052,9 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_update_by_query"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_update_by_query'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -4812,7 +5149,13 @@ class Elasticsearch(BaseClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="update_by_query",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4837,7 +5180,9 @@ class Elasticsearch(BaseClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_update_by_query/{_quote(task_id)}/_rethrottle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_update_by_query/{__path_parts["task_id"]}/_rethrottle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -4851,5 +5196,10 @@ class Elasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="update_by_query_rethrottle",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/_base.py
+++ b/elasticsearch/_sync/client/_base.py
@@ -257,6 +257,8 @@ class BaseClient:
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
+        endpoint_id: Union[DefaultType, str] = DEFAULT,
+        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
     ) -> ApiResponse[Any]:
         if headers:
             request_headers = self._headers.copy()
@@ -292,6 +294,8 @@ class BaseClient:
             retry_on_status=self._retry_on_status,
             retry_on_timeout=self._retry_on_timeout,
             client_meta=self._client_meta,
+            endpoint_id=endpoint_id,
+            path_parts=path_parts,
         )
 
         # HEAD with a 404 is returned as a normal response
@@ -383,9 +387,17 @@ class NamespacedClient(BaseClient):
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
+        endpoint_id: Union[DefaultType, str] = DEFAULT,
+        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
     ) -> ApiResponse[Any]:
         # Use the internal clients .perform_request() implementation
         # so we take advantage of their transport options.
         return self._client.perform_request(
-            method, path, params=params, headers=headers, body=body
+            method,
+            path,
+            params=params,
+            headers=headers,
+            body=body,
+            endpoint_id=endpoint_id,
+            path_parts=path_parts,
         )

--- a/elasticsearch/_sync/client/async_search.py
+++ b/elasticsearch/_sync/client/async_search.py
@@ -45,7 +45,9 @@ class AsyncSearchClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_async_search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_async_search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -57,7 +59,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="async_search.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -99,7 +106,9 @@ class AsyncSearchClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_async_search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_async_search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -117,7 +126,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="async_search.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -140,7 +154,9 @@ class AsyncSearchClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_async_search/status/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_async_search/status/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -152,7 +168,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="async_search.status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -428,9 +449,12 @@ class AsyncSearchClient(NamespacedClient):
             up to a certain timeout. When the async search completes within the timeout,
             the response won’t include the ID as the results are not stored in the cluster.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_async_search"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_async_search'
         else:
+            __path_parts = {}
             __path = "/_async_search"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -590,5 +614,11 @@ class AsyncSearchClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="async_search.submit",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/autoscaling.py
+++ b/elasticsearch/_sync/client/autoscaling.py
@@ -45,7 +45,9 @@ class AutoscalingClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_autoscaling/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -57,7 +59,12 @@ class AutoscalingClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="autoscaling.delete_autoscaling_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -75,6 +82,8 @@ class AutoscalingClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_autoscaling/capacity"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -87,7 +96,12 @@ class AutoscalingClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="autoscaling.get_autoscaling_capacity",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -110,7 +124,9 @@ class AutoscalingClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_autoscaling/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -122,7 +138,12 @@ class AutoscalingClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="autoscaling.get_autoscaling_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -156,7 +177,9 @@ class AutoscalingClient(NamespacedClient):
             )
         elif policy is not None and body is not None:
             raise ValueError("Cannot set both 'policy' and 'body'")
-        __path = f"/_autoscaling/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_autoscaling/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -169,5 +192,11 @@ class AutoscalingClient(NamespacedClient):
         __body = policy if policy is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="autoscaling.put_autoscaling_policy",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/cat.py
+++ b/elasticsearch/_sync/client/cat.py
@@ -77,9 +77,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_cat/aliases/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_cat/aliases/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/aliases"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -108,7 +111,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.aliases",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -157,9 +165,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_cat/allocation/{_quote(node_id)}"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_cat/allocation/{__path_parts["node_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/allocation"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -188,7 +199,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.allocation",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -232,9 +248,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_cat/component_templates/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_cat/component_templates/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/component_templates"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -261,7 +280,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.component_templates",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -307,9 +331,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/count/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/count/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/count"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -336,7 +363,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.count",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -385,9 +417,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if fields not in SKIP_IN_PATH:
-            __path = f"/_cat/fielddata/{_quote(fields)}"
+            __path_parts = {"fields": _quote(fields)}
+            __path = f'/_cat/fielddata/{__path_parts["fields"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/fielddata"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -416,7 +451,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.fielddata",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -463,6 +503,8 @@ class CatClient(NamespacedClient):
         :param ts: If true, returns `HH:MM:SS` and Unix epoch timestamps.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/health"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -493,7 +535,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.health",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -534,6 +581,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -560,7 +609,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.help",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -631,9 +685,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/indices/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/indices/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/indices"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -672,7 +729,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.indices",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -713,6 +775,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/master"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -739,7 +803,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.master",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -816,9 +885,12 @@ class CatClient(NamespacedClient):
         :param time: Unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/data_frame/analytics/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_cat/ml/data_frame/analytics/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/data_frame/analytics"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -851,7 +923,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -932,9 +1009,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/datafeeds/{_quote(datafeed_id)}"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_cat/ml/datafeeds/{__path_parts["datafeed_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/datafeeds"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -965,7 +1045,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_datafeeds",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1049,9 +1134,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/anomaly_detectors/{_quote(job_id)}"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_cat/ml/anomaly_detectors/{__path_parts["job_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/anomaly_detectors"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1084,7 +1172,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_jobs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1170,9 +1263,12 @@ class CatClient(NamespacedClient):
         :param size: The maximum number of transforms to display.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if model_id not in SKIP_IN_PATH:
-            __path = f"/_cat/ml/trained_models/{_quote(model_id)}"
+            __path_parts = {"model_id": _quote(model_id)}
+            __path = f'/_cat/ml/trained_models/{__path_parts["model_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/ml/trained_models"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1207,7 +1303,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.ml_trained_models",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1248,6 +1349,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/nodeattrs"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1274,7 +1377,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.nodeattrs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1325,6 +1433,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/nodes"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -1357,7 +1467,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.nodes",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1398,6 +1513,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/pending_tasks"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1424,7 +1541,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.pending_tasks",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1465,6 +1587,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/plugins"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1491,7 +1615,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.plugins",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1545,9 +1674,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/recovery/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/recovery/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/recovery"
         __query: t.Dict[str, t.Any] = {}
         if active_only is not None:
@@ -1580,7 +1712,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.recovery",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1621,6 +1758,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/repositories"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1647,7 +1786,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.repositories",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1696,9 +1840,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/segments/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/segments/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/segments"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -1727,7 +1874,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.segments",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1776,9 +1928,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cat/shards/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cat/shards/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/shards"
         __query: t.Dict[str, t.Any] = {}
         if bytes is not None:
@@ -1807,7 +1962,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.shards",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1855,9 +2015,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if repository not in SKIP_IN_PATH:
-            __path = f"/_cat/snapshots/{_quote(repository)}"
+            __path_parts = {"repository": _quote(repository)}
+            __path = f'/_cat/snapshots/{__path_parts["repository"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/snapshots"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1886,7 +2049,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.snapshots",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1938,6 +2106,8 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cat/tasks"
         __query: t.Dict[str, t.Any] = {}
         if actions is not None:
@@ -1972,7 +2142,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.tasks",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2016,9 +2191,12 @@ class CatClient(NamespacedClient):
             a suffix to the column name.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_cat/templates/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_cat/templates/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/templates"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2045,7 +2223,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.templates",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2094,9 +2277,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if thread_pool_patterns not in SKIP_IN_PATH:
-            __path = f"/_cat/thread_pool/{_quote(thread_pool_patterns)}"
+            __path_parts = {"thread_pool_patterns": _quote(thread_pool_patterns)}
+            __path = f'/_cat/thread_pool/{__path_parts["thread_pool_patterns"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/thread_pool"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2125,7 +2311,12 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.thread_pool",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2213,9 +2404,12 @@ class CatClient(NamespacedClient):
         :param time: The unit used to display time values.
         :param v: When set to `true` will enable verbose output.
         """
+        __path_parts: t.Dict[str, str]
         if transform_id not in SKIP_IN_PATH:
-            __path = f"/_cat/transforms/{_quote(transform_id)}"
+            __path_parts = {"transform_id": _quote(transform_id)}
+            __path = f'/_cat/transforms/{__path_parts["transform_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cat/transforms"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -2250,5 +2444,10 @@ class CatClient(NamespacedClient):
             __query["v"] = v
         __headers = {"accept": "text/plain,application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cat.transforms",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/ccr.py
+++ b/elasticsearch/_sync/client/ccr.py
@@ -44,7 +44,9 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.delete_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -129,7 +136,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/follow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/follow'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -175,7 +184,13 @@ class CcrClient(NamespacedClient):
                 __body["remote_cluster"] = remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.follow",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -199,7 +214,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/info"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/info'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -211,7 +228,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.follow_info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -235,7 +257,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/stats'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -247,7 +271,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.follow_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -286,7 +315,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/forget_follower"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/forget_follower'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -308,7 +339,13 @@ class CcrClient(NamespacedClient):
                 __body["leader_remote_cluster"] = leader_remote_cluster
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.forget_follower",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -330,9 +367,12 @@ class CcrClient(NamespacedClient):
         :param name: Specifies the auto-follow pattern collection that you want to retrieve.
             If you do not specify a name, the API returns information for all collections.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_ccr/auto_follow/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_ccr/auto_follow/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_ccr/auto_follow"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -345,7 +385,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.get_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -368,7 +413,9 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}/pause"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}/pause'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -380,7 +427,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.pause_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -404,7 +456,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/pause_follow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/pause_follow'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -416,7 +470,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.pause_follow",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -521,7 +580,9 @@ class CcrClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         if remote_cluster is None and body is None:
             raise ValueError("Empty value passed for parameter 'remote_cluster'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -573,7 +634,13 @@ class CcrClient(NamespacedClient):
                 __body["settings"] = settings
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.put_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -596,7 +663,9 @@ class CcrClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ccr/auto_follow/{_quote(name)}/resume"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_ccr/auto_follow/{__path_parts["name"]}/resume'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -608,7 +677,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.resume_auto_follow_pattern",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -668,7 +742,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/resume_follow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/resume_follow'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -712,7 +788,13 @@ class CcrClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ccr.resume_follow",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -729,6 +811,8 @@ class CcrClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ccr/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -741,7 +825,12 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -765,7 +854,9 @@ class CcrClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ccr/unfollow"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ccr/unfollow'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -777,5 +868,10 @@ class CcrClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ccr.unfollow",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/cluster.py
+++ b/elasticsearch/_sync/client/cluster.py
@@ -60,6 +60,8 @@ class ClusterClient(NamespacedClient):
         :param shard: Specifies the ID of the shard that you would like an explanation
             for.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/allocation/explain"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -90,7 +92,13 @@ class ClusterClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.allocation_explain",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -122,7 +130,9 @@ class ClusterClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_component_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_component_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -138,7 +148,12 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.delete_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -163,6 +178,8 @@ class ClusterClient(NamespacedClient):
             configuration exclusions list is cleared even if some excluded nodes are
             still in the cluster.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/voting_config_exclusions"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -177,7 +194,12 @@ class ClusterClient(NamespacedClient):
             __query["wait_for_removal"] = wait_for_removal
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.delete_voting_config_exclusions",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -210,7 +232,9 @@ class ClusterClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_component_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_component_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -226,7 +250,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.exists_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -261,9 +290,12 @@ class ClusterClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_component_template/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_component_template/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_component_template"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -284,7 +316,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.get_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -316,6 +353,8 @@ class ClusterClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -336,7 +375,12 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.get_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -419,9 +463,12 @@ class ClusterClient(NamespacedClient):
             provided) until the status of the cluster changes to the one provided or
             better, i.e. green > yellow > red. By default, will not wait for any status.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/_cluster/health/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cluster/health/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cluster/health"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -456,7 +503,12 @@ class ClusterClient(NamespacedClient):
             __query["wait_for_status"] = wait_for_status
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.health",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -488,7 +540,9 @@ class ClusterClient(NamespacedClient):
         """
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/_info/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"target": _quote(target)}
+        __path = f'/_info/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -500,7 +554,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -528,6 +587,8 @@ class ClusterClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/pending_tasks"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -544,7 +605,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.pending_tasks",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -574,6 +640,8 @@ class ClusterClient(NamespacedClient):
             If the timeout expires before the appropriate condition is satisfied, the
             request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/voting_config_exclusions"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -592,7 +660,12 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.post_voting_config_exclusions",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -655,7 +728,9 @@ class ClusterClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         if template is None and body is None:
             raise ValueError("Empty value passed for parameter 'template'")
-        __path = f"/_component_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_component_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -681,7 +756,13 @@ class ClusterClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.put_component_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -714,6 +795,8 @@ class ClusterClient(NamespacedClient):
         :param timeout: Explicit operation timeout
         :param transient:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/settings"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -738,7 +821,13 @@ class ClusterClient(NamespacedClient):
                 __body["transient"] = transient
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.put_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -755,6 +844,8 @@ class ClusterClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_remote/info"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -767,7 +858,12 @@ class ClusterClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.remote_info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -810,6 +906,8 @@ class ClusterClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_cluster/reroute"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -842,7 +940,13 @@ class ClusterClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="cluster.reroute",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -899,13 +1003,18 @@ class ClusterClient(NamespacedClient):
         :param wait_for_timeout: The maximum time to wait for wait_for_metadata_version
             before timing out
         """
+        __path_parts: t.Dict[str, str]
         if metric not in SKIP_IN_PATH and index not in SKIP_IN_PATH:
-            __path = f"/_cluster/state/{_quote(metric)}/{_quote(index)}"
+            __path_parts = {"metric": _quote(metric), "index": _quote(index)}
+            __path = f'/_cluster/state/{__path_parts["metric"]}/{__path_parts["index"]}'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_cluster/state/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_cluster/state/{__path_parts["metric"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/_cluster/state/_all/{_quote(index)}"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/_cluster/state/_all/{__path_parts["index"]}'
         else:
+            __path_parts = {}
             __path = "/_cluster/state"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -934,7 +1043,12 @@ class ClusterClient(NamespacedClient):
             __query["wait_for_timeout"] = wait_for_timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.state",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -962,9 +1076,12 @@ class ClusterClient(NamespacedClient):
             timed out nodes are included in the response’s `_nodes.failed` property.
             Defaults to no timeout.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_cluster/stats/nodes/{_quote(node_id)}"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_cluster/stats/nodes/{__path_parts["node_id"]}'
         else:
+            __path_parts = {}
             __path = "/_cluster/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -981,5 +1098,10 @@ class ClusterClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="cluster.stats",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/dangling_indices.py
+++ b/elasticsearch/_sync/client/dangling_indices.py
@@ -55,7 +55,9 @@ class DanglingIndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index_uuid'")
         if accept_data_loss is None:
             raise ValueError("Empty value passed for parameter 'accept_data_loss'")
-        __path = f"/_dangling/{_quote(index_uuid)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index_uuid": _quote(index_uuid)}
+        __path = f'/_dangling/{__path_parts["index_uuid"]}'
         __query: t.Dict[str, t.Any] = {}
         if accept_data_loss is not None:
             __query["accept_data_loss"] = accept_data_loss
@@ -73,7 +75,12 @@ class DanglingIndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="dangling_indices.delete_dangling_index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -106,7 +113,9 @@ class DanglingIndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index_uuid'")
         if accept_data_loss is None:
             raise ValueError("Empty value passed for parameter 'accept_data_loss'")
-        __path = f"/_dangling/{_quote(index_uuid)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index_uuid": _quote(index_uuid)}
+        __path = f'/_dangling/{__path_parts["index_uuid"]}'
         __query: t.Dict[str, t.Any] = {}
         if accept_data_loss is not None:
             __query["accept_data_loss"] = accept_data_loss
@@ -124,7 +133,12 @@ class DanglingIndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="dangling_indices.import_dangling_index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -141,6 +155,8 @@ class DanglingIndicesClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_dangling"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -153,5 +169,10 @@ class DanglingIndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="dangling_indices.list_dangling_indices",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/enrich.py
+++ b/elasticsearch/_sync/client/enrich.py
@@ -44,7 +44,9 @@ class EnrichClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_enrich/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_enrich/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class EnrichClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.delete_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -81,7 +88,9 @@ class EnrichClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_enrich/policy/{_quote(name)}/_execute"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_enrich/policy/{__path_parts["name"]}/_execute'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -95,7 +104,12 @@ class EnrichClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.execute_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -116,9 +130,12 @@ class EnrichClient(NamespacedClient):
         :param name: Comma-separated list of enrich policy names used to limit the request.
             To return information for all enrich policies, omit this parameter.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_enrich/policy/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_enrich/policy/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_enrich/policy"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -131,7 +148,12 @@ class EnrichClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.get_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -164,7 +186,9 @@ class EnrichClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_enrich/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_enrich/policy/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -184,7 +208,13 @@ class EnrichClient(NamespacedClient):
                 __body["range"] = range
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="enrich.put_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -202,6 +232,8 @@ class EnrichClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_enrich/_stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -214,5 +246,10 @@ class EnrichClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="enrich.stats",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/eql.py
+++ b/elasticsearch/_sync/client/eql.py
@@ -47,7 +47,9 @@ class EqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_eql/search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_eql/search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -59,7 +61,12 @@ class EqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="eql.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -91,7 +98,9 @@ class EqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_eql/search/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_eql/search/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -107,7 +116,12 @@ class EqlClient(NamespacedClient):
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="eql.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -130,7 +144,9 @@ class EqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_eql/search/status/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_eql/search/status/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -142,7 +158,12 @@ class EqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="eql.get_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -238,7 +259,9 @@ class EqlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
-        __path = f"/{_quote(index)}/_eql/search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_eql/search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -286,5 +309,11 @@ class EqlClient(NamespacedClient):
                 __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="eql.search",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/esql.py
+++ b/elasticsearch/_sync/client/esql.py
@@ -68,6 +68,8 @@ class EsqlClient(NamespacedClient):
         """
         if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -96,5 +98,11 @@ class EsqlClient(NamespacedClient):
                 __body["params"] = params
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="esql.query",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/features.py
+++ b/elasticsearch/_sync/client/features.py
@@ -40,6 +40,8 @@ class FeaturesClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_features"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -52,7 +54,12 @@ class FeaturesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="features.get_features",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -69,6 +76,8 @@ class FeaturesClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_features/_reset"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -81,5 +90,10 @@ class FeaturesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="features.reset_features",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/fleet.py
+++ b/elasticsearch/_sync/client/fleet.py
@@ -59,7 +59,9 @@ class FleetClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_fleet/global_checkpoints"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_fleet/global_checkpoints'
         __query: t.Dict[str, t.Any] = {}
         if checkpoints is not None:
             __query["checkpoints"] = checkpoints
@@ -79,7 +81,12 @@ class FleetClient(NamespacedClient):
             __query["wait_for_index"] = wait_for_index
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="fleet.global_checkpoints",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -171,9 +178,12 @@ class FleetClient(NamespacedClient):
             )
         elif searches is not None and body is not None:
             raise ValueError("Cannot set both 'searches' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_fleet/_fleet_msearch"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_fleet/_fleet_msearch'
         else:
+            __path_parts = {}
             __path = "/_fleet/_fleet_msearch"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -216,7 +226,13 @@ class FleetClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="fleet.msearch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -460,7 +476,9 @@ class FleetClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_fleet/_fleet_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_fleet/_fleet_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
@@ -613,5 +631,11 @@ class FleetClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="fleet.search",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/graph.py
+++ b/elasticsearch/_sync/client/graph.py
@@ -65,7 +65,9 @@ class GraphClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_graph/explore"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_graph/explore'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -95,5 +97,11 @@ class GraphClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="graph.explore",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/ilm.py
+++ b/elasticsearch/_sync/client/ilm.py
@@ -54,7 +54,9 @@ class IlmClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ilm/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy": _quote(name)}
+        __path = f'/_ilm/policy/{__path_parts["policy"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -70,7 +72,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.delete_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -111,7 +118,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ilm/explain"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ilm/explain'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -131,7 +140,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.explain_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -161,9 +175,12 @@ class IlmClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_ilm/policy/{_quote(name)}"
+            __path_parts = {"policy": _quote(name)}
+            __path = f'/_ilm/policy/{__path_parts["policy"]}'
         else:
+            __path_parts = {}
             __path = "/_ilm/policy"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -180,7 +197,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.get_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -197,6 +219,8 @@ class IlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -209,7 +233,12 @@ class IlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.get_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -239,6 +268,8 @@ class IlmClient(NamespacedClient):
         :param legacy_template_to_delete:
         :param node_attribute:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/migrate_to_data_tiers"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -263,7 +294,13 @@ class IlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ilm.migrate_to_data_tiers",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -292,7 +329,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/_ilm/move/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/_ilm/move/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -314,7 +353,13 @@ class IlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ilm.move_to_step",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -350,7 +395,9 @@ class IlmClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_ilm/policy/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy": _quote(name)}
+        __path = f'/_ilm/policy/{__path_parts["policy"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -374,7 +421,13 @@ class IlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ilm.put_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -396,7 +449,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ilm/remove"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ilm/remove'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -408,7 +463,12 @@ class IlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.remove_policy",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -431,7 +491,9 @@ class IlmClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_ilm/retry"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_ilm/retry'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -443,7 +505,12 @@ class IlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.retry",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -467,6 +534,8 @@ class IlmClient(NamespacedClient):
         :param master_timeout:
         :param timeout:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/start"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -483,7 +552,12 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.start",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -508,6 +582,8 @@ class IlmClient(NamespacedClient):
         :param master_timeout:
         :param timeout:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ilm/stop"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -524,5 +600,10 @@ class IlmClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ilm.stop",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/indices.py
+++ b/elasticsearch/_sync/client/indices.py
@@ -71,7 +71,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if block in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'block'")
-        __path = f"/{_quote(index)}/_block/{_quote(block)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "block": _quote(block)}
+        __path = f'/{__path_parts["index"]}/_block/{__path_parts["block"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -93,7 +95,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.add_block",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -155,9 +162,12 @@ class IndicesClient(NamespacedClient):
             as a multi-value field.
         :param tokenizer: Tokenizer to use to convert text into tokens.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_analyze"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_analyze'
         else:
+            __path_parts = {}
             __path = "/_analyze"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -194,7 +204,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.analyze",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -245,9 +261,12 @@ class IndicesClient(NamespacedClient):
         :param query: If `true`, clears the query cache.
         :param request: If `true`, clears the request cache.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_cache/clear"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_cache/clear'
         else:
+            __path_parts = {}
             __path = "/_cache/clear"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -274,7 +293,12 @@ class IndicesClient(NamespacedClient):
             __query["request"] = request
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.clear_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -322,7 +346,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/{_quote(index)}/_clone/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target": _quote(target)}
+        __path = f'/{__path_parts["index"]}/_clone/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -350,7 +376,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.clone",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -407,7 +439,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_close"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_close'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -431,7 +465,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.close",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -478,7 +517,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -508,7 +549,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.create",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -534,7 +581,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -546,7 +595,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.create_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -578,9 +632,12 @@ class IndicesClient(NamespacedClient):
         :param expand_wildcards: Type of data stream that wildcard patterns can match.
             Supports comma-separated values, such as `open,hidden`.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_data_stream/{_quote(name)}/_stats"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_data_stream/{__path_parts["name"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_data_stream/_stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -595,7 +652,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.data_streams_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -648,7 +710,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -670,7 +734,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -707,7 +776,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "name": _quote(name)}
+        __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -723,7 +794,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -762,7 +838,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}/_lifecycle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -780,7 +858,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -813,7 +896,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -827,7 +912,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -859,7 +949,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -875,7 +967,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -907,7 +1004,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -923,7 +1022,12 @@ class IndicesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.delete_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -975,7 +1079,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_disk_usage"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_disk_usage'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -997,7 +1103,12 @@ class IndicesClient(NamespacedClient):
             __query["run_expensive_tasks"] = run_expensive_tasks
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.disk_usage",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1034,7 +1145,9 @@ class IndicesClient(NamespacedClient):
             )
         elif config is not None and body is not None:
             raise ValueError("Cannot set both 'config' and 'body'")
-        __path = f"/{_quote(index)}/_downsample/{_quote(target_index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target_index": _quote(target_index)}
+        __path = f'/{__path_parts["index"]}/_downsample/{__path_parts["target_index"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1047,7 +1160,13 @@ class IndicesClient(NamespacedClient):
         __body = config if config is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.downsample",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1096,7 +1215,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -1120,7 +1241,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1168,10 +1294,13 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+            __path_parts = {"index": _quote(index), "name": _quote(name)}
+            __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         elif name not in SKIP_IN_PATH:
-            __path = f"/_alias/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_alias/{__path_parts["name"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1193,7 +1322,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1222,7 +1356,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1236,7 +1372,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1267,7 +1408,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1285,7 +1428,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "HEAD", __path, params=__query, headers=__headers
+            "HEAD",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.exists_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1315,7 +1463,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_lifecycle/explain"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_lifecycle/explain'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1331,7 +1481,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.explain_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1393,7 +1548,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_field_usage_stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_field_usage_stats'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -1419,7 +1576,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.field_usage_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1467,9 +1629,12 @@ class IndicesClient(NamespacedClient):
             when another flush operation is running. If `false`, Elasticsearch returns
             an error if you request a flush when another flush operation is running.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_flush"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_flush'
         else:
+            __path_parts = {}
             __path = "/_flush"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -1492,7 +1657,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_if_ongoing"] = wait_if_ongoing
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.flush",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1542,9 +1712,12 @@ class IndicesClient(NamespacedClient):
         :param wait_for_completion: Should the request wait until the force merge is
             completed.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_forcemerge"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_forcemerge'
         else:
+            __path_parts = {}
             __path = "/_forcemerge"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -1571,7 +1744,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.forcemerge",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1638,7 +1816,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -1666,7 +1846,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1713,13 +1898,18 @@ class IndicesClient(NamespacedClient):
         :param local: If `true`, the request retrieves information from the local node
             only.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+            __path_parts = {"index": _quote(index), "name": _quote(name)}
+            __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_alias"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_alias'
         elif name not in SKIP_IN_PATH:
-            __path = f"/_alias/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_alias/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_alias"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -1740,7 +1930,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1777,7 +1972,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}/_lifecycle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1793,7 +1990,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1828,9 +2030,12 @@ class IndicesClient(NamespacedClient):
         :param include_defaults: If true, returns all relevant default configurations
             for the index template.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_data_stream/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_data_stream/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_data_stream"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1847,7 +2052,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1898,10 +2108,13 @@ class IndicesClient(NamespacedClient):
         """
         if fields in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'fields'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and fields not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mapping/field/{_quote(fields)}"
+            __path_parts = {"index": _quote(index), "fields": _quote(fields)}
+            __path = f'/{__path_parts["index"]}/_mapping/field/{__path_parts["fields"]}'
         elif fields not in SKIP_IN_PATH:
-            __path = f"/_mapping/field/{_quote(fields)}"
+            __path_parts = {"fields": _quote(fields)}
+            __path = f'/_mapping/field/{__path_parts["fields"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1925,7 +2138,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_field_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1961,9 +2179,12 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_index_template/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_index_template/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_index_template"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1984,7 +2205,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2034,9 +2260,12 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_mapping"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_mapping'
         else:
+            __path_parts = {}
             __path = "/_mapping"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2059,7 +2288,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2117,13 +2351,18 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_settings/{_quote(name)}"
+            __path_parts = {"index": _quote(index), "name": _quote(name)}
+            __path = f'/{__path_parts["index"]}/_settings/{__path_parts["name"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_settings"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_settings'
         elif name not in SKIP_IN_PATH:
-            __path = f"/_settings/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_settings/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_settings"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2150,7 +2389,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2183,9 +2427,12 @@ class IndicesClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_template/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_template/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_template"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2204,7 +2451,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.get_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2226,7 +2478,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/_migrate/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/_migrate/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2238,7 +2492,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.migrate_to_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2263,6 +2522,8 @@ class IndicesClient(NamespacedClient):
         """
         if actions is None and body is None:
             raise ValueError("Empty value passed for parameter 'actions'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_data_stream/_modify"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2279,7 +2540,13 @@ class IndicesClient(NamespacedClient):
                 __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.modify_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2340,7 +2607,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_open"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_open'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -2364,7 +2633,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.open",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2387,7 +2661,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/_promote/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/_promote/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2399,7 +2675,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.promote_data_stream",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2466,7 +2747,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/{_quote(index)}/_alias/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "name": _quote(name)}
+        __path = f'/{__path_parts["index"]}/_alias/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2498,7 +2781,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2555,7 +2844,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_data_stream/{_quote(name)}/_lifecycle"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2583,7 +2874,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_data_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2645,7 +2942,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -2675,7 +2974,13 @@ class IndicesClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2785,7 +3090,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_mapping"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_mapping'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -2833,7 +3140,13 @@ class IndicesClient(NamespacedClient):
                 __body["_source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2899,9 +3212,12 @@ class IndicesClient(NamespacedClient):
             )
         elif settings is not None and body is not None:
             raise ValueError("Cannot set both 'settings' and 'body'")
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_settings"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_settings'
         else:
+            __path_parts = {}
             __path = "/_settings"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -2929,7 +3245,13 @@ class IndicesClient(NamespacedClient):
         __body = settings if settings is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2992,7 +3314,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_template/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_template/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -3026,7 +3350,13 @@ class IndicesClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.put_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3053,9 +3383,12 @@ class IndicesClient(NamespacedClient):
         :param detailed: If `true`, the response includes detailed information about
             shard recoveries.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_recovery"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_recovery'
         else:
+            __path_parts = {}
             __path = "/_recovery"
         __query: t.Dict[str, t.Any] = {}
         if active_only is not None:
@@ -3072,7 +3405,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.recovery",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3113,9 +3451,12 @@ class IndicesClient(NamespacedClient):
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_refresh"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_refresh'
         else:
+            __path_parts = {}
             __path = "/_refresh"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -3134,7 +3475,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.refresh",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3173,7 +3519,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_reload_search_analyzers"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_reload_search_analyzers'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -3191,7 +3539,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.reload_search_analyzers",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3240,7 +3593,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_resolve/cluster/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_resolve/cluster/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -3260,7 +3615,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.resolve_cluster",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3296,7 +3656,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_resolve/index/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_resolve/index/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3310,7 +3672,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.resolve_index",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3373,10 +3740,13 @@ class IndicesClient(NamespacedClient):
         """
         if alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'alias'")
+        __path_parts: t.Dict[str, str]
         if alias not in SKIP_IN_PATH and new_index not in SKIP_IN_PATH:
-            __path = f"/{_quote(alias)}/_rollover/{_quote(new_index)}"
+            __path_parts = {"alias": _quote(alias), "new_index": _quote(new_index)}
+            __path = f'/{__path_parts["alias"]}/_rollover/{__path_parts["new_index"]}'
         elif alias not in SKIP_IN_PATH:
-            __path = f"/{_quote(alias)}/_rollover"
+            __path_parts = {"alias": _quote(alias)}
+            __path = f'/{__path_parts["alias"]}/_rollover'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -3412,7 +3782,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.rollover",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3455,9 +3831,12 @@ class IndicesClient(NamespacedClient):
             a missing or closed index.
         :param verbose: If `true`, the request returns a verbose response.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_segments"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_segments'
         else:
+            __path_parts = {}
             __path = "/_segments"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -3478,7 +3857,12 @@ class IndicesClient(NamespacedClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.segments",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3523,9 +3907,12 @@ class IndicesClient(NamespacedClient):
             in the response.
         :param status: List of shard health statuses used to limit the request.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_shard_stores"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_shard_stores'
         else:
+            __path_parts = {}
             __path = "/_shard_stores"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -3546,7 +3933,12 @@ class IndicesClient(NamespacedClient):
             __query["status"] = status
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.shard_stores",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3594,7 +3986,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/{_quote(index)}/_shrink/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target": _quote(target)}
+        __path = f'/{__path_parts["index"]}/_shrink/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3622,7 +4016,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.shrink",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3704,7 +4104,9 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_index_template/_simulate_index/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_index_template/_simulate_index/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
@@ -3744,7 +4146,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.simulate_index_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3791,9 +4199,12 @@ class IndicesClient(NamespacedClient):
             )
         elif template is not None and body is not None:
             raise ValueError("Cannot set both 'template' and 'body'")
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_index_template/_simulate/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_index_template/_simulate/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_index_template/_simulate"
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
@@ -3817,7 +4228,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.simulate_template",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3865,7 +4282,9 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if target in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'target'")
-        __path = f"/{_quote(index)}/_split/{_quote(target)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index), "target": _quote(target)}
+        __path = f'/{__path_parts["index"]}/_split/{__path_parts["target"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3893,7 +4312,13 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.split",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3955,13 +4380,18 @@ class IndicesClient(NamespacedClient):
         :param level: Indicates whether statistics are aggregated at the cluster, index,
             or shard level.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_stats/{_quote(metric)}"
+            __path_parts = {"index": _quote(index), "metric": _quote(metric)}
+            __path = f'/{__path_parts["index"]}/_stats/{__path_parts["metric"]}'
         elif index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_stats"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_stats'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_stats/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_stats/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_stats"
         __query: t.Dict[str, t.Any] = {}
         if completion_fields is not None:
@@ -3992,7 +4422,12 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4047,7 +4482,9 @@ class IndicesClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_unfreeze"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_unfreeze'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -4071,7 +4508,12 @@ class IndicesClient(NamespacedClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="indices.unfreeze",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4103,6 +4545,8 @@ class IndicesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_aliases"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4123,7 +4567,13 @@ class IndicesClient(NamespacedClient):
                 __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.update_aliases",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4195,9 +4645,12 @@ class IndicesClient(NamespacedClient):
         :param rewrite: If `true`, returns a more detailed explanation showing the actual
             Lucene query that will be executed.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_validate/query"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_validate/query'
         else:
+            __path_parts = {}
             __path = "/_validate/query"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4242,5 +4695,11 @@ class IndicesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="indices.validate_query",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/inference.py
+++ b/elasticsearch/_sync/client/inference.py
@@ -48,10 +48,16 @@ class InferenceClient(NamespacedClient):
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -65,7 +71,12 @@ class InferenceClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="inference.delete_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -91,10 +102,16 @@ class InferenceClient(NamespacedClient):
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -108,7 +125,12 @@ class InferenceClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="inference.get_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -143,10 +165,16 @@ class InferenceClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'inference_id'")
         if input is None and body is None:
             raise ValueError("Empty value passed for parameter 'input'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -170,7 +198,13 @@ class InferenceClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.inference",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -207,10 +241,16 @@ class InferenceClient(NamespacedClient):
             )
         elif model_config is not None and body is not None:
             raise ValueError("Cannot set both 'model_config' and 'body'")
+        __path_parts: t.Dict[str, str]
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
         elif inference_id not in SKIP_IN_PATH:
-            __path = f"/_inference/{_quote(inference_id)}"
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -229,5 +269,11 @@ class InferenceClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.put_model",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/ingest.py
+++ b/elasticsearch/_sync/client/ingest.py
@@ -54,7 +54,9 @@ class IngestClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ingest/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ingest/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -70,7 +72,12 @@ class IngestClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.delete_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -87,6 +94,8 @@ class IngestClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ingest/geoip/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -99,7 +108,12 @@ class IngestClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.geo_ip_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -128,9 +142,12 @@ class IngestClient(NamespacedClient):
             returns an error.
         :param summary: Return pipelines without their definitions (default: false)
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ingest/pipeline/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ingest/pipeline/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_ingest/pipeline"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -147,7 +164,12 @@ class IngestClient(NamespacedClient):
             __query["summary"] = summary
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.get_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -164,6 +186,8 @@ class IngestClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ingest/processor/grok"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -176,7 +200,12 @@ class IngestClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ingest.processor_grok",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -233,7 +262,9 @@ class IngestClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ingest/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ingest/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -263,7 +294,13 @@ class IngestClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ingest.put_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -296,9 +333,12 @@ class IngestClient(NamespacedClient):
         :param verbose: If `true`, the response includes output data for each processor
             in the executed pipeline.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ingest/pipeline/{__path_parts["id"]}/_simulate'
         else:
+            __path_parts = {}
             __path = "/_ingest/pipeline/_simulate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -319,5 +359,11 @@ class IngestClient(NamespacedClient):
                 __body["pipeline"] = pipeline
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ingest.simulate",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/license.py
+++ b/elasticsearch/_sync/client/license.py
@@ -39,6 +39,8 @@ class LicenseClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -51,7 +53,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -77,6 +84,8 @@ class LicenseClient(NamespacedClient):
         :param local: Specifies whether to retrieve local information. The default value
             is `false`, which means the information is retrieved from the master node.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
         if accept_enterprise is not None:
@@ -93,7 +102,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -110,6 +124,8 @@ class LicenseClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/basic_status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -122,7 +138,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.get_basic_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -139,6 +160,8 @@ class LicenseClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/trial_status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -151,7 +174,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.get_trial_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -179,6 +207,8 @@ class LicenseClient(NamespacedClient):
         :param licenses: A sequence of one or more JSON documents containing the license
             information.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -203,7 +233,13 @@ class LicenseClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="license.post",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -224,6 +260,8 @@ class LicenseClient(NamespacedClient):
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/start_basic"
         __query: t.Dict[str, t.Any] = {}
         if acknowledge is not None:
@@ -238,7 +276,12 @@ class LicenseClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.post_start_basic",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -261,6 +304,8 @@ class LicenseClient(NamespacedClient):
             false)
         :param type_query_string:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_license/start_trial"
         __query: t.Dict[str, t.Any] = {}
         if acknowledge is not None:
@@ -277,5 +322,10 @@ class LicenseClient(NamespacedClient):
             __query["type_query_string"] = type_query_string
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="license.post_start_trial",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/logstash.py
+++ b/elasticsearch/_sync/client/logstash.py
@@ -44,7 +44,9 @@ class LogstashClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_logstash/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_logstash/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class LogstashClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="logstash.delete_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -76,9 +83,12 @@ class LogstashClient(NamespacedClient):
 
         :param id: Comma-separated list of pipeline identifiers.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_logstash/pipeline/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_logstash/pipeline/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_logstash/pipeline"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -91,7 +101,12 @@ class LogstashClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="logstash.get_pipeline",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -124,7 +139,9 @@ class LogstashClient(NamespacedClient):
             )
         elif pipeline is not None and body is not None:
             raise ValueError("Cannot set both 'pipeline' and 'body'")
-        __path = f"/_logstash/pipeline/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_logstash/pipeline/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -137,5 +154,11 @@ class LogstashClient(NamespacedClient):
         __body = pipeline if pipeline is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="logstash.put_pipeline",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/migration.py
+++ b/elasticsearch/_sync/client/migration.py
@@ -45,9 +45,12 @@ class MigrationClient(NamespacedClient):
         :param index: Comma-separate list of data streams or indices to check. Wildcard
             (*) expressions are supported.
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_migration/deprecations"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_migration/deprecations'
         else:
+            __path_parts = {}
             __path = "/_migration/deprecations"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -60,7 +63,12 @@ class MigrationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="migration.deprecations",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -77,6 +85,8 @@ class MigrationClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-feature-upgrade.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_migration/system_features"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -89,7 +99,12 @@ class MigrationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="migration.get_feature_upgrade_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -106,6 +121,8 @@ class MigrationClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-feature-upgrade.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_migration/system_features"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -118,5 +135,10 @@ class MigrationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="migration.post_feature_upgrade",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -44,7 +44,11 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/deployment/cache/_clear"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = (
+            f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/cache/_clear'
+        )
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +60,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.clear_trained_model_deployment_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -93,7 +102,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_close"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_close'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -117,7 +128,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.close_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -139,7 +156,9 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -151,7 +170,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_calendar",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -178,7 +202,12 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if event_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'event_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/events/{_quote(event_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "calendar_id": _quote(calendar_id),
+            "event_id": _quote(event_id),
+        }
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/events/{__path_parts["event_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -190,7 +219,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_calendar_event",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -217,7 +251,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/jobs/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id), "job_id": _quote(job_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/jobs/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -229,7 +265,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_calendar_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -256,7 +297,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -272,7 +315,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -300,7 +348,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -314,7 +364,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -344,9 +399,12 @@ class MlClient(NamespacedClient):
         :param timeout: How long can the underlying delete processes run until they are
             canceled.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/_delete_expired_data/{_quote(job_id)}"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/_delete_expired_data/{__path_parts["job_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/_delete_expired_data"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -369,7 +427,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.delete_expired_data",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -391,7 +455,9 @@ class MlClient(NamespacedClient):
         """
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
-        __path = f"/_ml/filters/{_quote(filter_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"filter_id": _quote(filter_id)}
+        __path = f'/_ml/filters/{__path_parts["filter_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -403,7 +469,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_filter",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -438,10 +509,16 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and forecast_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast/{_quote(forecast_id)}"
+            __path_parts = {
+                "job_id": _quote(job_id),
+                "forecast_id": _quote(forecast_id),
+            }
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_forecast/{__path_parts["forecast_id"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_forecast'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -459,7 +536,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_forecast",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -491,7 +573,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if delete_user_annotations is not None:
             __query["delete_user_annotations"] = delete_user_annotations
@@ -509,7 +593,12 @@ class MlClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -535,7 +624,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -547,7 +638,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_model_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -573,7 +669,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -587,7 +685,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_trained_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -613,7 +716,12 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if model_alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_alias'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/model_aliases/{_quote(model_alias)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "model_id": _quote(model_id),
+            "model_alias": _quote(model_alias),
+        }
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/model_aliases/{__path_parts["model_alias"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -625,7 +733,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.delete_trained_model_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -667,6 +780,8 @@ class MlClient(NamespacedClient):
             from the request if no detectors have a `by_field_name`, `over_field_name`
             or `partition_field_name`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/anomaly_detectors/_estimate_model_memory"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -687,7 +802,13 @@ class MlClient(NamespacedClient):
                 __body["overall_cardinality"] = overall_cardinality
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.estimate_model_memory",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -719,6 +840,8 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'evaluation'")
         if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/data_frame/_evaluate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -739,7 +862,13 @@ class MlClient(NamespacedClient):
                 __body["query"] = query
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.evaluate_data_frame",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -805,9 +934,12 @@ class MlClient(NamespacedClient):
         :param source: The configuration of how to source the analysis data. It requires
             an index. Optionally, query and _source may be specified.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}/_explain"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_explain'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics/_explain"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -842,7 +974,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.explain_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -877,7 +1015,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_flush"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_flush'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -905,7 +1045,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.flush_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -938,7 +1084,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_forecast"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_forecast'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -962,7 +1110,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.forecast",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1022,10 +1176,13 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and timestamp not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/buckets/{_quote(timestamp)}"
+            __path_parts = {"job_id": _quote(job_id), "timestamp": _quote(timestamp)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/buckets/{__path_parts["timestamp"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/buckets"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/buckets'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1065,7 +1222,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_buckets",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1103,7 +1266,9 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/events'
         __query: t.Dict[str, t.Any] = {}
         if end is not None:
             __query["end"] = end
@@ -1125,7 +1290,12 @@ class MlClient(NamespacedClient):
             __query["start"] = start
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_calendar_events",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1160,9 +1330,12 @@ class MlClient(NamespacedClient):
         :param size: Specifies the maximum number of calendars to obtain. This parameter
             is supported only when you omit the calendar identifier.
         """
+        __path_parts: t.Dict[str, str]
         if calendar_id not in SKIP_IN_PATH:
-            __path = f"/_ml/calendars/{_quote(calendar_id)}"
+            __path_parts = {"calendar_id": _quote(calendar_id)}
+            __path = f'/_ml/calendars/{__path_parts["calendar_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/calendars"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1187,7 +1360,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_calendars",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1227,10 +1406,18 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and category_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/categories/{_quote(category_id)}"
+            __path_parts = {
+                "job_id": _quote(job_id),
+                "category_id": _quote(category_id),
+            }
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/categories/{__path_parts["category_id"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/categories"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = (
+                f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/categories'
+            )
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1258,7 +1445,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_categories",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1299,9 +1492,12 @@ class MlClient(NamespacedClient):
         :param from_: Skips the specified number of data frame analytics jobs.
         :param size: Specifies the maximum number of data frame analytics jobs to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1322,7 +1518,12 @@ class MlClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1361,9 +1562,12 @@ class MlClient(NamespacedClient):
         :param size: Specifies the maximum number of data frame analytics jobs to obtain.
         :param verbose: Defines whether the stats response should be verbose.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}/_stats"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1384,7 +1588,12 @@ class MlClient(NamespacedClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_data_frame_analytics_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1414,9 +1623,12 @@ class MlClient(NamespacedClient):
             when there are partial matches. If this parameter is `false`, the request
             returns a `404` status code when there are no matches or only partial matches.
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stats"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/datafeeds/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1431,7 +1643,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_datafeed_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1465,9 +1682,12 @@ class MlClient(NamespacedClient):
             the configuration on retrieval. This allows the configuration to be in an
             acceptable format to be retrieved and then added to another cluster.
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/datafeeds"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1484,7 +1704,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_datafeeds",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1510,9 +1735,12 @@ class MlClient(NamespacedClient):
         :param from_: Skips the specified number of filters.
         :param size: Specifies the maximum number of filters to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if filter_id not in SKIP_IN_PATH:
-            __path = f"/_ml/filters/{_quote(filter_id)}"
+            __path_parts = {"filter_id": _quote(filter_id)}
+            __path = f'/_ml/filters/{__path_parts["filter_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/filters"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1529,7 +1757,12 @@ class MlClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_filters",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1579,7 +1812,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/influencers"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/influencers'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if desc is not None:
@@ -1615,7 +1850,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_influencers",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1646,9 +1887,12 @@ class MlClient(NamespacedClient):
             partial matches. If `false`, the API returns a `404` status code when there
             are no matches or only partial matches.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_stats"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/anomaly_detectors/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1663,7 +1907,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_job_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1697,9 +1946,12 @@ class MlClient(NamespacedClient):
             the configuration on retrieval. This allows the configuration to be in an
             acceptable format to be retrieved and then added to another cluster.
         """
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/anomaly_detectors"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -1716,7 +1968,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_jobs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1746,9 +2003,12 @@ class MlClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_ml/memory/{_quote(node_id)}/_stats"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_ml/memory/{__path_parts["node_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/memory/_stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1765,7 +2025,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_memory_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1803,7 +2068,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_upgrade/_stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_upgrade/_stats'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -1817,7 +2084,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_model_snapshot_upgrade_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1863,10 +2135,16 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
+        __path_parts: t.Dict[str, str]
         if job_id not in SKIP_IN_PATH and snapshot_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}"
+            __path_parts = {
+                "job_id": _quote(job_id),
+                "snapshot_id": _quote(snapshot_id),
+            }
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}'
         elif job_id not in SKIP_IN_PATH:
-            __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots"
+            __path_parts = {"job_id": _quote(job_id)}
+            __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -1900,7 +2178,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_model_snapshots",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1954,7 +2238,11 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/overall_buckets"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = (
+            f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/overall_buckets'
+        )
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -1986,7 +2274,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_overall_buckets",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2039,7 +2333,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/records"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/results/records'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2075,7 +2371,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.get_records",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2127,9 +2429,12 @@ class MlClient(NamespacedClient):
             tags, or none. When supplied, only trained models that contain all the supplied
             tags are returned.
         """
+        __path_parts: t.Dict[str, str]
         if model_id not in SKIP_IN_PATH:
-            __path = f"/_ml/trained_models/{_quote(model_id)}"
+            __path_parts = {"model_id": _quote(model_id)}
+            __path = f'/_ml/trained_models/{__path_parts["model_id"]}'
         else:
+            __path_parts = {}
             __path = "/_ml/trained_models"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -2156,7 +2461,12 @@ class MlClient(NamespacedClient):
             __query["tags"] = tags
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_trained_models",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2189,9 +2499,12 @@ class MlClient(NamespacedClient):
         :param from_: Skips the specified number of models.
         :param size: Specifies the maximum number of models to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if model_id not in SKIP_IN_PATH:
-            __path = f"/_ml/trained_models/{_quote(model_id)}/_stats"
+            __path_parts = {"model_id": _quote(model_id)}
+            __path = f'/_ml/trained_models/{__path_parts["model_id"]}/_stats'
         else:
+            __path_parts = {}
             __path = "/_ml/trained_models/_stats"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -2210,7 +2523,12 @@ class MlClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.get_trained_models_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2247,7 +2565,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if docs is None and body is None:
             raise ValueError("Empty value passed for parameter 'docs'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/_infer"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/_infer'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2267,7 +2587,13 @@ class MlClient(NamespacedClient):
                 __body["inference_config"] = inference_config
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.infer_trained_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2284,6 +2610,8 @@ class MlClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/info"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -2296,7 +2624,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2323,7 +2656,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_open"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_open'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2343,7 +2678,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.open_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2374,7 +2715,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if events is None and body is None:
             raise ValueError("Empty value passed for parameter 'events'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/events'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2390,7 +2733,13 @@ class MlClient(NamespacedClient):
                 __body["events"] = events
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.post_calendar_events",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2428,7 +2777,9 @@ class MlClient(NamespacedClient):
             )
         elif data is not None and body is not None:
             raise ValueError("Cannot set both 'data' and 'body'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_data"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_data'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2448,7 +2799,13 @@ class MlClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.post_data",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2475,9 +2832,12 @@ class MlClient(NamespacedClient):
             analytics jobs. Note that `id` and `dest` don’t need to be provided in the
             context of this API.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_ml/data_frame/analytics/{_quote(id)}/_preview"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_preview'
         else:
+            __path_parts = {}
             __path = "/_ml/data_frame/analytics/_preview"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2498,7 +2858,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.preview_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2538,9 +2904,12 @@ class MlClient(NamespacedClient):
             object unless you also supply a `datafeed_config` object.
         :param start: The start time from where the datafeed preview should begin
         """
+        __path_parts: t.Dict[str, str]
         if datafeed_id not in SKIP_IN_PATH:
-            __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_preview"
+            __path_parts = {"datafeed_id": _quote(datafeed_id)}
+            __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_preview'
         else:
+            __path_parts = {}
             __path = "/_ml/datafeeds/_preview"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2567,7 +2936,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.preview_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2596,7 +2971,9 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2618,7 +2995,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_calendar",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2645,7 +3028,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/calendars/{_quote(calendar_id)}/jobs/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"calendar_id": _quote(calendar_id), "job_id": _quote(job_id)}
+        __path = f'/_ml/calendars/{__path_parts["calendar_id"]}/jobs/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2657,7 +3042,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.put_calendar_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2763,7 +3153,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'dest'")
         if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2797,7 +3189,13 @@ class MlClient(NamespacedClient):
                 __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2932,7 +3330,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -2984,7 +3384,13 @@ class MlClient(NamespacedClient):
                 __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3014,7 +3420,9 @@ class MlClient(NamespacedClient):
         """
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
-        __path = f"/_ml/filters/{_quote(filter_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"filter_id": _quote(filter_id)}
+        __path = f'/_ml/filters/{__path_parts["filter_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3032,7 +3440,13 @@ class MlClient(NamespacedClient):
                 __body["items"] = items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_filter",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3165,7 +3579,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'analysis_config'")
         if data_description is None and body is None:
             raise ValueError("Empty value passed for parameter 'data_description'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3211,7 +3627,13 @@ class MlClient(NamespacedClient):
                 __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3288,7 +3710,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_definition_decompression is not None:
@@ -3324,7 +3748,13 @@ class MlClient(NamespacedClient):
                 __body["tags"] = tags
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_trained_model",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3355,7 +3785,12 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if model_alias in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_alias'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/model_aliases/{_quote(model_alias)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "model_id": _quote(model_id),
+            "model_alias": _quote(model_alias),
+        }
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/model_aliases/{__path_parts["model_alias"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3369,7 +3804,12 @@ class MlClient(NamespacedClient):
             __query["reassign"] = reassign
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.put_trained_model_alias",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3417,7 +3857,9 @@ class MlClient(NamespacedClient):
             )
         if total_parts is None and body is None:
             raise ValueError("Empty value passed for parameter 'total_parts'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/definition/{_quote(part)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id), "part": _quote(part)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/definition/{__path_parts["part"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3437,7 +3879,13 @@ class MlClient(NamespacedClient):
                 __body["total_parts"] = total_parts
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_trained_model_definition_part",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3470,7 +3918,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if vocabulary is None and body is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/vocabulary'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3490,7 +3940,13 @@ class MlClient(NamespacedClient):
                 __body["scores"] = scores
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.put_trained_model_vocabulary",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3519,7 +3975,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_reset"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_reset'
         __query: t.Dict[str, t.Any] = {}
         if delete_user_annotations is not None:
             __query["delete_user_annotations"] = delete_user_annotations
@@ -3535,7 +3993,12 @@ class MlClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.reset_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3569,7 +4032,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_revert"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_revert'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3589,7 +4054,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.revert_model_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3614,6 +4085,8 @@ class MlClient(NamespacedClient):
             starting.
         :param timeout: The time to wait for the request to be completed.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/set_upgrade_mode"
         __query: t.Dict[str, t.Any] = {}
         if enabled is not None:
@@ -3630,7 +4103,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.set_upgrade_mode",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3657,7 +4135,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -3671,7 +4151,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.start_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3705,7 +4190,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3729,7 +4216,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.start_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3785,7 +4278,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/deployment/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/_start'
         __query: t.Dict[str, t.Any] = {}
         if cache_size is not None:
             __query["cache_size"] = cache_size
@@ -3813,7 +4308,12 @@ class MlClient(NamespacedClient):
             __query["wait_for"] = wait_for
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.start_trained_model_deployment",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3851,7 +4351,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -3869,7 +4371,12 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.stop_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -3904,7 +4411,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -3928,7 +4437,13 @@ class MlClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.stop_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -3961,7 +4476,9 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        __path = f"/_ml/trained_models/{_quote(model_id)}/deployment/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"model_id": _quote(model_id)}
+        __path = f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/_stop'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -3977,7 +4494,12 @@ class MlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.stop_trained_model_deployment",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4025,7 +4547,9 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_ml/data_frame/analytics/{_quote(id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_ml/data_frame/analytics/{__path_parts["id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4047,7 +4571,13 @@ class MlClient(NamespacedClient):
                 __body["model_memory_limit"] = model_memory_limit
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_data_frame_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4190,7 +4720,9 @@ class MlClient(NamespacedClient):
         """
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
-        __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"datafeed_id": _quote(datafeed_id)}
+        __path = f'/_ml/datafeeds/{__path_parts["datafeed_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
@@ -4240,7 +4772,13 @@ class MlClient(NamespacedClient):
                 __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_datafeed",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4271,7 +4809,9 @@ class MlClient(NamespacedClient):
         """
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
-        __path = f"/_ml/filters/{_quote(filter_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"filter_id": _quote(filter_id)}
+        __path = f'/_ml/filters/{__path_parts["filter_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4291,7 +4831,13 @@ class MlClient(NamespacedClient):
                 __body["remove_items"] = remove_items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_filter",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4398,7 +4944,9 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4444,7 +4992,13 @@ class MlClient(NamespacedClient):
                 __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4479,7 +5033,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -4497,7 +5053,13 @@ class MlClient(NamespacedClient):
                 __body["retain"] = retain
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.update_model_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -4530,7 +5092,9 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         if snapshot_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot_id'")
-        __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/model_snapshots/{_quote(snapshot_id)}/_upgrade"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"job_id": _quote(job_id), "snapshot_id": _quote(snapshot_id)}
+        __path = f'/_ml/anomaly_detectors/{__path_parts["job_id"]}/model_snapshots/{__path_parts["snapshot_id"]}/_upgrade'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -4546,7 +5110,12 @@ class MlClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ml.upgrade_job_snapshot",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4595,6 +5164,8 @@ class MlClient(NamespacedClient):
         :param model_snapshot_retention_days:
         :param results_index_name:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/anomaly_detectors/_validate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -4627,7 +5198,13 @@ class MlClient(NamespacedClient):
                 __body["results_index_name"] = results_index_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.validate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -4656,6 +5233,8 @@ class MlClient(NamespacedClient):
             )
         elif detector is not None and body is not None:
             raise ValueError("Cannot set both 'detector' and 'body'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ml/anomaly_detectors/_validate/detector"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -4669,5 +5248,11 @@ class MlClient(NamespacedClient):
         __body = detector if detector is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="ml.validate_detector",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/monitoring.py
+++ b/elasticsearch/_sync/client/monitoring.py
@@ -63,6 +63,8 @@ class MonitoringClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'system_api_version'")
         if system_id is None:
             raise ValueError("Empty value passed for parameter 'system_id'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_monitoring/bulk"
         __query: t.Dict[str, t.Any] = {}
         if interval is not None:
@@ -85,5 +87,11 @@ class MonitoringClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="monitoring.bulk",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/nodes.py
+++ b/elasticsearch/_sync/client/nodes.py
@@ -50,7 +50,12 @@ class NodesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'node_id'")
         if max_archive_version in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'max_archive_version'")
-        __path = f"/_nodes/{_quote(node_id)}/_repositories_metering/{_quote(max_archive_version)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "node_id": _quote(node_id),
+            "max_archive_version": _quote(max_archive_version),
+        }
+        __path = f'/_nodes/{__path_parts["node_id"]}/_repositories_metering/{__path_parts["max_archive_version"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -62,7 +67,12 @@ class NodesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.clear_repositories_metering_archive",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -85,7 +95,9 @@ class NodesClient(NamespacedClient):
         """
         if node_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'node_id'")
-        __path = f"/_nodes/{_quote(node_id)}/_repositories_metering"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"node_id": _quote(node_id)}
+        __path = f'/_nodes/{__path_parts["node_id"]}/_repositories_metering'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -97,7 +109,12 @@ class NodesClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.get_repositories_metering_info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -143,9 +160,12 @@ class NodesClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         :param type: The type to sample.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/hot_threads"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/hot_threads'
         else:
+            __path_parts = {}
             __path = "/_nodes/hot_threads"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -174,7 +194,12 @@ class NodesClient(NamespacedClient):
             __query["type"] = type
         __headers = {"accept": "text/plain"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.hot_threads",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -209,13 +234,18 @@ class NodesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/{_quote(metric)}"
+            __path_parts = {"node_id": _quote(node_id), "metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/{__path_parts["metric"]}'
         elif node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_nodes"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -234,7 +264,12 @@ class NodesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -262,9 +297,12 @@ class NodesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/reload_secure_settings"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/reload_secure_settings'
         else:
+            __path_parts = {}
             __path = "/_nodes/reload_secure_settings"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -287,7 +325,13 @@ class NodesClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="nodes.reload_secure_settings",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -350,21 +394,37 @@ class NodesClient(NamespacedClient):
         :param types: A comma-separated list of document types for the indexing index
             metric.
         """
+        __path_parts: t.Dict[str, str]
         if (
             node_id not in SKIP_IN_PATH
             and metric not in SKIP_IN_PATH
             and index_metric not in SKIP_IN_PATH
         ):
-            __path = f"/_nodes/{_quote(node_id)}/stats/{_quote(metric)}/{_quote(index_metric)}"
+            __path_parts = {
+                "node_id": _quote(node_id),
+                "metric": _quote(metric),
+                "index_metric": _quote(index_metric),
+            }
+            __path = f'/_nodes/{__path_parts["node_id"]}/stats/{__path_parts["metric"]}/{__path_parts["index_metric"]}'
         elif node_id not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/stats/{_quote(metric)}"
+            __path_parts = {"node_id": _quote(node_id), "metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/stats/{__path_parts["metric"]}'
         elif metric not in SKIP_IN_PATH and index_metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/stats/{_quote(metric)}/{_quote(index_metric)}"
+            __path_parts = {
+                "metric": _quote(metric),
+                "index_metric": _quote(index_metric),
+            }
+            __path = (
+                f'/_nodes/stats/{__path_parts["metric"]}/{__path_parts["index_metric"]}'
+            )
         elif node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/stats"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/stats'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/stats/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_nodes/stats/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_nodes/stats"
         __query: t.Dict[str, t.Any] = {}
         if completion_fields is not None:
@@ -397,7 +457,12 @@ class NodesClient(NamespacedClient):
             __query["types"] = types
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -425,13 +490,18 @@ class NodesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH and metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/usage/{_quote(metric)}"
+            __path_parts = {"node_id": _quote(node_id), "metric": _quote(metric)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/usage/{__path_parts["metric"]}'
         elif node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/usage"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/usage'
         elif metric not in SKIP_IN_PATH:
-            __path = f"/_nodes/usage/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_nodes/usage/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_nodes/usage"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -446,5 +516,10 @@ class NodesClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="nodes.usage",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/query_ruleset.py
+++ b/elasticsearch/_sync/client/query_ruleset.py
@@ -44,7 +44,9 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ruleset_id": _quote(ruleset_id)}
+        __path = f'/_query_rules/{__path_parts["ruleset_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class QueryRulesetClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="query_ruleset.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -78,7 +85,9 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ruleset_id": _quote(ruleset_id)}
+        __path = f'/_query_rules/{__path_parts["ruleset_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -90,7 +99,12 @@ class QueryRulesetClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="query_ruleset.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -114,6 +128,8 @@ class QueryRulesetClient(NamespacedClient):
         :param from_: Starting offset (default: 0)
         :param size: specifies a max number of results to get
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_query_rules"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -130,7 +146,12 @@ class QueryRulesetClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="query_ruleset.list",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -160,7 +181,9 @@ class QueryRulesetClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
         if rules is None and body is None:
             raise ValueError("Empty value passed for parameter 'rules'")
-        __path = f"/_query_rules/{_quote(ruleset_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ruleset_id": _quote(ruleset_id)}
+        __path = f'/_query_rules/{__path_parts["ruleset_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -176,5 +199,11 @@ class QueryRulesetClient(NamespacedClient):
                 __body["rules"] = rules
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="query_ruleset.put",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/rollup.py
+++ b/elasticsearch/_sync/client/rollup.py
@@ -44,7 +44,9 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_rollup/job/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.delete_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -77,9 +84,12 @@ class RollupClient(NamespacedClient):
         :param id: Identifier for the rollup job. If it is `_all` or omitted, the API
             returns all rollup jobs.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_rollup/job/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_rollup/job/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_rollup/job"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -92,7 +102,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.get_jobs",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -114,9 +129,12 @@ class RollupClient(NamespacedClient):
         :param id: Index, indices or index-pattern to return rollup capabilities for.
             `_all` may be used to fetch rollup capabilities from all jobs.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_rollup/data/{_quote(id)}"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_rollup/data/{__path_parts["id"]}'
         else:
+            __path_parts = {}
             __path = "/_rollup/data"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -129,7 +147,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.get_rollup_caps",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -153,7 +176,9 @@ class RollupClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_rollup/data"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_rollup/data'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -165,7 +190,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.get_rollup_index_caps",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -256,7 +286,9 @@ class RollupClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'page_size'")
         if rollup_index is None and body is None:
             raise ValueError("Empty value passed for parameter 'rollup_index'")
-        __path = f"/_rollup/job/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -286,7 +318,13 @@ class RollupClient(NamespacedClient):
                 __body["timeout"] = timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="rollup.put_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -325,7 +363,9 @@ class RollupClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/{_quote(index)}/_rollup_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"index": _quote(index)}
+        __path = f'/{__path_parts["index"]}/_rollup_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -351,7 +391,13 @@ class RollupClient(NamespacedClient):
                 __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="rollup.rollup_search",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -373,7 +419,9 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_rollup/job/{_quote(id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -385,7 +433,12 @@ class RollupClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.start_job",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -415,7 +468,9 @@ class RollupClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_rollup/job/{_quote(id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_rollup/job/{__path_parts["id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -431,5 +486,10 @@ class RollupClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="rollup.stop_job",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/search_application.py
+++ b/elasticsearch/_sync/client/search_application.py
@@ -44,7 +44,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -78,7 +85,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/analytics/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -90,7 +99,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.delete_behavioral_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -112,7 +126,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -124,7 +140,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -144,9 +165,12 @@ class SearchApplicationClient(NamespacedClient):
 
         :param name: A list of analytics collections to limit the returned information
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_application/analytics/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_application/analytics/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_application/analytics"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -159,7 +183,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.get_behavioral_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -185,6 +214,8 @@ class SearchApplicationClient(NamespacedClient):
         :param q: Query in the Lucene query string syntax.
         :param size: Specifies a max number of results to get.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_application/search_application"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -203,7 +234,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.list",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -239,7 +275,9 @@ class SearchApplicationClient(NamespacedClient):
             )
         elif search_application is not None and body is not None:
             raise ValueError("Cannot set both 'search_application' and 'body'")
-        __path = f"/_application/search_application/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
             __query["create"] = create
@@ -254,7 +292,13 @@ class SearchApplicationClient(NamespacedClient):
         __body = search_application if search_application is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_application.put",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -276,7 +320,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/analytics/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/analytics/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -288,7 +334,12 @@ class SearchApplicationClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="search_application.put_behavioral_analytics",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -317,7 +368,9 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_application/search_application/{_quote(name)}/_search"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_application/search_application/{__path_parts["name"]}/_search'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -337,5 +390,11 @@ class SearchApplicationClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="search_application.search",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/searchable_snapshots.py
+++ b/elasticsearch/_sync/client/searchable_snapshots.py
@@ -48,9 +48,12 @@ class SearchableSnapshotsClient(NamespacedClient):
             to, leave empty to get information from all nodes
         :param master_timeout:
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_searchable_snapshots/{_quote(node_id)}/cache/stats"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_searchable_snapshots/{__path_parts["node_id"]}/cache/stats'
         else:
+            __path_parts = {}
             __path = "/_searchable_snapshots/cache/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -65,7 +68,12 @@ class SearchableSnapshotsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="searchable_snapshots.cache_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -102,9 +110,12 @@ class SearchableSnapshotsClient(NamespacedClient):
         :param ignore_unavailable: Whether specified concrete indices should be ignored
             when unavailable (missing or closed)
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_searchable_snapshots/cache/clear"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_searchable_snapshots/cache/clear'
         else:
+            __path_parts = {}
             __path = "/_searchable_snapshots/cache/clear"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
@@ -123,7 +134,12 @@ class SearchableSnapshotsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="searchable_snapshots.clear_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -178,7 +194,11 @@ class SearchableSnapshotsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'snapshot'")
         if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_mount"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = (
+            f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_mount'
+        )
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -206,7 +226,13 @@ class SearchableSnapshotsClient(NamespacedClient):
                 __body["renamed_index"] = renamed_index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="searchable_snapshots.mount",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -230,9 +256,12 @@ class SearchableSnapshotsClient(NamespacedClient):
         :param index: A comma-separated list of index names
         :param level: Return stats aggregated at cluster, index or shard level
         """
+        __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
-            __path = f"/{_quote(index)}/_searchable_snapshots/stats"
+            __path_parts = {"index": _quote(index)}
+            __path = f'/{__path_parts["index"]}/_searchable_snapshots/stats'
         else:
+            __path_parts = {}
             __path = "/_searchable_snapshots/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -247,5 +276,10 @@ class SearchableSnapshotsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="searchable_snapshots.stats",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/security.py
+++ b/elasticsearch/_sync/client/security.py
@@ -55,6 +55,8 @@ class SecurityClient(NamespacedClient):
         """
         if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/profile/_activate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -77,7 +79,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.activate_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -95,6 +103,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/_authenticate"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -107,7 +117,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.authenticate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -145,9 +160,12 @@ class SecurityClient(NamespacedClient):
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
         """
+        __path_parts: t.Dict[str, str]
         if username not in SKIP_IN_PATH:
-            __path = f"/_security/user/{_quote(username)}/_password"
+            __path_parts = {"username": _quote(username)}
+            __path = f'/_security/user/{__path_parts["username"]}/_password'
         else:
+            __path_parts = {}
             __path = "/_security/user/_password"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -168,7 +186,13 @@ class SecurityClient(NamespacedClient):
                 __body["password_hash"] = password_hash
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.change_password",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -191,7 +215,9 @@ class SecurityClient(NamespacedClient):
         """
         if ids in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ids'")
-        __path = f"/_security/api_key/{_quote(ids)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"ids": _quote(ids)}
+        __path = f'/_security/api_key/{__path_parts["ids"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -203,7 +229,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_api_key_cache",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -225,7 +256,9 @@ class SecurityClient(NamespacedClient):
         """
         if application in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'application'")
-        __path = f"/_security/privilege/{_quote(application)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"application": _quote(application)}
+        __path = f'/_security/privilege/{__path_parts["application"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -237,7 +270,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -262,7 +300,9 @@ class SecurityClient(NamespacedClient):
         """
         if realms in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'realms'")
-        __path = f"/_security/realm/{_quote(realms)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"realms": _quote(realms)}
+        __path = f'/_security/realm/{__path_parts["realms"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -276,7 +316,12 @@ class SecurityClient(NamespacedClient):
             __query["usernames"] = usernames
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_realms",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -298,7 +343,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role/{_quote(name)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role/{__path_parts["name"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -310,7 +357,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_roles",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -340,7 +392,13 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'service'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token/{_quote(name)}/_clear_cache"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "namespace": _quote(namespace),
+            "service": _quote(service),
+            "name": _quote(name),
+        }
+        __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token/{__path_parts["name"]}/_clear_cache'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -352,7 +410,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.clear_cached_service_tokens",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -397,6 +460,8 @@ class SecurityClient(NamespacedClient):
             is the same as the request for create role API. For more details, see create
             or update roles API.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -421,7 +486,13 @@ class SecurityClient(NamespacedClient):
                 __body["role_descriptors"] = role_descriptors
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.create_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -455,15 +526,22 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'namespace'")
         if service in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'service'")
+        __path_parts: t.Dict[str, str]
         if (
             namespace not in SKIP_IN_PATH
             and service not in SKIP_IN_PATH
             and name not in SKIP_IN_PATH
         ):
-            __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token/{_quote(name)}"
+            __path_parts = {
+                "namespace": _quote(namespace),
+                "service": _quote(service),
+                "name": _quote(name),
+            }
+            __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token/{__path_parts["name"]}'
             __method = "PUT"
         elif namespace not in SKIP_IN_PATH and service not in SKIP_IN_PATH:
-            __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token"
+            __path_parts = {"namespace": _quote(namespace), "service": _quote(service)}
+            __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token'
             __method = "POST"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
@@ -480,7 +558,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            __method, __path, params=__query, headers=__headers
+            __method,
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.create_service_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -512,7 +595,11 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'application'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/privilege/{_quote(application)}/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"application": _quote(application), "name": _quote(name)}
+        __path = (
+            f'/_security/privilege/{__path_parts["application"]}/{__path_parts["name"]}'
+        )
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -526,7 +613,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -554,7 +646,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -568,7 +662,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_role",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -596,7 +695,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role_mapping/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role_mapping/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -610,7 +711,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_role_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -646,7 +752,13 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'service'")
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential/token/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "namespace": _quote(namespace),
+            "service": _quote(service),
+            "name": _quote(name),
+        }
+        __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential/token/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -660,7 +772,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_service_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -688,7 +805,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -702,7 +821,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.delete_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -730,7 +854,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}/_disable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}/_disable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -744,7 +870,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.disable_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -772,7 +903,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}/_disable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}/_disable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -786,7 +919,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.disable_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -814,7 +952,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}/_enable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}/_enable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -828,7 +968,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enable_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -856,7 +1001,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}/_enable"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}/_enable'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -870,7 +1017,12 @@ class SecurityClient(NamespacedClient):
             __query["refresh"] = refresh
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enable_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -888,6 +1040,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/enroll/kibana"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -900,7 +1054,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enroll_kibana",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -917,6 +1076,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/enroll/node"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -929,7 +1090,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.enroll_node",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -974,6 +1140,8 @@ class SecurityClient(NamespacedClient):
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
         if active_only is not None:
@@ -1000,7 +1168,12 @@ class SecurityClient(NamespacedClient):
             __query["with_limited_by"] = with_limited_by
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1018,6 +1191,8 @@ class SecurityClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/privilege/_builtin"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1030,7 +1205,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_builtin_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1052,11 +1232,15 @@ class SecurityClient(NamespacedClient):
         :param application: Application name
         :param name: Privilege name
         """
+        __path_parts: t.Dict[str, str]
         if application not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
-            __path = f"/_security/privilege/{_quote(application)}/{_quote(name)}"
+            __path_parts = {"application": _quote(application), "name": _quote(name)}
+            __path = f'/_security/privilege/{__path_parts["application"]}/{__path_parts["name"]}'
         elif application not in SKIP_IN_PATH:
-            __path = f"/_security/privilege/{_quote(application)}"
+            __path_parts = {"application": _quote(application)}
+            __path = f'/_security/privilege/{__path_parts["application"]}'
         else:
+            __path_parts = {}
             __path = "/_security/privilege"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1069,7 +1253,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1091,9 +1280,12 @@ class SecurityClient(NamespacedClient):
             list. If you do not specify this parameter, the API returns information about
             all roles.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_security/role/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_security/role/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_security/role"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1106,7 +1298,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_role",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1130,9 +1327,12 @@ class SecurityClient(NamespacedClient):
             mapping names as a comma-separated list. If you do not specify this parameter,
             the API returns information about all role mappings.
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_security/role_mapping/{_quote(name)}"
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_security/role_mapping/{__path_parts["name"]}'
         else:
+            __path_parts = {}
             __path = "/_security/role_mapping"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1145,7 +1345,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_role_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1170,11 +1375,15 @@ class SecurityClient(NamespacedClient):
         :param service: Name of the service name. Omit this parameter to retrieve information
             about all service accounts that belong to the specified `namespace`.
         """
+        __path_parts: t.Dict[str, str]
         if namespace not in SKIP_IN_PATH and service not in SKIP_IN_PATH:
-            __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}"
+            __path_parts = {"namespace": _quote(namespace), "service": _quote(service)}
+            __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}'
         elif namespace not in SKIP_IN_PATH:
-            __path = f"/_security/service/{_quote(namespace)}"
+            __path_parts = {"namespace": _quote(namespace)}
+            __path = f'/_security/service/{__path_parts["namespace"]}'
         else:
+            __path_parts = {}
             __path = "/_security/service"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1187,7 +1396,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_service_accounts",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1213,7 +1427,9 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'namespace'")
         if service in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'service'")
-        __path = f"/_security/service/{_quote(namespace)}/{_quote(service)}/credential"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"namespace": _quote(namespace), "service": _quote(service)}
+        __path = f'/_security/service/{__path_parts["namespace"]}/{__path_parts["service"]}/credential'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -1225,7 +1441,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_service_credentials",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1270,6 +1491,8 @@ class SecurityClient(NamespacedClient):
         :param scope:
         :param username:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1296,7 +1519,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.get_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1321,9 +1550,12 @@ class SecurityClient(NamespacedClient):
         :param with_profile_uid: If true will return the User Profile ID for a user,
             if any.
         """
+        __path_parts: t.Dict[str, str]
         if username not in SKIP_IN_PATH:
-            __path = f"/_security/user/{_quote(username)}"
+            __path_parts = {"username": _quote(username)}
+            __path = f'/_security/user/{__path_parts["username"]}'
         else:
+            __path_parts = {}
             __path = "/_security/user"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1338,7 +1570,12 @@ class SecurityClient(NamespacedClient):
             __query["with_profile_uid"] = with_profile_uid
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1365,6 +1602,8 @@ class SecurityClient(NamespacedClient):
             the API returns information about all privileges for the requested application.
         :param username:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/user/_privileges"
         __query: t.Dict[str, t.Any] = {}
         if application is not None:
@@ -1383,7 +1622,12 @@ class SecurityClient(NamespacedClient):
             __query["username"] = username
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_user_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -1410,7 +1654,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}'
         __query: t.Dict[str, t.Any] = {}
         if data is not None:
             __query["data"] = data
@@ -1424,7 +1670,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.get_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1477,6 +1728,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'api_key'")
         if grant_type is None and body is None:
             raise ValueError("Empty value passed for parameter 'grant_type'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key/grant"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1503,7 +1756,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.grant_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1539,9 +1798,12 @@ class SecurityClient(NamespacedClient):
         :param cluster: A list of the cluster privileges that you want to check.
         :param index:
         """
+        __path_parts: t.Dict[str, str]
         if user not in SKIP_IN_PATH:
-            __path = f"/_security/user/{_quote(user)}/_has_privileges"
+            __path_parts = {"user": _quote(user)}
+            __path = f'/_security/user/{__path_parts["user"]}/_has_privileges'
         else:
+            __path_parts = {}
             __path = "/_security/user/_has_privileges"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1562,7 +1824,13 @@ class SecurityClient(NamespacedClient):
                 __body["index"] = index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.has_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1593,6 +1861,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'privileges'")
         if uids is None and body is None:
             raise ValueError("Empty value passed for parameter 'uids'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/profile/_has_privileges"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1611,7 +1881,13 @@ class SecurityClient(NamespacedClient):
                 __body["uids"] = uids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.has_privileges_user_profile",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1651,6 +1927,8 @@ class SecurityClient(NamespacedClient):
         :param username: The username of a user. This parameter cannot be used with either
             `ids` or `name`, or when `owner` flag is set to `true`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1677,7 +1955,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.invalidate_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1706,6 +1990,8 @@ class SecurityClient(NamespacedClient):
         :param token:
         :param username:
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/oauth2/token"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -1728,7 +2014,13 @@ class SecurityClient(NamespacedClient):
                 __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers, body=__body
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.invalidate_token",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1765,6 +2057,8 @@ class SecurityClient(NamespacedClient):
             )
         elif privileges is not None and body is not None:
             raise ValueError("Cannot set both 'privileges' and 'body'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/privilege"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -1780,7 +2074,13 @@ class SecurityClient(NamespacedClient):
         __body = privileges if privileges is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_privileges",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1850,7 +2150,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -1880,7 +2182,13 @@ class SecurityClient(NamespacedClient):
                 __body["transient_metadata"] = transient_metadata
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_role",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -1930,7 +2238,9 @@ class SecurityClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_security/role_mapping/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"name": _quote(name)}
+        __path = f'/_security/role_mapping/{__path_parts["name"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -1958,7 +2268,13 @@ class SecurityClient(NamespacedClient):
                 __body["run_as"] = run_as
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_role_mapping",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2012,7 +2328,9 @@ class SecurityClient(NamespacedClient):
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
-        __path = f"/_security/user/{_quote(username)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"username": _quote(username)}
+        __path = f'/_security/user/{__path_parts["username"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2042,7 +2360,13 @@ class SecurityClient(NamespacedClient):
                 __body["roles"] = roles
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.put_user",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2094,6 +2418,8 @@ class SecurityClient(NamespacedClient):
             associated with the API key. An API key's actual permission is the intersection
             of its assigned role descriptors and the owner user's role descriptors.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/_query/api_key"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2135,7 +2461,13 @@ class SecurityClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.query_api_keys",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2170,6 +2502,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'content'")
         if ids is None and body is None:
             raise ValueError("Empty value passed for parameter 'ids'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/authenticate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2190,7 +2524,13 @@ class SecurityClient(NamespacedClient):
                 __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_authenticate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2228,6 +2568,8 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'ids'")
         if realm is None and body is None:
             raise ValueError("Empty value passed for parameter 'realm'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/complete_logout"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2250,7 +2592,13 @@ class SecurityClient(NamespacedClient):
                 __body["query_string"] = query_string
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_complete_logout",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2291,6 +2639,8 @@ class SecurityClient(NamespacedClient):
         """
         if query_string is None and body is None:
             raise ValueError("Empty value passed for parameter 'query_string'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/invalidate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2311,7 +2661,13 @@ class SecurityClient(NamespacedClient):
                 __body["realm"] = realm
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_invalidate",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2343,6 +2699,8 @@ class SecurityClient(NamespacedClient):
         """
         if token is None and body is None:
             raise ValueError("Empty value passed for parameter 'token'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/logout"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2361,7 +2719,13 @@ class SecurityClient(NamespacedClient):
                 __body["refresh_token"] = refresh_token
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_logout",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2394,6 +2758,8 @@ class SecurityClient(NamespacedClient):
             API returns as the RelayState query parameter. If the Authentication Request
             is signed, this value is used as part of the signature computation.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/saml/prepare"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2414,7 +2780,13 @@ class SecurityClient(NamespacedClient):
                 __body["relay_state"] = relay_state
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.saml_prepare_authentication",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -2436,7 +2808,9 @@ class SecurityClient(NamespacedClient):
         """
         if realm_name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'realm_name'")
-        __path = f"/_security/saml/metadata/{_quote(realm_name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"realm_name": _quote(realm_name)}
+        __path = f'/_security/saml/metadata/{__path_parts["realm_name"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -2448,7 +2822,12 @@ class SecurityClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="security.saml_service_provider_metadata",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2484,6 +2863,8 @@ class SecurityClient(NamespacedClient):
             Name-related fields are the user's `username`, `full_name`, and `email`.
         :param size: Number of profiles to return.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_security/profile/_suggest"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -2510,7 +2891,13 @@ class SecurityClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.suggest_user_profiles",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2550,7 +2937,9 @@ class SecurityClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_security/api_key/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_security/api_key/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2574,7 +2963,13 @@ class SecurityClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.update_api_key",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -2617,7 +3012,9 @@ class SecurityClient(NamespacedClient):
         """
         if uid in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'uid'")
-        __path = f"/_security/profile/{_quote(uid)}/_data"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"uid": _quote(uid)}
+        __path = f'/_security/profile/{__path_parts["uid"]}/_data'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -2641,5 +3038,11 @@ class SecurityClient(NamespacedClient):
                 __body["labels"] = labels
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="security.update_user_profile_data",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/shutdown.py
+++ b/elasticsearch/_sync/client/shutdown.py
@@ -56,7 +56,9 @@ class ShutdownClient(NamespacedClient):
         """
         if node_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'node_id'")
-        __path = f"/_nodes/{_quote(node_id)}/shutdown"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"node_id": _quote(node_id)}
+        __path = f'/_nodes/{__path_parts["node_id"]}/shutdown'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -72,7 +74,12 @@ class ShutdownClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="shutdown.delete_node",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -104,9 +111,12 @@ class ShutdownClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if node_id not in SKIP_IN_PATH:
-            __path = f"/_nodes/{_quote(node_id)}/shutdown"
+            __path_parts = {"node_id": _quote(node_id)}
+            __path = f'/_nodes/{__path_parts["node_id"]}/shutdown'
         else:
+            __path_parts = {}
             __path = "/_nodes/shutdown"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -123,7 +133,12 @@ class ShutdownClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="shutdown.get_node",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -196,7 +211,9 @@ class ShutdownClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'reason'")
         if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
-        __path = f"/_nodes/{_quote(node_id)}/shutdown"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"node_id": _quote(node_id)}
+        __path = f'/_nodes/{__path_parts["node_id"]}/shutdown'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -222,5 +239,11 @@ class ShutdownClient(NamespacedClient):
                 __body["target_node_name"] = target_node_name
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="shutdown.put_node",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/slm.py
+++ b/elasticsearch/_sync/client/slm.py
@@ -44,7 +44,9 @@ class SlmClient(NamespacedClient):
         """
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
-        __path = f"/_slm/policy/{_quote(policy_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy_id": _quote(policy_id)}
+        __path = f'/_slm/policy/{__path_parts["policy_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.delete_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -79,7 +86,9 @@ class SlmClient(NamespacedClient):
         """
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
-        __path = f"/_slm/policy/{_quote(policy_id)}/_execute"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy_id": _quote(policy_id)}
+        __path = f'/_slm/policy/{__path_parts["policy_id"]}/_execute'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -91,7 +100,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.execute_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -108,6 +122,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/_execute_retention"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -120,7 +136,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.execute_retention",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -141,9 +162,12 @@ class SlmClient(NamespacedClient):
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         """
+        __path_parts: t.Dict[str, str]
         if policy_id not in SKIP_IN_PATH:
-            __path = f"/_slm/policy/{_quote(policy_id)}"
+            __path_parts = {"policy_id": _quote(policy_id)}
+            __path = f'/_slm/policy/{__path_parts["policy_id"]}'
         else:
+            __path_parts = {}
             __path = "/_slm/policy"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -156,7 +180,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.get_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -174,6 +203,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/stats"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -186,7 +217,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.get_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -203,6 +239,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -215,7 +253,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.get_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -266,7 +309,9 @@ class SlmClient(NamespacedClient):
         """
         if policy_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'policy_id'")
-        __path = f"/_slm/policy/{_quote(policy_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"policy_id": _quote(policy_id)}
+        __path = f'/_slm/policy/{__path_parts["policy_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -298,7 +343,13 @@ class SlmClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="slm.put_lifecycle",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -315,6 +366,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/start"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -327,7 +380,12 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.start",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -344,6 +402,8 @@ class SlmClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_slm/stop"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -356,5 +416,10 @@ class SlmClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="slm.stop",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/snapshot.py
+++ b/elasticsearch/_sync/client/snapshot.py
@@ -50,7 +50,9 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_snapshot/{_quote(name)}/_cleanup"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/_cleanup'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -66,7 +68,12 @@ class SnapshotClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.cleanup_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -109,7 +116,13 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'target_snapshot'")
         if indices is None and body is None:
             raise ValueError("Empty value passed for parameter 'indices'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_clone/{_quote(target_snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {
+            "repository": _quote(repository),
+            "snapshot": _quote(snapshot),
+            "target_snapshot": _quote(target_snapshot),
+        }
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_clone/{__path_parts["target_snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -129,7 +142,13 @@ class SnapshotClient(NamespacedClient):
                 __body["indices"] = indices
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.clone",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -203,7 +222,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -237,7 +258,13 @@ class SnapshotClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.create",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -280,7 +307,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'settings'")
         if type is None and body is None:
             raise ValueError("Empty value passed for parameter 'type'")
-        __path = f"/_snapshot/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -306,7 +335,13 @@ class SnapshotClient(NamespacedClient):
                 __body["repository"] = repository
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.create_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -336,7 +371,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -350,7 +387,12 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.delete",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -379,7 +421,9 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_snapshot/{_quote(name)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -395,7 +439,12 @@ class SnapshotClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.delete_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -479,7 +528,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}'
         __query: t.Dict[str, t.Any] = {}
         if after is not None:
             __query["after"] = after
@@ -517,7 +568,12 @@ class SnapshotClient(NamespacedClient):
             __query["verbose"] = verbose
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -544,9 +600,12 @@ class SnapshotClient(NamespacedClient):
             node (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
         """
+        __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
-            __path = f"/_snapshot/{_quote(name)}"
+            __path_parts = {"repository": _quote(name)}
+            __path = f'/_snapshot/{__path_parts["repository"]}'
         else:
+            __path_parts = {}
             __path = "/_snapshot"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -563,7 +622,12 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.get_repository",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -630,7 +694,9 @@ class SnapshotClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'repository'")
         if snapshot in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'snapshot'")
-        __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_restore"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(repository), "snapshot": _quote(snapshot)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_restore'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -672,7 +738,13 @@ class SnapshotClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="snapshot.restore",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -701,11 +773,18 @@ class SnapshotClient(NamespacedClient):
             to false which means a SnapshotMissingException is thrown
         :param master_timeout: Explicit operation timeout for connection to master node
         """
+        __path_parts: t.Dict[str, str]
         if repository not in SKIP_IN_PATH and snapshot not in SKIP_IN_PATH:
-            __path = f"/_snapshot/{_quote(repository)}/{_quote(snapshot)}/_status"
+            __path_parts = {
+                "repository": _quote(repository),
+                "snapshot": _quote(snapshot),
+            }
+            __path = f'/_snapshot/{__path_parts["repository"]}/{__path_parts["snapshot"]}/_status'
         elif repository not in SKIP_IN_PATH:
-            __path = f"/_snapshot/{_quote(repository)}/_status"
+            __path_parts = {"repository": _quote(repository)}
+            __path = f'/_snapshot/{__path_parts["repository"]}/_status'
         else:
+            __path_parts = {}
             __path = "/_snapshot/_status"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -722,7 +801,12 @@ class SnapshotClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -750,7 +834,9 @@ class SnapshotClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        __path = f"/_snapshot/{_quote(name)}/_verify"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"repository": _quote(name)}
+        __path = f'/_snapshot/{__path_parts["repository"]}/_verify'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -766,5 +852,10 @@ class SnapshotClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="snapshot.verify_repository",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/sql.py
+++ b/elasticsearch/_sync/client/sql.py
@@ -47,6 +47,8 @@ class SqlClient(NamespacedClient):
         """
         if cursor is None and body is None:
             raise ValueError("Empty value passed for parameter 'cursor'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_sql/close"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -63,7 +65,13 @@ class SqlClient(NamespacedClient):
                 __body["cursor"] = cursor
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="sql.clear_cursor",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -86,7 +94,9 @@ class SqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_sql/async/delete/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_sql/async/delete/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -98,7 +108,12 @@ class SqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="sql.delete_async",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -136,7 +151,9 @@ class SqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_sql/async/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_sql/async/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if delimiter is not None:
             __query["delimiter"] = delimiter
@@ -156,7 +173,12 @@ class SqlClient(NamespacedClient):
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="sql.get_async",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -179,7 +201,9 @@ class SqlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_sql/async/status/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_sql/async/status/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -191,7 +215,12 @@ class SqlClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="sql.get_async_status",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -281,6 +310,8 @@ class SqlClient(NamespacedClient):
             to no timeout, meaning the request waits for complete search results. If
             the search doesn’t finish within this period, the search becomes async.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_sql"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -329,7 +360,13 @@ class SqlClient(NamespacedClient):
                 __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="sql.query",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -360,6 +397,8 @@ class SqlClient(NamespacedClient):
         """
         if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_sql/translate"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -382,5 +421,11 @@ class SqlClient(NamespacedClient):
                 __body["time_zone"] = time_zone
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="sql.translate",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/ssl.py
+++ b/elasticsearch/_sync/client/ssl.py
@@ -40,6 +40,8 @@ class SslClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_ssl/certificates"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -52,5 +54,10 @@ class SslClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="ssl.certificates",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/synonyms.py
+++ b/elasticsearch/_sync/client/synonyms.py
@@ -44,7 +44,9 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_synonyms/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_synonyms/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -56,7 +58,12 @@ class SynonymsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.delete_synonym",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -82,7 +89,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"set_id": _quote(set_id), "rule_id": _quote(rule_id)}
+        __path = f'/_synonyms/{__path_parts["set_id"]}/{__path_parts["rule_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -94,7 +103,12 @@ class SynonymsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.delete_synonym_rule",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -122,7 +136,9 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_synonyms/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_synonyms/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -138,7 +154,12 @@ class SynonymsClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.get_synonym",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -164,7 +185,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"set_id": _quote(set_id), "rule_id": _quote(rule_id)}
+        __path = f'/_synonyms/{__path_parts["set_id"]}/{__path_parts["rule_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -176,7 +199,12 @@ class SynonymsClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.get_synonym_rule",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -200,6 +228,8 @@ class SynonymsClient(NamespacedClient):
         :param from_: Starting offset
         :param size: specifies a max number of results to get
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_synonyms"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -216,7 +246,12 @@ class SynonymsClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="synonyms.get_synonyms_sets",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -245,7 +280,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'id'")
         if synonyms_set is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms_set'")
-        __path = f"/_synonyms/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_synonyms/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -261,7 +298,13 @@ class SynonymsClient(NamespacedClient):
                 __body["synonyms_set"] = synonyms_set
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="synonyms.put_synonym",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -294,7 +337,9 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'rule_id'")
         if synonyms is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms'")
-        __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"set_id": _quote(set_id), "rule_id": _quote(rule_id)}
+        __path = f'/_synonyms/{__path_parts["set_id"]}/{__path_parts["rule_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
@@ -310,5 +355,11 @@ class SynonymsClient(NamespacedClient):
                 __body["synonyms"] = synonyms
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="synonyms.put_synonym_rule",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/tasks.py
+++ b/elasticsearch/_sync/client/tasks.py
@@ -52,9 +52,12 @@ class TasksClient(NamespacedClient):
         :param wait_for_completion: Should the request block until the cancellation of
             the task and its descendant tasks is completed. Defaults to false
         """
+        __path_parts: t.Dict[str, str]
         if task_id not in SKIP_IN_PATH:
-            __path = f"/_tasks/{_quote(task_id)}/_cancel"
+            __path_parts = {"task_id": _quote(task_id)}
+            __path = f'/_tasks/{__path_parts["task_id"]}/_cancel'
         else:
+            __path_parts = {}
             __path = "/_tasks/_cancel"
         __query: t.Dict[str, t.Any] = {}
         if actions is not None:
@@ -75,7 +78,12 @@ class TasksClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="tasks.cancel",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -103,7 +111,9 @@ class TasksClient(NamespacedClient):
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
-        __path = f"/_tasks/{_quote(task_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"task_id": _quote(task_id)}
+        __path = f'/_tasks/{__path_parts["task_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -119,7 +129,12 @@ class TasksClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="tasks.get",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -165,6 +180,8 @@ class TasksClient(NamespacedClient):
         :param wait_for_completion: If `true`, the request blocks until the operation
             is complete.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_tasks"
         __query: t.Dict[str, t.Any] = {}
         if actions is not None:
@@ -193,5 +210,10 @@ class TasksClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="tasks.list",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/text_structure.py
+++ b/elasticsearch/_sync/client/text_structure.py
@@ -127,6 +127,8 @@ class TextStructureClient(NamespacedClient):
             )
         elif text_files is not None and body is not None:
             raise ValueError("Cannot set both 'text_files' and 'body'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_text_structure/find_structure"
         __query: t.Dict[str, t.Any] = {}
         if charset is not None:
@@ -165,7 +167,13 @@ class TextStructureClient(NamespacedClient):
             "content-type": "application/x-ndjson",
         }
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="text_structure.find_structure",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -186,7 +194,7 @@ class TextStructureClient(NamespacedClient):
         """
         Tests a Grok pattern on some text.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-grok-pattern-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-grok-pattern.html>`_
 
         :param grok_pattern: Grok pattern to run on the text.
         :param text: Lines of text to run the Grok pattern on.
@@ -197,6 +205,8 @@ class TextStructureClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'grok_pattern'")
         if text is None and body is None:
             raise ValueError("Empty value passed for parameter 'text'")
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_text_structure/test_grok_pattern"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -217,5 +227,11 @@ class TextStructureClient(NamespacedClient):
                 __body["text"] = text
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="text_structure.test_grok_pattern",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -55,7 +55,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}'
         __query: t.Dict[str, t.Any] = {}
         if delete_dest_index is not None:
             __query["delete_dest_index"] = delete_dest_index
@@ -73,7 +75,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.delete_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -111,9 +118,12 @@ class TransformClient(NamespacedClient):
         :param from_: Skips the specified number of transforms.
         :param size: Specifies the maximum number of transforms to obtain.
         """
+        __path_parts: t.Dict[str, str]
         if transform_id not in SKIP_IN_PATH:
-            __path = f"/_transform/{_quote(transform_id)}"
+            __path_parts = {"transform_id": _quote(transform_id)}
+            __path = f'/_transform/{__path_parts["transform_id"]}'
         else:
+            __path_parts = {}
             __path = "/_transform"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
@@ -134,7 +144,12 @@ class TransformClient(NamespacedClient):
             __query["size"] = size
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.get_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -172,7 +187,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_stats"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_stats'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -192,7 +209,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.get_transform_stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -255,9 +277,12 @@ class TransformClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
         if transform_id not in SKIP_IN_PATH:
-            __path = f"/_transform/{_quote(transform_id)}/_preview"
+            __path_parts = {"transform_id": _quote(transform_id)}
+            __path = f'/_transform/{__path_parts["transform_id"]}/_preview'
         else:
+            __path_parts = {}
             __path = "/_transform/_preview"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -296,7 +321,13 @@ class TransformClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="transform.preview_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -377,7 +408,9 @@ class TransformClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'dest'")
         if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
-        __path = f"/_transform/{_quote(transform_id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
@@ -415,7 +448,13 @@ class TransformClient(NamespacedClient):
                 __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="transform.put_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -443,7 +482,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_reset"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_reset'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -457,7 +498,12 @@ class TransformClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.reset_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -481,7 +527,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_schedule_now"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_schedule_now'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -495,7 +543,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.schedule_now_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -526,7 +579,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_start"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_start'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -542,7 +597,12 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.start_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -589,7 +649,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_stop"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_stop'
         __query: t.Dict[str, t.Any] = {}
         if allow_no_match is not None:
             __query["allow_no_match"] = allow_no_match
@@ -611,7 +673,12 @@ class TransformClient(NamespacedClient):
             __query["wait_for_completion"] = wait_for_completion
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.stop_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -673,7 +740,9 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        __path = f"/_transform/{_quote(transform_id)}/_update"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"transform_id": _quote(transform_id)}
+        __path = f'/_transform/{__path_parts["transform_id"]}/_update'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
@@ -707,7 +776,13 @@ class TransformClient(NamespacedClient):
                 __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="transform.update_transform",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -730,6 +805,8 @@ class TransformClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_transform/_upgrade"
         __query: t.Dict[str, t.Any] = {}
         if dry_run is not None:
@@ -746,5 +823,10 @@ class TransformClient(NamespacedClient):
             __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="transform.upgrade_transforms",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/watcher.py
+++ b/elasticsearch/_sync/client/watcher.py
@@ -46,10 +46,16 @@ class WatcherClient(NamespacedClient):
         """
         if watch_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'watch_id'")
+        __path_parts: t.Dict[str, str]
         if watch_id not in SKIP_IN_PATH and action_id not in SKIP_IN_PATH:
-            __path = f"/_watcher/watch/{_quote(watch_id)}/_ack/{_quote(action_id)}"
+            __path_parts = {
+                "watch_id": _quote(watch_id),
+                "action_id": _quote(action_id),
+            }
+            __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_ack/{__path_parts["action_id"]}'
         elif watch_id not in SKIP_IN_PATH:
-            __path = f"/_watcher/watch/{_quote(watch_id)}/_ack"
+            __path_parts = {"watch_id": _quote(watch_id)}
+            __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_ack'
         else:
             raise ValueError("Couldn't find a path for the given parameters")
         __query: t.Dict[str, t.Any] = {}
@@ -63,7 +69,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.ack_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -85,7 +96,9 @@ class WatcherClient(NamespacedClient):
         """
         if watch_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'watch_id'")
-        __path = f"/_watcher/watch/{_quote(watch_id)}/_activate"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"watch_id": _quote(watch_id)}
+        __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_activate'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -97,7 +110,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.activate_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -119,7 +137,9 @@ class WatcherClient(NamespacedClient):
         """
         if watch_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'watch_id'")
-        __path = f"/_watcher/watch/{_quote(watch_id)}/_deactivate"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"watch_id": _quote(watch_id)}
+        __path = f'/_watcher/watch/{__path_parts["watch_id"]}/_deactivate'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -131,7 +151,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.deactivate_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -153,7 +178,9 @@ class WatcherClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_watcher/watch/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_watcher/watch/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -165,7 +192,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "DELETE", __path, params=__query, headers=__headers
+            "DELETE",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.delete_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -229,9 +261,12 @@ class WatcherClient(NamespacedClient):
             the request. This watch is not persisted to the index and record_execution
             cannot be set.
         """
+        __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
-            __path = f"/_watcher/watch/{_quote(id)}/_execute"
+            __path_parts = {"id": _quote(id)}
+            __path = f'/_watcher/watch/{__path_parts["id"]}/_execute'
         else:
+            __path_parts = {}
             __path = "/_watcher/watch/_execute"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -266,7 +301,13 @@ class WatcherClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="watcher.execute_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -288,7 +329,9 @@ class WatcherClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_watcher/watch/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_watcher/watch/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
@@ -300,7 +343,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.get_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -357,7 +405,9 @@ class WatcherClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        __path = f"/_watcher/watch/{_quote(id)}"
+        __path_parts: t.Dict[str, str]
+        __path_parts = {"id": _quote(id)}
+        __path = f'/_watcher/watch/{__path_parts["id"]}'
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if active is not None:
@@ -397,7 +447,13 @@ class WatcherClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "PUT", __path, params=__query, headers=__headers, body=__body
+            "PUT",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="watcher.put_watch",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters(
@@ -437,6 +493,8 @@ class WatcherClient(NamespacedClient):
         :param size: The number of hits to return. Needs to be non-negative.
         :param sort: Optional sort definition.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_watcher/_query/watches"
         __query: t.Dict[str, t.Any] = {}
         __body: t.Dict[str, t.Any] = body if body is not None else {}
@@ -476,7 +534,13 @@ class WatcherClient(NamespacedClient):
         if __body is not None:
             __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers, body=__body
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="watcher.query_watches",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -493,6 +557,8 @@ class WatcherClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_watcher/_start"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -505,7 +571,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.start",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -541,9 +612,12 @@ class WatcherClient(NamespacedClient):
         :param emit_stacktraces: Defines whether stack traces are generated for each
             watch that is running.
         """
+        __path_parts: t.Dict[str, str]
         if metric not in SKIP_IN_PATH:
-            __path = f"/_watcher/stats/{_quote(metric)}"
+            __path_parts = {"metric": _quote(metric)}
+            __path = f'/_watcher/stats/{__path_parts["metric"]}'
         else:
+            __path_parts = {}
             __path = "/_watcher/stats"
         __query: t.Dict[str, t.Any] = {}
         if emit_stacktraces is not None:
@@ -558,7 +632,12 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.stats",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -575,6 +654,8 @@ class WatcherClient(NamespacedClient):
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_watcher/_stop"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -587,5 +668,10 @@ class WatcherClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "POST", __path, params=__query, headers=__headers
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="watcher.stop",
+            path_parts=__path_parts,
         )

--- a/elasticsearch/_sync/client/xpack.py
+++ b/elasticsearch/_sync/client/xpack.py
@@ -49,6 +49,8 @@ class XPackClient(NamespacedClient):
         :param categories: A comma-separated list of the information categories to include
             in the response. For example, `build,license,features`.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_xpack"
         __query: t.Dict[str, t.Any] = {}
         if accept_enterprise is not None:
@@ -65,7 +67,12 @@ class XPackClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="xpack.info",
+            path_parts=__path_parts,
         )
 
     @_rewrite_parameters()
@@ -89,6 +96,8 @@ class XPackClient(NamespacedClient):
             no response is received before the timeout expires, the request fails and
             returns an error.
         """
+        __path_parts: t.Dict[str, str]
+        __path_parts = {}
         __path = "/_xpack/usage"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -103,5 +112,10 @@ class XPackClient(NamespacedClient):
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
-            "GET", __path, params=__query, headers=__headers
+            "GET",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="xpack.usage",
+            path_parts=__path_parts,
         )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,10 @@ packages = [
     if package == package_name or package.startswith(package_name + ".")
 ]
 
-install_requires = ["elastic-transport>=8,<9"]
+# TODO switch back to elastic-transport>=8,<9 between elastic-transport release and elasticsearch-py release
+install_requires = [
+    "elastic-transport @ git+https://github.com/elastic/elastic-transport-python"
+]
 async_requires = ["aiohttp>=3,<4"]
 
 setup(

--- a/test_elasticsearch/test_client/test_options.py
+++ b/test_elasticsearch/test_client/test_options.py
@@ -142,6 +142,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
         }
 
         # Can be overwritten with .options()
@@ -160,6 +162,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
             "request_timeout": 1,
             "max_retries": 2,
             "retry_on_status": (404,),
@@ -185,6 +189,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
             "request_timeout": 1,
             "max_retries": 2,
             "retry_on_status": (404,),
@@ -212,6 +218,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
         }
 
         # Can be overwritten with .options()
@@ -230,6 +238,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
             "request_timeout": 1,
             "max_retries": 2,
             "retry_on_status": (404,),
@@ -255,6 +265,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
             "request_timeout": 1,
             "max_retries": 2,
             "retry_on_status": (404,),
@@ -390,6 +402,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
             "request_timeout": 1,
             "max_retries": 2,
             "retry_on_status": (404,),
@@ -419,6 +433,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
             "request_timeout": 2,
             "max_retries": 3,
             "retry_on_status": (400,),
@@ -443,6 +459,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
         }
 
         client = Elasticsearch(
@@ -464,6 +482,8 @@ class TestOptions(DummyTransportTestCase):
                 "accept": "application/vnd.elasticsearch+json; compatible-with=8",
             },
             "body": None,
+            "endpoint_id": "indices.get",
+            "path_parts": {"index": "test"},
             "request_timeout": 1,
             "max_retries": 2,
             "retry_on_status": (404,),


### PR DESCRIPTION
As part of https://github.com/elastic/elasticsearch-py/issues/2435, the transport needs to know the endpoint id and path parts, and can only get them from the client. This pull request makes sure to pass that info to the client.

There are two commits here:

* [`5ff3169` (#2457)](https://github.com/elastic/elasticsearch-py/pull/2457/commits/5ff3169a3e14422b2d830d917ee132a64448a71c) which accepts endpoint_id/path_parts in base clients, updates tests and depends on the main branch of elastic-transport
* [`2ce3c32` (#2457)](https://github.com/elastic/elasticsearch-py/pull/2457/commits/2ce3c3205f0a1e016d760873f1218bb5e74c4a2d) that runs code generation to define endpoint_id/path_parts in all APIs

This PR depends on https://github.com/elastic/elastic-transport-python/pull/151.

I'm wondering about the type of those new parameters. The natural way in elastic-transport was `str | DefaultType` while here it's `str | None`. `DEFAULT ` is a way to make `None` meaningful, but that's not needed here.