### PR TITLE
Fix reference docs

### DIFF
--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -17,6 +17,7 @@ arguments are required for all calls.
    :maxdepth: 1
 
    api/elasticsearch
+   api/async-search
    api/autoscaling
    api/cat
    api/ccr

--- a/docs/sphinx/api/async-search.rst
+++ b/docs/sphinx/api/async-search.rst
@@ -1,0 +1,10 @@
+.. _async_search:
+
+Async Search
+------------
+
+.. py:module:: elasticsearch.client
+   :no-index:
+
+.. autoclass:: AsyncSearchClient 
+   :members:

--- a/docs/sphinx/api/autoscaling.rst
+++ b/docs/sphinx/api/autoscaling.rst
@@ -3,7 +3,7 @@
 Autoscaling
 -----------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: AutoscalingClient
    :members:

--- a/docs/sphinx/api/cat.rst
+++ b/docs/sphinx/api/cat.rst
@@ -3,7 +3,7 @@
 Cat
 ---
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: CatClient
    :members:

--- a/docs/sphinx/api/ccr.rst
+++ b/docs/sphinx/api/ccr.rst
@@ -3,7 +3,7 @@
 Cross-Cluster Replication (CCR)
 -------------------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: CcrClient
    :members:

--- a/docs/sphinx/api/cluster.rst
+++ b/docs/sphinx/api/cluster.rst
@@ -3,7 +3,7 @@
 Cluster
 -------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: ClusterClient
    :members:

--- a/docs/sphinx/api/connector.rst
+++ b/docs/sphinx/api/connector.rst
@@ -3,7 +3,7 @@
 Connector
 ---------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: ConnectorClient
    :members:

--- a/docs/sphinx/api/dangling-indices.rst
+++ b/docs/sphinx/api/dangling-indices.rst
@@ -3,7 +3,7 @@
 Dangling Indices
 ----------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: DanglingIndicesClient
    :members:

--- a/docs/sphinx/api/elasticsearch.rst
+++ b/docs/sphinx/api/elasticsearch.rst
@@ -3,9 +3,7 @@
 Elasticsearch
 -------------
 
-.. py:module:: elasticsearch
+.. py:module:: elasticsearch.client
 
 .. autoclass:: Elasticsearch
    :members:
-
-.. py:module:: elasticsearch.client

--- a/docs/sphinx/api/enrich-policies.rst
+++ b/docs/sphinx/api/enrich-policies.rst
@@ -3,7 +3,7 @@
 Enrich Policies
 ---------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: EnrichClient
    :members:

--- a/docs/sphinx/api/eql.rst
+++ b/docs/sphinx/api/eql.rst
@@ -3,7 +3,7 @@
 Event Query Language (EQL)
 --------------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: EqlClient
    :members:

--- a/docs/sphinx/api/esql.rst
+++ b/docs/sphinx/api/esql.rst
@@ -3,7 +3,7 @@
 ES|QL
 -----
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: EsqlClient
    :members:

--- a/docs/sphinx/api/fleet.rst
+++ b/docs/sphinx/api/fleet.rst
@@ -3,7 +3,7 @@
 Fleet
 -----
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: FleetClient
    :members:

--- a/docs/sphinx/api/graph-explore.rst
+++ b/docs/sphinx/api/graph-explore.rst
@@ -3,7 +3,7 @@
 Graph Explore
 -------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: GraphClient
    :members:

--- a/docs/sphinx/api/index-lifecycle-management.rst
+++ b/docs/sphinx/api/index-lifecycle-management.rst
@@ -3,7 +3,7 @@
 Index Lifecycle Management (ILM)
 --------------------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: IlmClient
    :members:

--- a/docs/sphinx/api/indices.rst
+++ b/docs/sphinx/api/indices.rst
@@ -3,7 +3,7 @@
 Indices
 -------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: IndicesClient
    :members:

--- a/docs/sphinx/api/inference.rst
+++ b/docs/sphinx/api/inference.rst
@@ -3,7 +3,7 @@
 Inference
 ---------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: InferenceClient
    :members:

--- a/docs/sphinx/api/ingest-pipelines.rst
+++ b/docs/sphinx/api/ingest-pipelines.rst
@@ -3,7 +3,7 @@
 Ingest Pipelines
 ----------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: IngestClient
    :members:

--- a/docs/sphinx/api/license.rst
+++ b/docs/sphinx/api/license.rst
@@ -3,7 +3,7 @@
 License
 -------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: LicenseClient
    :members:

--- a/docs/sphinx/api/logstash.rst
+++ b/docs/sphinx/api/logstash.rst
@@ -3,7 +3,7 @@
 Logstash
 --------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: LogstashClient
    :members:

--- a/docs/sphinx/api/migration.rst
+++ b/docs/sphinx/api/migration.rst
@@ -3,7 +3,7 @@
 Migration
 ---------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: MigrationClient
    :members:

--- a/docs/sphinx/api/ml.rst
+++ b/docs/sphinx/api/ml.rst
@@ -3,7 +3,7 @@
 Machine Learning (ML)
 ---------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: MlClient
    :members:

