### PR TITLE
Changed API Key from tuple to encoding in the docs

### DIFF
--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -265,7 +265,7 @@ es.options(
 # You can persist the authenticated client to use
 # later or use for multiple API calls:
 auth_client = es.options(
-    api_key=("api-key-id", "api-key-secret")
+    api_key="api_key"
 )
 for i in range(10):
     auth_client.index(
@@ -321,8 +321,8 @@ es = Elasticsearch(
 ==== API Key authentication
 
 You can configure the client to use {es}'s API Key for connecting to your 
-cluster. Note that you need the values of `id` and `api_key` to
-https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[authenticate via an API Key].
+cluster. Note that you need the API Key credential representing the Base64-encoding of the id and api_key value 
+https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[generated from the API Key].
 
 [source,python]
 ----
@@ -332,7 +332,7 @@ from elasticsearch import Elasticsearch
 es = Elasticsearch(
     "https://localhost:9200",
     ca_certs="/path/to/http_ca.crt",
-    api_key=("api_key.id", "api_key.api_key")
+    api_key="api_key"
 )
 ----
 

--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -321,8 +321,8 @@ es = Elasticsearch(
 ==== API Key authentication
 
 You can configure the client to use {es}'s API Key for connecting to your 
-cluster. Note that you need the API Key credential representing the Base64-encoding of the id and api_key value 
-https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[generated from the API Key].
+cluster. Note that you need the API Key encoding you can 
+https://www.elastic.co/guide/en/kibana/current/api-keys.html#create-api-key[generated in Kibana].
 
 [source,python]
 ----

--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -264,9 +264,7 @@ es.options(
 
 # You can persist the authenticated client to use
 # later or use for multiple API calls:
-auth_client = es.options(
-    api_key="api_key"
-)
+auth_client = es.options(api_key="api_key")
 for i in range(10):
     auth_client.index(
         index="example-index",
@@ -320,7 +318,10 @@ es = Elasticsearch(
 [[auth-apikey]]
 ==== API Key authentication
 
-You can configure the client to use {es}'s API Key for connecting to your cluster. These can be generated through the https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Elasticsearch Create API key API] or https://www.elastic.co/guide/en/kibana/current/api-keys.html#create-api-key[Kibana Stack Management].
+You can configure the client to use {es}'s API Key for connecting to your
+cluster. These can be generated through the
+https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Elasticsearch Create API key API]
+or https://www.elastic.co/guide/en/kibana/current/api-keys.html#create-api-key[Kibana Stack Management].
 
 [source,python]
 ----
@@ -330,7 +331,7 @@ from elasticsearch import Elasticsearch
 es = Elasticsearch(
     "https://localhost:9200",
     ca_certs="/path/to/http_ca.crt",
-    api_key="api_key"
+    api_key="api_key",
 )
 ----
 

--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -320,9 +320,7 @@ es = Elasticsearch(
 [[auth-apikey]]
 ==== API Key authentication
 
-You can configure the client to use {es}'s API Key for connecting to your 
-cluster. Note that you need the API Key encoding you can 
-https://www.elastic.co/guide/en/kibana/current/api-keys.html#create-api-key[generated in Kibana].
+You can configure the client to use {es}'s API Key for connecting to your cluster. These can be generated through the https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Elasticsearch Create API key API] or https://www.elastic.co/guide/en/kibana/current/api-keys.html#create-api-key[Kibana Stack Management].
 
 [source,python]
 ----

--- a/docs/guide/getting-started.asciidoc
+++ b/docs/guide/getting-started.asciidoc
@@ -36,7 +36,7 @@ from elasticsearch import Elasticsearch
 
 client = Elasticsearch(
     "https://...",  # Elasticsearch endpoint
-    api_key='api_key',  # API key encoding
+    api_key='api_key',
 )
 ----
 

--- a/docs/guide/getting-started.asciidoc
+++ b/docs/guide/getting-started.asciidoc
@@ -36,7 +36,7 @@ from elasticsearch import Elasticsearch
 
 client = Elasticsearch(
     "https://...",  # Elasticsearch endpoint
-    api_key='api_key',
+    api_key="api_key",
 )
 ----
 

--- a/docs/guide/getting-started.asciidoc
+++ b/docs/guide/getting-started.asciidoc
@@ -36,7 +36,7 @@ from elasticsearch import Elasticsearch
 
 client = Elasticsearch(
     "https://...",  # Elasticsearch endpoint
-    api_key=('api-key-id', 'api-key-secret'),  # API key ID and secret
+    api_key='api_key',  # API key encoding
 )
 ----
 

--- a/docs/guide/migration.asciidoc
+++ b/docs/guide/migration.asciidoc
@@ -91,7 +91,7 @@ client = Elasticsearch(
 
     # Include your authentication like 'api_key'
     # 'basic_auth', or 'bearer_auth' here:
-    api_key=("<name>", "<key>")
+    api_key="api_key"
 )
 ------------------------------------
 
@@ -133,7 +133,7 @@ from elasticsearch import Elasticsearch
 client = Elasticsearch("http://localhost:9200")
 
 # 8.0+ SUPPORTED USAGE:
-client.options(api_key=("id", "api_key")).search(index="blogs")
+client.options(api_key="api_key").search(index="blogs")
 
 # 7.x DEPRECATED USAGE (Don't do this!):
 client.search(index="blogs", api_key=("id", "api_key"))
@@ -171,7 +171,7 @@ with the `security.grant_api_key` API:
 resp = (
     client.options(
         # This is the API key being used for the request
-        api_key=("request-id", "request-api-key")
+        api_key="request-api-key"
     ).security.grant_api_key(
         # This is the API key being granted
         api_key={
@@ -209,7 +209,7 @@ Starting with the 8.12 client, using a body parameter is fully supported again, 
 resp = (
     client.options(
         # This is the API key being used for the request
-        api_key=("request-id", "request-api-key")
+        api_key="request-api-key"
     ).security.grant_api_key(
         body={
             # This is the API key being granted

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -122,7 +122,7 @@ class Elasticsearch(BaseClient):
         # Set 'api_key' on the constructor
         client = Elasticsearch(
             "http://localhost:9200",
-            api_key="api_key"
+            api_key="api_key",
         )
         client.search(...)
 

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -122,12 +122,12 @@ class Elasticsearch(BaseClient):
         # Set 'api_key' on the constructor
         client = Elasticsearch(
             "http://localhost:9200",
-            api_key=("id", "api_key")
+            api_key="api_key"
         )
         client.search(...)
 
         # Set 'api_key' per request
-        client.options(api_key=("id", "api_key")).search(...)
+        client.options(api_key="api_key").search(...)
     """
 
     def __init__(


### PR DESCRIPTION
~~still to be added - the mention in the readthedocs index~~
no longer applicable with the redirect from master to latest