### PR TITLE
Fix api_key docstring in async case too

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -122,12 +122,12 @@ class AsyncElasticsearch(BaseClient):
         # Set 'api_key' on the constructor
         client = Elasticsearch(
             "http://localhost:9200",
-            api_key=("id", "api_key")
+            api_key="api_key",
         )
         client.search(...)
 
         # Set 'api_key' per request
-        client.options(api_key=("id", "api_key")).search(...)
+        client.options(api_key="api_key").search(...)
     """
 
     def __init__(


### PR DESCRIPTION
I noticed this because https://github.com/elastic/elasticsearch-py/pull/2475 was reverting the change. In fact, the sync code is generated by running unasync on the async code.