### PR TITLE
Fix Connector API

### DIFF
--- a/docs/sphinx/api/connector.rst
+++ b/docs/sphinx/api/connector.rst
@@ -1,4 +1,4 @@
-.. _cluster:
+.. _connector:
 
 Connector
 ---------

--- a/elasticsearch/client.py
+++ b/elasticsearch/client.py
@@ -85,6 +85,7 @@ __all__ = [
     "CatClient",
     "CcrClient",
     "ClusterClient",
+    "ConnectorClient",
     "DanglingIndicesClient",
     "Elasticsearch",
     "EnrichClient",


### PR DESCRIPTION
I noticed these issues when porting https://github.com/elastic/elasticsearch-py/pull/2621 to https://github.com/elastic/elasticsearch-serverless-python/pull/78