### PR TITLE
 adding index module code examples

### DIFF
--- a/docs/examples/156bc64c94f9f3334fbce25165d2286a.asciidoc
+++ b/docs/examples/156bc64c94f9f3334fbce25165d2286a.asciidoc
@@ -1,0 +1,15 @@
+// index-modules/index-sorting.asciidoc:16
+
+[source, python]
+----
+resp = client.indices.create(
+    index="my-index-000001",
+    body={
+        "settings": {
+            "index": {"sort.field": "date", "sort.order": "desc"}
+        },
+        "mappings": {"properties": {"date": {"type": "date"}}},
+    },
+)
+print(resp)
+----

--- a/docs/examples/17e6f3fac556f08a78f7a876e71acb89.asciidoc
+++ b/docs/examples/17e6f3fac556f08a78f7a876e71acb89.asciidoc
@@ -1,0 +1,12 @@
+// index-modules/allocation/delayed.asciidoc:40
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="_all",
+    body={
+        "settings": {"index.unassigned.node_left.delayed_timeout": "5m"}
+    },
+)
+print(resp)
+----

--- a/docs/examples/2342a56279106ea643026df657bf7f88.asciidoc
+++ b/docs/examples/2342a56279106ea643026df657bf7f88.asciidoc
@@ -1,0 +1,24 @@
+// index-modules/similarity.asciidoc:22
+
+[source, python]
+----
+resp = client.indices.create(
+    index="index",
+    body={
+        "settings": {
+            "index": {
+                "similarity": {
+                    "my_similarity": {
+                        "type": "DFR",
+                        "basic_model": "g",
+                        "after_effect": "l",
+                        "normalization": "h2",
+                        "normalization.h2.c": "3.0",
+                    }
+                }
+            }
+        }
+    },
+)
+print(resp)
+----

--- a/docs/examples/23af230e824f48b9cd56a4cf973d788c.asciidoc
+++ b/docs/examples/23af230e824f48b9cd56a4cf973d788c.asciidoc
@@ -1,0 +1,19 @@
+// index-modules/slowlog.asciidoc:31
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="my-index-000001",
+    body={
+        "index.search.slowlog.threshold.query.warn": "10s",
+        "index.search.slowlog.threshold.query.info": "5s",
+        "index.search.slowlog.threshold.query.debug": "2s",
+        "index.search.slowlog.threshold.query.trace": "500ms",
+        "index.search.slowlog.threshold.fetch.warn": "1s",
+        "index.search.slowlog.threshold.fetch.info": "800ms",
+        "index.search.slowlog.threshold.fetch.debug": "500ms",
+        "index.search.slowlog.threshold.fetch.trace": "200ms",
+    },
+)
+print(resp)
+----

--- a/docs/examples/25d40d3049e57e2bb70c2c5b88bd7b87.asciidoc
+++ b/docs/examples/25d40d3049e57e2bb70c2c5b88bd7b87.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/allocation/delayed.asciidoc:95
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="_all",
+    body={"settings": {"index.unassigned.node_left.delayed_timeout": "0"}},
+)
+print(resp)
+----

--- a/docs/examples/28ac880057135e46b3b00c7f3976538c.asciidoc
+++ b/docs/examples/28ac880057135e46b3b00c7f3976538c.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/allocation/filtering.asciidoc:122
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="test",
+    body={"index.routing.allocation.include._ip": "192.168.2.*"},
+)
+print(resp)
+----

--- a/docs/examples/2f07b81fd47ec3b074242a760f0c4e9e.asciidoc
+++ b/docs/examples/2f07b81fd47ec3b074242a760f0c4e9e.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/slowlog.asciidoc:149
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="my-index-000001",
+    body={"index.indexing.slowlog.include.user": True},
+)
+print(resp)
+----

--- a/docs/examples/34cdeefb09bbbe5206957a8bc1bd513d.asciidoc
+++ b/docs/examples/34cdeefb09bbbe5206957a8bc1bd513d.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/slowlog.asciidoc:66
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="my-index-000001",
+    body={"index.search.slowlog.include.user": True},
+)
+print(resp)
+----

