### PR TITLE
Configure mypy to ignore missing imports during build

### DIFF
--- a/utils/build-dists.py
+++ b/utils/build-dists.py
@@ -121,6 +121,7 @@ def test_dist(dist):
                 "--strict",
                 "--install-types",
                 "--non-interactive",
+                "--ignore-missing-imports",
                 os.path.join(base_dir, "test_elasticsearch/test_types/async_types.py"),
             )
 
@@ -144,6 +145,7 @@ def test_dist(dist):
                 "--strict",
                 "--install-types",
                 "--non-interactive",
+                "--ignore-missing-imports",
                 os.path.join(base_dir, "test_elasticsearch/test_types/sync_types.py"),
             )
         else:
@@ -154,6 +156,7 @@ def test_dist(dist):
                 "--strict",
                 "--install-types",
                 "--non-interactive",
+                "--ignore-missing-imports",
                 os.path.join(
                     base_dir, "test_elasticsearch/test_types/aliased_types.py"
                 ),


### PR DESCRIPTION
The build script runs mypy without the `ignore-missing-imports` flag. This used to be fine, but with the introduction of pyarrow the flag is needed because this library does not have type hints. The mypy build triggered from nox works fine because it already has this option enabled.