--- a/docs/sphinx/api/monitoring.rst
+++ b/docs/sphinx/api/monitoring.rst
@@ -3,7 +3,7 @@
 Monitoring
 ----------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: MonitoringClient
    :members:

--- a/docs/sphinx/api/nodes.rst
+++ b/docs/sphinx/api/nodes.rst
@@ -3,7 +3,7 @@
 Nodes
 -----
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: NodesClient
    :members:

--- a/docs/sphinx/api/query-rules.rst
+++ b/docs/sphinx/api/query-rules.rst
@@ -3,7 +3,7 @@
 Query rules
 -----------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: QueryRulesClient
    :members:

--- a/docs/sphinx/api/rollup-indices.rst
+++ b/docs/sphinx/api/rollup-indices.rst
@@ -3,7 +3,7 @@
 Rollup Indices
 --------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: RollupClient
    :members:

--- a/docs/sphinx/api/search-application.rst
+++ b/docs/sphinx/api/search-application.rst
@@ -3,7 +3,7 @@
 Search Applications
 -------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SearchApplicationClient
    :members:

--- a/docs/sphinx/api/searchable-snapshots.rst
+++ b/docs/sphinx/api/searchable-snapshots.rst
@@ -3,7 +3,7 @@
 Searchable Snapshots
 --------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SearchableSnapshotsClient
    :members:

--- a/docs/sphinx/api/security.rst
+++ b/docs/sphinx/api/security.rst
@@ -3,7 +3,7 @@
 Security
 --------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SecurityClient
    :members:

--- a/docs/sphinx/api/shutdown.rst
+++ b/docs/sphinx/api/shutdown.rst
@@ -3,7 +3,7 @@
 Shutdown
 --------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: ShutdownClient
    :members:

--- a/docs/sphinx/api/snapshot-lifecycle-management.rst
+++ b/docs/sphinx/api/snapshot-lifecycle-management.rst
@@ -3,7 +3,7 @@
 Snapshot Lifecycle Management (SLM)
 -----------------------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SlmClient
    :members:

--- a/docs/sphinx/api/snapshots.rst
+++ b/docs/sphinx/api/snapshots.rst
@@ -3,7 +3,7 @@
 Snapshots
 ---------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SnapshotClient
    :members:

--- a/docs/sphinx/api/snapshottable-features.rst
+++ b/docs/sphinx/api/snapshottable-features.rst
@@ -3,7 +3,7 @@
 Snapshottable Features
 ----------------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: FeaturesClient
    :members:

--- a/docs/sphinx/api/sql.rst
+++ b/docs/sphinx/api/sql.rst
@@ -3,7 +3,7 @@
 SQL
 ---
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SqlClient
    :members:

--- a/docs/sphinx/api/synonyms.rst
+++ b/docs/sphinx/api/synonyms.rst
@@ -3,7 +3,7 @@
 Synonyms
 --------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SynonymsClient
    :members:

--- a/docs/sphinx/api/tasks.rst
+++ b/docs/sphinx/api/tasks.rst
@@ -3,7 +3,7 @@
 Tasks
 -----
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: TasksClient
    :members:

--- a/docs/sphinx/api/text-structure.rst
+++ b/docs/sphinx/api/text-structure.rst
@@ -3,7 +3,7 @@
 Text Structure
 --------------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: TextStructureClient
    :members:

--- a/docs/sphinx/api/tls-ssl.rst
+++ b/docs/sphinx/api/tls-ssl.rst
@@ -3,7 +3,7 @@
 TLS/SSL
 -------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: SslClient
    :members:

--- a/docs/sphinx/api/transforms.rst
+++ b/docs/sphinx/api/transforms.rst
@@ -3,7 +3,7 @@
 Transforms
 ----------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: TransformClient
    :members:

--- a/docs/sphinx/api/watcher.rst
+++ b/docs/sphinx/api/watcher.rst
@@ -3,7 +3,7 @@
 Watcher
 -------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: WatcherClient
    :members:

--- a/docs/sphinx/api/x-pack.rst
+++ b/docs/sphinx/api/x-pack.rst
@@ -3,7 +3,7 @@
 X-Pack
 ------
 .. py:module:: elasticsearch.client
-   :noindex:
+   :no-index:
 
 .. autoclass:: XPackClient
    :members:

--- a/docs/sphinx/exceptions.rst
+++ b/docs/sphinx/exceptions.rst
@@ -4,7 +4,7 @@ Exceptions & Warnings
 =====================
 
 .. py:module:: elasticsearch
-   :noindex:
+   :no-index:
 
 API Errors
 ----------


### PR DESCRIPTION
* Add Async Search that got removed by mistake in a previous refactor
* Fix warnings caused by a typo in no-index 
* Prefer `elasticsearch.client` over `elasticsearch` for consistency
* Last remaining warning will be fixed by https://github.com/elastic/elasticsearch-specification/pull/2768