### PR TITLE
Allow simsimd again on Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     "nox",
     "orjson",
     "numpy",
-    "simsimd ; python_version<'3.13'",
+    "simsimd",
     "pyarrow",
     "pandas",
     "mapbox-vector-tile",

--- a/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
@@ -899,8 +899,6 @@ class TestVectorStore:
         self, sync_client: Elasticsearch, index: str
     ) -> None:
         """Test max marginal relevance search error conditions."""
-        pytest.importorskip("simsimd")
-
         texts = ["foo", "bar", "baz"]
         vector_field = "vector_field"
         embedding_service = ConsistentFakeEmbeddings()
@@ -942,8 +940,6 @@ class TestVectorStore:
         self, sync_client: Elasticsearch, index: str
     ) -> None:
         """Test max marginal relevance search."""
-        pytest.importorskip("simsimd")
-
         texts = ["foo", "bar", "baz"]
         vector_field = "vector_field"
         text_field = "text_field"


### PR DESCRIPTION
The 6.1.0 release has Python 3.13 wheels: https://pypi.org/project/simsimd/6.1.0/#files.