### PR TITLE
Ensure optional dependencies are optional

### DIFF
--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -65,7 +65,7 @@ from .serializer import JSONSerializer, JsonSerializer
 
 try:
     from .serializer import OrjsonSerializer
-except ModuleNotFoundError:
+except ImportError:
     OrjsonSerializer = None  # type: ignore[assignment,misc]
 
 # Only raise one warning per deprecation message so as not

--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -45,7 +45,7 @@ try:
     from elastic_transport import OrjsonSerializer as _OrjsonSerializer
 
     __all__.append("OrjsonSerializer")
-except ModuleNotFoundError:
+except ImportError:
     _OrjsonSerializer = None  # type: ignore[assignment,misc]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,14 +84,17 @@ def format(session):
 
 @nox.session()
 def lint(session):
-    session.install("flake8", "black~=24.0", "mypy", "isort", "types-requests")
+    # Check that importing the client still works without optional dependencies
+    session.install(".", env=INSTALL_ENV)
+    session.run("python", "-c", "from elasticsearch import Elasticsearch")
+    session.run("python", "-c", "from elasticsearch._otel import OpenTelemetry")
 
+    session.install("flake8", "black~=24.0", "mypy", "isort", "types-requests")
     session.run("isort", "--check", "--profile=black", *SOURCE_FILES)
     session.run("black", "--check", *SOURCE_FILES)
     session.run("flake8", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
 
-    # Workaround to make '-r' to still work despite uninstalling aiohttp below.
     session.install(".[async,requests,orjson]", env=INSTALL_ENV)
 
     # Run mypy on the package and then the type examples separately for


### PR DESCRIPTION
orjson is an optional dependency, but I was checking its absence with `ModuleNotFoundError`, a child exception of `ImportError`. While `import orjson` will indeed raise `ModuleNotFoundError`, `from .serializer import OrjsonSerializer` raises `ImportError` instead because the module (`.serializer`) was found.

OpenTelemetry is already tested in separate integration tests, but checking it explicitly in lint seemed useful as it's only one more line.