### PR TITLE
Build dists as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
       - name: Install dependencies
         run: |
           python3 -m pip install nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -18,6 +18,21 @@ jobs:
           python3 -m pip install nox
       - name: Lint the code
         run: nox -s lint
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python3 -m pip install build
+      - name: Build dists
+        run: python utils/build-dists.py
 
   test-linux:
     strategy:
@@ -32,9 +47,9 @@ jobs:
     continue-on-error: false
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set Up Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies

--- a/elasticsearch/_otel.py
+++ b/elasticsearch/_otel.py
@@ -102,7 +102,7 @@ class OpenTelemetry:
 
     @contextlib.contextmanager
     def use_span(self, span: OpenTelemetrySpan) -> Generator[None, None, None]:
-        if not self.enabled or self.tracer is None:
+        if not self.enabled or self.tracer is None or span.otel_span is None:
             yield
             return
 

--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -56,10 +56,9 @@ from elastic_transport.client_utils import (
     url_to_node_config,
 )
 
-from elasticsearch.exceptions import GeneralAvailabilityWarning
-
 from ..._version import __versionstr__
 from ...compat import to_bytes, to_str, warn_stacklevel
+from ...exceptions import GeneralAvailabilityWarning
 
 if TYPE_CHECKING:
     from ._base import NamespacedClient


### PR DESCRIPTION
The build-dists.py step often fails during publishing, let's add it to CI.