### PR TITLE
Fix tests without destructive_requires_names=false

### DIFF
--- a/test_elasticsearch/utils.py
+++ b/test_elasticsearch/utils.py
@@ -215,10 +215,13 @@ def wipe_data_streams(client):
 
 
 def wipe_indices(client):
-    client.options(ignore_status=404).indices.delete(
-        index="*,-.ds-ilm-history-*",
-        expand_wildcards="all",
-    )
+    indices = client.cat.indices().strip().splitlines()
+    if len(indices) > 0:
+        index_names = [i.split(" ")[2] for i in indices]
+        client.options(ignore_status=404).indices.delete(
+            index=",".join(index_names),
+            expand_wildcards="all",
+        )
 
 
 def wipe_searchable_snapshot_indices(client):


### PR DESCRIPTION
In CI, we launch Elasticsearch with `--env action.destructive_requires_name=false`,  which allows to delete all indices in one call. However, when I run tests locally, I'm not likely to have such an option enabled. And since it's only useful in one function, I thought I would change `wipe_indices` to not require this setting.