--- a/docs/examples/48de51de87a8ad9fd8b8db1ca25b85c1.asciidoc
+++ b/docs/examples/48de51de87a8ad9fd8b8db1ca25b85c1.asciidoc
@@ -1,0 +1,20 @@
+// index-modules/similarity.asciidoc:540
+
+[source, python]
+----
+resp = client.indices.close(
+    index="index",
+)
+print(resp)
+
+resp = client.indices.put_settings(
+    index="index",
+    body={"index": {"similarity": {"default": {"type": "boolean"}}}},
+)
+print(resp)
+
+resp = client.indices.open(
+    index="index",
+)
+print(resp)
+----

--- a/docs/examples/528e5f1c345c3769248cc6889e8cf552.asciidoc
+++ b/docs/examples/528e5f1c345c3769248cc6889e8cf552.asciidoc
@@ -1,0 +1,14 @@
+// index-modules/similarity.asciidoc:45
+
+[source, python]
+----
+resp = client.indices.put_mapping(
+    index="index",
+    body={
+        "properties": {
+            "title": {"type": "text", "similarity": "my_similarity"}
+        }
+    },
+)
+print(resp)
+----

--- a/docs/examples/553d79817bb1333970e99507c37a159a.asciidoc
+++ b/docs/examples/553d79817bb1333970e99507c37a159a.asciidoc
@@ -1,0 +1,14 @@
+// index-modules/similarity.asciidoc:520
+
+[source, python]
+----
+resp = client.indices.create(
+    index="index",
+    body={
+        "settings": {
+            "index": {"similarity": {"default": {"type": "boolean"}}}
+        }
+    },
+)
+print(resp)
+----

--- a/docs/examples/5f8fb5513d4f725434db2f517ad4298f.asciidoc
+++ b/docs/examples/5f8fb5513d4f725434db2f517ad4298f.asciidoc
@@ -1,0 +1,30 @@
+// index-modules/similarity.asciidoc:357
+
+[source, python]
+----
+resp = client.indices.create(
+    index="index",
+    body={
+        "settings": {
+            "number_of_shards": 1,
+            "similarity": {
+                "scripted_tfidf": {
+                    "type": "scripted",
+                    "weight_script": {
+                        "source": "double idf = Math.log((field.docCount+1.0)/(term.docFreq+1.0)) + 1.0; return query.boost * idf;"
+                    },
+                    "script": {
+                        "source": "double tf = Math.sqrt(doc.freq); double norm = 1/Math.sqrt(doc.length); return weight * tf * norm;"
+                    },
+                }
+            },
+        },
+        "mappings": {
+            "properties": {
+                "field": {"type": "text", "similarity": "scripted_tfidf"}
+            }
+        },
+    },
+)
+print(resp)
+----

--- a/docs/examples/7b3e913368e96eaa6e22e0d03c81310e.asciidoc
+++ b/docs/examples/7b3e913368e96eaa6e22e0d03c81310e.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/store.asciidoc:30
+
+[source, python]
+----
+resp = client.indices.create(
+    index="my-index-000001",
+    body={"settings": {"index.store.type": "hybridfs"}},
+)
+print(resp)
+----

--- a/docs/examples/844928da2ff9a1394af5347a5e2e4f78.asciidoc
+++ b/docs/examples/844928da2ff9a1394af5347a5e2e4f78.asciidoc
@@ -1,0 +1,16 @@
+// index-modules/slowlog.asciidoc:133
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="my-index-000001",
+    body={
+        "index.indexing.slowlog.threshold.index.warn": "10s",
+        "index.indexing.slowlog.threshold.index.info": "5s",
+        "index.indexing.slowlog.threshold.index.debug": "2s",
+        "index.indexing.slowlog.threshold.index.trace": "500ms",
+        "index.indexing.slowlog.source": "1000",
+    },
+)
+print(resp)
+----

--- a/docs/examples/8703f3b1b3895543abc36e2a7a0013d3.asciidoc
+++ b/docs/examples/8703f3b1b3895543abc36e2a7a0013d3.asciidoc
@@ -1,0 +1,26 @@
+// index-modules/allocation/prioritization.asciidoc:17
+
+[source, python]
+----
+resp = client.indices.create(
+    index="index_1",
+)
+print(resp)
+
+resp = client.indices.create(
+    index="index_2",
+)
+print(resp)
+
+resp = client.indices.create(
+    index="index_3",
+    body={"settings": {"index.priority": 10}},
+)
+print(resp)
+
+resp = client.indices.create(
+    index="index_4",
+    body={"settings": {"index.priority": 5}},
+)
+print(resp)
+----

