### PR TITLE
feat: extend default settings in AsyncVectorStore

### DIFF
--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -60,7 +60,7 @@ class AsyncVectorStore:
         vector_field: str = "vector_field",
         metadata_mappings: Optional[Dict[str, Any]] = None,
         user_agent: str = f"elasticsearch-py-vs/{lib_version}",
-        custom_settings: Optional[Dict[str, Any]] = None,
+        custom_index_settings: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         :param user_header: user agent header specific to the 3rd party integration.
@@ -73,6 +73,12 @@ class AsyncVectorStore:
             the embedding vector goes in this field.
         :param client: Elasticsearch client connection. Alternatively specify the
             Elasticsearch connection with the other es_* parameters.
+        :param custom_index_settings: A dictionary of custom settings for the index.
+        This can include configurations like the number of shards, number of replicas,
+        analysis settings, and other index-specific settings. If not provided, default
+        settings will be used. Note that if the same setting is provided by both the user
+        and the strategy, the value from the strategy will take precedence. This behavior
+        ensures that the default settings have a higher priority.
         """
         # Add integration-specific usage header for tracking usage in Elastic Cloud.
         # client.options preserves existing (non-user-agent) headers.
@@ -91,7 +97,7 @@ class AsyncVectorStore:
         self.text_field = text_field
         self.vector_field = vector_field
         self.metadata_mappings = metadata_mappings
-        self.custom_settings = custom_settings
+        self.custom_index_settings = custom_index_settings
 
     async def close(self) -> None:
         return await self.client.close()
@@ -308,9 +314,9 @@ class AsyncVectorStore:
             vector_field=self.vector_field,
             num_dimensions=self.num_dimensions,
         )
-        if self.custom_settings:
-            self.custom_settings.update(settings)
-            settings = self.custom_settings
+        if self.custom_index_settings:
+            self.custom_index_settings.update(settings)
+            settings = self.custom_index_settings
 
         if self.metadata_mappings:
             metadata = mappings["properties"].get("metadata", {"properties": {}})

--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -314,9 +314,15 @@ class AsyncVectorStore:
             vector_field=self.vector_field,
             num_dimensions=self.num_dimensions,
         )
+
         if self.custom_index_settings:
-            self.custom_index_settings.update(settings)
-            settings = self.custom_index_settings
+            conflicting_keys = set(self.custom_index_settings.keys()) & set(
+                settings.keys()
+            )
+            if conflicting_keys:
+                raise ValueError(f"Conflicting settings: {conflicting_keys}")
+            else:
+                settings.update(self.custom_index_settings)
 
         if self.metadata_mappings:
             metadata = mappings["properties"].get("metadata", {"properties": {}})

--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -77,8 +77,7 @@ class AsyncVectorStore:
             This can include configurations like the number of shards, number of replicas,
             analysis settings, and other index-specific settings. If not provided, default
             settings will be used. Note that if the same setting is provided by both the user
-            and the strategy, the value from the strategy will take precedence. This behavior
-            ensures that the default settings have a higher priority.
+            and the strategy, will raise an error.
         """
         # Add integration-specific usage header for tracking usage in Elastic Cloud.
         # client.options preserves existing (non-user-agent) headers.

--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -60,6 +60,7 @@ class AsyncVectorStore:
         vector_field: str = "vector_field",
         metadata_mappings: Optional[Dict[str, Any]] = None,
         user_agent: str = f"elasticsearch-py-vs/{lib_version}",
+        custom_settings: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         :param user_header: user agent header specific to the 3rd party integration.
@@ -90,6 +91,7 @@ class AsyncVectorStore:
         self.text_field = text_field
         self.vector_field = vector_field
         self.metadata_mappings = metadata_mappings
+        self.custom_settings = custom_settings
 
     async def close(self) -> None:
         return await self.client.close()
@@ -306,6 +308,10 @@ class AsyncVectorStore:
             vector_field=self.vector_field,
             num_dimensions=self.num_dimensions,
         )
+        if self.custom_settings:
+            self.custom_settings.update(settings)
+            settings = self.custom_settings
+
         if self.metadata_mappings:
             metadata = mappings["properties"].get("metadata", {"properties": {}})
             for key in self.metadata_mappings.keys():

--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -74,11 +74,11 @@ class AsyncVectorStore:
         :param client: Elasticsearch client connection. Alternatively specify the
             Elasticsearch connection with the other es_* parameters.
         :param custom_index_settings: A dictionary of custom settings for the index.
-        This can include configurations like the number of shards, number of replicas,
-        analysis settings, and other index-specific settings. If not provided, default
-        settings will be used. Note that if the same setting is provided by both the user
-        and the strategy, the value from the strategy will take precedence. This behavior
-        ensures that the default settings have a higher priority.
+            This can include configurations like the number of shards, number of replicas,
+            analysis settings, and other index-specific settings. If not provided, default
+            settings will be used. Note that if the same setting is provided by both the user
+            and the strategy, the value from the strategy will take precedence. This behavior
+            ensures that the default settings have a higher priority.
         """
         # Add integration-specific usage header for tracking usage in Elastic Cloud.
         # client.options preserves existing (non-user-agent) headers.

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -57,6 +57,7 @@ class VectorStore:
         vector_field: str = "vector_field",
         metadata_mappings: Optional[Dict[str, Any]] = None,
         user_agent: str = f"elasticsearch-py-vs/{lib_version}",
+        custom_index_settings: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         :param user_header: user agent header specific to the 3rd party integration.
@@ -69,6 +70,12 @@ class VectorStore:
             the embedding vector goes in this field.
         :param client: Elasticsearch client connection. Alternatively specify the
             Elasticsearch connection with the other es_* parameters.
+        :param custom_index_settings: A dictionary of custom settings for the index.
+            This can include configurations like the number of shards, number of replicas,
+            analysis settings, and other index-specific settings. If not provided, default
+            settings will be used. Note that if the same setting is provided by both the user
+            and the strategy, the value from the strategy will take precedence. This behavior
+            ensures that the default settings have a higher priority.
         """
         # Add integration-specific usage header for tracking usage in Elastic Cloud.
         # client.options preserves existing (non-user-agent) headers.
