### PR TITLE
Remove unnecessary override code

### DIFF
--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -83,10 +83,8 @@ class AsyncVectorStore:
         # client.options preserves existing (non-user-agent) headers.
         client = client.options(headers={"User-Agent": user_agent})
 
-        if hasattr(retrieval_strategy, "text_field"):
+        if hasattr(retrieval_strategy, "text_field") and retrieval_strategy.text_field is None:
             retrieval_strategy.text_field = text_field
-        if hasattr(retrieval_strategy, "vector_field"):
-            retrieval_strategy.vector_field = vector_field
 
         self.client = client
         self.index = index

--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -83,7 +83,10 @@ class AsyncVectorStore:
         # client.options preserves existing (non-user-agent) headers.
         client = client.options(headers={"User-Agent": user_agent})
 
-        if hasattr(retrieval_strategy, "text_field") and retrieval_strategy.text_field is None:
+        if (
+            hasattr(retrieval_strategy, "text_field")
+            and retrieval_strategy.text_field is None
+        ):
             retrieval_strategy.text_field = text_field
 
         self.client = client

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -80,10 +80,8 @@ class VectorStore:
         # client.options preserves existing (non-user-agent) headers.
         client = client.options(headers={"User-Agent": user_agent})
 
-        if hasattr(retrieval_strategy, "text_field"):
+        if hasattr(retrieval_strategy, "text_field") and retrieval_strategy.text_field is None:
             retrieval_strategy.text_field = text_field
-        if hasattr(retrieval_strategy, "vector_field"):
-            retrieval_strategy.vector_field = vector_field
 
         self.client = client
         self.index = index

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -80,7 +80,10 @@ class VectorStore:
         # client.options preserves existing (non-user-agent) headers.
         client = client.options(headers={"User-Agent": user_agent})
 
-        if hasattr(retrieval_strategy, "text_field") and retrieval_strategy.text_field is None:
+        if (
+            hasattr(retrieval_strategy, "text_field")
+            and retrieval_strategy.text_field is None
+        ):
             retrieval_strategy.text_field = text_field
 
         self.client = client


### PR DESCRIPTION
I tested below code to test DenseVectorStrategy:

```
strategy = DenseVectorStrategy(
    model_id=".multilingual-e5-small_linux-x86_64",
    hybrid=True,
    text_field="title",   
)
store = ElasticsearchStore(
    es_connection=elasticsearch_client,
    index_name=INDEX,
    vector_query_field="content_semantic.inference.chunks.embeddings",
    query_field="content",
    strategy=strategy,
)
```

But I realized `text_field="title"` parameter in the DenseVectorStrategy constructor doesn't affect since it is overridded in:

https://github.com/elastic/elasticsearch-py/blob/main/elasticsearch/helpers/vectorstore/_sync/vectorstore.py#L83-L86

And also there is no `vector_field` in all of strategy classes.

This PR intends to:
- Override `text_field` field only when it is not provided as part of constructor
- Remove unnecessary override code since `if hasattr(retrieval_strategy, "vector_field")` is always False