--- a/docs/examples/8d7193902a353872740a3324c60c5001.asciidoc
+++ b/docs/examples/8d7193902a353872740a3324c60c5001.asciidoc
@@ -1,0 +1,15 @@
+// index-modules/index-sorting.asciidoc:114
+
+[source, python]
+----
+resp = client.indices.create(
+    index="events",
+    body={
+        "settings": {
+            "index": {"sort.field": "timestamp", "sort.order": "desc"}
+        },
+        "mappings": {"properties": {"timestamp": {"type": "date"}}},
+    },
+)
+print(resp)
+----

--- a/docs/examples/9de4ea9d5f3d427a71ee07d998cb5611.asciidoc
+++ b/docs/examples/9de4ea9d5f3d427a71ee07d998cb5611.asciidoc
@@ -1,0 +1,6 @@
+// index-modules/blocks.asciidoc:137
+
+[source, python]
+----
+
+----

--- a/docs/examples/a38f29375eabd0103f8d7c00b17bb0ab.asciidoc
+++ b/docs/examples/a38f29375eabd0103f8d7c00b17bb0ab.asciidoc
@@ -1,0 +1,7 @@
+// index-modules/allocation/delayed.asciidoc:82
+
+[source, python]
+----
+resp = client.cluster.health()
+print(resp)
+----

--- a/docs/examples/a425fcab60f603504becee7d001f0a4b.asciidoc
+++ b/docs/examples/a425fcab60f603504becee7d001f0a4b.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/allocation/prioritization.asciidoc:48
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="index_4",
+    body={"index.priority": 1},
+)
+print(resp)
+----

--- a/docs/examples/beba2a9795c8a13653e1edf64eec4357.asciidoc
+++ b/docs/examples/beba2a9795c8a13653e1edf64eec4357.asciidoc
@@ -1,0 +1,13 @@
+// index-modules/allocation/filtering.asciidoc:74
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="test",
+    body={
+        "index.routing.allocation.require.size": "big",
+        "index.routing.allocation.require.rack": "rack1",
+    },
+)
+print(resp)
+----

--- a/docs/examples/d4fb482a51d67a1af48e429af6019a46.asciidoc
+++ b/docs/examples/d4fb482a51d67a1af48e429af6019a46.asciidoc
@@ -1,0 +1,23 @@
+// index-modules/index-sorting.asciidoc:41
+
+[source, python]
+----
+resp = client.indices.create(
+    index="my-index-000001",
+    body={
+        "settings": {
+            "index": {
+                "sort.field": ["username", "date"],
+                "sort.order": ["asc", "desc"],
+            }
+        },
+        "mappings": {
+            "properties": {
+                "username": {"type": "keyword", "doc_values": True},
+                "date": {"type": "date"},
+            }
+        },
+    },
+)
+print(resp)
+----

--- a/docs/examples/dad2d4add751fde5c39475ca709cc14b.asciidoc
+++ b/docs/examples/dad2d4add751fde5c39475ca709cc14b.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/allocation/filtering.asciidoc:54
+
+[source, python]
+----
+resp = client.indices.put_settings(
+    index="test",
+    body={"index.routing.allocation.include.size": "big,medium"},
+)
+print(resp)
+----

--- a/docs/examples/dfa16b7300d225e013f23625f44c087b.asciidoc
+++ b/docs/examples/dfa16b7300d225e013f23625f44c087b.asciidoc
@@ -1,0 +1,57 @@
+// index-modules/similarity.asciidoc:192
+
+[source, python]
+----
+resp = client.indices.create(
+    index="index",
+    body={
+        "settings": {
+            "number_of_shards": 1,
+            "similarity": {
+                "scripted_tfidf": {
+                    "type": "scripted",
+                    "script": {
+                        "source": "double tf = Math.sqrt(doc.freq); double idf = Math.log((field.docCount+1.0)/(term.docFreq+1.0)) + 1.0; double norm = 1/Math.sqrt(doc.length); return query.boost * tf * idf * norm;"
+                    },
+                }
+            },
+        },
+        "mappings": {
+            "properties": {
+                "field": {"type": "text", "similarity": "scripted_tfidf"}
+            }
+        },
+    },
+)
+print(resp)
+
+resp = client.index(
+    index="index",
+    id="1",
+    body={"field": "foo bar foo"},
+)
+print(resp)
+
+resp = client.index(
+    index="index",
+    id="2",
+    body={"field": "bar baz"},
+)
+print(resp)
+
+resp = client.indices.refresh(
+    index="index",
+)
+print(resp)
+
+resp = client.search(
+    index="index",
+    explain="true",
+    body={
+        "query": {
+            "query_string": {"query": "foo^1.7", "default_field": "field"}
+        }
+    },
+)
+print(resp)
+----