@@ -87,6 +94,7 @@ class VectorStore:
         self.text_field = text_field
         self.vector_field = vector_field
         self.metadata_mappings = metadata_mappings
+        self.custom_index_settings = custom_index_settings
 
     def close(self) -> None:
         return self.client.close()
@@ -303,6 +311,11 @@ class VectorStore:
             vector_field=self.vector_field,
             num_dimensions=self.num_dimensions,
         )
+
+        if self.custom_index_settings:
+            self.custom_index_settings.update(settings)
+            settings = self.custom_index_settings
+            
         if self.metadata_mappings:
             metadata = mappings["properties"].get("metadata", {"properties": {}})
             for key in self.metadata_mappings.keys():

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -311,11 +311,10 @@ class VectorStore:
             vector_field=self.vector_field,
             num_dimensions=self.num_dimensions,
         )
-
         if self.custom_index_settings:
             self.custom_index_settings.update(settings)
             settings = self.custom_index_settings
-            
+
         if self.metadata_mappings:
             metadata = mappings["properties"].get("metadata", {"properties": {}})
             for key in self.metadata_mappings.keys():

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -74,8 +74,7 @@ class VectorStore:
             This can include configurations like the number of shards, number of replicas,
             analysis settings, and other index-specific settings. If not provided, default
             settings will be used. Note that if the same setting is provided by both the user
-            and the strategy, the value from the strategy will take precedence. This behavior
-            ensures that the default settings have a higher priority.
+            and the strategy, will raise an error.
         """
         # Add integration-specific usage header for tracking usage in Elastic Cloud.
         # client.options preserves existing (non-user-agent) headers.

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -311,9 +311,15 @@ class VectorStore:
             vector_field=self.vector_field,
             num_dimensions=self.num_dimensions,
         )
+
         if self.custom_index_settings:
-            self.custom_index_settings.update(settings)
-            settings = self.custom_index_settings
+            conflicting_keys = set(self.custom_index_settings.keys()) & set(
+                settings.keys()
+            )
+            if conflicting_keys:
+                raise ValueError(f"Conflicting settings: {conflicting_keys}")
+            else:
+                settings.update(self.custom_index_settings)
 
         if self.metadata_mappings:
             metadata = mappings["properties"].get("metadata", {"properties": {}})

--- a/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
@@ -935,6 +935,13 @@ class TestVectorStore:
             custom_index_settings=test_settings,
         )
 
+        sample_texts = [
+            "Sample text one, with some keywords.",
+            "Another; sample, text with; different keywords.",
+            "Third example text, with more keywords."
+        ]
+        store.add_texts(texts=sample_texts)
+        
         # Fetch the actual index settings from Elasticsearch
         actual_settings = sync_client.indices.get_settings(index=index)
 

--- a/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
@@ -975,7 +975,7 @@ class TestVectorStore:
                         "tokenizer": "custom_tokenizer",
                     }
                 },
-            }
+            },
         }
 
         test_mappings = {

--- a/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
@@ -908,17 +908,23 @@ class TestVectorStore:
         for key, val in test_mappings.items():
             assert mapping_properties["metadata"]["properties"][key] == val
 
-    def test_custom_index_settings(self, sync_client: Elasticsearch, index: str) -> None:
+    def test_custom_index_settings(
+        self, sync_client: Elasticsearch, index: str
+    ) -> None:
         """Test that the custom index settings are applied."""
         test_settings = {
             "analysis": {
                 "tokenizer": {
-                    "custom_tokenizer": {
-                        "type": "pattern",
-                        "pattern": "[,;\\s]+"
-                    }},
+                    "custom_tokenizer": {"type": "pattern", "pattern": "[,;\\s]+"}
+                },
                 "analyzer": {
-                    "custom_analyzer": {"type": "custom", "tokenizer": "custom_tokenizer"}}}}
+                    "custom_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "custom_tokenizer",
+                    }
+                },
+            }
+        }
 
         test_mappings = {
             "my_field": {"type": "keyword"},
@@ -938,14 +944,17 @@ class TestVectorStore:
         sample_texts = [
             "Sample text one, with some keywords.",
             "Another; sample, text with; different keywords.",
-            "Third example text, with more keywords."
+            "Third example text, with more keywords.",
         ]
         store.add_texts(texts=sample_texts)
-        
+
         # Fetch the actual index settings from Elasticsearch
         actual_settings = sync_client.indices.get_settings(index=index)
 
         # Assert that the custom settings were applied correctly
-        custom_settings_applied = actual_settings[index]["settings"]["index"]["analysis"]
-        assert custom_settings_applied == test_settings["analysis"], \
-            f"Expected custom index settings {test_settings} but got {custom_settings_applied}"
+        custom_settings_applied = actual_settings[index]["settings"]["index"][
+            "analysis"
+        ]
+        assert (
+            custom_settings_applied == test_settings["analysis"]
+        ), f"Expected custom index settings {test_settings} but got {custom_settings_applied}"


### PR DESCRIPTION
This commit introduces a new parameter, custom_settings, to the AsyncVectorStore class. This allows users to provide their own settings that will extend the default settings. This increases the flexibility of the class and allows it to be tailored to specific use cases. The custom settings are applied in the _create_index_if_not_exists method.