### PR TITLE
Fix formatting of Markdown code blocks

### DIFF
--- a/docs/sphinx/_static/css/custom.css
+++ b/docs/sphinx/_static/css/custom.css
@@ -1,0 +1,16 @@
+/* Display GitHub Flavored Markdown code blocks correctly */
+
+.rst-content pre {
+  background-color: #f5f5f5;
+  border-radius: 6px;
+  padding: 16px;
+  margin: 16px 0;
+  overflow-x: auto;
+}
+
+.rst-content pre code {
+  background-color: #f5f5f5;
+  white-space: pre;
+  border: none;
+  padding: 0;
+}

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -44,8 +44,8 @@ release = version
 pygments_style = "sphinx"
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ['_static']
-html_css_files = ['css/custom.css']
+html_static_path = ["_static"]
+html_css_files = ["css/custom.css"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -44,6 +44,8 @@ release = version
 pygments_style = "sphinx"
 
 html_theme = "sphinx_rtd_theme"
+html_static_path = ['_static']
+html_css_files = ['css/custom.css']
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
I'm fixing the generated description to render Markdown correctly. Part of this is fixing the rendering of code blocks. Without this custom CSS, they show up as a single line.