### PR TITLE
Add sphinx.configuration to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,3 +14,6 @@ python:
     - path: .
       extra_requirements:
         - "docs"
+
+sphinx:
+  configuration: docs/sphinx/conf.py


### PR DESCRIPTION
As mentioned in https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/. There was a brownout yesterday, which is how I noticed this.