### PR TITLE
Mark requests 2.32.2 as incompatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     python_requires=">=3.7",
     install_requires=["elastic-transport>=8.13,<9"],
     extras_require={
-        "requests": ["requests>=2.4.0, <3.0.0"],
+        "requests": ["requests>=2.4.0, !=2.32.2, <3.0.0"],
         "async": ["aiohttp>=3,<4"],
         "orjson": ["orjson>=3"],
         # Maximal Marginal Relevance (MMR) for search results


### PR DESCRIPTION
Custom SSL contexts are currently ignored.

As reported in https://github.com/psf/requests/pull/6667#issuecomment-2124283071.