### PR TITLE
[7.17] Add sphinx.configuration to .readthedocs.yml (#2740)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,3 +13,6 @@ python:
   install:
     - requirements: dev-requirements.txt
     - path: .
+
+sphinx:
+  configuration: docs/sphinx/conf.py


### PR DESCRIPTION
(cherry picked from commit 1f66af588fb8d2a96188674bd9ce23f813318aaa)

Co-authored-by: Quentin Pradet <quentin.pradet@elastic.co>