### PR TITLE
Fix import when trace is missing from opentelemetry

### DIFF
--- a/elasticsearch/_otel.py
+++ b/elasticsearch/_otel.py
@@ -25,7 +25,7 @@ try:
     from opentelemetry import trace
 
     _tracer: trace.Tracer | None = trace.get_tracer("elasticsearch-api")
-except ModuleNotFoundError:
+except ImportError:
     _tracer = None
 
 from elastic_transport import OpenTelemetrySpan


### PR DESCRIPTION
otel dependency is optional but if I try to use latest elastic client it fails to bootstrap due to 
```
../../../vdp/config_verification/elastic_sink/elastic_config_verification.py:21: in <module>
    from elasticsearch import Elasticsearch
../../../../.venv/lib/python3.11/site-packages/elasticsearch/__init__.py:45: in <module>
    from ._async.client import AsyncElasticsearch as AsyncElasticsearch
../../../../.venv/lib/python3.11/site-packages/elasticsearch/_async/client/__init__.py:38: in <module>
    from ._base import (
../../../../.venv/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:48: in <module>
    from ..._otel import OpenTelemetry
../../../../.venv/lib/python3.11/site-packages/elasticsearch/_otel.py:25: in <module>
    from opentelemetry import trace
E   ImportError: cannot import name 'trace' from 'opentelemetry' (unknown location)
```

## Fix
While is usually correct to catch `ModuleNotFoundError`, in case of opentelemetry this is a bit different since the actual "opentelemetry" package doesn't exist at all (we got opentelemetry-api and opentelemetry-sdk) and in that case Python (3.11 in my case) throws a more generic ImportError