### PR TITLE
Type endpoint_id and path_parts as Optional

### DIFF
--- a/elasticsearch/_async/client/_base.py
+++ b/elasticsearch/_async/client/_base.py
@@ -257,8 +257,8 @@ class BaseClient:
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
-        endpoint_id: Union[DefaultType, str] = DEFAULT,
-        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
+        endpoint_id: Optional[str] = None,
+        path_parts: Optional[Mapping[str, Any]] = None,
     ) -> ApiResponse[Any]:
         if headers:
             request_headers = self._headers.copy()
@@ -387,8 +387,8 @@ class NamespacedClient(BaseClient):
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
-        endpoint_id: Union[DefaultType, str] = DEFAULT,
-        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
+        endpoint_id: Optional[str] = None,
+        path_parts: Optional[Mapping[str, Any]] = None,
     ) -> ApiResponse[Any]:
         # Use the internal clients .perform_request() implementation
         # so we take advantage of their transport options.

--- a/elasticsearch/_sync/client/_base.py
+++ b/elasticsearch/_sync/client/_base.py
@@ -257,8 +257,8 @@ class BaseClient:
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
-        endpoint_id: Union[DefaultType, str] = DEFAULT,
-        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
+        endpoint_id: Optional[str] = None,
+        path_parts: Optional[Mapping[str, Any]] = None,
     ) -> ApiResponse[Any]:
         if headers:
             request_headers = self._headers.copy()
@@ -387,8 +387,8 @@ class NamespacedClient(BaseClient):
         params: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[Any] = None,
-        endpoint_id: Union[DefaultType, str] = DEFAULT,
-        path_parts: Union[DefaultType, Mapping[str, Any]] = DEFAULT,
+        endpoint_id: Optional[str] = None,
+        path_parts: Optional[Mapping[str, Any]] = None,
     ) -> ApiResponse[Any]:
         # Use the internal clients .perform_request() implementation
         # so we take advantage of their transport options.


### PR DESCRIPTION
It is more consistent with the other parameters typed as optional. We also don't need to make the difference between `None` and `DEFAULT`. lint won't work until https://github.com/elastic/elastic-transport-python/pull/156 is merged, but I've checked locally that it's OK.