### PR TITLE
Remove redundant/deprecated `np.float_` use to fix NumPy 2.0 compat

### DIFF
--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -171,7 +171,6 @@ def _attempt_serialize_numpy(data: Any) -> Tuple[bool, Any]:
         elif isinstance(
             data,
             (
-                np.float_,
                 np.float16,
                 np.float32,
                 np.float64,

--- a/test_elasticsearch/test_serializer.py
+++ b/test_elasticsearch/test_serializer.py
@@ -89,7 +89,6 @@ def test_serializes_numpy_integers(json_serializer):
 @requires_numpy_and_pandas
 def test_serializes_numpy_floats(json_serializer):
     for np_type in (
-        np.float_,
         np.float32,
         np.float64,
     ):


### PR DESCRIPTION
Remove the explicit use of `np.float_` type that is an alias to `np.float64` and that has been removed in NumPy 2.0.  This fixes a hard error when running on this version on NumPy, while preserving compatibility with NumPy 1.

Fixes #2550