--- a/docs/examples/e1f6ea7c0937cf7e6ea7e8209e52e8bb.asciidoc
+++ b/docs/examples/e1f6ea7c0937cf7e6ea7e8209e52e8bb.asciidoc
@@ -1,0 +1,14 @@
+// index-modules/index-sorting.asciidoc:159
+
+[source, python]
+----
+resp = client.search(
+    index="events",
+    body={
+        "size": 10,
+        "sort": [{"timestamp": "desc"}],
+        "track_total_hits": False,
+    },
+)
+print(resp)
+----

--- a/docs/examples/e3b3a8ae12ab947ad3ba96eb228402ca.asciidoc
+++ b/docs/examples/e3b3a8ae12ab947ad3ba96eb228402ca.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/store.asciidoc:122
+
+[source, python]
+----
+resp = client.indices.create(
+    index="my-index-000001",
+    body={"settings": {"index.store.preload": ["nvd", "dvd"]}},
+)
+print(resp)
+----

--- a/docs/examples/fc8a426f8a5112e61e2acb913982a8d9.asciidoc
+++ b/docs/examples/fc8a426f8a5112e61e2acb913982a8d9.asciidoc
@@ -1,0 +1,10 @@
+// index-modules/index-sorting.asciidoc:138
+
+[source, python]
+----
+resp = client.search(
+    index="events",
+    body={"size": 10, "sort": [{"timestamp": "desc"}]},
+)
+print(resp)
+----

--- a/utils/generate-examples.py
+++ b/utils/generate-examples.py
@@ -143,6 +143,17 @@ files_to_generate = [
     "modules/cluster/remote-clusters-migration.asciidoc",
     "modules/cluster/remote-clusters-troubleshooting.asciidoc",
     "upgrade/archived-settings.asciidoc",
+    "index-modules/allocation/filtering.asciidoc",
+    "index-modules/allocation/delayed.asciidoc",
+    "index-modules/allocation/prioritization.asciidoc",
+    "index-modules/allocation/total_shards.asciidoc",
+    "index-modules/allocation/data_tier_allocation.asciidoc",
+    "index-modules/blocks.asciidoc",
+    "index-modules/similarity.asciidoc",
+    "index-modules/slowlog.asciidoc",
+    "index-modules/store.asciidoc",
+    "index-modules/index-sorting.asciidoc",
+    "index-modules/indexing-pressure.asciidoc"
 ]
 
 

--- a/utils/generate-examples.py
+++ b/utils/generate-examples.py
@@ -153,7 +153,7 @@ files_to_generate = [
     "index-modules/slowlog.asciidoc",
     "index-modules/store.asciidoc",
     "index-modules/index-sorting.asciidoc",
-    "index-modules/indexing-pressure.asciidoc"
+    "index-modules/indexing-pressure.asciidoc",
 ]
 
 


### PR DESCRIPTION
Hi! I found additional docs that do not have the Python code examples.

[Index Modules](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules.html):

- [Index-level shard allocation filtering](https://www.elastic.co/guide/en/elasticsearch/reference/master/shard-allocation-filtering.html)
- [Delaying allocation when a node leaves](https://www.elastic.co/guide/en/elasticsearch/reference/master/delayed-allocation.html)
- [Index recovery prioritization](https://www.elastic.co/guide/en/elasticsearch/reference/master/recovery-prioritization.html)
- [Index-level data tier allocation filtering](https://www.elastic.co/guide/en/elasticsearch/reference/master/allocation-total-shards.html)
- [Index blocks](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html)
- [Similarity module](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-similarity.html)
- [Slow Log](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-slowlog.html)
- [Store](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-store.html)
- [Preloading data into the file system cache](https://www.elastic.co/guide/en/elasticsearch/reference/master/preload-data-to-file-system-cache.html) ** part of the Store ascii doc
- [Index Sorting](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-index-sorting.html)
- [Indexing pressure](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-indexing-pressure.html)