### PR TITLE
[DOCS] Adds compatibility matrix to docs and readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,22 @@ Usage
 Compatibility
 -------------
 
-Language clients are forward compatible; meaning that clients support communicating
-with greater or equal minor versions of Elasticsearch. Elasticsearch language clients
-are only backwards compatible with default distributions and without guarantees made.
+Language clients are forward compatible; meaning that the clients support
+communicating with greater or equal minor versions of Elasticsearch without
+breaking. It does not mean that the clients automatically support new features
+of newer Elasticsearch versions; it is only possible after a release of a new
+client version. For example, a 8.12 client version won't automatically support
+the new features of the 8.13 version of Elasticsearch, the 8.13 client version
+is required for that. Elasticsearch language clients are only backwards
+compatible with default distributions and without guarantees made.
+
++-----------------------+-------------------------+-----------+
+| Elasticsearch Version | Elasticsearch-py Branch | Supported |
++=======================+=========================+===========+
+| main                  | main                    |           |
+| 8.x                   | 8.x                     | 8.x       |
+| 7.x                   | 7.x                     | 7.17      |
++-----------------------+-------------------------+-----------+
 
 If you have a need to have multiple versions installed at the same time older
 versions are also released as ``elasticsearch2`` and ``elasticsearch5``.

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ compatible with default distributions and without guarantees made.
 +-----------------------+-------------------------+-----------+
 
 If you have a need to have multiple versions installed at the same time older
-versions are also released as ``elasticsearch2`` and ``elasticsearch5``.
+versions are also released as ``elasticsearch7`` and ``elasticsearch8``.
 
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -85,10 +85,12 @@ is required for that. Elasticsearch language clients are only backwards
 compatible with default distributions and without guarantees made.
 
 +-----------------------+-------------------------+-----------+
-| Elasticsearch Version | Elasticsearch-py Branch | Supported |
+| Elasticsearch version | elasticsearch-py branch | Supported |
 +=======================+=========================+===========+
 | main                  | main                    |           |
++-----------------------+-------------------------+-----------+
 | 8.x                   | 8.x                     | 8.x       |
++-----------------------+-------------------------+-----------+
 | 7.x                   | 7.x                     | 7.17      |
 +-----------------------+-------------------------+-----------+
 

--- a/docs/guide/installation.asciidoc
+++ b/docs/guide/installation.asciidoc
@@ -1,9 +1,9 @@
 [[installation]]
 == Installation
 
-**[Download the latest version of Elasticsearch](https://www.elastic.co/downloads/elasticsearch)**
+**https://www.elastic.co/downloads/elasticsearch[Download the latest version of Elasticsearch]**
 or
-**[sign-up](https://cloud.elastic.co/registration?elektra=en-ess-sign-up-page)**
+**https://cloud.elastic.co/registration?elektra=en-ess-sign-up-page[sign-up]**
 **for a free trial of Elastic Cloud**.
 
 The Python client for {es} can be installed with pip:

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -10,9 +10,22 @@ on https://elasticsearch-py.readthedocs.io[Read the Docs].
 [discrete]
 === Compatibility
 
-Language clients are forward compatible; meaning that clients support communicating
-with greater or equal minor versions of Elasticsearch. Elasticsearch language clients
-are only backwards compatible with default distributions and without guarantees made.
+Language clients are forward compatible; meaning that the clients support
+communicating with greater or equal minor versions of {es} without breaking. It
+does not mean that the clients automatically support new features of newer
+{es} versions; it is only possible after a release of a new client version. For
+example, a 8.12 client version won't automatically support the new features of
+the 8.13 version of {es}, the 8.13 client version is required for that. {es}
+language clients are only backwards compatible with default distributions and
+without guarantees made.
+
+|===
+| Elasticsearch Version | Elasticsearch-py Branch   | Supported
+
+| main                  | main                      | 
+| 8.x                   | 8.x                       | 8.x
+| 7.x                   | 7.x                       | 7.17
+|===
 
 If you have a need to have multiple versions installed at the same time older
 versions are also released as `elasticsearch2` and `elasticsearch5`.

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -28,7 +28,7 @@ without guarantees made.
 |===
 
 If you have a need to have multiple versions installed at the same time older
-versions are also released as `elasticsearch2` and `elasticsearch5`.
+versions are also released as `elasticsearch7` and `elasticsearch8`.
 
 
 [discrete]

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -34,9 +34,22 @@ Read more about `how to use asyncio with this project <async.html>`_.
 Compatibility
 -------------
 
-Language clients are forward compatible; meaning that clients support communicating
-with greater or equal minor versions of Elasticsearch. Elasticsearch language clients
-are only backwards compatible with default distributions and without guarantees made.
+Language clients are forward compatible; meaning that the clients support
+communicating with greater or equal minor versions of Elasticsearch without
+breaking. It does not mean that the clients automatically support new features
+of newer Elasticsearch versions; it is only possible after a release of a new
+client version. For example, a 8.12 client version won't automatically support
+the new features of the 8.13 version of Elasticsearch, the 8.13 client version
+is required for that. Elasticsearch language clients are only backwards
+compatible with default distributions and without guarantees made.
+
++-----------------------+-------------------------+-----------+
+| Elasticsearch Version | Elasticsearch-py Branch | Supported |
++=======================+=========================+===========+
+| main                  | main                    |           |
+| 8.x                   | 8.x                     | 8.x       |
+| 7.x                   | 7.x                     | 7.17      |
++-----------------------+-------------------------+-----------+
 
 If you need multiple versions installed at the same time, versions are
 also released, such as ``elasticsearch7`` and ``elasticsearch8``.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -44,10 +44,12 @@ is required for that. Elasticsearch language clients are only backwards
 compatible with default distributions and without guarantees made.
 
 +-----------------------+-------------------------+-----------+
-| Elasticsearch Version | Elasticsearch-py Branch | Supported |
+| Elasticsearch version | elasticsearch-py branch | Supported |
 +=======================+=========================+===========+
 | main                  | main                    |           |
++-----------------------+-------------------------+-----------+
 | 8.x                   | 8.x                     | 8.x       |
++-----------------------+-------------------------+-----------+
 | 7.x                   | 7.x                     | 7.17      |
 +-----------------------+-------------------------+-----------+
 


### PR DESCRIPTION
## Overview

This PR adds a compatibility matrix to the Overview section of the Python book and the repo readme. It also fixes the markup of the links at the top of the Installation page.

### Preview

* [Compatibility](https://elasticsearch-py_bk_2458.docs-preview.app.elstc.co/guide/en/elasticsearch/client/python-api/master/overview.html#_compatibility)
* [Installation](https://elasticsearch-py_bk_2458.docs-preview.app.elstc.co/guide/en/elasticsearch/client/python-api/master/installation.html)