### PR TITLE
Improve mapbox tests

### DIFF
--- a/test_elasticsearch/test_async/test_server/test_helpers.py
+++ b/test_elasticsearch/test_async/test_server/test_helpers.py
@@ -350,11 +350,7 @@ class TestBulk(object):
         assert "42" == error["index"]["_id"]
         assert "i" == error["index"]["_index"]
         print(error["index"]["error"])
-        assert error["index"]["error"]["type"] in [
-            "mapper_parsing_exception",
-            # Elasticsearch 8.8+: https://github.com/elastic/elasticsearch/pull/92646
-            "document_parsing_exception",
-        ]
+        assert error["index"]["error"]["type"] == "document_parsing_exception"
 
     async def test_error_is_raised(self, async_client):
         await async_client.indices.create(

--- a/test_elasticsearch/test_server/test_helpers.py
+++ b/test_elasticsearch/test_server/test_helpers.py
@@ -337,11 +337,7 @@ def test_errors_are_reported_correctly(sync_client):
     assert "42" == error["index"]["_id"]
     assert "i" == error["index"]["_index"]
     print(error["index"]["error"])
-    assert error["index"]["error"]["type"] in [
-        "mapper_parsing_exception",
-        # Elasticsearch 8.8+: https://github.com/elastic/elasticsearch/pull/92646
-        "document_parsing_exception",
-    ]
+    assert error["index"]["error"]["type"] == "document_parsing_exception"
 
 
 def test_error_is_raised(sync_client):


### PR DESCRIPTION
Assuming Elasticsearch 8.8+ is now fine in a testing context.

Relates https://github.com/elastic/elasticsearch-serverless-python/pull/44