### PR TITLE
Auto-generated code for 8.x

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -724,7 +724,7 @@ class AsyncElasticsearch(BaseClient):
         only wait for those three shards to refresh. The other two shards that make up
         the index do not participate in the `_bulk` request at all.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-bulk.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-bulk.html>`_
 
         :param operations:
         :param index: The name of the data stream, index, or index alias to perform bulk
@@ -842,7 +842,7 @@ class AsyncElasticsearch(BaseClient):
         Clear a scrolling search. Clear the search context and results for a scrolling
         search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-scroll-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-scroll-api.html>`_
 
         :param scroll_id: The scroll IDs to clear. To clear all scroll IDs, use `_all`.
         """
@@ -896,7 +896,7 @@ class AsyncElasticsearch(BaseClient):
         period has elapsed. However, keeping points in time has a cost; close them as
         soon as they are no longer required for search requests.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/point-in-time-api.html>`_
 
         :param id: The ID of the point-in-time.
         """
@@ -977,7 +977,7 @@ class AsyncElasticsearch(BaseClient):
         a replica is chosen and the search is run against it. This means that replicas
         increase the scalability of the count.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-count.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams and indices,
@@ -1117,38 +1117,119 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Index a document. Adds a JSON document to the specified data stream or index
-        and makes it searchable. If the target is an index and the document already exists,
-        the request updates the document and increments its version.
+        Create a new document in the index. You can index a new JSON document with the
+        `/<target>/_doc/` or `/<target>/_create/<_id>` APIs Using `_create` guarantees
+        that the document is indexed only if it does not already exist. It returns a
+        409 response when a document with a same ID already exists in the index. To update
+        an existing document, you must use the `/<target>/_doc/` API. If the Elasticsearch
+        security features are enabled, you must have the following index privileges for
+        the target data stream, index, or index alias: * To add a document using the
+        `PUT /<target>/_create/<_id>` or `POST /<target>/_create/<_id>` request formats,
+        you must have the `create_doc`, `create`, `index`, or `write` index privilege.
+        * To automatically create a data stream or index with this API request, you must
+        have the `auto_configure`, `create_index`, or `manage` index privilege. Automatic
+        data stream creation requires a matching index template with data stream enabled.
+        **Automatically create data streams and indices** If the request's target doesn't
+        exist and matches an index template with a `data_stream` definition, the index
+        operation automatically creates the data stream. If the target doesn't exist
+        and doesn't match a data stream template, the operation automatically creates
+        the index and applies any matching index templates. NOTE: Elasticsearch includes
+        several built-in index templates. To avoid naming collisions with these templates,
+        refer to index pattern documentation. If no mapping exists, the index operation
+        creates a dynamic mapping. By default, new fields and objects are automatically
+        added to the mapping if needed. Automatic index creation is controlled by the
+        `action.auto_create_index` setting. If it is `true`, any index can be created
+        automatically. You can modify this setting to explicitly allow or block automatic
+        creation of indices that match specified patterns or set it to `false` to turn
+        off automatic index creation entirely. Specify a comma-separated list of patterns
+        you want to allow or prefix each pattern with `+` or `-` to indicate whether
+        it should be allowed or blocked. When a list is specified, the default behaviour
+        is to disallow. NOTE: The `action.auto_create_index` setting affects the automatic
+        creation of indices only. It does not affect the creation of data streams. **Routing**
+        By default, shard placement — or routing — is controlled by using a hash of the
+        document's ID value. For more explicit control, the value fed into the hash function
+        used by the router can be directly specified on a per-operation basis using the
+        `routing` parameter. When setting up explicit mapping, you can also use the `_routing`
+        field to direct the index operation to extract the routing value from the document
+        itself. This does come at the (very minimal) cost of an additional document parsing
+        pass. If the `_routing` mapping is defined and set to be required, the index
+        operation will fail if no routing value is provided or extracted. NOTE: Data
+        streams do not support custom routing unless they were created with the `allow_custom_routing`
+        setting enabled in the template. **Distributed** The index operation is directed
+        to the primary shard based on its route and performed on the actual node containing
+        this shard. After the primary shard completes the operation, if needed, the update
+        is distributed to applicable replicas. **Active shards** To improve the resiliency
+        of writes to the system, indexing operations can be configured to wait for a
+        certain number of active shard copies before proceeding with the operation. If
+        the requisite number of active shard copies are not available, then the write
+        operation must wait and retry, until either the requisite shard copies have started
+        or a timeout occurs. By default, write operations only wait for the primary shards
+        to be active before proceeding (that is to say `wait_for_active_shards` is `1`).
+        This default can be overridden in the index settings dynamically by setting `index.write.wait_for_active_shards`.
+        To alter this behavior per operation, use the `wait_for_active_shards request`
+        parameter. Valid values are all or any positive integer up to the total number
+        of configured copies per shard in the index (which is `number_of_replicas`+1).
+        Specifying a negative value or a number greater than the number of shard copies
+        will throw an error. For example, suppose you have a cluster of three nodes,
+        A, B, and C and you create an index index with the number of replicas set to
+        3 (resulting in 4 shard copies, one more copy than there are nodes). If you attempt
+        an indexing operation, by default the operation will only ensure the primary
+        copy of each shard is available before proceeding. This means that even if B
+        and C went down and A hosted the primary shard copies, the indexing operation
+        would still proceed with only one copy of the data. If `wait_for_active_shards`
+        is set on the request to `3` (and all three nodes are up), the indexing operation
+        will require 3 active shard copies before proceeding. This requirement should
+        be met because there are 3 active nodes in the cluster, each one holding a copy
+        of the shard. However, if you set `wait_for_active_shards` to `all` (or to `4`,
+        which is the same in this situation), the indexing operation will not proceed
+        as you do not have all 4 copies of each shard active in the index. The operation
+        will timeout unless a new node is brought up in the cluster to host the fourth
+        copy of the shard. It is important to note that this setting greatly reduces
+        the chances of the write operation not writing to the requisite number of shard
+        copies, but it does not completely eliminate the possibility, because this check
+        occurs before the write operation starts. After the write operation is underway,
+        it is still possible for replication to fail on any number of shard copies but
+        still succeed on the primary. The `_shards` section of the API response reveals
+        the number of shard copies on which replication succeeded and failed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-index_.html>`_
 
-        :param index: Name of the data stream or index to target. If the target doesn’t
+        :param index: The name of the data stream or index to target. If the target doesn't
             exist and matches the name or wildcard (`*`) pattern of an index template
             with a `data_stream` definition, this request creates the data stream. If
-            the target doesn’t exist and doesn’t match a data stream template, this request
+            the target doesn't exist and doesn’t match a data stream template, this request
             creates the index.
-        :param id: Unique identifier for the document.
+        :param id: A unique identifier for the document. To automatically generate a
+            document ID, use the `POST /<target>/_doc/` request format.
         :param document:
-        :param pipeline: ID of the pipeline to use to preprocess incoming documents.
-            If the index has a default ingest pipeline specified, then setting the value
-            to `_none` disables the default ingest pipeline for this request. If a final
-            pipeline is configured it will always run, regardless of the value of this
+        :param pipeline: The ID of the pipeline to use to preprocess incoming documents.
+            If the index has a default ingest pipeline specified, setting the value to
+            `_none` turns off the default ingest pipeline for this request. If a final
+            pipeline is configured, it will always run regardless of the value of this
             parameter.
         :param refresh: If `true`, Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` do nothing with refreshes.
-            Valid values: `true`, `false`, `wait_for`.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param timeout: Period the request waits for the following operations: automatic
-            index creation, dynamic mapping updates, waiting for active shards.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+            this operation visible to search. If `wait_for`, it waits for a refresh to
+            make this operation visible to search. If `false`, it does nothing with refreshes.
+        :param routing: A custom value that is used to route operations to a specific
+            shard.
+        :param timeout: The period the request waits for the following operations: automatic
+            index creation, dynamic mapping updates, waiting for active shards. Elasticsearch
+            waits for at least the specified timeout period before failing. The actual
+            wait time could be longer, particularly when multiple waits occur. This parameter
+            is useful for situations where the primary shard assigned to perform the
+            operation might not be available when the operation runs. Some reasons for
+            this might be that the primary shard is currently recovering from a gateway
+            or undergoing relocation. By default, the operation will wait on the primary
+            shard to become available for at least 1 minute before failing and responding
+            with an error. The actual wait time could be longer, particularly when multiple
+            waits occur.
+        :param version: The explicit version number for concurrency control. It must
+            be a non-negative long number.
+        :param version_type: The version type.
         :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to `all` or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            before proceeding with the operation. You can set it to `all` or any positive
+            integer up to the total number of shards in the index (`number_of_replicas+1`).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1223,29 +1304,57 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete a document. Removes a JSON document from the specified index.
+        Delete a document. Remove a JSON document from the specified index. NOTE: You
+        cannot send deletion requests directly to a data stream. To delete a document
+        in a data stream, you must target the backing index containing the document.
+        **Optimistic concurrency control** Delete operations can be made conditional
+        and only be performed if the last modification to the document was assigned the
+        sequence number and primary term specified by the `if_seq_no` and `if_primary_term`
+        parameters. If a mismatch is detected, the operation will result in a `VersionConflictException`
+        and a status code of `409`. **Versioning** Each document indexed is versioned.
+        When deleting a document, the version can be specified to make sure the relevant
+        document you are trying to delete is actually being deleted and it has not changed
+        in the meantime. Every write operation run on a document, deletes included, causes
+        its version to be incremented. The version number of a deleted document remains
+        available for a short time after deletion to allow for control of concurrent
+        operations. The length of time for which a deleted document's version remains
+        available is determined by the `index.gc_deletes` index setting. **Routing**
+        If routing is used during indexing, the routing value also needs to be specified
+        to delete a document. If the `_routing` mapping is set to `required` and no routing
+        value is specified, the delete API throws a `RoutingMissingException` and rejects
+        the request. For example: ``` DELETE /my-index-000001/_doc/1?routing=shard-1
+        ``` This request deletes the document with ID 1, but it is routed based on the
+        user. The document is not deleted if the correct routing is not specified. **Distributed**
+        The delete operation gets hashed into a specific shard ID. It then gets redirected
+        into the primary shard within that ID group and replicated (if needed) to shard
+        replicas within that ID group.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-delete.html>`_
 
-        :param index: Name of the target index.
-        :param id: Unique identifier for the document.
+        :param index: The name of the target index.
+        :param id: A unique identifier for the document.
         :param if_primary_term: Only perform the operation if the document has this primary
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
         :param refresh: If `true`, Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` do nothing with refreshes.
-            Valid values: `true`, `false`, `wait_for`.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param timeout: Period to wait for active shards.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
-        :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to `all` or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            this operation visible to search. If `wait_for`, it waits for a refresh to
+            make this operation visible to search. If `false`, it does nothing with refreshes.
+        :param routing: A custom value used to route operations to a specific shard.
+        :param timeout: The period to wait for active shards. This parameter is useful
+            for situations where the primary shard assigned to perform the delete operation
+            might not be available when the delete operation runs. Some reasons for this
+            might be that the primary shard is currently recovering from a store or undergoing
+            relocation. By default, the delete operation will wait on the primary shard
+            to become available for up to 1 minute before failing and responding with
+            an error.
+        :param version: An explicit version number for concurrency control. It must match
+            the current version of the document for the request to succeed.
+        :param version_type: The version type.
+        :param wait_for_active_shards: The minimum number of shard copies that must be
+            active before proceeding with the operation. You can set it to `all` or any
+            positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1347,7 +1456,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Delete documents. Deletes documents that match the specified query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-delete-by-query.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams or indices, omit this
@@ -1528,7 +1637,7 @@ class AsyncElasticsearch(BaseClient):
         takes effect immediately but rethrotting that slows down the query takes effect
         after completing the current batch to prevent scroll timeouts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-delete-by-query.html>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per
@@ -1574,7 +1683,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Delete a script or search template. Deletes a stored script or search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
 
         :param id: Identifier for the stored script or search template.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -1640,32 +1749,54 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
     ) -> HeadApiResponse:
         """
-        Check a document. Checks if a specified document exists.
+        Check a document. Verify that a document exists. For example, check to see if
+        a document with the `_id` 0 exists: ``` HEAD my-index-000001/_doc/0 ``` If the
+        document exists, the API returns a status code of `200 - OK`. If the document
+        doesn’t exist, the API returns `404 - Not Found`. **Versioning support** You
+        can use the `version` parameter to check the document only if its current version
+        is equal to the specified one. Internally, Elasticsearch has marked the old document
+        as deleted and added an entirely new document. The old version of the document
+        doesn't disappear immediately, although you won't be able to access it. Elasticsearch
+        cleans up deleted documents in the background as you continue to index more data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases. Supports
-            wildcards (`*`).
-        :param id: Identifier of the document.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param index: A comma-separated list of data streams, indices, and aliases. It
+            supports wildcards (`*`).
+        :param id: A unique document identifier.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas. If it is
+            set to `_local`, the operation will prefer to be run on a local allocated
+            shard when possible. If it is set to a custom value, the value is used to
+            guarantee that the same shards will be used for the same custom value. This
+            can help with "jumping values" when hitting different shards in different
+            refresh states. A sample value can be something like the web session ID or
+            the user name.
         :param realtime: If `true`, the request is real-time as opposed to near-real-time.
-        :param refresh: If `true`, Elasticsearch refreshes all shards involved in the
-            delete by query after the request completes.
-        :param routing: Target the specified primary shard.
-        :param source: `true` or `false` to return the `_source` field or not, or a list
-            of fields to return.
-        :param source_excludes: A comma-separated list of source fields to exclude in
-            the response.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
+        :param source_excludes: A comma-separated list of source fields to exclude from
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
         :param source_includes: A comma-separated list of source fields to include in
-            the response.
-        :param stored_fields: List of stored fields to return as part of a hit. If no
-            fields are specified, no stored fields are included in the response. If this
-            field is specified, the `_source` parameter defaults to false.
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
+        :param stored_fields: A comma-separated list of stored fields to return as part
+            of a hit. If no fields are specified, no stored fields are included in the
+            response. If this field is specified, the `_source` parameter defaults to
+            `false`.
         :param version: Explicit version number for concurrency control. The specified
             version must match the current version of the document for the request to
             succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1741,29 +1872,32 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
     ) -> HeadApiResponse:
         """
-        Check for a document source. Checks if a document's `_source` is stored.
+        Check for a document source. Check whether a document source exists in an index.
+        For example: ``` HEAD my-index-000001/_source/1 ``` A document's source is not
+        available if it is disabled in the mapping.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases. Supports
-            wildcards (`*`).
-        :param id: Identifier of the document.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param realtime: If true, the request is real-time as opposed to near-real-time.
-        :param refresh: If `true`, Elasticsearch refreshes all shards involved in the
-            delete by query after the request completes.
-        :param routing: Target the specified primary shard.
-        :param source: `true` or `false` to return the `_source` field or not, or a list
-            of fields to return.
+        :param index: A comma-separated list of data streams, indices, and aliases. It
+            supports wildcards (`*`).
+        :param id: A unique identifier for the document.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas.
+        :param realtime: If `true`, the request is real-time as opposed to near-real-time.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
         :param source_excludes: A comma-separated list of source fields to exclude in
             the response.
         :param source_includes: A comma-separated list of source fields to include in
             the response.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+        :param version: The version number for concurrency control. It must match the
+            current version of the document for the request to succeed.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1844,7 +1978,7 @@ class AsyncElasticsearch(BaseClient):
         Explain a document match result. Returns information about why a specific document
         matches, or doesn’t match, a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-explain.html>`_
 
         :param index: Index names used to limit the request. Only a single index name
             can be provided to this parameter.
@@ -1967,7 +2101,7 @@ class AsyncElasticsearch(BaseClient):
         field. For example, a runtime field with a type of keyword is returned the same
         as any other field that belongs to the `keyword` family.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-field-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-field-caps.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (*). To target all data streams
@@ -2081,36 +2215,78 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get a document by its ID. Retrieves the document with the specified ID from an
-        index.
+        Get a document by its ID. Get a document and its source or stored fields from
+        an index. By default, this API is realtime and is not affected by the refresh
+        rate of the index (when data will become visible for search). In the case where
+        stored fields are requested with the `stored_fields` parameter and the document
+        has been updated but is not yet refreshed, the API will have to parse and analyze
+        the source to extract the stored fields. To turn off realtime behavior, set the
+        `realtime` parameter to false. **Source filtering** By default, the API returns
+        the contents of the `_source` field unless you have used the `stored_fields`
+        parameter or the `_source` field is turned off. You can turn off `_source` retrieval
+        by using the `_source` parameter: ``` GET my-index-000001/_doc/0?_source=false
+        ``` If you only need one or two fields from the `_source`, use the `_source_includes`
+        or `_source_excludes` parameters to include or filter out particular fields.
+        This can be helpful with large documents where partial retrieval can save on
+        network overhead Both parameters take a comma separated list of fields or wildcard
+        expressions. For example: ``` GET my-index-000001/_doc/0?_source_includes=*.id&_source_excludes=entities
+        ``` If you only want to specify includes, you can use a shorter notation: ```
+        GET my-index-000001/_doc/0?_source=*.id ``` **Routing** If routing is used during
+        indexing, the routing value also needs to be specified to retrieve a document.
+        For example: ``` GET my-index-000001/_doc/2?routing=user1 ``` This request gets
+        the document with ID 2, but it is routed based on the user. The document is not
+        fetched if the correct routing is not specified. **Distributed** The GET operation
+        is hashed into a specific shard ID. It is then redirected to one of the replicas
+        within that shard ID and returns the result. The replicas are the primary shard
+        and its replicas within that shard ID group. This means that the more replicas
+        you have, the better your GET scaling will be. **Versioning support** You can
+        use the `version` parameter to retrieve the document only if its current version
+        is equal to the specified one. Internally, Elasticsearch has marked the old document
+        as deleted and added an entirely new document. The old version of the document
+        doesn't disappear immediately, although you won't be able to access it. Elasticsearch
+        cleans up deleted documents in the background as you continue to index more data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Name of the index that contains the document.
-        :param id: Unique identifier of the document.
-        :param force_synthetic_source: Should this request force synthetic _source? Use
-            this to test if the mapping supports synthetic _source and to get a sense
-            of the worst case performance. Fetches with this enabled will be slower the
-            enabling synthetic source natively in the index.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param index: The name of the index that contains the document.
+        :param id: A unique document identifier.
+        :param force_synthetic_source: Indicates whether the request forces synthetic
+            `_source`. Use this paramater to test if the mapping supports synthetic `_source`
+            and to get a sense of the worst case performance. Fetches with this parameter
+            enabled will be slower than enabling synthetic source natively in the index.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas. If it is
+            set to `_local`, the operation will prefer to be run on a local allocated
+            shard when possible. If it is set to a custom value, the value is used to
+            guarantee that the same shards will be used for the same custom value. This
+            can help with "jumping values" when hitting different shards in different
+            refresh states. A sample value can be something like the web session ID or
+            the user name.
         :param realtime: If `true`, the request is real-time as opposed to near-real-time.
-        :param refresh: If true, Elasticsearch refreshes the affected shards to make
-            this operation visible to search. If false, do nothing with refreshes.
-        :param routing: Target the specified primary shard.
-        :param source: True or false to return the _source field or not, or a list of
-            fields to return.
-        :param source_excludes: A comma-separated list of source fields to exclude in
-            the response.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
+        :param source_excludes: A comma-separated list of source fields to exclude from
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
         :param source_includes: A comma-separated list of source fields to include in
-            the response.
-        :param stored_fields: List of stored fields to return as part of a hit. If no
-            fields are specified, no stored fields are included in the response. If this
-            field is specified, the `_source` parameter defaults to false.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: internal, external, external_gte.
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
+        :param stored_fields: A comma-separated list of stored fields to return as part
+            of a hit. If no fields are specified, no stored fields are included in the
+            response. If this field is specified, the `_source` parameter defaults to
+            `false`. Only leaf fields can be retrieved with the `stored_field` option.
+            Object fields can't be returned;​if specified, the request fails.
+        :param version: The version number for concurrency control. It must match the
+            current version of the document for the request to succeed.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2173,7 +2349,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Get a script or search template. Retrieves a stored script or search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
 
         :param id: Identifier for the stored script or search template.
         :param master_timeout: Specify timeout for connection to master
@@ -2215,7 +2391,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Get script contexts. Get a list of supported script contexts and their methods.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.16/painless-contexts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.17/painless-contexts.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_context"
@@ -2250,7 +2426,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Get script languages. Get a list of available script types, languages, and contexts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_language"
@@ -2303,29 +2479,34 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get a document's source. Returns the source of a document.
+        Get a document's source. Get the source of a document. For example: ``` GET my-index-000001/_source/1
+        ``` You can use the source filtering parameters to control which parts of the
+        `_source` are returned: ``` GET my-index-000001/_source/1/?_source_includes=*.id&_source_excludes=entities
+        ```
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Name of the index that contains the document.
-        :param id: Unique identifier of the document.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param realtime: Boolean) If true, the request is real-time as opposed to near-real-time.
-        :param refresh: If true, Elasticsearch refreshes the affected shards to make
-            this operation visible to search. If false, do nothing with refreshes.
-        :param routing: Target the specified primary shard.
-        :param source: True or false to return the _source field or not, or a list of
-            fields to return.
+        :param index: The name of the index that contains the document.
+        :param id: A unique document identifier.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas.
+        :param realtime: If `true`, the request is real-time as opposed to near-real-time.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
         :param source_excludes: A comma-separated list of source fields to exclude in
             the response.
         :param source_includes: A comma-separated list of source fields to include in
             the response.
-        :param stored_fields:
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: internal, external, external_gte.
+        :param stored_fields: A comma-separated list of stored fields to return as part
+            of a hit.
+        :param version: The version number for concurrency control. It must match the
+            current version of the document for the request to succeed.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2407,7 +2588,7 @@ class AsyncElasticsearch(BaseClient):
         for health status, set verbose to false to disable the more expensive analysis
         logic.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/health-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/health-api.html>`_
 
         :param feature: A feature of the cluster, as returned by the top-level health
             report API.
@@ -2480,44 +2661,170 @@ class AsyncElasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Index a document. Adds a JSON document to the specified data stream or index
-        and makes it searchable. If the target is an index and the document already exists,
-        the request updates the document and increments its version.
+        Create or update a document in an index. Add a JSON document to the specified
+        data stream or index and make it searchable. If the target is an index and the
+        document already exists, the request updates the document and increments its
+        version. NOTE: You cannot use this API to send update requests for existing documents
+        in a data stream. If the Elasticsearch security features are enabled, you must
+        have the following index privileges for the target data stream, index, or index
+        alias: * To add or overwrite a document using the `PUT /<target>/_doc/<_id>`
+        request format, you must have the `create`, `index`, or `write` index privilege.
+        * To add a document using the `POST /<target>/_doc/` request format, you must
+        have the `create_doc`, `create`, `index`, or `write` index privilege. * To automatically
+        create a data stream or index with this API request, you must have the `auto_configure`,
+        `create_index`, or `manage` index privilege. Automatic data stream creation requires
+        a matching index template with data stream enabled. NOTE: Replica shards might
+        not all be started when an indexing operation returns successfully. By default,
+        only the primary is required. Set `wait_for_active_shards` to change this default
+        behavior. **Automatically create data streams and indices** If the request's
+        target doesn't exist and matches an index template with a `data_stream` definition,
+        the index operation automatically creates the data stream. If the target doesn't
+        exist and doesn't match a data stream template, the operation automatically creates
+        the index and applies any matching index templates. NOTE: Elasticsearch includes
+        several built-in index templates. To avoid naming collisions with these templates,
+        refer to index pattern documentation. If no mapping exists, the index operation
+        creates a dynamic mapping. By default, new fields and objects are automatically
+        added to the mapping if needed. Automatic index creation is controlled by the
+        `action.auto_create_index` setting. If it is `true`, any index can be created
+        automatically. You can modify this setting to explicitly allow or block automatic
+        creation of indices that match specified patterns or set it to `false` to turn
+        off automatic index creation entirely. Specify a comma-separated list of patterns
+        you want to allow or prefix each pattern with `+` or `-` to indicate whether
+        it should be allowed or blocked. When a list is specified, the default behaviour
+        is to disallow. NOTE: The `action.auto_create_index` setting affects the automatic
+        creation of indices only. It does not affect the creation of data streams. **Optimistic
+        concurrency control** Index operations can be made conditional and only be performed
+        if the last modification to the document was assigned the sequence number and
+        primary term specified by the `if_seq_no` and `if_primary_term` parameters. If
+        a mismatch is detected, the operation will result in a `VersionConflictException`
+        and a status code of `409`. **Routing** By default, shard placement — or routing
+        — is controlled by using a hash of the document's ID value. For more explicit
+        control, the value fed into the hash function used by the router can be directly
+        specified on a per-operation basis using the `routing` parameter. When setting
+        up explicit mapping, you can also use the `_routing` field to direct the index
+        operation to extract the routing value from the document itself. This does come
+        at the (very minimal) cost of an additional document parsing pass. If the `_routing`
+        mapping is defined and set to be required, the index operation will fail if no
+        routing value is provided or extracted. NOTE: Data streams do not support custom
+        routing unless they were created with the `allow_custom_routing` setting enabled
+        in the template. **Distributed** The index operation is directed to the primary
+        shard based on its route and performed on the actual node containing this shard.
+        After the primary shard completes the operation, if needed, the update is distributed
+        to applicable replicas. **Active shards** To improve the resiliency of writes
+        to the system, indexing operations can be configured to wait for a certain number
+        of active shard copies before proceeding with the operation. If the requisite
+        number of active shard copies are not available, then the write operation must
+        wait and retry, until either the requisite shard copies have started or a timeout
+        occurs. By default, write operations only wait for the primary shards to be active
+        before proceeding (that is to say `wait_for_active_shards` is `1`). This default
+        can be overridden in the index settings dynamically by setting `index.write.wait_for_active_shards`.
+        To alter this behavior per operation, use the `wait_for_active_shards request`
+        parameter. Valid values are all or any positive integer up to the total number
+        of configured copies per shard in the index (which is `number_of_replicas`+1).
+        Specifying a negative value or a number greater than the number of shard copies
+        will throw an error. For example, suppose you have a cluster of three nodes,
+        A, B, and C and you create an index index with the number of replicas set to
+        3 (resulting in 4 shard copies, one more copy than there are nodes). If you attempt
+        an indexing operation, by default the operation will only ensure the primary
+        copy of each shard is available before proceeding. This means that even if B
+        and C went down and A hosted the primary shard copies, the indexing operation
+        would still proceed with only one copy of the data. If `wait_for_active_shards`
+        is set on the request to `3` (and all three nodes are up), the indexing operation
+        will require 3 active shard copies before proceeding. This requirement should
+        be met because there are 3 active nodes in the cluster, each one holding a copy
+        of the shard. However, if you set `wait_for_active_shards` to `all` (or to `4`,
+        which is the same in this situation), the indexing operation will not proceed
+        as you do not have all 4 copies of each shard active in the index. The operation
+        will timeout unless a new node is brought up in the cluster to host the fourth
+        copy of the shard. It is important to note that this setting greatly reduces
+        the chances of the write operation not writing to the requisite number of shard
+        copies, but it does not completely eliminate the possibility, because this check
+        occurs before the write operation starts. After the write operation is underway,
+        it is still possible for replication to fail on any number of shard copies but
+        still succeed on the primary. The `_shards` section of the API response reveals
+        the number of shard copies on which replication succeeded and failed. **No operation
+        (noop) updates** When updating a document by using this API, a new version of
+        the document is always created even if the document hasn't changed. If this isn't
+        acceptable use the `_update` API with `detect_noop` set to `true`. The `detect_noop`
+        option isn't available on this API because it doesn’t fetch the old source and
+        isn't able to compare it against the new source. There isn't a definitive rule
+        for when noop updates aren't acceptable. It's a combination of lots of factors
+        like how frequently your data source sends updates that are actually noops and
+        how many queries per second Elasticsearch runs on the shard receiving the updates.
+        **Versioning** Each indexed document is given a version number. By default, internal
+        versioning is used that starts at 1 and increments with each update, deletes
+        included. Optionally, the version number can be set to an external value (for
+        example, if maintained in a database). To enable this functionality, `version_type`
+        should be set to `external`. The value provided must be a numeric, long value
+        greater than or equal to 0, and less than around `9.2e+18`. NOTE: Versioning
+        is completely real time, and is not affected by the near real time aspects of
+        search operations. If no version is provided, the operation runs without any
+        version checks. When using the external version type, the system checks to see
+        if the version number passed to the index request is greater than the version
+        of the currently stored document. If true, the document will be indexed and the
+        new version number used. If the value provided is less than or equal to the stored
+        document's version number, a version conflict will occur and the index operation
+        will fail. For example: ``` PUT my-index-000001/_doc/1?version=2&version_type=external
+        { "user": { "id": "elkbee" } } In this example, the operation will succeed since
+        the supplied version of 2 is higher than the current document version of 1. If
+        the document was already updated and its version was set to 2 or higher, the
+        indexing command will fail and result in a conflict (409 HTTP status code). A
+        nice side effect is that there is no need to maintain strict ordering of async
+        indexing operations run as a result of changes to a source database, as long
+        as version numbers from the source database are used. Even the simple case of
+        updating the Elasticsearch index using data from a database is simplified if
+        external versioning is used, as only the latest version will be used if the index
+        operations arrive out of order.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-index_.html>`_
 
-        :param index: Name of the data stream or index to target.
+        :param index: The name of the data stream or index to target. If the target doesn't
+            exist and matches the name or wildcard (`*`) pattern of an index template
+            with a `data_stream` definition, this request creates the data stream. If
+            the target doesn't exist and doesn't match a data stream template, this request
+            creates the index. You can check for existing targets with the resolve index
+            API.
         :param document:
-        :param id: Unique identifier for the document.
+        :param id: A unique identifier for the document. To automatically generate a
+            document ID, use the `POST /<target>/_doc/` request format and omit this
+            parameter.
         :param if_primary_term: Only perform the operation if the document has this primary
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
-        :param op_type: Set to create to only index the document if it does not already
+        :param op_type: Set to `create` to only index the document if it does not already
             exist (put if absent). If a document with the specified `_id` already exists,
-            the indexing operation will fail. Same as using the `<index>/_create` endpoint.
-            Valid values: `index`, `create`. If document id is specified, it defaults
-            to `index`. Otherwise, it defaults to `create`.
-        :param pipeline: ID of the pipeline to use to preprocess incoming documents.
+            the indexing operation will fail. The behavior is the same as using the `<index>/_create`
+            endpoint. If a document ID is specified, this paramater defaults to `index`.
+            Otherwise, it defaults to `create`. If the request targets a data stream,
+            an `op_type` of `create` is required.
+        :param pipeline: The ID of the pipeline to use to preprocess incoming documents.
             If the index has a default ingest pipeline specified, then setting the value
             to `_none` disables the default ingest pipeline for this request. If a final
             pipeline is configured it will always run, regardless of the value of this
             parameter.
         :param refresh: If `true`, Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` do nothing with refreshes.
-            Valid values: `true`, `false`, `wait_for`.
+            this operation visible to search. If `wait_for`, it waits for a refresh to
+            make this operation visible to search. If `false`, it does nothing with refreshes.
         :param require_alias: If `true`, the destination must be an index alias.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param timeout: Period the request waits for the following operations: automatic
-            index creation, dynamic mapping updates, waiting for active shards.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+        :param routing: A custom value that is used to route operations to a specific
+            shard.
+        :param timeout: The period the request waits for the following operations: automatic
+            index creation, dynamic mapping updates, waiting for active shards. This
+            parameter is useful for situations where the primary shard assigned to perform
+            the operation might not be available when the operation runs. Some reasons
+            for this might be that the primary shard is currently recovering from a gateway
+            or undergoing relocation. By default, the operation will wait on the primary
+            shard to become available for at least 1 minute before failing and responding
+            with an error. The actual wait time could be longer, particularly when multiple
+            waits occur.
+        :param version: An explicit version number for concurrency control. It must be
+            a non-negative long number.
+        :param version_type: The version type.
         :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to all or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            before proceeding with the operation. You can set it to `all` or any positive
+            integer up to the total number of shards in the index (`number_of_replicas+1`).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2593,7 +2900,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Get cluster info. Get basic build, version, and cluster information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rest-api-root.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rest-api-root.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/"
@@ -2658,7 +2965,7 @@ class AsyncElasticsearch(BaseClient):
         The kNN search API supports restricting the search using a filter. The search
         will return the top k documents that also match the filter query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             to perform the operation on all indices
@@ -2762,7 +3069,7 @@ class AsyncElasticsearch(BaseClient):
         IDs in the request body. To ensure fast responses, this multi get (mget) API
         responds with partial results if one or more shards fail.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-multi-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-multi-get.html>`_
 
         :param index: Name of the index to retrieve documents from when `ids` are specified,
             or when a document in the `docs` array does not specify an index.
@@ -2889,7 +3196,7 @@ class AsyncElasticsearch(BaseClient):
         Each newline character may be preceded by a carriage return `\\r`. When sending
         requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-multi-search.html>`_
 
         :param searches:
         :param index: Comma-separated list of data streams, indices, and index aliases
@@ -3021,7 +3328,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Run multiple templated searches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-multi-search.html>`_
 
         :param search_templates:
         :param index: Comma-separated list of data streams, indices, and aliases to search.
@@ -3120,7 +3427,7 @@ class AsyncElasticsearch(BaseClient):
         with all the fetched termvectors. Each element has the structure provided by
         the termvectors API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-multi-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-multi-termvectors.html>`_
 
         :param index: Name of the index that contains the documents.
         :param docs: Array of existing or artificial documents.
@@ -3240,7 +3547,7 @@ class AsyncElasticsearch(BaseClient):
         A point in time must be opened explicitly before being used in search requests.
         The `keep_alive` parameter tells Elasticsearch how long it should persist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/point-in-time-api.html>`_
 
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
@@ -3328,7 +3635,7 @@ class AsyncElasticsearch(BaseClient):
         Create or update a script or search template. Creates or updates a stored script
         or search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
 
         :param id: Identifier for the stored script or search template. Must be unique
             within the cluster.
@@ -3414,7 +3721,7 @@ class AsyncElasticsearch(BaseClient):
         Evaluate ranked search results. Evaluate the quality of ranked search results
         over a set of typical search queries.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-rank-eval.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-rank-eval.html>`_
 
         :param requests: A set of typical search requests, together with their provided
             ratings.
@@ -3506,33 +3813,191 @@ class AsyncElasticsearch(BaseClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Reindex documents. Copies documents from a source to a destination. The source
-        can be any existing index, alias, or data stream. The destination must differ
-        from the source. For example, you cannot reindex a data stream into itself.
+        Reindex documents. Copy documents from a source to a destination. You can copy
+        all documents to the destination index or reindex a subset of the documents.
+        The source can be any existing index, alias, or data stream. The destination
+        must differ from the source. For example, you cannot reindex a data stream into
+        itself. IMPORTANT: Reindex requires `_source` to be enabled for all documents
+        in the source. The destination should be configured as wanted before calling
+        the reindex API. Reindex does not copy the settings from the source or its associated
+        template. Mappings, shard counts, and replicas, for example, must be configured
+        ahead of time. If the Elasticsearch security features are enabled, you must have
+        the following security privileges: * The `read` index privilege for the source
+        data stream, index, or alias. * The `write` index privilege for the destination
+        data stream, index, or index alias. * To automatically create a data stream or
+        index with a reindex API request, you must have the `auto_configure`, `create_index`,
+        or `manage` index privilege for the destination data stream, index, or alias.
+        * If reindexing from a remote cluster, the `source.remote.user` must have the
+        `monitor` cluster privilege and the `read` index privilege for the source data
+        stream, index, or alias. If reindexing from a remote cluster, you must explicitly
+        allow the remote host in the `reindex.remote.whitelist` setting. Automatic data
+        stream creation requires a matching index template with data stream enabled.
+        The `dest` element can be configured like the index API to control optimistic
+        concurrency control. Omitting `version_type` or setting it to `internal` causes
+        Elasticsearch to blindly dump documents into the destination, overwriting any
+        that happen to have the same ID. Setting `version_type` to `external` causes
+        Elasticsearch to preserve the `version` from the source, create any documents
+        that are missing, and update any documents that have an older version in the
+        destination than they do in the source. Setting `op_type` to `create` causes
+        the reindex API to create only missing documents in the destination. All existing
+        documents will cause a version conflict. IMPORTANT: Because data streams are
+        append-only, any reindex request to a destination data stream must have an `op_type`
+        of `create`. A reindex can only add new documents to a destination data stream.
+        It cannot update existing documents in a destination data stream. By default,
+        version conflicts abort the reindex process. To continue reindexing if there
+        are conflicts, set the `conflicts` request body property to `proceed`. In this
+        case, the response includes a count of the version conflicts that were encountered.
+        Note that the handling of other error types is unaffected by the `conflicts`
+        property. Additionally, if you opt to count version conflicts, the operation
+        could attempt to reindex more documents from the source than `max_docs` until
+        it has successfully indexed `max_docs` documents into the target or it has gone
+        through every document in the source query. NOTE: The reindex API makes no effort
+        to handle ID collisions. The last document written will "win" but the order isn't
+        usually predictable so it is not a good idea to rely on this behavior. Instead,
+        make sure that IDs are unique by using a script. **Running reindex asynchronously**
+        If the request contains `wait_for_completion=false`, Elasticsearch performs some
+        preflight checks, launches the request, and returns a task you can use to cancel
+        or get the status of the task. Elasticsearch creates a record of this task as
+        a document at `_tasks/<task_id>`. **Reindex from multiple sources** If you have
+        many sources to reindex it is generally better to reindex them one at a time
+        rather than using a glob pattern to pick up multiple sources. That way you can
+        resume the process if there are any errors by removing the partially completed
+        source and starting over. It also makes parallelizing the process fairly simple:
+        split the list of sources to reindex and run each list in parallel. For example,
+        you can use a bash script like this: ``` for index in i1 i2 i3 i4 i5; do curl
+        -HContent-Type:application/json -XPOST localhost:9200/_reindex?pretty -d'{ "source":
+        { "index": "'$index'" }, "dest": { "index": "'$index'-reindexed" } }' done ```
+        **Throttling** Set `requests_per_second` to any positive decimal number (`1.4`,
+        `6`, `1000`, for example) to throttle the rate at which reindex issues batches
+        of index operations. Requests are throttled by padding each batch with a wait
+        time. To turn off throttling, set `requests_per_second` to `-1`. The throttling
+        is done by waiting between batches so that the scroll that reindex uses internally
+        can be given a timeout that takes into account the padding. The padding time
+        is the difference between the batch size divided by the `requests_per_second`
+        and the time spent writing. By default the batch size is `1000`, so if `requests_per_second`
+        is set to `500`: ``` target_time = 1000 / 500 per second = 2 seconds wait_time
+        = target_time - write_time = 2 seconds - .5 seconds = 1.5 seconds ``` Since the
+        batch is issued as a single bulk request, large batch sizes cause Elasticsearch
+        to create many requests and then wait for a while before starting the next set.
+        This is "bursty" instead of "smooth". **Slicing** Reindex supports sliced scroll
+        to parallelize the reindexing process. This parallelization can improve efficiency
+        and provide a convenient way to break the request down into smaller parts. NOTE:
+        Reindexing from remote clusters does not support manual or automatic slicing.
+        You can slice a reindex request manually by providing a slice ID and total number
+        of slices to each request. You can also let reindex automatically parallelize
+        by using sliced scroll to slice on `_id`. The `slices` parameter specifies the
+        number of slices to use. Adding `slices` to the reindex request just automates
+        the manual process, creating sub-requests which means it has some quirks: * You
+        can see these requests in the tasks API. These sub-requests are "child" tasks
+        of the task for the request with slices. * Fetching the status of the task for
+        the request with `slices` only contains the status of completed slices. * These
+        sub-requests are individually addressable for things like cancellation and rethrottling.
+        * Rethrottling the request with `slices` will rethrottle the unfinished sub-request
+        proportionally. * Canceling the request with `slices` will cancel each sub-request.
+        * Due to the nature of `slices`, each sub-request won't get a perfectly even
+        portion of the documents. All documents will be addressed, but some slices may
+        be larger than others. Expect larger slices to have a more even distribution.
+        * Parameters like `requests_per_second` and `max_docs` on a request with `slices`
+        are distributed proportionally to each sub-request. Combine that with the previous
+        point about distribution being uneven and you should conclude that using `max_docs`
+        with `slices` might not result in exactly `max_docs` documents being reindexed.
+        * Each sub-request gets a slightly different snapshot of the source, though these
+        are all taken at approximately the same time. If slicing automatically, setting
+        `slices` to `auto` will choose a reasonable number for most indices. If slicing
+        manually or otherwise tuning automatic slicing, use the following guidelines.
+        Query performance is most efficient when the number of slices is equal to the
+        number of shards in the index. If that number is large (for example, `500`),
+        choose a lower number as too many slices will hurt performance. Setting slices
+        higher than the number of shards generally does not improve efficiency and adds
+        overhead. Indexing performance scales linearly across available resources with
+        the number of slices. Whether query or indexing performance dominates the runtime
+        depends on the documents being reindexed and cluster resources. **Modify documents
+        during reindexing** Like `_update_by_query`, reindex operations support a script
+        that modifies the document. Unlike `_update_by_query`, the script is allowed
+        to modify the document's metadata. Just as in `_update_by_query`, you can set
+        `ctx.op` to change the operation that is run on the destination. For example,
+        set `ctx.op` to `noop` if your script decides that the document doesn’t have
+        to be indexed in the destination. This "no operation" will be reported in the
+        `noop` counter in the response body. Set `ctx.op` to `delete` if your script
+        decides that the document must be deleted from the destination. The deletion
+        will be reported in the `deleted` counter in the response body. Setting `ctx.op`
+        to anything else will return an error, as will setting any other field in `ctx`.
+        Think of the possibilities! Just be careful; you are able to change: * `_id`
+        * `_index` * `_version` * `_routing` Setting `_version` to `null` or clearing
+        it from the `ctx` map is just like not sending the version in an indexing request.
+        It will cause the document to be overwritten in the destination regardless of
+        the version on the target or the version type you use in the reindex API. **Reindex
+        from remote** Reindex supports reindexing from a remote Elasticsearch cluster.
+        The `host` parameter must contain a scheme, host, port, and optional path. The
+        `username` and `password` parameters are optional and when they are present the
+        reindex operation will connect to the remote Elasticsearch node using basic authentication.
+        Be sure to use HTTPS when using basic authentication or the password will be
+        sent in plain text. There are a range of settings available to configure the
+        behavior of the HTTPS connection. When using Elastic Cloud, it is also possible
+        to authenticate against the remote cluster through the use of a valid API key.
+        Remote hosts must be explicitly allowed with the `reindex.remote.whitelist` setting.
+        It can be set to a comma delimited list of allowed remote host and port combinations.
+        Scheme is ignored; only the host and port are used. For example: ``` reindex.remote.whitelist:
+        [otherhost:9200, another:9200, 127.0.10.*:9200, localhost:*"] ``` The list of
+        allowed hosts must be configured on any nodes that will coordinate the reindex.
+        This feature should work with remote clusters of any version of Elasticsearch.
+        This should enable you to upgrade from any version of Elasticsearch to the current
+        version by reindexing from a cluster of the old version. WARNING: Elasticsearch
+        does not support forward compatibility across major versions. For example, you
+        cannot reindex from a 7.x cluster into a 6.x cluster. To enable queries sent
+        to older versions of Elasticsearch, the `query` parameter is sent directly to
+        the remote host without validation or modification. NOTE: Reindexing from remote
+        clusters does not support manual or automatic slicing. Reindexing from a remote
+        server uses an on-heap buffer that defaults to a maximum size of 100mb. If the
+        remote index includes very large documents you'll need to use a smaller batch
+        size. It is also possible to set the socket read timeout on the remote connection
+        with the `socket_timeout` field and the connection timeout with the `connect_timeout`
+        field. Both default to 30 seconds. **Configuring SSL parameters** Reindex from
+        remote supports configurable SSL settings. These must be specified in the `elasticsearch.yml`
+        file, with the exception of the secure settings, which you add in the Elasticsearch
+        keystore. It is not possible to configure SSL in the body of the reindex request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-reindex.html>`_
 
         :param dest: The destination you are copying to.
         :param source: The source you are copying from.
-        :param conflicts: Set to proceed to continue reindexing even if there are conflicts.
-        :param max_docs: The maximum number of documents to reindex.
+        :param conflicts: Indicates whether to continue reindexing even when there are
+            conflicts.
+        :param max_docs: The maximum number of documents to reindex. By default, all
+            documents are reindexed. If it is a value less then or equal to `scroll_size`,
+            a scroll will not be used to retrieve the results for the operation. If `conflicts`
+            is set to `proceed`, the reindex operation could attempt to reindex more
+            documents from the source than `max_docs` until it has successfully indexed
+            `max_docs` documents into the target or it has gone through every document
+            in the source query.
         :param refresh: If `true`, the request refreshes affected shards to make this
             operation visible to search.
         :param requests_per_second: The throttle for this request in sub-requests per
-            second. Defaults to no throttle.
+            second. By default, there is no throttle.
         :param require_alias: If `true`, the destination must be an index alias.
         :param script: The script to run to update the document source or metadata when
             reindexing.
-        :param scroll: Specifies how long a consistent view of the index should be maintained
-            for scrolled search.
+        :param scroll: The period of time that a consistent view of the index should
+            be maintained for scrolled search.
         :param size:
-        :param slices: The number of slices this task should be divided into. Defaults
-            to 1 slice, meaning the task isn’t sliced into subtasks.
-        :param timeout: Period each indexing waits for automatic index creation, dynamic
-            mapping updates, and waiting for active shards.
+        :param slices: The number of slices this task should be divided into. It defaults
+            to one slice, which means the task isn't sliced into subtasks. Reindex supports
+            sliced scroll to parallelize the reindexing process. This parallelization
+            can improve efficiency and provide a convenient way to break the request
+            down into smaller parts. NOTE: Reindexing from remote clusters does not support
+            manual or automatic slicing. If set to `auto`, Elasticsearch chooses the
+            number of slices to use. This setting will use one slice per shard, up to
+            a certain limit. If there are multiple sources, it will choose the number
+            of slices based on the index or backing index with the smallest number of
+            shards.
+        :param timeout: The period each indexing waits for automatic index creation,
+            dynamic mapping updates, and waiting for active shards. By default, Elasticsearch
+            waits for at least one minute before failing. The actual wait time could
+            be longer, particularly when multiple waits occur.
         :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to `all` or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            before proceeding with the operation. Set it to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`). The
+            default value is one, which means it waits for each primary shard to be active.
         :param wait_for_completion: If `true`, the request blocks until the operation
             is complete.
         """
@@ -3605,13 +4070,17 @@ class AsyncElasticsearch(BaseClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Throttle a reindex operation. Change the number of requests per second for a
-        particular reindex operation.
+        particular reindex operation. For example: ``` POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1
+        ``` Rethrottling that speeds up the query takes effect immediately. Rethrottling
+        that slows down the query will take effect after completing the current batch.
+        This behavior prevents scroll timeouts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-reindex.html>`_
 
-        :param task_id: Identifier for the task.
+        :param task_id: The task identifier, which can be found by using the tasks API.
         :param requests_per_second: The throttle for this request in sub-requests per
-            second.
+            second. It can be either `-1` to turn off throttling or any decimal number
+            like `1.7` or `12` to throttle to that level.
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
@@ -3658,7 +4127,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Render a search template. Render a search template as a search request body.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/render-search-template-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/render-search-template-api.html>`_
 
         :param id: ID of the search template to render. If no `source` is specified,
             this or the `id` request body parameter is required.
@@ -3727,7 +4196,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Run a script. Runs a script and returns a result.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.16/painless-execute-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.17/painless-execute-api.html>`_
 
         :param context: The context that the script should run in.
         :param context_setup: Additional parameters for the `context`.
@@ -3800,7 +4269,7 @@ class AsyncElasticsearch(BaseClient):
         of the index at the time of the initial search request. Subsequent indexing or
         document changes only affect later search and scroll requests.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-request-body.html#request-body-search-scroll>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-request-body.html#request-body-search-scroll>`_
 
         :param scroll_id: Scroll ID of the search.
         :param rest_total_hits_as_int: If true, the API response’s hit.total property
@@ -3992,7 +4461,7 @@ class AsyncElasticsearch(BaseClient):
         can provide search queries using the `q` query string parameter or the request
         body. If both are specified, only the query parameter is used.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-search.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams and indices, omit this
@@ -4422,7 +4891,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Search a vector tile. Search a vector tile for geospatial values.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-vector-tile-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-vector-tile-api.html>`_
 
         :param index: Comma-separated list of data streams, indices, or aliases to search
         :param field: Field containing geospatial data to return
@@ -4580,7 +5049,7 @@ class AsyncElasticsearch(BaseClient):
         optimizations with routing and shard preferences. When filtered aliases are used,
         the filter is returned as part of the indices section.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-shards.html>`_
 
         :param index: Returns the indices and shards that a search request would be executed
             against.
@@ -4684,7 +5153,7 @@ class AsyncElasticsearch(BaseClient):
         """
         Run a search with a search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-template.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (*).
@@ -4824,7 +5293,7 @@ class AsyncElasticsearch(BaseClient):
         are actually deleted. Until that happens, the terms enum API will return terms
         from these documents.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-terms-enum.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-terms-enum.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             to search. Wildcard (*) expressions are supported.
@@ -4923,7 +5392,7 @@ class AsyncElasticsearch(BaseClient):
         Get term vector information. Get information and statistics about terms in the
         fields of a particular document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-termvectors.html>`_
 
         :param index: Name of the index that contains the document.
         :param id: Unique identifier of the document.
@@ -5063,46 +5532,60 @@ class AsyncElasticsearch(BaseClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Update a document. Updates a document by running a script or passing a partial
-        document.
+        Update a document. Update a document by running a script or passing a partial
+        document. If the Elasticsearch security features are enabled, you must have the
+        `index` or `write` index privilege for the target index or index alias. The script
+        can update, delete, or skip modifying the document. The API also supports passing
+        a partial document, which is merged into the existing document. To fully replace
+        an existing document, use the index API. This operation: * Gets the document
+        (collocated with the shard) from the index. * Runs the specified script. * Indexes
+        the result. The document must still be reindexed, but using this API removes
+        some network roundtrips and reduces chances of version conflicts between the
+        GET and the index operation. The `_source` field must be enabled to use this
+        API. In addition to `_source`, you can access the following variables through
+        the `ctx` map: `_index`, `_type`, `_id`, `_version`, `_routing`, and `_now` (the
+        current timestamp).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-update.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-update.html>`_
 
-        :param index: The name of the index
-        :param id: Document ID
-        :param detect_noop: Set to false to disable setting 'result' in the response
-            to 'noop' if no change to the document occurred.
-        :param doc: A partial update to an existing document.
-        :param doc_as_upsert: Set to true to use the contents of 'doc' as the value of
-            'upsert'
+        :param index: The name of the target index. By default, the index is created
+            automatically if it doesn't exist.
+        :param id: A unique identifier for the document to be updated.
+        :param detect_noop: If `true`, the `result` in the response is set to `noop`
+            (no operation) when there are no changes to the document.
+        :param doc: A partial update to an existing document. If both `doc` and `script`
+            are specified, `doc` is ignored.
+        :param doc_as_upsert: If `true`, use the contents of 'doc' as the value of 'upsert'.
+            NOTE: Using ingest pipelines with `doc_as_upsert` is not supported.
         :param if_primary_term: Only perform the operation if the document has this primary
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
         :param lang: The script language.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if 'wait_for' then wait for a refresh to
-            make this operation visible to search, if 'false' do nothing with refreshes.
-        :param require_alias: If true, the destination must be an index alias.
-        :param retry_on_conflict: Specify how many times should the operation be retried
+            this operation visible to search. If 'wait_for', it waits for a refresh to
+            make this operation visible to search. If 'false', it does nothing with refreshes.
+        :param require_alias: If `true`, the destination must be an index alias.
+        :param retry_on_conflict: The number of times the operation should be retried
             when a conflict occurs.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param script: Script to execute to update the document.
-        :param scripted_upsert: Set to true to execute the script whether or not the
-            document exists.
-        :param source: Set to false to disable source retrieval. You can also specify
-            a comma-separated list of the fields you want to retrieve.
-        :param source_excludes: Specify the source fields you want to exclude.
-        :param source_includes: Specify the source fields you want to retrieve.
-        :param timeout: Period to wait for dynamic mapping updates and active shards.
-            This guarantees Elasticsearch waits for at least the timeout before failing.
-            The actual wait time could be longer, particularly when multiple waits occur.
+        :param routing: A custom value used to route operations to a specific shard.
+        :param script: The script to run to update the document.
+        :param scripted_upsert: If `true`, run the script whether or not the document
+            exists.
+        :param source: If `false`, turn off source retrieval. You can also specify a
+            comma-separated list of the fields you want to retrieve.
+        :param source_excludes: The source fields you want to exclude.
+        :param source_includes: The source fields you want to retrieve.
+        :param timeout: The period to wait for the following operations: dynamic mapping
+            updates and waiting for active shards. Elasticsearch waits for at least the
+            timeout period before failing. The actual wait time could be longer, particularly
+            when multiple waits occur.
         :param upsert: If the document does not already exist, the contents of 'upsert'
-            are inserted as a new document. If the document exists, the 'script' is executed.
-        :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operations. Set to 'all' or any positive integer
-            up to the total number of shards in the index (number_of_replicas+1). Defaults
-            to 1 meaning the primary shard.
+            are inserted as a new document. If the document exists, the 'script' is run.
+        :param wait_for_active_shards: The number of copies of each shard that must be
+            active before proceeding with the operation. Set to 'all' or any positive
+            integer up to the total number of shards in the index (`number_of_replicas`+1).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5232,7 +5715,7 @@ class AsyncElasticsearch(BaseClient):
         is specified, performs an update on every document in the data stream or index
         without modifying the source, which is useful for picking up mapping changes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-update-by-query.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams or indices, omit this
@@ -5431,7 +5914,7 @@ class AsyncElasticsearch(BaseClient):
         takes effect immediately but rethrotting that slows down the query takes effect
         after completing the current batch to prevent scroll timeouts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-update-by-query.html>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -42,7 +42,7 @@ class AsyncSearchClient(NamespacedClient):
         the authenticated user that submitted the original search request; users that
         have the `cancel_task` cluster privilege.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -90,7 +90,7 @@ class AsyncSearchClient(NamespacedClient):
         the results of a specific async search is restricted to the user or API key that
         submitted it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         :param keep_alive: Specifies how long the async search should be available in
@@ -154,7 +154,7 @@ class AsyncSearchClient(NamespacedClient):
         security features are enabled, use of this API is restricted to the `monitoring_user`
         role.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         :param keep_alive: Specifies how long the async search needs to be available.
@@ -336,7 +336,7 @@ class AsyncSearchClient(NamespacedClient):
         can be set by changing the `search.max_async_search_response_size` cluster level
         setting.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices

--- a/elasticsearch/_async/client/autoscaling.py
+++ b/elasticsearch/_async/client/autoscaling.py
@@ -42,7 +42,7 @@ class AutoscalingClient(NamespacedClient):
         by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes.
         Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-delete-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-delete-autoscaling-policy.html>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -102,7 +102,7 @@ class AutoscalingClient(NamespacedClient):
         capacity was required. This information is provided for diagnosis only. Do not
         use this information to make autoscaling decisions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-get-autoscaling-capacity.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -147,7 +147,7 @@ class AutoscalingClient(NamespacedClient):
         Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes.
         Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-get-autoscaling-capacity.html>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -200,7 +200,7 @@ class AutoscalingClient(NamespacedClient):
         use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on
         Kubernetes. Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-put-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-put-autoscaling-policy.html>`_
 
         :param name: the name of the autoscaling policy
         :param policy:

--- a/elasticsearch/_async/client/cat.py
+++ b/elasticsearch/_async/client/cat.py
@@ -57,18 +57,20 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get aliases. Retrieves the cluster’s index aliases, including filter and routing
-        information. The API does not return data stream aliases. CAT APIs are only intended
+        Get aliases. Get the cluster's index aliases, including filter and routing information.
+        This API does not return data stream aliases. IMPORTANT: CAT APIs are only intended
         for human consumption using the command line or the Kibana console. They are
         not intended for use by applications. For application consumption, use the aliases
         API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-alias.html>`_
 
         :param name: A comma-separated list of aliases to retrieve. Supports wildcards
             (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. It supports comma-separated
+            values, such as `open,hidden`.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -78,7 +80,10 @@ class CatClient(NamespacedClient):
             the local cluster state. If `false` the list of selected nodes are computed
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. To indicated that the request should never timeout,
+            you can set it to `-1`.
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
@@ -147,13 +152,14 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Provides a snapshot of the number of shards allocated to each data node and their
-        disk space. IMPORTANT: cat APIs are only intended for human consumption using
-        the command line or Kibana console. They are not intended for use by applications.
+        Get shard allocation information. Get a snapshot of the number of shards allocated
+        to each data node and their disk space. IMPORTANT: CAT APIs are only intended
+        for human consumption using the command line or Kibana console. They are not
+        intended for use by applications.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-allocation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-allocation.html>`_
 
-        :param node_id: Comma-separated list of node identifiers or names used to limit
+        :param node_id: A comma-separated list of node identifiers or names used to limit
             the returned information.
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -231,17 +237,17 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get component templates. Returns information about component templates in a cluster.
+        Get component templates. Get information about component templates in a cluster.
         Component templates are building blocks for constructing index templates that
-        specify index mappings, settings, and aliases. CAT APIs are only intended for
-        human consumption using the command line or Kibana console. They are not intended
-        for use by applications. For application consumption, use the get component template
-        API.
+        specify index mappings, settings, and aliases. IMPORTANT: CAT APIs are only intended
+        for human consumption using the command line or Kibana console. They are not
+        intended for use by applications. For application consumption, use the get component
+        template API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-component-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-component-templates.html>`_
 
-        :param name: The name of the component template. Accepts wildcard expressions.
-            If omitted, all component templates are returned.
+        :param name: The name of the component template. It accepts wildcard expressions.
+            If it is omitted, all component templates are returned.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -251,7 +257,7 @@ class CatClient(NamespacedClient):
             the local cluster state. If `false` the list of selected nodes are computed
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param master_timeout: The period to wait for a connection to the master node.
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
@@ -313,17 +319,17 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get a document count. Provides quick access to a document count for a data stream,
+        Get a document count. Get quick access to a document count for a data stream,
         an index, or an entire cluster. The document count only includes live documents,
-        not deleted documents which have not yet been removed by the merge process. CAT
-        APIs are only intended for human consumption using the command line or Kibana
+        not deleted documents which have not yet been removed by the merge process. IMPORTANT:
+        CAT APIs are only intended for human consumption using the command line or Kibana
         console. They are not intended for use by applications. For application consumption,
         use the count API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-count.html>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases used
-            to limit the request. Supports wildcards (`*`). To target all data streams
+        :param index: A comma-separated list of data streams, indices, and aliases used
+            to limit the request. It supports wildcards (`*`). To target all data streams
             and indices, omit this parameter or use `*` or `_all`.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -390,12 +396,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns the amount of heap memory currently used by the field data cache on every
-        data node in the cluster. IMPORTANT: cat APIs are only intended for human consumption
-        using the command line or Kibana console. They are not intended for use by applications.
-        For application consumption, use the nodes stats API.
+        Get field data cache information. Get the amount of heap memory currently used
+        by the field data cache on every data node in the cluster. IMPORTANT: cat APIs
+        are only intended for human consumption using the command line or Kibana console.
+        They are not intended for use by applications. For application consumption, use
+        the nodes stats API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-fielddata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-fielddata.html>`_
 
         :param fields: Comma-separated list of fields used to limit returned information.
             To retrieve all fields, omit this parameter.
@@ -467,19 +474,19 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns the health status of a cluster, similar to the cluster health API. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the cluster health API. This API is often used to check malfunctioning clusters.
-        To help you track cluster health alongside log files and alerting systems, the
-        API returns timestamps in two formats: `HH:MM:SS`, which is human-readable but
-        includes no date information; `Unix epoch time`, which is machine-sortable and
-        includes date information. The latter format is useful for cluster recoveries
-        that take multiple days. You can use the cat health API to verify cluster health
-        across multiple nodes. You also can use the API to track the recovery of a large
-        cluster over a longer period of time.
+        Get the cluster health status. IMPORTANT: CAT APIs are only intended for human
+        consumption using the command line or Kibana console. They are not intended for
+        use by applications. For application consumption, use the cluster health API.
+        This API is often used to check malfunctioning clusters. To help you track cluster
+        health alongside log files and alerting systems, the API returns timestamps in
+        two formats: `HH:MM:SS`, which is human-readable but includes no date information;
+        `Unix epoch time`, which is machine-sortable and includes date information. The
+        latter format is useful for cluster recoveries that take multiple days. You can
+        use the cat health API to verify cluster health across multiple nodes. You also
+        can use the API to track the recovery of a large cluster over a longer period
+        of time.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-health.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -531,9 +538,9 @@ class CatClient(NamespacedClient):
     @_rewrite_parameters()
     async def help(self) -> TextApiResponse:
         """
-        Get CAT help. Returns help for the CAT APIs.
+        Get CAT help. Get help for the CAT APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_cat"
@@ -582,7 +589,7 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get index information. Returns high-level information about indices in a cluster,
+        Get index information. Get high-level information about indices in a cluster,
         including backing indices for data streams. Use this request to get the following
         information for each index in a cluster: - shard count - document count - deleted
         document count - primary store size - total store size of all shards, including
@@ -593,7 +600,7 @@ class CatClient(NamespacedClient):
         using the command line or Kibana console. They are not intended for use by applications.
         For application consumption, use an index endpoint.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-indices.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -684,12 +691,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the master node, including the ID, bound IP address,
-        and name. IMPORTANT: cat APIs are only intended for human consumption using the
-        command line or Kibana console. They are not intended for use by applications.
-        For application consumption, use the nodes info API.
+        Get master node information. Get information about the master node, including
+        the ID, bound IP address, and name. IMPORTANT: cat APIs are only intended for
+        human consumption using the command line or Kibana console. They are not intended
+        for use by applications. For application consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-master.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-master.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -858,13 +865,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get data frame analytics jobs. Returns configuration and usage information about
-        data frame analytics jobs. CAT APIs are only intended for human consumption using
-        the Kibana console or command line. They are not intended for use by applications.
+        Get data frame analytics jobs. Get configuration and usage information about
+        data frame analytics jobs. IMPORTANT: CAT APIs are only intended for human consumption
+        using the Kibana console or command line. They are not intended for use by applications.
         For application consumption, use the get data frame analytics jobs statistics
         API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-dfanalytics.html>`_
 
         :param id: The ID of the data frame analytics to fetch
         :param allow_no_match: Whether to ignore if a wildcard expression matches no
@@ -1020,14 +1027,15 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get datafeeds. Returns configuration and usage information about datafeeds. This
+        Get datafeeds. Get configuration and usage information about datafeeds. This
         API returns a maximum of 10,000 datafeeds. If the Elasticsearch security features
         are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`
-        cluster privileges to use this API. CAT APIs are only intended for human consumption
-        using the Kibana console or command line. They are not intended for use by applications.
-        For application consumption, use the get datafeed statistics API.
+        cluster privileges to use this API. IMPORTANT: CAT APIs are only intended for
+        human consumption using the Kibana console or command line. They are not intended
+        for use by applications. For application consumption, use the get datafeed statistics
+        API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-datafeeds.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-datafeeds.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed.
@@ -1381,15 +1389,15 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get anomaly detection jobs. Returns configuration and usage information for anomaly
+        Get anomaly detection jobs. Get configuration and usage information for anomaly
         detection jobs. This API returns a maximum of 10,000 jobs. If the Elasticsearch
         security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`,
-        or `manage` cluster privileges to use this API. CAT APIs are only intended for
-        human consumption using the Kibana console or command line. They are not intended
-        for use by applications. For application consumption, use the get anomaly detection
-        job statistics API.
+        or `manage` cluster privileges to use this API. IMPORTANT: CAT APIs are only
+        intended for human consumption using the Kibana console or command line. They
+        are not intended for use by applications. For application consumption, use the
+        get anomaly detection job statistics API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-anomaly-detectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-anomaly-detectors.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param allow_no_match: Specifies what to do when the request: * Contains wildcard
@@ -1565,12 +1573,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get trained models. Returns configuration and usage information about inference
-        trained models. CAT APIs are only intended for human consumption using the Kibana
-        console or command line. They are not intended for use by applications. For application
-        consumption, use the get trained models statistics API.
+        Get trained models. Get configuration and usage information about inference trained
+        models. IMPORTANT: CAT APIs are only intended for human consumption using the
+        Kibana console or command line. They are not intended for use by applications.
+        For application consumption, use the get trained models statistics API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-trained-model.html>`_
 
         :param model_id: A unique identifier for the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -1656,12 +1664,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about custom node attributes. IMPORTANT: cat APIs are only
-        intended for human consumption using the command line or Kibana console. They
-        are not intended for use by applications. For application consumption, use the
-        nodes info API.
+        Get node attribute information. Get information about custom node attributes.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-nodeattrs.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-nodeattrs.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1737,12 +1745,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the nodes in a cluster. IMPORTANT: cat APIs are only
-        intended for human consumption using the command line or Kibana console. They
-        are not intended for use by applications. For application consumption, use the
-        nodes info API.
+        Get node information. Get information about the nodes in a cluster. IMPORTANT:
+        cat APIs are only intended for human consumption using the command line or Kibana
+        console. They are not intended for use by applications. For application consumption,
+        use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-nodes.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-nodes.html>`_
 
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -1822,12 +1830,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns cluster-level changes that have not yet been executed. IMPORTANT: cat
-        APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the pending cluster tasks API.
+        Get pending task information. Get information about cluster-level changes that
+        have not yet taken effect. IMPORTANT: cat APIs are only intended for human consumption
+        using the command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the pending cluster tasks API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-pending-tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-pending-tasks.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1900,12 +1908,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns a list of plugins running on each node of a cluster. IMPORTANT: cat APIs
-        are only intended for human consumption using the command line or Kibana console.
-        They are not intended for use by applications. For application consumption, use
-        the nodes info API.
+        Get plugin information. Get a list of plugins running on each node of a cluster.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-plugins.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-plugins.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1984,16 +1992,16 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about ongoing and completed shard recoveries. Shard recovery
-        is the process of initializing a shard copy, such as restoring a primary shard
-        from a snapshot or syncing a replica shard from a primary shard. When a shard
-        recovery completes, the recovered shard is available for search and indexing.
-        For data streams, the API returns information about the stream’s backing indices.
-        IMPORTANT: cat APIs are only intended for human consumption using the command
-        line or Kibana console. They are not intended for use by applications. For application
-        consumption, use the index recovery API.
+        Get shard recovery information. Get information about ongoing and completed shard
+        recoveries. Shard recovery is the process of initializing a shard copy, such
+        as restoring a primary shard from a snapshot or syncing a replica shard from
+        a primary shard. When a shard recovery completes, the recovered shard is available
+        for search and indexing. For data streams, the API returns information about
+        the stream’s backing indices. IMPORTANT: cat APIs are only intended for human
+        consumption using the command line or Kibana console. They are not intended for
+        use by applications. For application consumption, use the index recovery API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-recovery.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2074,12 +2082,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns the snapshot repositories for a cluster. IMPORTANT: cat APIs are only
-        intended for human consumption using the command line or Kibana console. They
-        are not intended for use by applications. For application consumption, use the
-        get snapshot repository API.
+        Get snapshot repository information. Get a list of snapshot repositories for
+        a cluster. IMPORTANT: cat APIs are only intended for human consumption using
+        the command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the get snapshot repository API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-repositories.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-repositories.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -2152,13 +2160,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns low-level information about the Lucene segments in index shards. For
-        data streams, the API returns information about the backing indices. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the index segments API.
+        Get segment information. Get low-level information about the Lucene segments
+        in index shards. For data streams, the API returns information about the backing
+        indices. IMPORTANT: cat APIs are only intended for human consumption using the
+        command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the index segments API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-segments.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2244,12 +2252,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the shards in a cluster. For data streams, the API
-        returns information about the backing indices. IMPORTANT: cat APIs are only intended
-        for human consumption using the command line or Kibana console. They are not
-        intended for use by applications.
+        Get shard information. Get information about the shards in a cluster. For data
+        streams, the API returns information about the backing indices. IMPORTANT: cat
+        APIs are only intended for human consumption using the command line or Kibana
+        console. They are not intended for use by applications.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-shards.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2330,13 +2338,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the snapshots stored in one or more repositories. A
-        snapshot is a backup of an index or running Elasticsearch cluster. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the get snapshot API.
+        Get snapshot information. Get information about the snapshots stored in one or
+        more repositories. A snapshot is a backup of an index or running Elasticsearch
+        cluster. IMPORTANT: cat APIs are only intended for human consumption using the
+        command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the get snapshot API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-snapshots.html>`_
 
         :param repository: A comma-separated list of snapshot repositories used to limit
             the request. Accepts wildcard expressions. `_all` returns all repositories.
@@ -2422,12 +2430,12 @@ class CatClient(NamespacedClient):
         wait_for_completion: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about tasks currently executing in the cluster. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the task management API.
+        Get task information. Get information about tasks currently running in the cluster.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the task management API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param actions: The task action names, which are used to limit the response.
         :param detailed: If `true`, the response includes detailed information about
@@ -2513,13 +2521,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about index templates in a cluster. You can use index templates
-        to apply index settings and field mappings to new indices at creation. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the get index template API.
+        Get index template information. Get information about the index templates in
+        a cluster. You can use index templates to apply index settings and field mappings
+        to new indices at creation. IMPORTANT: cat APIs are only intended for human consumption
+        using the command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the get index template API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-templates.html>`_
 
         :param name: The name of the template to return. Accepts wildcard expressions.
             If omitted, all templates are returned.
@@ -2599,13 +2607,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns thread pool statistics for each node in a cluster. Returned information
-        includes all built-in thread pools and custom thread pools. IMPORTANT: cat APIs
-        are only intended for human consumption using the command line or Kibana console.
-        They are not intended for use by applications. For application consumption, use
-        the nodes info API.
+        Get thread pool statistics. Get thread pool statistics for each node in a cluster.
+        Returned information includes all built-in thread pools and custom thread pools.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-thread-pool.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-thread-pool.html>`_
 
         :param thread_pool_patterns: A comma-separated list of thread pool names used
             to limit the request. Accepts wildcard expressions.
@@ -2853,12 +2861,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get transforms. Returns configuration and usage information about transforms.
+        Get transform information. Get configuration and usage information about transforms.
         CAT APIs are only intended for human consumption using the Kibana console or
         command line. They are not intended for use by applications. For application
         consumption, use the get transform statistics API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-transforms.html>`_
 
         :param transform_id: A transform identifier or a wildcard expression. If you
             do not specify one of these options, the API returns information for all

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -40,7 +40,7 @@ class CcrClient(NamespacedClient):
         Delete auto-follow patterns. Delete a collection of cross-cluster replication
         auto-follow patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-delete-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-delete-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -122,7 +122,7 @@ class CcrClient(NamespacedClient):
         cross-cluster replication starts replicating operations from the leader index
         to the follower index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-put-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-put-follow.html>`_
 
         :param index: The name of the follower index.
         :param leader_index: The name of the index in the leader cluster to follow.
@@ -249,7 +249,7 @@ class CcrClient(NamespacedClient):
         index names, replication options, and whether the follower indices are active
         or paused.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-follow-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-follow-info.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -296,7 +296,7 @@ class CcrClient(NamespacedClient):
         shard-level stats about the "following tasks" associated with each shard for
         the specified indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-follow-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-follow-stats.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -370,7 +370,7 @@ class CcrClient(NamespacedClient):
         API is to handle the case of failure to remove the following retention leases
         after the unfollow API is invoked.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-forget-follower.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-forget-follower.html>`_
 
         :param index: the name of the leader index for which specified follower retention
             leases should be removed
@@ -431,7 +431,7 @@ class CcrClient(NamespacedClient):
         """
         Get auto-follow patterns. Get cross-cluster replication auto-follow patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-auto-follow-pattern.html>`_
 
         :param name: Specifies the auto-follow pattern collection that you want to retrieve.
             If you do not specify a name, the API returns information for all collections.
@@ -486,7 +486,7 @@ class CcrClient(NamespacedClient):
         patterns. Remote indices that were created while the pattern was paused will
         also be followed, unless they have been deleted or closed in the interim.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-pause-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-pause-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern that should pause discovering
             new indices to follow.
@@ -534,7 +534,7 @@ class CcrClient(NamespacedClient):
         resume following with the resume follower API. You can pause and resume a follower
         index to change the configuration of the following task.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-pause-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-pause-follow.html>`_
 
         :param index: The name of the follower index that should pause following its
             leader index.
@@ -620,7 +620,7 @@ class CcrClient(NamespacedClient):
         that were configured automatically before updating an auto-follow pattern will
         remain unchanged even if they do not match against the new patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-put-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-put-auto-follow-pattern.html>`_
 
         :param name: The name of the collection of auto-follow patterns.
         :param remote_cluster: The remote cluster containing the leader indices to match
@@ -752,7 +752,7 @@ class CcrClient(NamespacedClient):
         Remote indices created while the pattern was paused will also be followed unless
         they have been deleted or closed in the interim.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-resume-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-resume-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern to resume discovering new indices
             to follow.
@@ -825,7 +825,7 @@ class CcrClient(NamespacedClient):
         to failures during following tasks. When this API returns, the follower index
         will resume fetching operations from the leader index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-resume-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-resume-follow.html>`_
 
         :param index: The name of the follow index to resume following.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -913,7 +913,7 @@ class CcrClient(NamespacedClient):
         Get cross-cluster replication stats. This API returns stats about auto-following
         and the same shard-level stats as the get follower stats API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-stats.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param timeout: Period to wait for a response. If no response is received before
@@ -964,7 +964,7 @@ class CcrClient(NamespacedClient):
         regular index to a follower index. Converting a follower index to a regular index
         is an irreversible operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-unfollow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-unfollow.html>`_
 
         :param index: The name of the follower index that should be turned into a regular
             index.

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -53,7 +53,7 @@ class ClusterClient(NamespacedClient):
         or why a shard continues to remain on its current node when you might expect
         otherwise.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-allocation-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-allocation-explain.html>`_
 
         :param current_node: Specifies the node ID or the name of the node to only explain
             a shard that is currently located on the specified node.
@@ -126,7 +126,7 @@ class ClusterClient(NamespacedClient):
         Delete component templates. Component templates are building blocks for constructing
         index templates that specify index mappings, settings, and aliases.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Comma-separated list or wildcard expression of component template
             names used to limit the request.
@@ -178,7 +178,7 @@ class ClusterClient(NamespacedClient):
         Clear cluster voting config exclusions. Remove master-eligible nodes from the
         voting configuration exclusion list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/voting-config-exclusions.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
@@ -229,7 +229,7 @@ class ClusterClient(NamespacedClient):
         Check component templates. Returns information about whether a particular component
         template exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (*) expressions are supported.
@@ -284,7 +284,7 @@ class ClusterClient(NamespacedClient):
         """
         Get component templates. Get information about component templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -348,7 +348,7 @@ class ClusterClient(NamespacedClient):
         Get cluster-wide settings. By default, it returns only settings that have been
         explicitly defined.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-get-settings.html>`_
 
         :param flat_settings: If `true`, returns settings in flat format.
         :param include_defaults: If `true`, returns default cluster settings from the
@@ -439,7 +439,7 @@ class ClusterClient(NamespacedClient):
         high watermark health level. The cluster status is controlled by the worst index
         status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-health.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (`*`) are supported. To target
@@ -543,7 +543,7 @@ class ClusterClient(NamespacedClient):
         """
         Get cluster info. Returns basic information about the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-info.html>`_
 
         :param target: Limits the information returned to the specific target. Supports
             a comma-separated list, such as http,ingest.
@@ -592,7 +592,7 @@ class ClusterClient(NamespacedClient):
         index command causes a cluster state update, the activity of this task might
         be reported by both task api and pending cluster tasks API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-pending.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-pending.html>`_
 
         :param local: If `true`, the request retrieves information from the local node
             only. If `false`, information is retrieved from the master node.
@@ -667,7 +667,7 @@ class ClusterClient(NamespacedClient):
         master-ineligible nodes or when removing fewer than half of the master-eligible
         nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/voting-config-exclusions.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param node_ids: A comma-separated list of the persistent ids of the nodes to
@@ -746,7 +746,7 @@ class ClusterClient(NamespacedClient):
         template to a data stream or index. To be applied, a component template must
         be included in an index template's `composed_of` list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Name of the component template to create. Elasticsearch includes
             the following built-in component templates: `logs-mappings`; `logs-settings`;
@@ -854,7 +854,7 @@ class ClusterClient(NamespacedClient):
         settings can clear unexpectedly, resulting in a potentially undesired cluster
         configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-update-settings.html>`_
 
         :param flat_settings: Return settings in flat format (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
@@ -910,7 +910,7 @@ class ClusterClient(NamespacedClient):
         This API returns connection and endpoint information keyed by the configured
         remote cluster alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-remote-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-remote-info.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_remote/info"
@@ -973,7 +973,7 @@ class ClusterClient(NamespacedClient):
         API with the `?retry_failed` URI query parameter, which will attempt a single
         retry round for these shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-reroute.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-reroute.html>`_
 
         :param commands: Defines the commands to perform.
         :param dry_run: If true, then the request simulates the operation. It will calculate
@@ -1081,7 +1081,7 @@ class ClusterClient(NamespacedClient):
         external monitoring tools. Instead, obtain the information you require using
         other more stable cluster APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-state.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-state.html>`_
 
         :param metric: Limit the information returned to the specified metrics
         :param index: A comma-separated list of index names; use `_all` or empty string
@@ -1167,7 +1167,7 @@ class ClusterClient(NamespacedClient):
         usage) and information about the current nodes that form the cluster (number,
         roles, os, jvm versions, memory usage, cpu and installed plugins).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-stats.html>`_
 
         :param node_id: Comma-separated list of node filters used to limit returned information.
             Defaults to all nodes in the cluster.

--- a/elasticsearch/_async/client/connector.py
+++ b/elasticsearch/_async/client/connector.py
@@ -46,7 +46,7 @@ class ConnectorClient(NamespacedClient):
         Check in a connector. Update the `last_seen` field in the connector and set it
         to the current timestamp.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/check-in-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/check-in-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be checked in
         """
@@ -91,7 +91,7 @@ class ConnectorClient(NamespacedClient):
         ingest pipelines, or data indices associated with the connector. These need to
         be removed manually.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be deleted
         :param delete_sync_jobs: A flag indicating if associated sync jobs should be
@@ -136,7 +136,7 @@ class ConnectorClient(NamespacedClient):
         """
         Get a connector. Get the details about a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector
         """
@@ -232,7 +232,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector last sync stats. Update the fields related to the last sync
         of a connector. This action is used for analytics and monitoring.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-last-sync-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-last-sync-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param last_access_control_sync_error:
@@ -327,7 +327,7 @@ class ConnectorClient(NamespacedClient):
         """
         Get all connectors. Get information about all connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-connector-api.html>`_
 
         :param connector_name: A comma-separated list of connector names to fetch connector
             documents for
@@ -406,7 +406,7 @@ class ConnectorClient(NamespacedClient):
         a managed service on Elastic Cloud. Self-managed connectors (Connector clients)
         are self-managed on your infrastructure.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-connector-api.html>`_
 
         :param description:
         :param index_name:
@@ -485,7 +485,7 @@ class ConnectorClient(NamespacedClient):
         """
         Create or update a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be created or
             updated. ID is auto-generated if not provided.
@@ -558,7 +558,7 @@ class ConnectorClient(NamespacedClient):
         connector service is then responsible for setting the status of connector sync
         jobs to cancelled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cancel-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cancel-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -607,7 +607,7 @@ class ConnectorClient(NamespacedClient):
         on your own infrastructure. This service runs automatically on Elastic Cloud
         for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/check-in-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/check-in-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be checked in.
@@ -665,7 +665,7 @@ class ConnectorClient(NamespacedClient):
         service on your own infrastructure. This service runs automatically on Elastic
         Cloud for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/claim-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/claim-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param worker_hostname: The host name of the current system that will run the
@@ -723,7 +723,7 @@ class ConnectorClient(NamespacedClient):
         Delete a connector sync job. Remove a connector sync job and its associated data.
         This is a destructive action that is not recoverable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be deleted
@@ -774,7 +774,7 @@ class ConnectorClient(NamespacedClient):
         you need to deploy the Elastic connector service on your own infrastructure.
         This service runs automatically on Elastic Cloud for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/set-connector-sync-job-error-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/set-connector-sync-job-error-api.html>`_
 
         :param connector_sync_job_id: The unique identifier for the connector sync job.
         :param error: The error for the connector sync job error field.
@@ -825,7 +825,7 @@ class ConnectorClient(NamespacedClient):
         """
         Get a connector sync job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -895,7 +895,7 @@ class ConnectorClient(NamespacedClient):
         Get all connector sync jobs. Get information about all stored connector sync
         jobs listed by their creation date in ascending order.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-connector-sync-jobs-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-connector-sync-jobs-api.html>`_
 
         :param connector_id: A connector id to fetch connector sync jobs for
         :param from_: Starting offset (default: 0)
@@ -958,7 +958,7 @@ class ConnectorClient(NamespacedClient):
         Create a connector sync job. Create a connector sync job document in the internal
         index and initialize its counters and timestamps with default values.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-connector-sync-job-api.html>`_
 
         :param id: The id of the associated connector
         :param job_type:
@@ -1031,7 +1031,7 @@ class ConnectorClient(NamespacedClient):
         service on your own infrastructure. This service runs automatically on Elastic
         Cloud for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/set-connector-sync-job-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/set-connector-sync-job-stats-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param deleted_document_count: The number of documents the sync job deleted.
@@ -1111,7 +1111,7 @@ class ConnectorClient(NamespacedClient):
         Activate the connector draft filter. Activates the valid draft filtering for
         a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-filtering-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         """
@@ -1161,7 +1161,7 @@ class ConnectorClient(NamespacedClient):
         secret ID is required only for Elastic managed (native) connectors. Self-managed
         connectors (connector clients) do not use this field.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-api-key-id-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-api-key-id-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param api_key_id:
@@ -1217,7 +1217,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector configuration. Update the configuration field in the connector
         document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-configuration-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-configuration-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param configuration:
@@ -1274,7 +1274,7 @@ class ConnectorClient(NamespacedClient):
         to error. Otherwise, if the error is reset to null, the connector status is updated
         to connected.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-error-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-error-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param error:
@@ -1334,7 +1334,7 @@ class ConnectorClient(NamespacedClient):
         on your own infrastructure. This service runs automatically on Elastic Cloud
         for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-features-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-features-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated.
         :param features:
@@ -1392,7 +1392,7 @@ class ConnectorClient(NamespacedClient):
         is activated once validated by the running Elastic connector service. The filtering
         property is used to configure sync rules (both basic and advanced) for a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-filtering-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param advanced_snippet:
@@ -1450,7 +1450,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector draft filtering validation. Update the draft filtering validation
         info for a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-filtering-validation-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-filtering-validation-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param validation:
@@ -1504,7 +1504,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector index name. Update the `index_name` field of a connector,
         specifying the index where the data ingested by the connector is stored.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-index-name-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-index-name-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param index_name:
@@ -1558,7 +1558,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector name and description.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-name-description-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-name-description-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param description:
@@ -1612,7 +1612,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector is_native flag.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-native-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-native-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param is_native:
@@ -1666,7 +1666,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector pipeline. When you create a new connector, the configuration
         of an ingest pipeline is populated with default settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-pipeline-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param pipeline:
@@ -1719,7 +1719,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector scheduling.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-scheduling-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-scheduling-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param scheduling:
@@ -1772,7 +1772,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector service type.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-service-type-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-service-type-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param service_type:
@@ -1832,7 +1832,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-status-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param status:

--- a/elasticsearch/_async/client/dangling_indices.py
+++ b/elasticsearch/_async/client/dangling_indices.py
@@ -44,7 +44,7 @@ class DanglingIndicesClient(NamespacedClient):
         For example, this can happen if you delete more than `cluster.indices.tombstones.size`
         indices while an Elasticsearch node is offline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/dangling-index-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/dangling-index-delete.html>`_
 
         :param index_uuid: The UUID of the index to delete. Use the get dangling indices
             API to find the UUID.
@@ -103,7 +103,7 @@ class DanglingIndicesClient(NamespacedClient):
         For example, this can happen if you delete more than `cluster.indices.tombstones.size`
         indices while an Elasticsearch node is offline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/dangling-index-import.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/dangling-index-import.html>`_
 
         :param index_uuid: The UUID of the index to import. Use the get dangling indices
             API to locate the UUID.
@@ -162,7 +162,7 @@ class DanglingIndicesClient(NamespacedClient):
         indices while an Elasticsearch node is offline. Use this API to list dangling
         indices, which you can then import or delete.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/dangling-indices-list.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/dangling-indices-list.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_dangling"

--- a/elasticsearch/_async/client/enrich.py
+++ b/elasticsearch/_async/client/enrich.py
@@ -39,7 +39,7 @@ class EnrichClient(NamespacedClient):
         """
         Delete an enrich policy. Deletes an existing enrich policy and its enrich index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-enrich-policy-api.html>`_
 
         :param name: Enrich policy to delete.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -84,7 +84,7 @@ class EnrichClient(NamespacedClient):
         """
         Run an enrich policy. Create the enrich index for an existing enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/execute-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/execute-enrich-policy-api.html>`_
 
         :param name: Enrich policy to execute.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -132,7 +132,7 @@ class EnrichClient(NamespacedClient):
         """
         Get an enrich policy. Returns information about an enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-enrich-policy-api.html>`_
 
         :param name: Comma-separated list of enrich policy names used to limit the request.
             To return information for all enrich policies, omit this parameter.
@@ -186,7 +186,7 @@ class EnrichClient(NamespacedClient):
         """
         Create an enrich policy. Creates an enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-enrich-policy-api.html>`_
 
         :param name: Name of the enrich policy to create or update.
         :param geo_match: Matches enrich data to incoming documents based on a `geo_shape`
@@ -244,7 +244,7 @@ class EnrichClient(NamespacedClient):
         Get enrich stats. Returns enrich coordinator statistics and information about
         enrich policies that are currently executing.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/enrich-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/enrich-stats-api.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_async/client/eql.py
+++ b/elasticsearch/_async/client/eql.py
@@ -39,7 +39,7 @@ class EqlClient(NamespacedClient):
         Delete an async EQL search. Delete an async EQL search or a stored synchronous
         EQL search. The API also deletes results for the search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/eql-search-api.html>`_
 
         :param id: Identifier for the search to delete. A search ID is provided in the
             EQL search API's response for an async search. A search ID is also provided
@@ -86,7 +86,7 @@ class EqlClient(NamespacedClient):
         Get async EQL search results. Get the current status and available results for
         an async EQL search or a stored synchronous EQL search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-eql-search-api.html>`_
 
         :param id: Identifier for the search.
         :param keep_alive: Period for which the search and its results are stored on
@@ -137,7 +137,7 @@ class EqlClient(NamespacedClient):
         Get the async EQL status. Get the current status for an async EQL search or a
         stored synchronous EQL search without returning results.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-eql-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-eql-status-api.html>`_
 
         :param id: Identifier for the search.
         """
@@ -233,7 +233,7 @@ class EqlClient(NamespacedClient):
         query. EQL assumes each document in a data stream or index corresponds to an
         event.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/eql-search-api.html>`_
 
         :param index: The name of the index to scope the operation
         :param query: EQL query you wish to run.

--- a/elasticsearch/_async/client/esql.py
+++ b/elasticsearch/_async/client/esql.py
@@ -78,7 +78,7 @@ class EsqlClient(NamespacedClient):
         The API accepts the same parameters and request body as the synchronous query
         API, along with additional async related properties.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-async-query-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-async-query-api.html>`_
 
         :param query: The ES|QL query API accepts an ES|QL query string in the query
             parameter, runs it, and returns the results.
@@ -189,7 +189,7 @@ class EsqlClient(NamespacedClient):
         authenticated user that submitted the original query request * Users with the
         `cancel_task` cluster privilege
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-async-query-delete-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-async-query-delete-api.html>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -240,7 +240,7 @@ class EsqlClient(NamespacedClient):
         features are enabled, only the user who first submitted the ES|QL query can retrieve
         the results using this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-async-query-get-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-async-query-get-api.html>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -334,7 +334,7 @@ class EsqlClient(NamespacedClient):
         Run an ES|QL query. Get search results for an ES|QL (Elasticsearch query language)
         query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-rest.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-rest.html>`_
 
         :param query: The ES|QL query API accepts an ES|QL query string in the query
             parameter, runs it, and returns the results.

--- a/elasticsearch/_async/client/features.py
+++ b/elasticsearch/_async/client/features.py
@@ -48,7 +48,7 @@ class FeaturesClient(NamespacedClient):
         this API and recognized as a valid feature state by the create snapshot API,
         the plugin that defines that feature must be installed on the master node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-features-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-features-api.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -102,7 +102,7 @@ class FeaturesClient(NamespacedClient):
         on the master node if you have any doubts about which plugins are installed on
         individual nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-snapshots.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_async/client/fleet.py
+++ b/elasticsearch/_async/client/fleet.py
@@ -49,7 +49,7 @@ class FleetClient(NamespacedClient):
         Returns the current global checkpoints for an index. This API is design for internal
         use by the fleet server project.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-global-checkpoints.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-global-checkpoints.html>`_
 
         :param index: A single index or index alias that resolves to a single index.
         :param checkpoints: A comma separated list of previous global checkpoints. When

--- a/elasticsearch/_async/client/graph.py
+++ b/elasticsearch/_async/client/graph.py
@@ -54,7 +54,7 @@ class GraphClient(NamespacedClient):
         from one more vertices of interest. You can exclude vertices that have already
         been returned.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/graph-explore-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/graph-explore-api.html>`_
 
         :param index: Name of the index.
         :param connections: Specifies or more fields from which you want to extract terms

--- a/elasticsearch/_async/client/ilm.py
+++ b/elasticsearch/_async/client/ilm.py
@@ -42,7 +42,7 @@ class IlmClient(NamespacedClient):
         If the policy is being used to manage any indices, the request fails and returns
         an error.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-delete-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -98,7 +98,7 @@ class IlmClient(NamespacedClient):
         lifecycle state, provides the definition of the running phase, and information
         about any failures.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-explain-lifecycle.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to target.
             Supports wildcards (`*`). To target all data streams and indices, use `*`
@@ -156,7 +156,7 @@ class IlmClient(NamespacedClient):
         """
         Get lifecycle policies.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-get-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -207,7 +207,7 @@ class IlmClient(NamespacedClient):
         """
         Get the ILM status. Get the current index lifecycle management status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-get-status.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ilm/status"
@@ -259,7 +259,7 @@ class IlmClient(NamespacedClient):
         stop ILM and get ILM status APIs to wait until the reported operation mode is
         `STOPPED`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-migrate-to-data-tiers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-migrate-to-data-tiers.html>`_
 
         :param dry_run: If true, simulates the migration from node attributes based allocation
             filters to data tiers, but does not perform the migration. This provides
@@ -333,7 +333,7 @@ class IlmClient(NamespacedClient):
         specified in the ILM policy are considered valid. An index cannot move to a step
         that is not part of its policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-move-to-step.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-move-to-step.html>`_
 
         :param index: The name of the index whose lifecycle step is to change
         :param current_step: The step that the index is expected to be in.
@@ -398,7 +398,7 @@ class IlmClient(NamespacedClient):
         and the policy version is incremented. NOTE: Only the latest version of the policy
         is stored, you cannot revert to previous versions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-put-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -458,7 +458,7 @@ class IlmClient(NamespacedClient):
         Remove policies from an index. Remove the assigned lifecycle policies from an
         index or a data stream's backing indices. It also stops managing the indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-remove-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-remove-policy.html>`_
 
         :param index: The name of the index to remove policy on
         """
@@ -501,7 +501,7 @@ class IlmClient(NamespacedClient):
         and runs the step. Use the explain lifecycle state API to determine whether an
         index is in the ERROR step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-retry-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-retry-policy.html>`_
 
         :param index: The name of the indices (comma-separated) whose failed lifecycle
             step is to be retry
@@ -545,7 +545,7 @@ class IlmClient(NamespacedClient):
         stopped. ILM is started automatically when the cluster is formed. Restarting
         ILM is necessary only when it has been stopped using the stop ILM API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-start.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -597,7 +597,7 @@ class IlmClient(NamespacedClient):
         might continue to run until in-progress operations complete and the plugin can
         be safely stopped. Use the get ILM status API to check whether ILM is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-stop.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -58,7 +58,7 @@ class IndicesClient(NamespacedClient):
         Add an index block. Limits the operations allowed on an index by blocking specific
         operation types.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/index-modules-blocks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-modules-blocks.html>`_
 
         :param index: A comma separated list of indices to add a block to
         :param block: The block to add (one of read, write, read_only or metadata)
@@ -150,7 +150,7 @@ class IndicesClient(NamespacedClient):
         of tokens gets generated, an error occurs. The `_analyze` endpoint without a
         specified index will always use `10000` as its limit.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-analyze.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-analyze.html>`_
 
         :param index: Index used to derive the analyzer. If specified, the `analyzer`
             or field parameter overrides this value. If no index is specified or the
@@ -255,7 +255,7 @@ class IndicesClient(NamespacedClient):
         `query`, or `request` parameters. To clear the cache only of specific fields,
         use the `fields` parameter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-clearcache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-clearcache.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -377,7 +377,7 @@ class IndicesClient(NamespacedClient):
         a new index to clone the shards to, the wait for active shards setting on index
         creation applies to the clone index action as well.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-clone-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-clone-index.html>`_
 
         :param index: Name of the source index to clone.
         :param target: Name of the target index to create.
@@ -482,7 +482,7 @@ class IndicesClient(NamespacedClient):
         can cause problems in managed environments. Closing indices can be turned off
         with the cluster settings API by setting `cluster.indices.close.enable` to `false`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-close.html>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -582,7 +582,7 @@ class IndicesClient(NamespacedClient):
         setting `index.write.wait_for_active_shards`. Note that changing this setting
         will also affect the `wait_for_active_shards` value on all subsequent write operations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-create-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-create-index.html>`_
 
         :param index: Name of the index you wish to create.
         :param aliases: Aliases for the index.
@@ -656,7 +656,7 @@ class IndicesClient(NamespacedClient):
         Create a data stream. Creates a data stream. You must have a matching index template
         with data stream enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Name of the data stream, which must meet the following criteria:
             Lowercase only; Cannot include `\\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`,
@@ -717,7 +717,7 @@ class IndicesClient(NamespacedClient):
         """
         Get data stream stats. Retrieves statistics for one or more data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Comma-separated list of data streams used to limit the request.
             Wildcard expressions (`*`) are supported. To target all data streams in a
@@ -782,7 +782,7 @@ class IndicesClient(NamespacedClient):
         delete the index, you must roll over the data stream so a new write index is
         created. You can then use the delete index API to delete the previous write index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-index.html>`_
 
         :param index: Comma-separated list of indices to delete. You cannot specify index
             aliases. By default, this parameter does not support wildcards (`*`) or `_all`.
@@ -852,7 +852,7 @@ class IndicesClient(NamespacedClient):
         """
         Delete an alias. Removes a data stream or index from an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-alias.html>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`).
@@ -917,7 +917,7 @@ class IndicesClient(NamespacedClient):
         Delete data stream lifecycles. Removes the data stream lifecycle from a data
         stream, rendering it not managed by the data stream lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-delete-lifecycle.html>`_
 
         :param name: A comma-separated list of data streams of which the data stream
             lifecycle will be deleted; use `*` to get all data streams
@@ -977,7 +977,7 @@ class IndicesClient(NamespacedClient):
         """
         Delete data streams. Deletes one or more data streams and their backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Comma-separated list of data streams to delete. Wildcard (`*`) expressions
             are supported.
@@ -1032,7 +1032,7 @@ class IndicesClient(NamespacedClient):
         then there is no wildcard support and the provided names should match completely
         with existing templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-template.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1084,7 +1084,7 @@ class IndicesClient(NamespacedClient):
         """
         Delete a legacy index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-template-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-template-v1.html>`_
 
         :param name: The name of the legacy index template to delete. Wildcard (`*`)
             expressions are supported.
@@ -1156,7 +1156,7 @@ class IndicesClient(NamespacedClient):
         The stored size of the `_id` field is likely underestimated while the `_source`
         field is overestimated.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-disk-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-disk-usage.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. It’s recommended to execute this API with a single
@@ -1237,7 +1237,7 @@ class IndicesClient(NamespacedClient):
         are supported. Neither field nor document level security can be defined on the
         source index. The source index must be read only (`index.blocks.write: true`).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-downsample-data-stream.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-downsample-data-stream.html>`_
 
         :param index: Name of the time series index to downsample.
         :param target_index: Name of the index to create.
@@ -1305,7 +1305,7 @@ class IndicesClient(NamespacedClient):
         """
         Check indices. Check if one or more indices, index aliases, or data streams exist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-exists.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-exists.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases. Supports
             wildcards (`*`).
@@ -1383,7 +1383,7 @@ class IndicesClient(NamespacedClient):
         """
         Check aliases. Checks if one or more data stream or index aliases exist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-aliases.html>`_
 
         :param name: Comma-separated list of aliases to check. Supports wildcards (`*`).
         :param index: Comma-separated list of data streams or indices used to limit the
@@ -1453,7 +1453,7 @@ class IndicesClient(NamespacedClient):
         """
         Check index templates. Check whether index templates exist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/index-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1506,7 +1506,7 @@ class IndicesClient(NamespacedClient):
         templates, which are deprecated and will be replaced by the composable templates
         introduced in Elasticsearch 7.8.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-template-exists-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-template-exists-v1.html>`_
 
         :param name: A comma-separated list of index template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -1563,7 +1563,7 @@ class IndicesClient(NamespacedClient):
         creation, time since rollover, the lifecycle configuration managing the index,
         or any errors encountered during lifecycle execution.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-explain-lifecycle.html>`_
 
         :param index: The name of the index to explain
         :param include_defaults: indicates if the API should return the default values
@@ -1631,7 +1631,7 @@ class IndicesClient(NamespacedClient):
         in the index. A given request will increment each count by a maximum value of
         1, even if the request accesses the same field multiple times.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/field-usage-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/field-usage-stats.html>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -1725,7 +1725,7 @@ class IndicesClient(NamespacedClient):
         documents then a successful response indicates that Elasticsearch has flushed
         all the documents that were indexed before the flush API was called.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-flush.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-flush.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to flush.
             Supports wildcards (`*`). To flush all data streams and indices, omit this
@@ -1850,7 +1850,7 @@ class IndicesClient(NamespacedClient):
         searches. For example: ``` POST /.ds-my-data-stream-2099.03.07-000001/_forcemerge?max_num_segments=1
         ```
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-forcemerge.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-forcemerge.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -1944,7 +1944,7 @@ class IndicesClient(NamespacedClient):
         Get index information. Get information about one or more indices. For data streams,
         the API returns information about the stream’s backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-index.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported.
@@ -2033,7 +2033,7 @@ class IndicesClient(NamespacedClient):
         """
         Get aliases. Retrieves information for one or more data stream or index aliases.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-alias.html>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`). To target all data streams and indices,
@@ -2116,7 +2116,7 @@ class IndicesClient(NamespacedClient):
         Get data stream lifecycles. Retrieves the data stream lifecycle configuration
         of one or more data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-get-lifecycle.html>`_
 
         :param name: Comma-separated list of data streams to limit the request. Supports
             wildcards (`*`). To target all data streams, omit this parameter or use `*`
@@ -2171,7 +2171,7 @@ class IndicesClient(NamespacedClient):
         Get data stream lifecycle stats. Get statistics about the data streams that are
         managed by a data stream lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-get-lifecycle-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-get-lifecycle-stats.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_lifecycle/stats"
@@ -2218,7 +2218,7 @@ class IndicesClient(NamespacedClient):
         """
         Get data streams. Retrieves information about one or more data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Comma-separated list of data stream names used to limit the request.
             Wildcard (`*`) expressions are supported. If omitted, all data streams are
@@ -2296,7 +2296,7 @@ class IndicesClient(NamespacedClient):
         This API is useful if you don't need a complete mapping or if an index mapping
         contains a large number of fields.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-field-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-field-mapping.html>`_
 
         :param fields: Comma-separated list or wildcard expression of fields used to
             limit returned information. Supports wildcards (`*`).
@@ -2373,7 +2373,7 @@ class IndicesClient(NamespacedClient):
         """
         Get index templates. Get information about one or more index templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-template.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -2447,7 +2447,7 @@ class IndicesClient(NamespacedClient):
         Get mapping definitions. For data streams, the API retrieves mappings for the
         stream’s backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-mapping.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2532,7 +2532,7 @@ class IndicesClient(NamespacedClient):
         Get index settings. Get setting information for one or more indices. For data
         streams, it returns setting information for the stream's backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-settings.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2621,7 +2621,7 @@ class IndicesClient(NamespacedClient):
         This documentation is about legacy index templates, which are deprecated and
         will be replaced by the composable templates introduced in Elasticsearch 7.8.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-template-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-template-v1.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (`*`) expressions are supported. To return all index templates,
@@ -2687,7 +2687,7 @@ class IndicesClient(NamespacedClient):
         with the same name. The indices for the alias become hidden backing indices for
         the stream. The write index for the alias becomes the write index for the stream.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Name of the index alias to convert to a data stream.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -2740,7 +2740,7 @@ class IndicesClient(NamespacedClient):
         Update data streams. Performs one or more data stream modification actions in
         a single atomic operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param actions: Actions to perform.
         """
@@ -2820,7 +2820,7 @@ class IndicesClient(NamespacedClient):
         setting on index creation applies to the `_open` and `_close` index actions as
         well.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-open-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-open-close.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). By default, you must explicitly
@@ -2906,7 +2906,7 @@ class IndicesClient(NamespacedClient):
         a matching index template is created. This will affect the lifecycle management
         of the data stream and interfere with the data stream size and retention.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: The name of the data stream
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -2968,7 +2968,7 @@ class IndicesClient(NamespacedClient):
         """
         Create or update an alias. Adds a data stream or index to an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-aliases.html>`_
 
         :param index: Comma-separated list of data streams or indices to add. Supports
             wildcards (`*`). Wildcard patterns that match both data streams and indices
@@ -3070,7 +3070,7 @@ class IndicesClient(NamespacedClient):
         Update data stream lifecycles. Update the data stream lifecycle of the specified
         data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-put-lifecycle.html>`_
 
         :param name: Comma-separated list of data streams used to limit the request.
             Supports wildcards (`*`). To target all data streams use `*` or `_all`.
@@ -3189,7 +3189,7 @@ class IndicesClient(NamespacedClient):
         default new `dynamic_templates` entries are appended onto the end. If an entry
         already exists with the same key, then it is overwritten by the new definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-put-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-put-template.html>`_
 
         :param name: Index or template name
         :param allow_auto_create: This setting overrides the value of the `action.auto_create_index`
@@ -3373,7 +3373,7 @@ class IndicesClient(NamespacedClient):
         invalidate data already indexed under the old field name. Instead, add an alias
         field to create an alternate field name.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-put-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-put-mapping.html>`_
 
         :param index: A comma-separated list of index names the mapping should be added
             to (supports wildcards); use `_all` or omit to add the mapping on all indices.
@@ -3516,7 +3516,7 @@ class IndicesClient(NamespacedClient):
         existing data. To change the analyzer for existing backing indices, you must
         create a new data stream and reindex your data into it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-update-settings.html>`_
 
         :param settings:
         :param index: Comma-separated list of data streams, indices, and aliases used
@@ -3637,7 +3637,7 @@ class IndicesClient(NamespacedClient):
         and higher orders overriding them. NOTE: Multiple matching templates with the
         same order value will result in a non-deterministic merging order.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-templates-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-templates-v1.html>`_
 
         :param name: The name of the template
         :param aliases: Aliases for the index.
@@ -3738,7 +3738,7 @@ class IndicesClient(NamespacedClient):
         onto a different node then the information about the original recovery will not
         be shown in the recovery API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-recovery.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -3812,7 +3812,7 @@ class IndicesClient(NamespacedClient):
         query parameter option. This option ensures the indexing operation waits for
         a periodic refresh before running the search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-refresh.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-refresh.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -3896,7 +3896,7 @@ class IndicesClient(NamespacedClient):
         a shard replica--before using this API. This ensures the synonym file is updated
         everywhere in the cluster in case shards are relocated in the future.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-reload-analyzers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-reload-analyzers.html>`_
 
         :param index: A comma-separated list of index names to reload analyzers for
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -3991,7 +3991,7 @@ class IndicesClient(NamespacedClient):
         errors will be shown.) * A remote cluster is an older version that does not support
         the feature you want to use in your search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-resolve-cluster-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-resolve-cluster-api.html>`_
 
         :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
             and data streams to resolve. Resources on remote clusters can be specified
@@ -4065,7 +4065,7 @@ class IndicesClient(NamespacedClient):
         Resolve indices. Resolve the names and/or index patterns for indices, aliases,
         and data streams. Multiple patterns and remote clusters are supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-resolve-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-resolve-index-api.html>`_
 
         :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
             and data streams to resolve. Resources on remote clusters can be specified
@@ -4164,7 +4164,7 @@ class IndicesClient(NamespacedClient):
         If you create the index on May 6, 2099, the index's name is `my-index-2099.05.06-000001`.
         If you roll over the alias on May 7, 2099, the new index's name is `my-index-2099.05.07-000002`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-rollover-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-rollover-index.html>`_
 
         :param alias: Name of the data stream or index alias to roll over.
         :param new_index: Name of the index to create. Supports date math. Data streams
@@ -4271,7 +4271,7 @@ class IndicesClient(NamespacedClient):
         shards. For data streams, the API returns information about the stream's backing
         indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-segments.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4357,7 +4357,7 @@ class IndicesClient(NamespacedClient):
         information only for primary shards that are unassigned or have one or more unassigned
         replica shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-shards-stores.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-shards-stores.html>`_
 
         :param index: List of data streams, indices, and aliases used to limit the request.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -4460,7 +4460,7 @@ class IndicesClient(NamespacedClient):
         must have sufficient free disk space to accommodate a second copy of the existing
         index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-shrink-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-shrink-index.html>`_
 
         :param index: Name of the source index to shrink.
         :param target: Name of the target index to create.
@@ -4536,7 +4536,7 @@ class IndicesClient(NamespacedClient):
         Simulate an index. Get the index configuration that would be applied to the specified
         index from an existing index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-simulate-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-simulate-index.html>`_
 
         :param name: Name of the index to simulate
         :param include_defaults: If true, returns all relevant default configurations
@@ -4614,7 +4614,7 @@ class IndicesClient(NamespacedClient):
         Simulate an index template. Get the index configuration that would be applied
         by a particular index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-simulate-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-simulate-template.html>`_
 
         :param name: Name of the index template to simulate. To test a template configuration
             before you add it to the cluster, omit this parameter and specify the template
@@ -4769,7 +4769,7 @@ class IndicesClient(NamespacedClient):
         in the source index. * The node handling the split process must have sufficient
         free disk space to accommodate a second copy of the existing index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-split-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-split-index.html>`_
 
         :param index: Name of the source index to split.
         :param target: Name of the target index to create.
@@ -4868,7 +4868,7 @@ class IndicesClient(NamespacedClient):
         cleared. Although the shard is no longer part of the node, that node retains
         any node-level statistics to which the shard contributed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-stats.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -4972,7 +4972,7 @@ class IndicesClient(NamespacedClient):
         Unfreeze an index. When a frozen index is unfrozen, the index goes through the
         normal recovery process and becomes writeable again.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/unfreeze-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/unfreeze-index-api.html>`_
 
         :param index: Identifier for the index.
         :param allow_no_indices: If `false`, the request returns an error if any wildcard
@@ -5046,7 +5046,7 @@ class IndicesClient(NamespacedClient):
         """
         Create or update an alias. Adds a data stream or index to an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-aliases.html>`_
 
         :param actions: Actions to perform.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -5121,7 +5121,7 @@ class IndicesClient(NamespacedClient):
         """
         Validate a query. Validates a query without running it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-validate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-validate.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams or indices, omit this

--- a/elasticsearch/_async/client/inference.py
+++ b/elasticsearch/_async/client/inference.py
@@ -46,7 +46,7 @@ class InferenceClient(NamespacedClient):
         """
         Delete an inference endpoint
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-inference-api.html>`_
 
         :param inference_id: The inference Id
         :param task_type: The task type
@@ -111,7 +111,7 @@ class InferenceClient(NamespacedClient):
         """
         Get an inference endpoint
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-inference-api.html>`_
 
         :param task_type: The task type
         :param inference_id: The inference Id
@@ -174,7 +174,7 @@ class InferenceClient(NamespacedClient):
         """
         Perform inference on the service
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/post-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/post-inference-api.html>`_
 
         :param inference_id: The inference Id
         :param input: Inference input. Either a string or an array of strings.
@@ -271,7 +271,7 @@ class InferenceClient(NamespacedClient):
         to use these models or if you want to use non-NLP models, use the machine learning
         trained model APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-inference-api.html>`_
 
         :param inference_id: The inference Id
         :param inference_config:
@@ -350,7 +350,7 @@ class InferenceClient(NamespacedClient):
         or if you want to use non-NLP models, use the machine learning trained model
         APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-inference-api.html>`_
 
         :param inference_id: The unique identifier of the inference endpoint.
         :param inference_config:

--- a/elasticsearch/_async/client/ingest.py
+++ b/elasticsearch/_async/client/ingest.py
@@ -41,7 +41,7 @@ class IngestClient(NamespacedClient):
         Delete GeoIP database configurations. Delete one or more IP geolocation database
         configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-geoip-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-geoip-database-api.html>`_
 
         :param id: A comma-separated list of geoip database configurations to delete
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -92,7 +92,7 @@ class IngestClient(NamespacedClient):
         """
         Delete IP geolocation database configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-ip-location-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-ip-location-database-api.html>`_
 
         :param id: A comma-separated list of IP location database configurations.
         :param master_timeout: The period to wait for a connection to the master node.
@@ -145,7 +145,7 @@ class IngestClient(NamespacedClient):
         """
         Delete pipelines. Delete one or more ingest pipelines.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-pipeline-api.html>`_
 
         :param id: Pipeline ID or wildcard expression of pipeline IDs used to limit the
             request. To delete all ingest pipelines in a cluster, use a value of `*`.
@@ -195,7 +195,7 @@ class IngestClient(NamespacedClient):
         Get GeoIP statistics. Get download statistics for GeoIP2 databases that are used
         with the GeoIP processor.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/geoip-processor.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/geoip-processor.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ingest/geoip/stats"
@@ -232,7 +232,7 @@ class IngestClient(NamespacedClient):
         Get GeoIP database configurations. Get information about one or more IP geolocation
         database configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-geoip-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-geoip-database-api.html>`_
 
         :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
             (`*`) expressions are supported. To get all database configurations, omit
@@ -278,7 +278,7 @@ class IngestClient(NamespacedClient):
         """
         Get IP geolocation database configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-ip-location-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-ip-location-database-api.html>`_
 
         :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
             (`*`) expressions are supported. To get all database configurations, omit
@@ -332,7 +332,7 @@ class IngestClient(NamespacedClient):
         Get pipelines. Get information about one or more ingest pipelines. This API returns
         a local reference of the pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-pipeline-api.html>`_
 
         :param id: Comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions
             are supported. To get all ingest pipelines, omit this parameter or use `*`.
@@ -386,7 +386,7 @@ class IngestClient(NamespacedClient):
         as the grok pattern you expect will match. A grok pattern is like a regular expression
         that supports aliased expressions that can be reused.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/grok-processor.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/grok-processor.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ingest/processor/grok"
@@ -430,7 +430,7 @@ class IngestClient(NamespacedClient):
         Create or update a GeoIP database configuration. Refer to the create or update
         IP geolocation database configuration API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-geoip-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-geoip-database-api.html>`_
 
         :param id: ID of the database configuration to create or update.
         :param maxmind: The configuration necessary to identify which IP geolocation
@@ -502,7 +502,7 @@ class IngestClient(NamespacedClient):
         """
         Create or update an IP geolocation database configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-ip-location-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-ip-location-database-api.html>`_
 
         :param id: The database configuration identifier.
         :param configuration:
@@ -584,7 +584,7 @@ class IngestClient(NamespacedClient):
         """
         Create or update a pipeline. Changes made using this API take effect immediately.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ingest.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ingest.html>`_
 
         :param id: ID of the ingest pipeline to create or update.
         :param deprecated: Marks this ingest pipeline as deprecated. When a deprecated
@@ -678,7 +678,7 @@ class IngestClient(NamespacedClient):
         You can either specify an existing pipeline to use with the provided documents
         or supply a pipeline definition in the body of the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/simulate-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/simulate-pipeline-api.html>`_
 
         :param docs: Sample documents to test in the pipeline.
         :param id: Pipeline to test. If you don’t specify a `pipeline` in the request

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -41,7 +41,7 @@ class LicenseClient(NamespacedClient):
         to Basic. If the operator privileges feature is enabled, only operator users
         can use this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-license.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param timeout: Period to wait for a response. If no response is received before
@@ -90,7 +90,7 @@ class LicenseClient(NamespacedClient):
         Not Found` response. If you receive an unexpected 404 response after cluster
         startup, wait a short period and retry the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-license.html>`_
 
         :param accept_enterprise: If `true`, this parameter returns enterprise for Enterprise
             license types. If `false`, this parameter returns platinum for both platinum
@@ -136,7 +136,7 @@ class LicenseClient(NamespacedClient):
         """
         Get the basic license status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-basic-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-basic-status.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/basic_status"
@@ -171,7 +171,7 @@ class LicenseClient(NamespacedClient):
         """
         Get the trial status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-trial-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-trial-status.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/trial_status"
@@ -221,7 +221,7 @@ class LicenseClient(NamespacedClient):
         TLS on the transport networking layer before you install the license. If the
         operator privileges feature is enabled, only operator users can use this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-license.html>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:
@@ -290,7 +290,7 @@ class LicenseClient(NamespacedClient):
         parameter set to `true`. To check the status of your basic license, use the get
         basic license API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-basic.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-basic.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
@@ -345,7 +345,7 @@ class LicenseClient(NamespacedClient):
         however, request an extended trial at https://www.elastic.co/trialextension.
         To check the status of your trial, use the get trial status API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-trial.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-trial.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)

--- a/elasticsearch/_async/client/logstash.py
+++ b/elasticsearch/_async/client/logstash.py
@@ -40,7 +40,7 @@ class LogstashClient(NamespacedClient):
         Management. If the request succeeds, you receive an empty response with an appropriate
         status code.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/logstash-api-delete-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/logstash-api-delete-pipeline.html>`_
 
         :param id: An identifier for the pipeline.
         """
@@ -80,7 +80,7 @@ class LogstashClient(NamespacedClient):
         """
         Get Logstash pipelines. Get pipelines that are used for Logstash Central Management.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/logstash-api-get-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/logstash-api-get-pipeline.html>`_
 
         :param id: A comma-separated list of pipeline identifiers.
         """
@@ -128,7 +128,7 @@ class LogstashClient(NamespacedClient):
         Create or update a Logstash pipeline. Create a pipeline that is used for Logstash
         Central Management. If the specified pipeline exists, it is replaced.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/logstash-api-put-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/logstash-api-put-pipeline.html>`_
 
         :param id: An identifier for the pipeline.
         :param pipeline:

--- a/elasticsearch/_async/client/migration.py
+++ b/elasticsearch/_async/client/migration.py
@@ -41,7 +41,7 @@ class MigrationClient(NamespacedClient):
         in the next major version. TIP: This APIs is designed for indirect use by the
         Upgrade Assistant. You are strongly recommended to use the Upgrade Assistant.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/migration-api-deprecation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/migration-api-deprecation.html>`_
 
         :param index: Comma-separate list of data streams or indices to check. Wildcard
             (*) expressions are supported.
@@ -88,7 +88,7 @@ class MigrationClient(NamespacedClient):
         in progress. TIP: This API is designed for indirect use by the Upgrade Assistant.
         You are strongly recommended to use the Upgrade Assistant.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/feature-migration-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/feature-migration-api.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"
@@ -127,7 +127,7 @@ class MigrationClient(NamespacedClient):
         unavailable during the migration process. TIP: The API is designed for indirect
         use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/feature-migration-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/feature-migration-api.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -42,7 +42,7 @@ class MlClient(NamespacedClient):
         may be cached on that individual node. Calling this API clears the caches without
         restarting the deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-trained-model-deployment-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-trained-model-deployment-cache.html>`_
 
         :param model_id: The unique identifier of the trained model.
         """
@@ -102,7 +102,7 @@ class MlClient(NamespacedClient):
         force parameters as the close job request. When a datafeed that has a specified
         end date stops, it automatically closes its associated job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-close-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-close-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. You can close multiple anomaly detection
@@ -164,7 +164,7 @@ class MlClient(NamespacedClient):
         Delete a calendar. Removes all scheduled events from a calendar, then deletes
         it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         """
@@ -205,7 +205,7 @@ class MlClient(NamespacedClient):
         """
         Delete events from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param event_id: Identifier for the scheduled event. You can obtain this identifier
@@ -253,7 +253,7 @@ class MlClient(NamespacedClient):
         """
         Delete anomaly jobs from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -302,7 +302,7 @@ class MlClient(NamespacedClient):
         """
         Delete a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param force: If `true`, it deletes a job that is not stopped; this method is
@@ -350,7 +350,7 @@ class MlClient(NamespacedClient):
         """
         Delete a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -408,7 +408,7 @@ class MlClient(NamespacedClient):
         expired data for all anomaly detection jobs by using _all, by specifying * as
         the <job_id>, or by omitting the <job_id>.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-expired-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-expired-data.html>`_
 
         :param job_id: Identifier for an anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression.
@@ -469,7 +469,7 @@ class MlClient(NamespacedClient):
         delete the filter. You must update or delete the job before you can delete the
         filter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         """
@@ -515,7 +515,7 @@ class MlClient(NamespacedClient):
         in the forecast jobs API. The delete forecast API enables you to delete one or
         more forecasts before they expire.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param forecast_id: A comma-separated list of forecast identifiers. If you do
@@ -587,7 +587,7 @@ class MlClient(NamespacedClient):
         delete datafeed API with the same timeout and force parameters as the delete
         job request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -643,7 +643,7 @@ class MlClient(NamespacedClient):
         that snapshot, first revert to a different one. To identify the active model
         snapshot, refer to the `model_snapshot_id` in the results from the get jobs API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -692,7 +692,7 @@ class MlClient(NamespacedClient):
         Delete an unreferenced trained model. The request deletes a trained inference
         model that is not referenced by an ingest pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param force: Forcefully deletes a trained model that is referenced by ingest
@@ -743,7 +743,7 @@ class MlClient(NamespacedClient):
         to a trained model. If the model alias is missing or refers to a model other
         than the one identified by the `model_id`, this API returns an error.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-trained-models-aliases.html>`_
 
         :param model_id: The trained model ID to which the model alias refers.
         :param model_alias: The model alias to delete.
@@ -800,7 +800,7 @@ class MlClient(NamespacedClient):
         an anomaly detection job model. It is based on analysis configuration details
         for the job and cardinality estimates for the fields it references.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-apis.html>`_
 
         :param analysis_config: For a list of the properties that you can specify in
             the `analysis_config` component of the body of this API.
@@ -868,7 +868,7 @@ class MlClient(NamespacedClient):
         for use on indexes created by data frame analytics. Evaluation requires both
         a ground truth field and an analytics result field to be present.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/evaluate-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/evaluate-dfanalytics.html>`_
 
         :param evaluation: Defines the type of evaluation you want to perform.
         :param index: Defines the `index` in which the evaluation will be performed.
@@ -948,7 +948,7 @@ class MlClient(NamespacedClient):
         setting later on. If you have object fields or fields that are excluded via source
         filtering, they are not included in the explanation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/explain-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/explain-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -1055,7 +1055,7 @@ class MlClient(NamespacedClient):
         and persists the model state to disk and the job must be opened again before
         analyzing further data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-flush-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-flush-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param advance_time: Refer to the description for the `advance_time` query parameter.
@@ -1126,7 +1126,7 @@ class MlClient(NamespacedClient):
         for a job that has an `over_field_name` in its configuration. Forcasts predict
         future behavior based on historical data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must be open
             when you create a forecast; otherwise, an error occurs.
@@ -1209,7 +1209,7 @@ class MlClient(NamespacedClient):
         Get anomaly detection job results for buckets. The API presents a chronological
         view of the records, grouped by bucket.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-bucket.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-bucket.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timestamp: The timestamp of a single bucket result. If you do not specify
@@ -1304,7 +1304,7 @@ class MlClient(NamespacedClient):
         """
         Get info about events in calendars.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1370,7 +1370,7 @@ class MlClient(NamespacedClient):
         """
         Get calendar configuration info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1443,7 +1443,7 @@ class MlClient(NamespacedClient):
         """
         Get anomaly detection job results for categories.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-category.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-category.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param category_id: Identifier for the category, which is unique in the job.
@@ -1527,7 +1527,7 @@ class MlClient(NamespacedClient):
         multiple data frame analytics jobs in a single API request by using a comma-separated
         list of data frame analytics jobs or a wildcard expression.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1599,7 +1599,7 @@ class MlClient(NamespacedClient):
         """
         Get data frame analytics jobs usage info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-dfanalytics-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-dfanalytics-stats.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1669,7 +1669,7 @@ class MlClient(NamespacedClient):
         the only information you receive is the `datafeed_id` and the `state`. This API
         returns a maximum of 10,000 datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-datafeed-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-datafeed-stats.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1729,7 +1729,7 @@ class MlClient(NamespacedClient):
         `*` as the `<feed_id>`, or by omitting the `<feed_id>`. This API returns a maximum
         of 10,000 datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1792,7 +1792,7 @@ class MlClient(NamespacedClient):
         """
         Get filters. You can get a single filter or all filters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param from_: Skips the specified number of filters.
@@ -1856,7 +1856,7 @@ class MlClient(NamespacedClient):
         that have contributed to, or are to blame for, the anomalies. Influencer results
         are available only if an `influencer_field_name` is specified in the job configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-influencer.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-influencer.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: If true, the results are sorted in descending order.
@@ -1937,7 +1937,7 @@ class MlClient(NamespacedClient):
         """
         Get anomaly detection jobs usage info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-job-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs, or a wildcard expression. If
@@ -1998,7 +1998,7 @@ class MlClient(NamespacedClient):
         detection jobs by using `_all`, by specifying `*` as the `<job_id>`, or by omitting
         the `<job_id>`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. If you do not specify one of these
@@ -2061,7 +2061,7 @@ class MlClient(NamespacedClient):
         jobs and trained models are using memory, on each node, both within the JVM heap,
         and natively, outside of the JVM.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-ml-memory.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-ml-memory.html>`_
 
         :param node_id: The names of particular nodes in the cluster to target. For example,
             `nodeId1,nodeId2` or `ml:true`
@@ -2116,7 +2116,7 @@ class MlClient(NamespacedClient):
         """
         Get anomaly detection job model snapshot upgrade usage info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-job-model-snapshot-upgrade-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job-model-snapshot-upgrade-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2187,7 +2187,7 @@ class MlClient(NamespacedClient):
         """
         Get model snapshots info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2300,7 +2300,7 @@ class MlClient(NamespacedClient):
         its default), the `overall_score` is the maximum `overall_score` of the overall
         buckets that have a span equal to the jobs' largest bucket span.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-overall-buckets.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-overall-buckets.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs or groups, or a wildcard expression.
@@ -2405,7 +2405,7 @@ class MlClient(NamespacedClient):
         found in each bucket, which relates to the number of time series being modeled
         and the number of detectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-record.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-record.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: Refer to the description for the `desc` query parameter.
@@ -2501,7 +2501,7 @@ class MlClient(NamespacedClient):
         """
         Get trained model configuration info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             You can get information for multiple trained models in a single API request
@@ -2589,7 +2589,7 @@ class MlClient(NamespacedClient):
         models in a single API request by using a comma-separated list of model IDs or
         a wildcard expression.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-trained-models-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-trained-models-stats.html>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             It can be a comma-separated list or a wildcard expression.
@@ -2652,7 +2652,7 @@ class MlClient(NamespacedClient):
         """
         Evaluate a trained model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/infer-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/infer-trained-model.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param docs: An array of objects to pass to the model for inference. The objects
@@ -2714,7 +2714,7 @@ class MlClient(NamespacedClient):
         what those defaults are. It also provides information about the maximum size
         of machine learning jobs that could run in the current cluster configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-ml-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-ml-info.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ml/info"
@@ -2759,7 +2759,7 @@ class MlClient(NamespacedClient):
         job is ready to resume its analysis from where it left off, once new data is
         received.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-open-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-open-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timeout: Refer to the description for the `timeout` query parameter.
@@ -2813,7 +2813,7 @@ class MlClient(NamespacedClient):
         """
         Add scheduled events to the calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-post-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-post-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param events: A list of one of more scheduled events. The event’s start and
@@ -2871,7 +2871,7 @@ class MlClient(NamespacedClient):
         data can be accepted from only a single connection at a time. It is not currently
         possible to post data to multiple jobs using wildcards or a comma-separated list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-post-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-post-data.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must have a
             state of open to receive and process the data.
@@ -2935,7 +2935,7 @@ class MlClient(NamespacedClient):
         Preview features used by data frame analytics. Previews the extracted features
         used by a data frame analytics config.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/preview-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/preview-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param config: A data frame analytics config as described in create data frame
@@ -3005,7 +3005,7 @@ class MlClient(NamespacedClient):
         that accurately reflects the behavior of the datafeed, use the appropriate credentials.
         You can also use secondary authorization headers to supply the credentials.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-preview-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-preview-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3081,7 +3081,7 @@ class MlClient(NamespacedClient):
         """
         Create a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param description: A description of the calendar.
@@ -3135,7 +3135,7 @@ class MlClient(NamespacedClient):
         """
         Add anomaly detection job to calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -3216,7 +3216,7 @@ class MlClient(NamespacedClient):
         parameters, hyperparameter optimization occurs. It determines a value for each
         of the undefined parameters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3400,7 +3400,7 @@ class MlClient(NamespacedClient):
         directly to the `.ml-config` index. Do not give users `write` privileges on the
         `.ml-config` index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3559,7 +3559,7 @@ class MlClient(NamespacedClient):
         more anomaly detection jobs. Specifically, filters are referenced in the `custom_rules`
         property of detector configuration objects.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param description: A description of the filter.
@@ -3658,7 +3658,7 @@ class MlClient(NamespacedClient):
         have read index privileges on the source index. If you include a `datafeed_config`
         but do not provide a query, the datafeed uses `{"match_all": {"boost": 1}}`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-job.html>`_
 
         :param job_id: The identifier for the anomaly detection job. This identifier
             can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and
@@ -3863,7 +3863,7 @@ class MlClient(NamespacedClient):
         Create a trained model. Enable you to supply a trained model that is not created
         by data frame analytics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param compressed_definition: The compressed (GZipped and Base64 encoded) inference
@@ -3977,7 +3977,7 @@ class MlClient(NamespacedClient):
         common between the old and new trained models for the model alias, the API returns
         a warning.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-models-aliases.html>`_
 
         :param model_id: The identifier for the trained model that the alias refers to.
         :param model_alias: The alias to create or update. This value cannot end in numbers.
@@ -4035,7 +4035,7 @@ class MlClient(NamespacedClient):
         """
         Create part of a trained model definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-model-definition-part.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-model-definition-part.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param part: The definition part number. When the definition is loaded for inference
@@ -4114,7 +4114,7 @@ class MlClient(NamespacedClient):
         processing (NLP) models. The vocabulary is stored in the index as described in
         `inference_config.*.vocabulary` of the trained model definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-model-vocabulary.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-model-vocabulary.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
@@ -4172,7 +4172,7 @@ class MlClient(NamespacedClient):
         job is ready to start over as if it had just been created. It is not currently
         possible to reset multiple jobs using wildcards or a comma separated list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-reset-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-reset-job.html>`_
 
         :param job_id: The ID of the job to reset.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -4232,7 +4232,7 @@ class MlClient(NamespacedClient):
         For example, you might consider reverting to a saved snapshot after Black Friday
         or a critical system failure.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-revert-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-revert-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: You can specify `empty` as the <snapshot_id>. Reverting to
@@ -4302,7 +4302,7 @@ class MlClient(NamespacedClient):
         the current value for the upgrade_mode setting by using the get machine learning
         info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-set-upgrade-mode.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-set-upgrade-mode.html>`_
 
         :param enabled: When `true`, it enables `upgrade_mode` which temporarily halts
             all job and datafeed tasks and prohibits new job and datafeed tasks from
@@ -4357,7 +4357,7 @@ class MlClient(NamespacedClient):
         exists, it is used as is. You can therefore set up the destination index in advance
         with custom settings and mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4419,7 +4419,7 @@ class MlClient(NamespacedClient):
         headers when you created or updated the datafeed, those credentials are used
         instead.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-start-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-start-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -4489,7 +4489,7 @@ class MlClient(NamespacedClient):
         Start a trained model deployment. It allocates the model to every machine learning
         node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
@@ -4573,7 +4573,7 @@ class MlClient(NamespacedClient):
         Stop data frame analytics jobs. A data frame analytics job can be started and
         stopped multiple times throughout its lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/stop-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/stop-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4639,7 +4639,7 @@ class MlClient(NamespacedClient):
         Stop datafeeds. A datafeed that is stopped ceases to retrieve data from Elasticsearch.
         A datafeed can be started and stopped multiple times throughout its lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-stop-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-stop-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. You can stop multiple datafeeds
             in a single API request by using a comma-separated list of datafeeds or a
@@ -4701,7 +4701,7 @@ class MlClient(NamespacedClient):
         """
         Stop a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/stop-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/stop-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -4766,7 +4766,7 @@ class MlClient(NamespacedClient):
         """
         Update a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4878,7 +4878,7 @@ class MlClient(NamespacedClient):
         query using those same roles. If you provide secondary authorization headers,
         those credentials are used instead.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -5042,7 +5042,7 @@ class MlClient(NamespacedClient):
         Update a filter. Updates the description of a filter, adds items, or removes
         items from the list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param add_items: The items to add to the filter.
@@ -5133,7 +5133,7 @@ class MlClient(NamespacedClient):
         Update an anomaly detection job. Updates certain properties of an anomaly detection
         job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-job.html>`_
 
         :param job_id: Identifier for the job.
         :param allow_lazy_open: Advanced configuration option. Specifies whether this
@@ -5261,7 +5261,7 @@ class MlClient(NamespacedClient):
         """
         Update a snapshot. Updates certain properties of a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -5322,7 +5322,7 @@ class MlClient(NamespacedClient):
         """
         Update a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
@@ -5388,7 +5388,7 @@ class MlClient(NamespacedClient):
         a time and the upgraded snapshot cannot be the current snapshot of the anomaly
         detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-upgrade-job-model-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-upgrade-job-model-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -5464,7 +5464,7 @@ class MlClient(NamespacedClient):
         """
         Validate an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/machine-learning/8.16/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.17/ml-jobs.html>`_
 
         :param analysis_config:
         :param analysis_limits:
@@ -5534,7 +5534,7 @@ class MlClient(NamespacedClient):
         """
         Validate an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/machine-learning/8.16/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.17/ml-jobs.html>`_
 
         :param detector:
         """

--- a/elasticsearch/_async/client/monitoring.py
+++ b/elasticsearch/_async/client/monitoring.py
@@ -45,7 +45,7 @@ class MonitoringClient(NamespacedClient):
         Send monitoring data. This API is used by the monitoring features to send monitoring
         data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/monitor-elasticsearch-cluster.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/monitor-elasticsearch-cluster.html>`_
 
         :param interval: Collection interval (e.g., '10s' or '10000ms') of the payload
         :param operations:

--- a/elasticsearch/_async/client/nodes.py
+++ b/elasticsearch/_async/client/nodes.py
@@ -47,7 +47,7 @@ class NodesClient(NamespacedClient):
         Clear the archived repositories metering. Clear the archived repositories metering
         information in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-repositories-metering-archive-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-repositories-metering-archive-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -100,7 +100,7 @@ class NodesClient(NamespacedClient):
         over a period of time. Additionally, the information exposed by this API is volatile,
         meaning that it will not be present after node restarts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-repositories-metering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-repositories-metering-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -154,7 +154,7 @@ class NodesClient(NamespacedClient):
         node in the cluster. The output is plain text with a breakdown of the top hot
         threads for each node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-hot-threads.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-hot-threads.html>`_
 
         :param node_id: List of node IDs or names used to limit returned information.
         :param ignore_idle_threads: If true, known idle threads (e.g. waiting in a socket
@@ -224,7 +224,7 @@ class NodesClient(NamespacedClient):
         Get node information. By default, the API returns all attributes and core settings
         for cluster nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-info.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -299,7 +299,7 @@ class NodesClient(NamespacedClient):
         by locally accessing the API and passing the node-specific Elasticsearch keystore
         password.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/secure-settings.html#reloadable-secure-settings>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/secure-settings.html#reloadable-secure-settings>`_
 
         :param node_id: The names of particular nodes in the cluster to target.
         :param secure_settings_password: The password for the Elasticsearch keystore.
@@ -370,7 +370,7 @@ class NodesClient(NamespacedClient):
         Get node statistics. Get statistics for nodes in a cluster. By default, all stats
         are returned. You can limit the returned information by using metrics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-stats.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -482,7 +482,7 @@ class NodesClient(NamespacedClient):
         """
         Get feature usage information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-usage.html>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting

--- a/elasticsearch/_async/client/query_rules.py
+++ b/elasticsearch/_async/client/query_rules.py
@@ -41,7 +41,7 @@ class QueryRulesClient(NamespacedClient):
         action that is only recoverable by re-adding the same rule with the create or
         update query rule API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-query-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-query-rule.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to delete
@@ -90,7 +90,7 @@ class QueryRulesClient(NamespacedClient):
         Delete a query ruleset. Remove a query ruleset and its associated data. This
         is a destructive action that is not recoverable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to delete
         """
@@ -131,7 +131,7 @@ class QueryRulesClient(NamespacedClient):
         """
         Get a query rule. Get details about a query rule within a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-query-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-query-rule.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to retrieve
@@ -179,7 +179,7 @@ class QueryRulesClient(NamespacedClient):
         """
         Get a query ruleset. Get details about a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset
         """
@@ -222,7 +222,7 @@ class QueryRulesClient(NamespacedClient):
         """
         Get all query rulesets. Get summarized information about the query rulesets.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-query-rulesets.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-query-rulesets.html>`_
 
         :param from_: The offset from the first result to fetch.
         :param size: The maximum number of results to retrieve.
@@ -281,7 +281,7 @@ class QueryRulesClient(NamespacedClient):
         than 100 documents, only the first 100 documents are pinned in the order they
         are specified in the ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-query-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-query-rule.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to be created or updated.
@@ -366,7 +366,7 @@ class QueryRulesClient(NamespacedClient):
         rules pin more than 100 documents, only the first 100 documents are pinned in
         the order they are specified in the ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated.
@@ -420,7 +420,7 @@ class QueryRulesClient(NamespacedClient):
         Test a query ruleset. Evaluate match criteria against a query ruleset to identify
         the rules that would match that criteria.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/test-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/test-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated

--- a/elasticsearch/_async/client/rollup.py
+++ b/elasticsearch/_async/client/rollup.py
@@ -58,7 +58,7 @@ class RollupClient(NamespacedClient):
         index. For example: ``` POST my_rollup_index/_delete_by_query { "query": { "term":
         { "_rollup.id": "the_rollup_job_id" } } } ```
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-delete-job.html>`_
 
         :param id: Identifier for the job.
         """
@@ -103,7 +103,7 @@ class RollupClient(NamespacedClient):
         any details about it. For details about a historical rollup job, the rollup capabilities
         API may be more useful.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-get-job.html>`_
 
         :param id: Identifier for the rollup job. If it is `_all` or omitted, the API
             returns all rollup jobs.
@@ -156,7 +156,7 @@ class RollupClient(NamespacedClient):
         the first question, what fields were rolled up, what aggregations can be performed,
         and where does the data live?
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-get-rollup-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-get-rollup-caps.html>`_
 
         :param id: Index, indices or index-pattern to return rollup capabilities for.
             `_all` may be used to fetch rollup capabilities from all jobs.
@@ -206,7 +206,7 @@ class RollupClient(NamespacedClient):
         via a pattern)? * What target indices were rolled up, what fields were used in
         those rollups, and what aggregations can be performed on each job?
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-get-rollup-index-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-get-rollup-index-caps.html>`_
 
         :param index: Data stream or index to check for rollup capabilities. Wildcard
             (`*`) expressions are supported.
@@ -278,7 +278,7 @@ class RollupClient(NamespacedClient):
         and what metrics to collect for each group. Jobs are created in a `STOPPED` state.
         You can start them with the start rollup jobs API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-put-job.html>`_
 
         :param id: Identifier for the rollup job. This can be any alphanumeric string
             and uniquely identifies the data that is associated with the rollup job.
@@ -413,7 +413,7 @@ class RollupClient(NamespacedClient):
         During the merging process, if there is any overlap in buckets between the two
         responses, the buckets from the non-rollup index are used.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-search.html>`_
 
         :param index: A comma-separated list of data streams and indices used to limit
             the request. This parameter has the following rules: * At least one data
@@ -487,7 +487,7 @@ class RollupClient(NamespacedClient):
         Start rollup jobs. If you try to start a job that does not exist, an exception
         occurs. If you try to start a job that is already started, nothing happens.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-start-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-start-job.html>`_
 
         :param id: Identifier for the rollup job.
         """
@@ -537,7 +537,7 @@ class RollupClient(NamespacedClient):
         moved to STOPPED or the specified time has elapsed. If the specified time elapses
         without the job moving to STOPPED, a timeout exception occurs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-stop-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-stop-job.html>`_
 
         :param id: Identifier for the rollup job.
         :param timeout: If `wait_for_completion` is `true`, the API blocks for (at maximum)

--- a/elasticsearch/_async/client/search_application.py
+++ b/elasticsearch/_async/client/search_application.py
@@ -46,7 +46,7 @@ class SearchApplicationClient(NamespacedClient):
         Delete a search application. Remove a search application and its associated alias.
         Indices attached to the search application are not removed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-search-application.html>`_
 
         :param name: The name of the search application to delete
         """
@@ -88,7 +88,7 @@ class SearchApplicationClient(NamespacedClient):
         Delete a behavioral analytics collection. The associated data stream is also
         deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-analytics-collection.html>`_
 
         :param name: The name of the analytics collection to be deleted
         """
@@ -129,7 +129,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Get search application details.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-search-application.html>`_
 
         :param name: The name of the search application
         """
@@ -170,7 +170,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Get behavioral analytics collections.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-analytics-collection.html>`_
 
         :param name: A list of analytics collections to limit the returned information
         """
@@ -218,7 +218,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Get search applications. Get information about search applications.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-search-applications.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-search-applications.html>`_
 
         :param from_: Starting offset.
         :param q: Query in the Lucene query string syntax.
@@ -271,7 +271,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Create a behavioral analytics collection event.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/post-analytics-collection-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/post-analytics-collection-event.html>`_
 
         :param collection_name: The name of the behavioral analytics collection.
         :param event_type: The analytics event type.
@@ -335,7 +335,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Create or update a search application.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-search-application.html>`_
 
         :param name: The name of the search application to be created or updated.
         :param search_application:
@@ -389,7 +389,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Create a behavioral analytics collection.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-analytics-collection.html>`_
 
         :param name: The name of the analytics collection to be created or updated.
         """
@@ -441,7 +441,7 @@ class SearchApplicationClient(NamespacedClient):
         generated and run by calling the search application search API. You must have
         `read` privileges on the backing alias of the search application.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-application-render-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-application-render-query.html>`_
 
         :param name: The name of the search application to render teh query for.
         :param params:
@@ -503,7 +503,7 @@ class SearchApplicationClient(NamespacedClient):
         the search application or default template. Unspecified template parameters are
         assigned their default values if applicable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-application-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-application-search.html>`_
 
         :param name: The name of the search application to be searched.
         :param params: Query parameters specific to this request, which will override

--- a/elasticsearch/_async/client/searchable_snapshots.py
+++ b/elasticsearch/_async/client/searchable_snapshots.py
@@ -47,7 +47,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         Get cache statistics. Get statistics about the shared cache for partially mounted
         indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-cache-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-cache-stats.html>`_
 
         :param node_id: The names of the nodes in the cluster to target.
         :param master_timeout:
@@ -105,7 +105,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         Clear the cache. Clear indices and data streams from the shared cache for partially
         mounted indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-clear-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-clear-cache.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             clear from the cache. It supports wildcards (`*`).
@@ -180,7 +180,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         this API for snapshots managed by index lifecycle management (ILM). Manually
         mounting ILM-managed snapshots can interfere with ILM processes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-mount-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-mount-snapshot.html>`_
 
         :param repository: The name of the repository containing the snapshot of the
             index to mount.
@@ -265,7 +265,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Get searchable snapshot statistics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-stats.html>`_
 
         :param index: A comma-separated list of data streams and indices to retrieve
             statistics for.

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -60,7 +60,7 @@ class SecurityClient(NamespacedClient):
         the document if it was disabled. Any updates do not change existing content for
         either the `labels` or `data` fields.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-activate-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-activate-user-profile.html>`_
 
         :param grant_type: The type of grant.
         :param access_token: The user's Elasticsearch access token or JWT. Both `access`
@@ -124,7 +124,7 @@ class SecurityClient(NamespacedClient):
         and information about the realms that authenticated and authorized the user.
         If the user cannot be authenticated, this API returns a 401 status code.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-authenticate.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_authenticate"
@@ -168,7 +168,7 @@ class SecurityClient(NamespacedClient):
         manage roles, rather than using file-based role management. The bulk delete roles
         API cannot delete roles that are defined in roles files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-bulk-delete-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-bulk-delete-role.html>`_
 
         :param names: An array of role names to delete
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -226,7 +226,7 @@ class SecurityClient(NamespacedClient):
         way to manage roles, rather than using file-based role management. The bulk create
         or update roles API cannot update roles that are defined in roles files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-bulk-put-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-bulk-put-role.html>`_
 
         :param roles: A dictionary of role name to RoleDescriptor objects to add or update
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -298,7 +298,7 @@ class SecurityClient(NamespacedClient):
         the requested changes and did not require an update, and error details for any
         failed update.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-bulk-update-api-keys.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-bulk-update-api-keys.html>`_
 
         :param ids: The API key identifiers.
         :param expiration: Expiration time for the API keys. By default, API keys never
@@ -373,7 +373,7 @@ class SecurityClient(NamespacedClient):
         Change passwords. Change the passwords of users in the native realm and built-in
         users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-change-password.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-change-password.html>`_
 
         :param username: The user whose password you want to change. If you do not specify
             this parameter, the password is changed for the current user.
@@ -436,7 +436,7 @@ class SecurityClient(NamespacedClient):
         Clear the API key cache. Evict a subset of all entries from the API key cache.
         The cache is also automatically cleared on state changes of the security index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-api-key-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-api-key-cache.html>`_
 
         :param ids: Comma-separated list of API key IDs to evict from the API key cache.
             To evict all API keys, use `*`. Does not support other wildcard patterns.
@@ -479,9 +479,10 @@ class SecurityClient(NamespacedClient):
         cache. The cache is also automatically cleared for applications that have their
         privileges updated.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-privilege-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-privilege-cache.html>`_
 
-        :param application: A comma-separated list of application names
+        :param application: A comma-separated list of applications. To clear all applications,
+            use an asterism (`*`). It does not support other wildcard patterns.
         """
         if application in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'application'")
@@ -519,12 +520,19 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Clear the user cache. Evict users from the user cache. You can completely clear
-        the cache or evict specific users.
+        the cache or evict specific users. User credentials are cached in memory on each
+        node to avoid connecting to a remote authentication service or hitting the disk
+        for every incoming request. There are realm settings that you can use to configure
+        the user cache. For more information, refer to the documentation about controlling
+        the user cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-cache.html>`_
 
-        :param realms: Comma-separated list of realms to clear
-        :param usernames: Comma-separated list of usernames to clear from the cache
+        :param realms: A comma-separated list of realms. To clear all realms, use an
+            asterisk (`*`). It does not support other wildcard patterns.
+        :param usernames: A comma-separated list of the users to clear from the cache.
+            If you do not specify this parameter, the API evicts all users from the user
+            cache.
         """
         if realms in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'realms'")
@@ -564,9 +572,11 @@ class SecurityClient(NamespacedClient):
         """
         Clear the roles cache. Evict roles from the native role cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-role-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-role-cache.html>`_
 
-        :param name: Role name
+        :param name: A comma-separated list of roles to evict from the role cache. To
+            evict all roles, use an asterisk (`*`). It does not support other wildcard
+            patterns.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -605,13 +615,20 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Clear service account token caches. Evict a subset of all entries from the service
-        account token caches.
+        account token caches. Two separate caches exist for service account tokens: one
+        cache for tokens backed by the `service_tokens` file, and another for tokens
+        backed by the `.security` index. This API clears matching entries from both caches.
+        The cache for service account tokens backed by the `.security` index is cleared
+        automatically on state changes of the security index. The cache for tokens backed
+        by the `service_tokens` file is cleared automatically on file changes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-service-token-caches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-service-token-caches.html>`_
 
-        :param namespace: An identifier for the namespace
-        :param service: An identifier for the service name
-        :param name: A comma-separated list of service token names
+        :param namespace: The namespace, which is a top-level grouping of service accounts.
+        :param service: The name of the service, which must be unique within its namespace.
+        :param name: A comma-separated list of token names to evict from the service
+            account token caches. Use a wildcard (`*`) to evict all tokens that belong
+            to a service account. It does not support other wildcard patterns.
         """
         if namespace in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'namespace'")
@@ -665,30 +682,40 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Create an API key. Create an API key for access without requiring basic authentication.
-        A successful request returns a JSON structure that contains the API key, its
-        unique id, and its name. If applicable, it also returns expiration information
-        for the API key in milliseconds. NOTE: By default, API keys never expire. You
-        can specify expiration information when you create the API keys.
+        IMPORTANT: If the credential that is used to authenticate this request is an
+        API key, the derived API key cannot have any privileges. If you specify privileges,
+        the API returns an error. A successful request returns a JSON structure that
+        contains the API key, its unique id, and its name. If applicable, it also returns
+        expiration information for the API key in milliseconds. NOTE: By default, API
+        keys never expire. You can specify expiration information when you create the
+        API keys. The API keys are created by the Elasticsearch API key service, which
+        is automatically enabled. To configure or turn off the API key service, refer
+        to API key service setting documentation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-create-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-create-api-key.html>`_
 
-        :param expiration: Expiration time for the API key. By default, API keys never
-            expire.
+        :param expiration: The expiration time for the API key. By default, API keys
+            never expire.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
             It supports nested data structure. Within the metadata object, keys beginning
             with `_` are reserved for system usage.
-        :param name: Specifies the name for this API key.
+        :param name: A name for the API key.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
-        :param role_descriptors: An array of role descriptors for this API key. This
-            parameter is optional. When it is not specified or is an empty array, then
-            the API key will have a point in time snapshot of permissions of the authenticated
-            user. If you supply role descriptors then the resultant permissions would
-            be an intersection of API keys permissions and authenticated user’s permissions
-            thereby limiting the access scope for API keys. The structure of role descriptor
-            is the same as the request for create role API. For more details, see create
-            or update roles API.
+        :param role_descriptors: An array of role descriptors for this API key. When
+            it is not specified or it is an empty array, the API key will have a point
+            in time snapshot of permissions of the authenticated user. If you supply
+            role descriptors, the resultant permissions are an intersection of API keys
+            permissions and the authenticated user's permissions thereby limiting the
+            access scope for API keys. The structure of role descriptor is the same as
+            the request for the create role API. For more details, refer to the create
+            or update roles API. NOTE: Due to the way in which this permission intersection
+            is calculated, it is not possible to create an API key that is a child of
+            another API key, unless the derived key is created without any privileges.
+            In this case, you must explicitly specify a role descriptor with no privileges.
+            The derived API key can be used for authentication; it will not have authority
+            to call Elasticsearch APIs.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/api_key"
@@ -757,7 +784,7 @@ class SecurityClient(NamespacedClient):
         API key API. Attempting to update them with the update REST API key API or the
         bulk update REST API keys API will result in an error.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-create-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-create-cross-cluster-api-key.html>`_
 
         :param access: The access to be granted to this API key. The access is composed
             of permissions for cross-cluster search and cross-cluster replication. At
@@ -825,13 +852,21 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Create a service account token. Create a service accounts token for access without
-        requiring basic authentication.
+        requiring basic authentication. NOTE: Service account tokens never expire. You
+        must actively delete them if they are no longer needed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-create-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-create-service-token.html>`_
 
-        :param namespace: An identifier for the namespace
-        :param service: An identifier for the service name
-        :param name: An identifier for the token name
+        :param namespace: The name of the namespace, which is a top-level grouping of
+            service accounts.
+        :param service: The name of the service.
+        :param name: The name for the service account token. If omitted, a random name
+            will be generated. Token names must be at least one and no more than 256
+            characters. They can contain alphanumeric characters (a-z, A-Z, 0-9), dashes
+            (`-`), and underscores (`_`), but cannot begin with an underscore. NOTE:
+            Token names must be unique in the context of the associated service account.
+            They must also be globally unique with their fully qualified names, which
+            are comprised of the service account principal and token name, such as `<namespace>/<service>/<token-name>`.
         :param refresh: If `true` then refresh the affected shards to make this operation
             visible to search, if `wait_for` (the default) then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -909,7 +944,7 @@ class SecurityClient(NamespacedClient):
         the TLS authentication and this API translates that authentication into an Elasticsearch
         access token.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delegate-pki-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delegate-pki-authentication.html>`_
 
         :param x509_certificate_chain: The X509Certificate chain, which is represented
             as an ordered string array. Each string in the array is a base64-encoded
@@ -963,12 +998,16 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete application privileges.
+        Delete application privileges. To use this API, you must have one of the following
+        privileges: * The `manage_security` cluster privilege (or a greater privilege
+        such as `all`). * The "Manage Application Privileges" global privilege for the
+        application being referenced in the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-privilege.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-privilege.html>`_
 
-        :param application: Application name
-        :param name: Privilege name
+        :param application: The name of the application. Application privileges are always
+            associated with exactly one application.
+        :param name: The name of the privilege.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1019,11 +1058,14 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete roles. Delete roles in the native realm.
+        Delete roles. Delete roles in the native realm. The role management APIs are
+        generally the preferred way to manage roles, rather than using file-based role
+        management. The delete roles API cannot remove roles that are defined in roles
+        files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-role.html>`_
 
-        :param name: Role name
+        :param name: The name of the role.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1067,11 +1109,16 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete role mappings.
+        Delete role mappings. Role mappings define which roles are assigned to each user.
+        The role mapping APIs are generally the preferred way to manage role mappings
+        rather than using role mapping files. The delete role mappings API cannot remove
+        role mappings that are defined in role mapping files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-role-mapping.html>`_
 
-        :param name: Role-mapping name
+        :param name: The distinct name that identifies the role mapping. The name is
+            used solely as an identifier to facilitate interaction via the API; it does
+            not affect the behavior of the mapping in any way.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1120,11 +1167,11 @@ class SecurityClient(NamespacedClient):
         Delete service account tokens. Delete service account tokens for a service in
         a specified namespace.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-service-token.html>`_
 
-        :param namespace: An identifier for the namespace
-        :param service: An identifier for the service name
-        :param name: An identifier for the token name
+        :param namespace: The namespace, which is a top-level grouping of service accounts.
+        :param service: The service name.
+        :param name: The name of the service account token.
         :param refresh: If `true` then refresh the affected shards to make this operation
             visible to search, if `wait_for` (the default) then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1178,9 +1225,9 @@ class SecurityClient(NamespacedClient):
         """
         Delete users. Delete users from the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-user.html>`_
 
-        :param username: username
+        :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1224,11 +1271,12 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Disable users. Disable users in the native realm.
+        Disable users. Disable users in the native realm. By default, when you create
+        users, they are enabled. You can use this API to revoke a user's access to Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-disable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-disable-user.html>`_
 
-        :param username: The username of the user to disable
+        :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1282,7 +1330,7 @@ class SecurityClient(NamespacedClient):
         API to disable a user profile so it’s not visible in these searches. To re-enable
         a disabled user profile, use the enable user profile API .
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-disable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-disable-user-profile.html>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1328,11 +1376,12 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Enable users. Enable users in the native realm.
+        Enable users. Enable users in the native realm. By default, when you create users,
+        they are enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-enable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-enable-user.html>`_
 
-        :param username: The username of the user to enable
+        :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1385,7 +1434,7 @@ class SecurityClient(NamespacedClient):
         profile searches. If you later disable the user profile, you can use the enable
         user profile API to make the profile visible in these searches again.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-enable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-enable-user-profile.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1428,9 +1477,12 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Enroll Kibana. Enable a Kibana instance to configure itself for communication
-        with a secured Elasticsearch cluster.
+        with a secured Elasticsearch cluster. NOTE: This API is currently intended for
+        internal use only by Kibana. Kibana uses this API internally to configure itself
+        for communications with an Elasticsearch cluster that already has security features
+        enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-kibana-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-kibana-enrollment.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/kibana"
@@ -1464,9 +1516,13 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Enroll a node. Enroll a new node to allow it to join an existing cluster with
-        security features enabled.
+        security features enabled. The response contains all the necessary information
+        for the joining node to bootstrap discovery and security related settings so
+        that it can successfully join the cluster. The response contains key and certificate
+        material that allows the caller to generate valid signed certificates for the
+        HTTP layer of all nodes in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-node-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-node-enrollment.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/node"
@@ -1513,7 +1569,7 @@ class SecurityClient(NamespacedClient):
         privileges (including `manage_security`), this API returns all API keys regardless
         of ownership.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-api-key.html>`_
 
         :param active_only: A boolean flag that can be used to query API keys that are
             currently active. An API key is considered active if it is neither invalidated,
@@ -1588,7 +1644,7 @@ class SecurityClient(NamespacedClient):
         Get builtin privileges. Get the list of cluster privileges and index privileges
         that are available in this version of Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-builtin-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-builtin-privileges.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/privilege/_builtin"
@@ -1623,12 +1679,18 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get application privileges.
+        Get application privileges. To use this API, you must have one of the following
+        privileges: * The `read_security` cluster privilege (or a greater privilege such
+        as `manage_security` or `all`). * The "Manage Application Privileges" global
+        privilege for the application being referenced in the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-privileges.html>`_
 
-        :param application: Application name
-        :param name: Privilege name
+        :param application: The name of the application. Application privileges are always
+            associated with exactly one application. If you do not specify this parameter,
+            the API returns information about all privileges for all applications.
+        :param name: The name of the privilege. If you do not specify this parameter,
+            the API returns information about all privileges for the requested application.
         """
         __path_parts: t.Dict[str, str]
         if application not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
@@ -1674,7 +1736,7 @@ class SecurityClient(NamespacedClient):
         the preferred way to manage roles, rather than using file-based role management.
         The get roles API cannot retrieve roles that are defined in roles files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-role.html>`_
 
         :param name: The name of the role. You can specify multiple roles as a comma-separated
             list. If you do not specify this parameter, the API returns information about
@@ -1722,7 +1784,7 @@ class SecurityClient(NamespacedClient):
         rather than using role mapping files. The get role mappings API cannot retrieve
         role mappings that are defined in role mapping files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-role-mapping.html>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1769,14 +1831,15 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Get service accounts. Get a list of service accounts that match the provided
-        path parameters.
+        path parameters. NOTE: Currently, only the `elastic/fleet-server` service account
+        is available.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-service-accounts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-service-accounts.html>`_
 
-        :param namespace: Name of the namespace. Omit this parameter to retrieve information
-            about all service accounts. If you omit this parameter, you must also omit
-            the `service` parameter.
-        :param service: Name of the service name. Omit this parameter to retrieve information
+        :param namespace: The name of the namespace. Omit this parameter to retrieve
+            information about all service accounts. If you omit this parameter, you must
+            also omit the `service` parameter.
+        :param service: The service name. Omit this parameter to retrieve information
             about all service accounts that belong to the specified `namespace`.
         """
         __path_parts: t.Dict[str, str]
@@ -1820,12 +1883,19 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get service account credentials.
+        Get service account credentials. To use this API, you must have at least the
+        `read_security` cluster privilege (or a greater privilege such as `manage_service_account`
+        or `manage_security`). The response includes service account tokens that were
+        created with the create service account tokens API as well as file-backed tokens
+        from all nodes of the cluster. NOTE: For tokens backed by the `service_tokens`
+        file, the API collects them from all nodes of the cluster. Tokens with the same
+        name from different nodes are assumed to be the same token and are only counted
+        once towards the total number of service tokens.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-service-credentials.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-service-credentials.html>`_
 
-        :param namespace: Name of the namespace.
-        :param service: Name of the service name.
+        :param namespace: The name of the namespace.
+        :param service: The service name.
         """
         if namespace in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'namespace'")
@@ -1867,9 +1937,11 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Get security index settings. Get the user-configurable settings for the security
-        internal index (`.security` and associated indices).
+        internal index (`.security` and associated indices). Only a subset of the index
+        settings — those that are user-configurable—will be shown. This includes: * `index.auto_expand_replicas`
+        * `index.number_of_replicas`
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-settings.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -1932,15 +2004,39 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Get a token. Create a bearer token for access without requiring basic authentication.
+        The tokens are created by the Elasticsearch Token Service, which is automatically
+        enabled when you configure TLS on the HTTP interface. Alternatively, you can
+        explicitly enable the `xpack.security.authc.token.enabled` setting. When you
+        are running in production mode, a bootstrap check prevents you from enabling
+        the token service unless you also enable TLS on the HTTP interface. The get token
+        API takes the same parameters as a typical OAuth 2.0 token API except for the
+        use of a JSON request body. A successful get token API call returns a JSON structure
+        that contains the access token, the amount of time (seconds) that the token expires
+        in, the type, and the scope if available. The tokens returned by the get token
+        API have a finite period of time for which they are valid and after that time
+        period, they can no longer be used. That time period is defined by the `xpack.security.authc.token.timeout`
+        setting. If you want to invalidate a token immediately, you can do so by using
+        the invalidate token API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-token.html>`_
 
-        :param grant_type:
-        :param kerberos_ticket:
-        :param password:
-        :param refresh_token:
-        :param scope:
-        :param username:
+        :param grant_type: The type of grant. Supported grant types are: `password`,
+            `_kerberos`, `client_credentials`, and `refresh_token`.
+        :param kerberos_ticket: The base64 encoded kerberos ticket. If you specify the
+            `_kerberos` grant type, this parameter is required. This parameter is not
+            valid with any other supported grant type.
+        :param password: The user's password. If you specify the `password` grant type,
+            this parameter is required. This parameter is not valid with any other supported
+            grant type.
+        :param refresh_token: The string that was returned when you created the token,
+            which enables you to extend its life. If you specify the `refresh_token`
+            grant type, this parameter is required. This parameter is not valid with
+            any other supported grant type.
+        :param scope: The scope of the token. Currently tokens are only issued for a
+            scope of FULL regardless of the value sent with the request.
+        :param username: The username that identifies the user. If you specify the `password`
+            grant type, this parameter is required. This parameter is not valid with
+            any other supported grant type.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/oauth2/token"
@@ -1992,13 +2088,13 @@ class SecurityClient(NamespacedClient):
         """
         Get users. Get information about users in the native realm and built-in users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-user.html>`_
 
         :param username: An identifier for the user. You can specify multiple usernames
             as a comma-separated list. If you omit this parameter, the API retrieves
             information about all users.
-        :param with_profile_uid: If true will return the User Profile ID for a user,
-            if any.
+        :param with_profile_uid: Determines whether to retrieve the user profile UID,
+            if it exists, for the users.
         """
         __path_parts: t.Dict[str, str]
         if username not in SKIP_IN_PATH:
@@ -2041,9 +2137,12 @@ class SecurityClient(NamespacedClient):
         username: t.Optional[t.Union[None, str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get user privileges.
+        Get user privileges. Get the security privileges for the logged in user. All
+        users can use this API, but only to determine their own privileges. To check
+        the privileges of other users, you must use the run as feature. To check whether
+        a user has a specific list of privileges, use the has privileges API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-user-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-user-privileges.html>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -2097,7 +2196,7 @@ class SecurityClient(NamespacedClient):
         applications should not call this API directly. Elastic reserves the right to
         change or remove this feature in future releases without prior notice.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-user-profile.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: A comma-separated list of filters for the `data` field of the profile
@@ -2162,28 +2261,30 @@ class SecurityClient(NamespacedClient):
         Grant an API key. Create an API key on behalf of another user. This API is similar
         to the create API keys API, however it creates the API key for a user that is
         different than the user that runs the API. The caller must have authentication
-        credentials (either an access token, or a username and password) for the user
-        on whose behalf the API key will be created. It is not possible to use this API
-        to create an API key without that user’s credentials. The user, for whom the
-        authentication credentials is provided, can optionally "run as" (impersonate)
-        another user. In this case, the API key will be created on behalf of the impersonated
-        user. This API is intended be used by applications that need to create and manage
-        API keys for end users, but cannot guarantee that those users have permission
-        to create API keys on their own behalf. A successful grant API key API call returns
-        a JSON structure that contains the API key, its unique id, and its name. If applicable,
+        credentials for the user on whose behalf the API key will be created. It is not
+        possible to use this API to create an API key without that user's credentials.
+        The supported user authentication credential types are: * username and password
+        * Elasticsearch access tokens * JWTs The user, for whom the authentication credentials
+        is provided, can optionally "run as" (impersonate) another user. In this case,
+        the API key will be created on behalf of the impersonated user. This API is intended
+        be used by applications that need to create and manage API keys for end users,
+        but cannot guarantee that those users have permission to create API keys on their
+        own behalf. The API keys are created by the Elasticsearch API key service, which
+        is automatically enabled. A successful grant API key API call returns a JSON
+        structure that contains the API key, its unique id, and its name. If applicable,
         it also returns expiration information for the API key in milliseconds. By default,
         API keys never expire. You can specify expiration information when you create
         the API keys.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-grant-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-grant-api-key.html>`_
 
-        :param api_key: Defines the API key.
+        :param api_key: The API key.
         :param grant_type: The type of grant. Supported grant types are: `access_token`,
             `password`.
-        :param access_token: The user’s access token. If you specify the `access_token`
+        :param access_token: The user's access token. If you specify the `access_token`
             grant type, this parameter is required. It is not valid with other grant
             types.
-        :param password: The user’s password. If you specify the `password` grant type,
+        :param password: The user's password. If you specify the `password` grant type,
             this parameter is required. It is not valid with other grant types.
         :param run_as: The name of the user to be impersonated.
         :param username: The user name that identifies the user. If you specify the `password`
@@ -2315,9 +2416,10 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Check user privileges. Determine whether the specified user has a specified list
-        of privileges.
+        of privileges. All users can use this API, but only to determine their own privileges.
+        To check the privileges of other users, you must use the run as feature.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-has-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-has-privileges.html>`_
 
         :param user: Username
         :param application:
@@ -2381,7 +2483,7 @@ class SecurityClient(NamespacedClient):
         applications should not call this API directly. Elastic reserves the right to
         change or remove this feature in future releases without prior notice.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-has-privileges-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-has-privileges-user-profile.html>`_
 
         :param privileges: An object containing all the privileges to be checked.
         :param uids: A list of profile IDs. The privileges are checked for associated
@@ -2442,29 +2544,33 @@ class SecurityClient(NamespacedClient):
         key or grant API key APIs. Invalidated API keys fail authentication, but they
         can still be viewed using the get API key information and query API key information
         APIs, for at least the configured retention period, until they are automatically
-        deleted. The `manage_api_key` privilege allows deleting any API keys. The `manage_own_api_key`
-        only allows deleting API keys that are owned by the user. In addition, with the
-        `manage_own_api_key` privilege, an invalidation request must be issued in one
-        of the three formats: - Set the parameter `owner=true`. - Or, set both `username`
-        and `realm_name` to match the user’s identity. - Or, if the request is issued
-        by an API key, that is to say an API key invalidates itself, specify its ID in
-        the `ids` field.
+        deleted. To use this API, you must have at least the `manage_security`, `manage_api_key`,
+        or `manage_own_api_key` cluster privileges. The `manage_security` privilege allows
+        deleting any API key, including both REST and cross cluster API keys. The `manage_api_key`
+        privilege allows deleting any REST API key, but not cross cluster API keys. The
+        `manage_own_api_key` only allows deleting REST API keys that are owned by the
+        user. In addition, with the `manage_own_api_key` privilege, an invalidation request
+        must be issued in one of the three formats: - Set the parameter `owner=true`.
+        - Or, set both `username` and `realm_name` to match the user's identity. - Or,
+        if the request is issued by an API key, that is to say an API key invalidates
+        itself, specify its ID in the `ids` field.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-invalidate-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-invalidate-api-key.html>`_
 
         :param id:
         :param ids: A list of API key ids. This parameter cannot be used with any of
             `name`, `realm_name`, or `username`.
         :param name: An API key name. This parameter cannot be used with any of `ids`,
             `realm_name` or `username`.
-        :param owner: Can be used to query API keys owned by the currently authenticated
-            user. The `realm_name` or `username` parameters cannot be specified when
-            this parameter is set to `true` as they are assumed to be the currently authenticated
-            ones.
+        :param owner: Query API keys owned by the currently authenticated user. The `realm_name`
+            or `username` parameters cannot be specified when this parameter is set to
+            `true` as they are assumed to be the currently authenticated ones. NOTE:
+            At least one of `ids`, `name`, `username`, and `realm_name` must be specified
+            if `owner` is `false`.
         :param realm_name: The name of an authentication realm. This parameter cannot
             be used with either `ids` or `name`, or when `owner` flag is set to `true`.
         :param username: The username of a user. This parameter cannot be used with either
-            `ids` or `name`, or when `owner` flag is set to `true`.
+            `ids` or `name` or when `owner` flag is set to `true`.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/api_key"
@@ -2524,14 +2630,21 @@ class SecurityClient(NamespacedClient):
         longer be used. The time period is defined by the `xpack.security.authc.token.timeout`
         setting. The refresh tokens returned by the get token API are only valid for
         24 hours. They can also be used exactly once. If you want to invalidate one or
-        more access or refresh tokens immediately, use this invalidate token API.
+        more access or refresh tokens immediately, use this invalidate token API. NOTE:
+        While all parameters are optional, at least one of them is required. More specifically,
+        either one of `token` or `refresh_token` parameters is required. If none of these
+        two are specified, then `realm_name` and/or `username` need to be specified.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-invalidate-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-invalidate-token.html>`_
 
-        :param realm_name:
-        :param refresh_token:
-        :param token:
-        :param username:
+        :param realm_name: The name of an authentication realm. This parameter cannot
+            be used with either `refresh_token` or `token`.
+        :param refresh_token: A refresh token. This parameter cannot be used if any of
+            `refresh_token`, `realm_name`, or `username` are used.
+        :param token: An access token. This parameter cannot be used if any of `refresh_token`,
+            `realm_name`, or `username` are used.
+        :param username: The username of a user. This parameter cannot be used with either
+            `refresh_token` or `token`.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/oauth2/token"
@@ -2589,7 +2702,7 @@ class SecurityClient(NamespacedClient):
         are used internally by Kibana in order to provide OpenID Connect based authentication,
         but can also be used by other, custom web applications or other clients.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-oidc-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-oidc-authenticate.html>`_
 
         :param nonce: Associate a client session with an ID token and mitigate replay
             attacks. This value needs to be the same as the one that was provided to
@@ -2670,7 +2783,7 @@ class SecurityClient(NamespacedClient):
         Connect based authentication, but can also be used by other, custom web applications
         or other clients.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-oidc-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-oidc-logout.html>`_
 
         :param access_token: The access token to be invalidated.
         :param refresh_token: The refresh token to be invalidated.
@@ -2733,7 +2846,7 @@ class SecurityClient(NamespacedClient):
         Connect based authentication, but can also be used by other, custom web applications
         or other clients.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-oidc-prepare-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-oidc-prepare-authentication.html>`_
 
         :param iss: In the case of a third party initiated single sign on, this is the
             issuer identifier for the OP that the RP is to send the authentication request
@@ -2808,9 +2921,22 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Create or update application privileges.
+        Create or update application privileges. To use this API, you must have one of
+        the following privileges: * The `manage_security` cluster privilege (or a greater
+        privilege such as `all`). * The "Manage Application Privileges" global privilege
+        for the application being referenced in the request. Application names are formed
+        from a prefix, with an optional suffix that conform to the following rules: *
+        The prefix must begin with a lowercase ASCII letter. * The prefix must contain
+        only ASCII letters or digits. * The prefix must be at least 3 characters long.
+        * If the suffix exists, it must begin with either a dash `-` or `_`. * The suffix
+        cannot contain any of the following characters: `\\`, `/`, `*`, `?`, `"`, `<`,
+        `>`, `|`, `,`, `*`. * No part of the name can contain whitespace. Privilege names
+        must begin with a lowercase ASCII letter and must contain only ASCII letters
+        and digits along with the characters `_`, `-`, and `.`. Action names can contain
+        any number of printable ASCII characters and must contain at least one of the
+        following characters: `/`, `*`, `:`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-privileges.html>`_
 
         :param privileges:
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -2959,7 +3085,7 @@ class SecurityClient(NamespacedClient):
         The create or update roles API cannot update roles that are defined in roles
         files. File-based role management is not available in Elastic Serverless.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-role.html>`_
 
         :param name: The name of the role.
         :param applications: A list of application privilege entries.
@@ -2976,7 +3102,10 @@ class SecurityClient(NamespacedClient):
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
         :param remote_cluster: A list of remote cluster permissions entries.
-        :param remote_indices: A list of remote indices permissions entries.
+        :param remote_indices: A list of remote indices permissions entries. NOTE: Remote
+            indices are effective for remote clusters configured with the API key based
+            model. They have no effect for remote clusters configured with the certificate
+            based model.
         :param run_as: A list of users that the owners of this role can impersonate.
             *Note*: in Serverless, the run-as feature is disabled. For API compatibility,
             you can still specify an empty `run_as` field, but a non-empty list will
@@ -3071,21 +3200,45 @@ class SecurityClient(NamespacedClient):
         that are granted to those users. The role mapping APIs are generally the preferred
         way to manage role mappings rather than using role mapping files. The create
         or update role mappings API cannot update role mappings that are defined in role
-        mapping files. This API does not create roles. Rather, it maps users to existing
-        roles. Roles can be created by using the create or update roles API or roles
-        files.
+        mapping files. NOTE: This API does not create roles. Rather, it maps users to
+        existing roles. Roles can be created by using the create or update roles API
+        or roles files. **Role templates** The most common use for role mappings is to
+        create a mapping from a known value on the user to a fixed role name. For example,
+        all users in the `cn=admin,dc=example,dc=com` LDAP group should be given the
+        superuser role in Elasticsearch. The `roles` field is used for this purpose.
+        For more complex needs, it is possible to use Mustache templates to dynamically
+        determine the names of the roles that should be granted to the user. The `role_templates`
+        field is used for this purpose. NOTE: To use role templates successfully, the
+        relevant scripting feature must be enabled. Otherwise, all attempts to create
+        a role mapping with role templates fail. All of the user fields that are available
+        in the role mapping rules are also available in the role templates. Thus it is
+        possible to assign a user to a role that reflects their username, their groups,
+        or the name of the realm to which they authenticated. By default a template is
+        evaluated to produce a single string that is the name of the role which should
+        be assigned to the user. If the format of the template is set to "json" then
+        the template is expected to produce a JSON string or an array of JSON strings
+        for the role names.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-role-mapping.html>`_
 
-        :param name: Role-mapping name
-        :param enabled:
-        :param metadata:
+        :param name: The distinct name that identifies the role mapping. The name is
+            used solely as an identifier to facilitate interaction via the API; it does
+            not affect the behavior of the mapping in any way.
+        :param enabled: Mappings that have `enabled` set to `false` are ignored when
+            role mapping is performed.
+        :param metadata: Additional metadata that helps define which roles are assigned
+            to each user. Within the metadata object, keys beginning with `_` are reserved
+            for system usage.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
-        :param role_templates:
-        :param roles:
-        :param rules:
+        :param role_templates: A list of Mustache templates that will be evaluated to
+            determine the roles names that should granted to the users that match the
+            role mapping rules. Exactly one of `roles` or `role_templates` must be specified.
+        :param roles: A list of role names that are granted to the users that match the
+            role mapping rules. Exactly one of `roles` or `role_templates` must be specified.
+        :param rules: The rules that determine which users should be matched by the mapping.
+            A rule is a logical condition that is expressed by using a JSON DSL.
         :param run_as:
         """
         if name in SKIP_IN_PATH:
@@ -3160,23 +3313,38 @@ class SecurityClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Create or update users. A password is required for adding a new user but is optional
-        when updating an existing user. To change a user’s password without updating
-        any other fields, use the change password API.
+        Create or update users. Add and update users in the native realm. A password
+        is required for adding a new user but is optional when updating an existing user.
+        To change a user's password without updating any other fields, use the change
+        password API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-user.html>`_
 
-        :param username: The username of the User
-        :param email:
-        :param enabled:
-        :param full_name:
-        :param metadata:
-        :param password:
-        :param password_hash:
-        :param refresh: If `true` (the default) then refresh the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` then do nothing with refreshes.
-        :param roles:
+        :param username: An identifier for the user. NOTE: Usernames must be at least
+            1 and no more than 507 characters. They can contain alphanumeric characters
+            (a-z, A-Z, 0-9), spaces, punctuation, and printable symbols in the Basic
+            Latin (ASCII) block. Leading or trailing whitespace is not allowed.
+        :param email: The email of the user.
+        :param enabled: Specifies whether the user is enabled.
+        :param full_name: The full name of the user.
+        :param metadata: Arbitrary metadata that you want to associate with the user.
+        :param password: The user's password. Passwords must be at least 6 characters
+            long. When adding a user, one of `password` or `password_hash` is required.
+            When updating an existing user, the password is optional, so that other fields
+            on the user (such as their roles) may be updated without modifying the user's
+            password
+        :param password_hash: A hash of the user's password. This must be produced using
+            the same hashing algorithm as has been configured for password storage. For
+            more details, see the explanation of the `xpack.security.authc.password_hashing.algorithm`
+            setting in the user cache and password hash algorithm documentation. Using
+            this parameter allows the client to pre-hash the password for performance
+            and/or confidentiality reasons. The `password` parameter and the `password_hash`
+            parameter cannot be used in the same request.
+        :param refresh: Valid values are `true`, `false`, and `wait_for`. These values
+            have the same meaning as in the index API, but the default value for this
+            API is true.
+        :param roles: A set of roles the user has. The roles determine the user's access
+            permissions. To create a user without any roles, specify an empty list (`[]`).
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
@@ -3260,9 +3428,14 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Find API keys with a query. Get a paginated list of API keys and their information.
-        You can optionally filter the results with a query.
+        You can optionally filter the results with a query. To use this API, you must
+        have at least the `manage_own_api_key` or the `read_security` cluster privileges.
+        If you have only the `manage_own_api_key` privilege, this API returns only the
+        API keys that you own. If you have the `read_security`, `manage_api_key`, or
+        greater privileges (including `manage_security`), this API returns all API keys
+        regardless of ownership.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-query-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-query-api-key.html>`_
 
         :param aggregations: Any aggregations to run over the corpus of returned API
             keys. Aggregations and queries work together. Aggregations are computed only
@@ -3276,30 +3449,39 @@ class SecurityClient(NamespacedClient):
             `terms`, `range`, `date_range`, `missing`, `cardinality`, `value_count`,
             `composite`, `filter`, and `filters`. Additionally, aggregations only run
             over the same subset of fields that query works with.
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the `search_after` parameter.
+        :param from_: The starting document offset. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
         :param query: A query to filter which API keys to return. If the query parameter
             is missing, it is equivalent to a `match_all` query. The query supports a
             subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,
             `ids`, `prefix`, `wildcard`, `exists`, `range`, and `simple_query_string`.
             You can query the following public information associated with an API key:
             `id`, `type`, `name`, `creation`, `expiration`, `invalidated`, `invalidation`,
-            `username`, `realm`, and `metadata`.
-        :param search_after: Search after definition
-        :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the `from` and `size` parameters. To page through
-            more hits, use the `search_after` parameter.
-        :param sort: Other than `id`, all public fields of an API key are eligible for
-            sorting. In addition, sort can also be applied to the `_doc` field to sort
-            by index order.
+            `username`, `realm`, and `metadata`. NOTE: The queryable string values associated
+            with API keys are internally mapped as keywords. Consequently, if no `analyzer`
+            parameter is specified for a `match` query, then the provided match query
+            string is interpreted as a single keyword value. Such a match query is hence
+            equivalent to a `term` query.
+        :param search_after: The search after definition.
+        :param size: The number of hits to return. It must not be negative. The `size`
+            parameter can be set to `0`, in which case no API key matches are returned,
+            only the aggregation results. By default, you cannot page through more than
+            10,000 hits using the `from` and `size` parameters. To page through more
+            hits, use the `search_after` parameter.
+        :param sort: The sort definition. Other than `id`, all public fields of an API
+            key are eligible for sorting. In addition, sort can also be applied to the
+            `_doc` field to sort by index order.
         :param typed_keys: Determines whether aggregation names are prefixed by their
             respective types in the response.
         :param with_limited_by: Return the snapshot of the owner user's role descriptors
             associated with the API key. An API key's actual permission is the intersection
-            of its assigned role descriptors and the owner user's role descriptors.
-        :param with_profile_uid: Determines whether to also retrieve the profile uid,
-            for the API key owner principal, if it exists.
+            of its assigned role descriptors and the owner user's role descriptors (effectively
+            limited by it). An API key cannot retrieve any API key’s limited-by role
+            descriptors (including itself) unless it has `manage_api_key` or higher privileges.
+        :param with_profile_uid: Determines whether to also retrieve the profile UID
+            for the API key owner principal. If it exists, the profile UID is returned
+            under the `profile_uid` response field for each API key.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_query/api_key"
@@ -3386,26 +3568,30 @@ class SecurityClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Find roles with a query. Get roles in a paginated manner. You can optionally
-        filter the results with a query.
+        Find roles with a query. Get roles in a paginated manner. The role management
+        APIs are generally the preferred way to manage roles, rather than using file-based
+        role management. The query roles API does not retrieve roles that are defined
+        in roles files, nor built-in ones. You can optionally filter the results with
+        a query. Also, the results can be paginated and sorted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-query-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-query-role.html>`_
 
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the `search_after` parameter.
+        :param from_: The starting document offset. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
         :param query: A query to filter which roles to return. If the query parameter
             is missing, it is equivalent to a `match_all` query. The query supports a
             subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,
             `ids`, `prefix`, `wildcard`, `exists`, `range`, and `simple_query_string`.
             You can query the following information associated with roles: `name`, `description`,
-            `metadata`, `applications.application`, `applications.privileges`, `applications.resources`.
-        :param search_after: Search after definition
-        :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the `from` and `size` parameters. To page through
-            more hits, use the `search_after` parameter.
-        :param sort: All public fields of a role are eligible for sorting. In addition,
-            sort can also be applied to the `_doc` field to sort by index order.
+            `metadata`, `applications.application`, `applications.privileges`, and `applications.resources`.
+        :param search_after: The search after definition.
+        :param size: The number of hits to return. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
+        :param sort: The sort definition. You can sort on `username`, `roles`, or `enabled`.
+            In addition, sort can also be applied to the `_doc` field to sort by index
+            order.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_query/role"
@@ -3473,27 +3659,30 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Find users with a query. Get information for users in a paginated manner. You
-        can optionally filter the results with a query.
+        can optionally filter the results with a query. NOTE: As opposed to the get user
+        API, built-in users are excluded from the result. This API is only for native
+        users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-query-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-query-user.html>`_
 
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the `search_after` parameter.
+        :param from_: The starting document offset. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
         :param query: A query to filter which users to return. If the query parameter
             is missing, it is equivalent to a `match_all` query. The query supports a
             subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,
             `ids`, `prefix`, `wildcard`, `exists`, `range`, and `simple_query_string`.
             You can query the following information associated with user: `username`,
-            `roles`, `enabled`
-        :param search_after: Search after definition
-        :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the `from` and `size` parameters. To page through
-            more hits, use the `search_after` parameter.
-        :param sort: Fields eligible for sorting are: username, roles, enabled In addition,
-            sort can also be applied to the `_doc` field to sort by index order.
-        :param with_profile_uid: If true will return the User Profile ID for the users
-            in the query result, if any.
+            `roles`, `enabled`, `full_name`, and `email`.
+        :param search_after: The search after definition
+        :param size: The number of hits to return. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
+        :param sort: The sort definition. Fields eligible for sorting are: `username`,
+            `roles`, `enabled`. In addition, sort can also be applied to the `_doc` field
+            to sort by index order.
+        :param with_profile_uid: Determines whether to retrieve the user profile UID,
+            if it exists, for the users.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_query/user"
@@ -3565,7 +3754,7 @@ class SecurityClient(NamespacedClient):
         Elasticsearch access and refresh tokens, which can be used for authentication
         against Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-authenticate.html>`_
 
         :param content: The SAML response as it was sent by the user's browser, usually
             a Base64 encoded XML document.
@@ -3636,7 +3825,7 @@ class SecurityClient(NamespacedClient):
         of this API must prepare the request accordingly so that this API can handle
         either of them.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-complete-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-complete-logout.html>`_
 
         :param ids: A JSON array with all the valid SAML Request Ids that the caller
             of the API has for the current user.
@@ -3710,7 +3899,7 @@ class SecurityClient(NamespacedClient):
         to that specific SAML principal and provides a URL that contains a SAML LogoutResponse
         message. Thus the user can be redirected back to their IdP.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-invalidate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-invalidate.html>`_
 
         :param query_string: The query part of the URL that the user was redirected to
             by the SAML IdP to initiate the Single Logout. This query should include
@@ -3784,7 +3973,7 @@ class SecurityClient(NamespacedClient):
         a URL to redirect the user to the IdP that contains a SAML logout request (starting
         an SP-initiated SAML Single Logout).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-logout.html>`_
 
         :param token: The access token that was returned as a response to calling the
             SAML authenticate API. Alternatively, the most recent token that was received
@@ -3854,7 +4043,7 @@ class SecurityClient(NamespacedClient):
         request. The caller of this API needs to store this identifier as it needs to
         be used in a following step of the authentication process.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-prepare-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-prepare-authentication.html>`_
 
         :param acs: The Assertion Consumer Service URL that matches the one of the SAML
             realms in Elasticsearch. The realm is used to generate the authentication
@@ -3913,7 +4102,7 @@ class SecurityClient(NamespacedClient):
         This API generates Service Provider metadata based on the configuration of a
         SAML realm in Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-sp-metadata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-sp-metadata.html>`_
 
         :param realm_name: The name of the SAML realm in Elasticsearch.
         """
@@ -3964,7 +4153,7 @@ class SecurityClient(NamespacedClient):
         Elastic reserves the right to change or remove this feature in future releases
         without prior notice.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-suggest-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-suggest-user-profile.html>`_
 
         :param data: A comma-separated list of filters for the `data` field of the profile
             document. To return all content use `data=*`. To return a subset of content,
@@ -4033,38 +4222,44 @@ class SecurityClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Update an API key. Updates attributes of an existing API key. Users can only
-        update API keys that they created or that were granted to them. Use this API
-        to update API keys created by the create API Key or grant API Key APIs. If you
-        need to apply the same update to many API keys, you can use bulk update API Keys
-        to reduce overhead. It’s not possible to update expired API keys, or API keys
-        that have been invalidated by invalidate API Key. This API supports updates to
-        an API key’s access scope and metadata. The access scope of an API key is derived
-        from the `role_descriptors` you specify in the request, and a snapshot of the
-        owner user’s permissions at the time of the request. The snapshot of the owner’s
-        permissions is updated automatically on every call. If you don’t specify `role_descriptors`
-        in the request, a call to this API might still change the API key’s access scope.
-        This change can occur if the owner user’s permissions have changed since the
-        API key was created or last modified. To update another user’s API key, use the
-        `run_as` feature to submit a request on behalf of another user. IMPORTANT: It’s
-        not possible to use an API key as the authentication credential for this API.
-        To update an API key, the owner user’s credentials are required.
+        Update an API key. Update attributes of an existing API key. This API supports
+        updates to an API key's access scope, expiration, and metadata. To use this API,
+        you must have at least the `manage_own_api_key` cluster privilege. Users can
+        only update API keys that they created or that were granted to them. To update
+        another user’s API key, use the `run_as` feature to submit a request on behalf
+        of another user. IMPORTANT: It's not possible to use an API key as the authentication
+        credential for this API. The owner user’s credentials are required. Use this
+        API to update API keys created by the create API key or grant API Key APIs. If
+        you need to apply the same update to many API keys, you can use the bulk update
+        API keys API to reduce overhead. It's not possible to update expired API keys
+        or API keys that have been invalidated by the invalidate API key API. The access
+        scope of an API key is derived from the `role_descriptors` you specify in the
+        request and a snapshot of the owner user's permissions at the time of the request.
+        The snapshot of the owner's permissions is updated automatically on every call.
+        IMPORTANT: If you don't specify `role_descriptors` in the request, a call to
+        this API might still change the API key's access scope. This change can occur
+        if the owner user's permissions have changed since the API key was created or
+        last modified.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-api-key.html>`_
 
         :param id: The ID of the API key to update.
-        :param expiration: Expiration time for the API key.
+        :param expiration: The expiration time for the API key. By default, API keys
+            never expire. This property can be omitted to leave the expiration unchanged.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
-            It supports nested data structure. Within the metadata object, keys beginning
-            with _ are reserved for system usage.
-        :param role_descriptors: An array of role descriptors for this API key. This
-            parameter is optional. When it is not specified or is an empty array, then
-            the API key will have a point in time snapshot of permissions of the authenticated
-            user. If you supply role descriptors then the resultant permissions would
-            be an intersection of API keys permissions and authenticated user’s permissions
-            thereby limiting the access scope for API keys. The structure of role descriptor
-            is the same as the request for create role API. For more details, see create
-            or update roles API.
+            It supports a nested data structure. Within the metadata object, keys beginning
+            with `_` are reserved for system usage. When specified, this value fully
+            replaces the metadata previously associated with the API key.
+        :param role_descriptors: The role descriptors to assign to this API key. The
+            API key's effective permissions are an intersection of its assigned privileges
+            and the point in time snapshot of permissions of the owner user. You can
+            assign new privileges by specifying them in this parameter. To remove assigned
+            privileges, you can supply an empty `role_descriptors` parameter, that is
+            to say, an empty object `{}`. If an API key has no assigned privileges, it
+            inherits the owner user's full permissions. The snapshot of the owner's permissions
+            is always updated, whether you supply the `role_descriptors` parameter or
+            not. The structure of a role descriptor is the same as the request for the
+            create API keys API.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -4133,7 +4328,7 @@ class SecurityClient(NamespacedClient):
         API keys, which should be updated by either the update API key or bulk update
         API keys API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-cross-cluster-api-key.html>`_
 
         :param id: The ID of the cross-cluster API key to update.
         :param access: The access to be granted to this API key. The access is composed
@@ -4205,12 +4400,14 @@ class SecurityClient(NamespacedClient):
         """
         Update security index settings. Update the user-configurable settings for the
         security internal index (`.security` and associated indices). Only a subset of
-        settings are allowed to be modified, for example `index.auto_expand_replicas`
-        and `index.number_of_replicas`. If a specific index is not in use on the system
-        and settings are provided for it, the request will be rejected. This API does
-        not yet support configuring the settings for indices before they are in use.
+        settings are allowed to be modified. This includes `index.auto_expand_replicas`
+        and `index.number_of_replicas`. NOTE: If `index.auto_expand_replicas` is set,
+        `index.number_of_replicas` will be ignored during updates. If a specific index
+        is not in use on the system and settings are provided for it, the request will
+        be rejected. This API does not yet support configuring the settings for indices
+        before they are in use.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-settings.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -4291,7 +4488,7 @@ class SecurityClient(NamespacedClient):
         data, content is namespaced by the top-level fields. The `update_profile_data`
         global privilege grants privileges for updating only the allowed namespaces.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-user-profile-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-user-profile-data.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: Non-searchable data that you want to associate with the user profile.

--- a/elasticsearch/_async/client/shutdown.py
+++ b/elasticsearch/_async/client/shutdown.py
@@ -50,7 +50,7 @@ class ShutdownClient(NamespacedClient):
         and Elastic Cloud on Kubernetes. Direct use is not supported. If the operator
         privileges feature is enabled, you must be an operator to use this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-shutdown.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-shutdown.html>`_
 
         :param node_id: The node id of node to be removed from the shutdown state
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -108,7 +108,7 @@ class ShutdownClient(NamespacedClient):
         the operator privileges feature is enabled, you must be an operator to use this
         API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-shutdown.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-shutdown.html>`_
 
         :param node_id: Which node for which to retrieve the shutdown status
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -182,7 +182,7 @@ class ShutdownClient(NamespacedClient):
         IMPORTANT: This API does NOT terminate the Elasticsearch process. Monitor the
         node shutdown status to determine when it is safe to stop Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-shutdown.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-shutdown.html>`_
 
         :param node_id: The node identifier. This parameter is not validated against
             the cluster's active nodes. This enables you to register a node for shut

--- a/elasticsearch/_async/client/simulate.py
+++ b/elasticsearch/_async/client/simulate.py
@@ -87,7 +87,7 @@ class SimulateClient(NamespacedClient):
         This can be used to replace existing pipeline definitions or to create new ones.
         The pipeline substitutions are used only within this request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/simulate-ingest-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/simulate-ingest-api.html>`_
 
         :param docs: Sample documents to test in the pipeline.
         :param index: The index to simulate ingesting into. This value can be overridden

--- a/elasticsearch/_async/client/slm.py
+++ b/elasticsearch/_async/client/slm.py
@@ -42,7 +42,7 @@ class SlmClient(NamespacedClient):
         prevents any future snapshots from being taken but does not cancel in-progress
         snapshots or remove previously-taken snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-delete-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-delete-policy.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to remove
         :param master_timeout: The period to wait for a connection to the master node.
@@ -96,7 +96,7 @@ class SlmClient(NamespacedClient):
         applied according to its schedule, but you might want to manually run a policy
         before performing an upgrade or other maintenance.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-execute-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-execute-lifecycle.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to be executed
         :param master_timeout: The period to wait for a connection to the master node.
@@ -148,7 +148,7 @@ class SlmClient(NamespacedClient):
         removal of snapshots that are expired according to the snapshot lifecycle policy
         retention rules. The retention policy is normally applied according to its schedule.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-execute-retention.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-execute-retention.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -197,7 +197,7 @@ class SlmClient(NamespacedClient):
         Get policy information. Get snapshot lifecycle policy definitions and information
         about the latest snapshot attempts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-get-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-get-policy.html>`_
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         :param master_timeout: The period to wait for a connection to the master node.
@@ -251,7 +251,7 @@ class SlmClient(NamespacedClient):
         Get snapshot lifecycle management statistics. Get global and policy-level statistics
         about actions taken by snapshot lifecycle management.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-get-stats.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -298,7 +298,7 @@ class SlmClient(NamespacedClient):
         """
         Get the snapshot lifecycle management status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-get-status.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -358,7 +358,7 @@ class SlmClient(NamespacedClient):
         policy already exists, this request increments the policy version. Only the latest
         version of a policy is stored.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-put-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-put-policy.html>`_
 
         :param policy_id: The identifier for the snapshot lifecycle policy you want to
             create or update.
@@ -441,7 +441,7 @@ class SlmClient(NamespacedClient):
         automatically when a cluster is formed. Manually starting SLM is necessary only
         if it has been stopped using the stop SLM API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-start.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -498,7 +498,7 @@ class SlmClient(NamespacedClient):
         complete and it can be safely stopped. Use the get snapshot lifecycle management
         status API to see if SLM is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-stop.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -47,7 +47,7 @@ class SnapshotClient(NamespacedClient):
         Clean up the snapshot repository. Trigger the review of the contents of a snapshot
         repository and delete any stale data not referenced by existing snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clean-up-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clean-up-snapshot-repo-api.html>`_
 
         :param name: Snapshot repository to clean up.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -101,7 +101,7 @@ class SnapshotClient(NamespacedClient):
         Clone a snapshot. Clone part of all of a snapshot into another snapshot in the
         same repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clone-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clone-snapshot-api.html>`_
 
         :param repository: A repository name
         :param snapshot: The name of the snapshot to clone from
@@ -181,7 +181,7 @@ class SnapshotClient(NamespacedClient):
         """
         Create a snapshot. Take a snapshot of a cluster or of data streams and indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-snapshot-api.html>`_
 
         :param repository: Repository for the snapshot.
         :param snapshot: Name of the snapshot. Must be unique in the repository.
@@ -289,7 +289,7 @@ class SnapshotClient(NamespacedClient):
         be writeable. Ensure there are no cluster blocks (for example, `cluster.blocks.read_only`
         and `clsuter.blocks.read_only_allow_delete` settings) that prevent write access.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-snapshots.html>`_
 
         :param name: A repository name
         :param repository:
@@ -349,7 +349,7 @@ class SnapshotClient(NamespacedClient):
         """
         Delete snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-snapshot-api.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -402,7 +402,7 @@ class SnapshotClient(NamespacedClient):
         removes only the reference to the location where the repository is storing the
         snapshots. The snapshots themselves are left untouched and in place.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-snapshot-repo-api.html>`_
 
         :param name: Name of the snapshot repository to unregister. Wildcard (`*`) patterns
             are supported.
@@ -476,7 +476,7 @@ class SnapshotClient(NamespacedClient):
         """
         Get snapshot information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-snapshot-api.html>`_
 
         :param repository: Comma-separated list of snapshot repository names used to
             limit the request. Wildcard (*) expressions are supported.
@@ -588,7 +588,7 @@ class SnapshotClient(NamespacedClient):
         """
         Get snapshot repository information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-snapshot-repo-api.html>`_
 
         :param name: A comma-separated list of repository names
         :param local: Return local information, do not retrieve the state from master
@@ -763,7 +763,7 @@ class SnapshotClient(NamespacedClient):
         Some operations also verify the behavior on small blobs with sizes other than
         8 bytes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/repo-analysis-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/repo-analysis-api.html>`_
 
         :param name: The name of the repository.
         :param blob_count: The total number of blobs to write to the repository during
@@ -899,7 +899,7 @@ class SnapshotClient(NamespacedClient):
         in future versions. NOTE: This API may not work correctly in a mixed-version
         cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/verify-repo-integrity-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/verify-repo-integrity-api.html>`_
 
         :param name: A repository name
         :param blob_thread_pool_concurrency: Number of threads to use for reading blob
@@ -1009,7 +1009,7 @@ class SnapshotClient(NamespacedClient):
         or Workplace Search, you must restore the Enterprise Search encryption key before
         you restore the snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/restore-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/restore-snapshot-api.html>`_
 
         :param repository: A repository name
         :param snapshot: A snapshot name
@@ -1113,7 +1113,7 @@ class SnapshotClient(NamespacedClient):
         These requests can also tax machine resources and, when using cloud storage,
         incur high processing costs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-snapshot-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-snapshot-status-api.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -1173,7 +1173,7 @@ class SnapshotClient(NamespacedClient):
         Verify a snapshot repository. Check for common misconfigurations in a snapshot
         repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/verify-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/verify-snapshot-repo-api.html>`_
 
         :param name: A repository name
         :param master_timeout: Explicit operation timeout for connection to master node

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -41,7 +41,7 @@ class SqlClient(NamespacedClient):
         """
         Clear an SQL search cursor.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-sql-cursor-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-sql-cursor-api.html>`_
 
         :param cursor: Cursor to clear.
         """
@@ -90,7 +90,7 @@ class SqlClient(NamespacedClient):
         a search: * Users with the `cancel_task` cluster privilege. * The user who first
         submitted the search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-async-sql-search-api.html>`_
 
         :param id: The identifier for the search.
         """
@@ -139,7 +139,7 @@ class SqlClient(NamespacedClient):
         features are enabled, only the user who first submitted the SQL search can retrieve
         the search using this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-sql-search-api.html>`_
 
         :param id: The identifier for the search.
         :param delimiter: The separator for CSV results. The API supports this parameter
@@ -198,7 +198,7 @@ class SqlClient(NamespacedClient):
         Get the async SQL search status. Get the current status of an async SQL search
         or a stored synchronous SQL search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-sql-search-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-sql-search-status-api.html>`_
 
         :param id: The identifier for the search.
         """
@@ -283,7 +283,7 @@ class SqlClient(NamespacedClient):
         """
         Get SQL search results. Run an SQL request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/sql-search-api.html>`_
 
         :param allow_partial_search_results: If `true`, the response has partial results
             when there are shard request timeouts or shard failures. If `false`, the
@@ -406,7 +406,7 @@ class SqlClient(NamespacedClient):
         API request containing Query DSL. It accepts the same request body parameters
         as the SQL search API, excluding `cursor`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/sql-translate-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/sql-translate-api.html>`_
 
         :param query: The SQL query to run.
         :param fetch_size: The maximum number of rows (or entries) to return in one response.

--- a/elasticsearch/_async/client/ssl.py
+++ b/elasticsearch/_async/client/ssl.py
@@ -53,7 +53,7 @@ class SslClient(NamespacedClient):
         the API output includes all certificates in that store, even though some of the
         certificates might not be in active use within the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-ssl.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-ssl.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ssl/certificates"

--- a/elasticsearch/_async/client/synonyms.py
+++ b/elasticsearch/_async/client/synonyms.py
@@ -52,7 +52,7 @@ class SynonymsClient(NamespacedClient):
         finished, you can delete the index. When the synonyms set is not used in analyzers,
         you will be able to delete it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-synonyms-set.html>`_
 
         :param id: The synonyms set identifier to delete.
         """
@@ -93,7 +93,7 @@ class SynonymsClient(NamespacedClient):
         """
         Delete a synonym rule. Delete a synonym rule from a synonym set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-synonym-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-synonym-rule.html>`_
 
         :param set_id: The ID of the synonym set to update.
         :param rule_id: The ID of the synonym rule to delete.
@@ -143,7 +143,7 @@ class SynonymsClient(NamespacedClient):
         """
         Get a synonym set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-synonyms-set.html>`_
 
         :param id: The synonyms set identifier to retrieve.
         :param from_: The starting offset for query rules to retrieve.
@@ -190,7 +190,7 @@ class SynonymsClient(NamespacedClient):
         """
         Get a synonym rule. Get a synonym rule from a synonym set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-synonym-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-synonym-rule.html>`_
 
         :param set_id: The ID of the synonym set to retrieve the synonym rule from.
         :param rule_id: The ID of the synonym rule to retrieve.
@@ -239,7 +239,7 @@ class SynonymsClient(NamespacedClient):
         """
         Get all synonym sets. Get a summary of all defined synonym sets.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-synonyms-set.html>`_
 
         :param from_: The starting offset for synonyms sets to retrieve.
         :param size: The maximum number of synonyms sets to retrieve.
@@ -293,7 +293,7 @@ class SynonymsClient(NamespacedClient):
         equivalent to invoking the reload search analyzers API for all indices that use
         the synonyms set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-synonyms-set.html>`_
 
         :param id: The ID of the synonyms set to be created or updated.
         :param synonyms_set: The synonym rules definitions for the synonyms set.
@@ -349,7 +349,7 @@ class SynonymsClient(NamespacedClient):
         When you update a synonym rule, all analyzers using the synonyms set will be
         reloaded automatically to reflect the new rule.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-synonym-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-synonym-rule.html>`_
 
         :param set_id: The ID of the synonym set.
         :param rule_id: The ID of the synonym rule to be updated or created.

--- a/elasticsearch/_async/client/tasks.py
+++ b/elasticsearch/_async/client/tasks.py
@@ -61,7 +61,7 @@ class TasksClient(NamespacedClient):
         threads API to obtain detailed information about the work the system is doing
         instead of completing the cancelled task.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param task_id: The task identifier.
         :param actions: A comma-separated list or wildcard expression of actions that
@@ -126,7 +126,7 @@ class TasksClient(NamespacedClient):
         task identifier is not found, a 404 response code indicates that there are no
         resources that match the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param task_id: The task identifier.
         :param timeout: The period to wait for a response. If no response is received
@@ -203,7 +203,7 @@ class TasksClient(NamespacedClient):
         initiated by the REST request. The `X-Opaque-Id` in the children `headers` is
         the child task of the task that was initiated by the REST request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param actions: A comma-separated list or wildcard expression of actions used
             to limit the request. For example, you can use `cluser:*` to retrieve all

--- a/elasticsearch/_async/client/text_structure.py
+++ b/elasticsearch/_async/client/text_structure.py
@@ -70,7 +70,7 @@ class TextStructureClient(NamespacedClient):
         `explain` query parameter and an explanation will appear in the response. It
         helps determine why the returned structure was chosen.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/find-field-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/find-field-structure.html>`_
 
         :param field: The field that should be analyzed.
         :param index: The name of the index that contains the analyzed field.
@@ -255,7 +255,7 @@ class TextStructureClient(NamespacedClient):
         an explanation will appear in the response. It helps determine why the returned
         structure was chosen.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/find-message-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/find-message-structure.html>`_
 
         :param messages: The list of messages you want to analyze.
         :param column_names: If the format is `delimited`, you can specify the column
@@ -427,7 +427,7 @@ class TextStructureClient(NamespacedClient):
         However, you can optionally override some of the decisions about the text structure
         by specifying one or more query parameters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/find-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/find-structure.html>`_
 
         :param text_files:
         :param charset: The text's character set. It must be a character set that is
@@ -611,7 +611,7 @@ class TextStructureClient(NamespacedClient):
         indicates whether the lines match the pattern together with the offsets and lengths
         of the matched substrings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/test-grok-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/test-grok-pattern.html>`_
 
         :param grok_pattern: The Grok pattern to run on the text.
         :param text: The lines of text to run the Grok pattern on.

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -41,7 +41,7 @@ class TransformClient(NamespacedClient):
         """
         Delete a transform. Deletes a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param delete_dest_index: If this value is true, the destination index is deleted
@@ -101,7 +101,7 @@ class TransformClient(NamespacedClient):
         """
         Get transforms. Retrieves configuration information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-transform.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -170,7 +170,7 @@ class TransformClient(NamespacedClient):
         """
         Get transform stats. Retrieves usage information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-transform-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-transform-stats.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -256,7 +256,7 @@ class TransformClient(NamespacedClient):
         These values are determined based on the field types of the source index and
         the transform aggregations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/preview-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/preview-transform.html>`_
 
         :param transform_id: Identifier for the transform to preview. If you specify
             this path parameter, you cannot provide transform configuration details in
@@ -393,7 +393,7 @@ class TransformClient(NamespacedClient):
         If you used transforms prior to 7.5, also do not give users any privileges on
         `.data-frame-internal*` indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -496,7 +496,7 @@ class TransformClient(NamespacedClient):
         it; alternatively, use the `force` query parameter. If the destination index
         was created by the transform, it is deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/reset-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/reset-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -552,7 +552,7 @@ class TransformClient(NamespacedClient):
         the transform will be processed again at now + frequency unless _schedule_now
         API is called again in the meantime.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/schedule-now-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/schedule-now-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param timeout: Controls the time to wait for the scheduling to take place
@@ -616,7 +616,7 @@ class TransformClient(NamespacedClient):
         privileges on the source and destination indices, the transform fails when it
         attempts unauthorized operations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param from_: Restricts the set of transformed entities to those changed after
@@ -670,7 +670,7 @@ class TransformClient(NamespacedClient):
         """
         Stop transforms. Stops one or more transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/stop-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/stop-transform.html>`_
 
         :param transform_id: Identifier for the transform. To stop multiple transforms,
             use a comma-separated list or a wildcard expression. To stop all transforms,
@@ -770,7 +770,7 @@ class TransformClient(NamespacedClient):
         which roles the user who updated it had at the time of update and runs with those
         privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -864,7 +864,7 @@ class TransformClient(NamespacedClient):
         example, from 7.16 to 8.0 – it is recommended to upgrade transforms before upgrading
         the cluster. You may want to perform a recent cluster backup prior to the upgrade.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/upgrade-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/upgrade-transforms.html>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -46,7 +46,7 @@ class WatcherClient(NamespacedClient):
         `ack.state` is reset to `awaits_successful_execution`. This happens when the
         condition of the watch is not met (the condition evaluates to false).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-ack-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-ack-watch.html>`_
 
         :param watch_id: The watch identifier.
         :param action_id: A comma-separated list of the action identifiers to acknowledge.
@@ -98,7 +98,7 @@ class WatcherClient(NamespacedClient):
         """
         Activate a watch. A watch can be either active or inactive.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-activate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-activate-watch.html>`_
 
         :param watch_id: The watch identifier.
         """
@@ -138,7 +138,7 @@ class WatcherClient(NamespacedClient):
         """
         Deactivate a watch. A watch can be either active or inactive.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-deactivate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-deactivate-watch.html>`_
 
         :param watch_id: The watch identifier.
         """
@@ -184,7 +184,7 @@ class WatcherClient(NamespacedClient):
         delete document API When Elasticsearch security features are enabled, make sure
         no write privileges are granted to anyone for the `.watches` index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-delete-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-delete-watch.html>`_
 
         :param id: The watch identifier.
         """
@@ -267,7 +267,7 @@ class WatcherClient(NamespacedClient):
         that called the API will be used as a base, instead of the information who stored
         the watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-execute-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-execute-watch.html>`_
 
         :param id: The watch identifier.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -352,7 +352,7 @@ class WatcherClient(NamespacedClient):
         Only a subset of settings are shown, for example `index.auto_expand_replicas`
         and `index.number_of_replicas`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-get-settings.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -394,7 +394,7 @@ class WatcherClient(NamespacedClient):
         """
         Get a watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-get-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-get-watch.html>`_
 
         :param id: The watch identifier.
         """
@@ -468,7 +468,7 @@ class WatcherClient(NamespacedClient):
         for which the user that stored the watch has privileges. If the user is able
         to read index `a`, but not index `b`, the same will apply when the watch runs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-put-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-put-watch.html>`_
 
         :param id: The identifier for the watch.
         :param actions: The list of actions that will be run if the condition matches.
@@ -578,7 +578,7 @@ class WatcherClient(NamespacedClient):
         filter watches by a query. Note that only the `_id` and `metadata.*` fields are
         queryable or sortable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-query-watches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-query-watches.html>`_
 
         :param from_: The offset from the first result to fetch. It must be non-negative.
         :param query: A query that filters the watches to be returned.
@@ -649,7 +649,7 @@ class WatcherClient(NamespacedClient):
         """
         Start the watch service. Start the Watcher service if it is not already running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-start.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -711,7 +711,7 @@ class WatcherClient(NamespacedClient):
         Get Watcher statistics. This API always returns basic metrics. You retrieve more
         metrics by using the metric parameter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-stats.html>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -758,7 +758,7 @@ class WatcherClient(NamespacedClient):
         """
         Stop the watch service. Stop the Watcher service if it is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-stop.html>`_
 
         :param master_timeout: The period to wait for the master node. If the master
             node is not available before the timeout expires, the request fails and returns
@@ -812,7 +812,7 @@ class WatcherClient(NamespacedClient):
         (`.watches`). Only a subset of settings can be modified. This includes `index.auto_expand_replicas`
         and `index.number_of_replicas`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-update-settings.html>`_
 
         :param index_auto_expand_replicas:
         :param index_number_of_replicas:

--- a/elasticsearch/_async/client/xpack.py
+++ b/elasticsearch/_async/client/xpack.py
@@ -48,7 +48,7 @@ class XPackClient(NamespacedClient):
         installed license. * Feature information for the features that are currently
         enabled and available under the current license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/info-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/info-api.html>`_
 
         :param accept_enterprise: If this param is used it must be set to true
         :param categories: A comma-separated list of the information categories to include
@@ -94,7 +94,7 @@ class XPackClient(NamespacedClient):
         enabled and available under the current license. The API also provides some usage
         statistics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/usage-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/usage-api.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -722,7 +722,7 @@ class Elasticsearch(BaseClient):
         only wait for those three shards to refresh. The other two shards that make up
         the index do not participate in the `_bulk` request at all.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-bulk.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-bulk.html>`_
 
         :param operations:
         :param index: The name of the data stream, index, or index alias to perform bulk
@@ -840,7 +840,7 @@ class Elasticsearch(BaseClient):
         Clear a scrolling search. Clear the search context and results for a scrolling
         search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-scroll-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-scroll-api.html>`_
 
         :param scroll_id: The scroll IDs to clear. To clear all scroll IDs, use `_all`.
         """
@@ -894,7 +894,7 @@ class Elasticsearch(BaseClient):
         period has elapsed. However, keeping points in time has a cost; close them as
         soon as they are no longer required for search requests.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/point-in-time-api.html>`_
 
         :param id: The ID of the point-in-time.
         """
@@ -975,7 +975,7 @@ class Elasticsearch(BaseClient):
         a replica is chosen and the search is run against it. This means that replicas
         increase the scalability of the count.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-count.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams and indices,
@@ -1115,38 +1115,119 @@ class Elasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Index a document. Adds a JSON document to the specified data stream or index
-        and makes it searchable. If the target is an index and the document already exists,
-        the request updates the document and increments its version.
+        Create a new document in the index. You can index a new JSON document with the
+        `/<target>/_doc/` or `/<target>/_create/<_id>` APIs Using `_create` guarantees
+        that the document is indexed only if it does not already exist. It returns a
+        409 response when a document with a same ID already exists in the index. To update
+        an existing document, you must use the `/<target>/_doc/` API. If the Elasticsearch
+        security features are enabled, you must have the following index privileges for
+        the target data stream, index, or index alias: * To add a document using the
+        `PUT /<target>/_create/<_id>` or `POST /<target>/_create/<_id>` request formats,
+        you must have the `create_doc`, `create`, `index`, or `write` index privilege.
+        * To automatically create a data stream or index with this API request, you must
+        have the `auto_configure`, `create_index`, or `manage` index privilege. Automatic
+        data stream creation requires a matching index template with data stream enabled.
+        **Automatically create data streams and indices** If the request's target doesn't
+        exist and matches an index template with a `data_stream` definition, the index
+        operation automatically creates the data stream. If the target doesn't exist
+        and doesn't match a data stream template, the operation automatically creates
+        the index and applies any matching index templates. NOTE: Elasticsearch includes
+        several built-in index templates. To avoid naming collisions with these templates,
+        refer to index pattern documentation. If no mapping exists, the index operation
+        creates a dynamic mapping. By default, new fields and objects are automatically
+        added to the mapping if needed. Automatic index creation is controlled by the
+        `action.auto_create_index` setting. If it is `true`, any index can be created
+        automatically. You can modify this setting to explicitly allow or block automatic
+        creation of indices that match specified patterns or set it to `false` to turn
+        off automatic index creation entirely. Specify a comma-separated list of patterns
+        you want to allow or prefix each pattern with `+` or `-` to indicate whether
+        it should be allowed or blocked. When a list is specified, the default behaviour
+        is to disallow. NOTE: The `action.auto_create_index` setting affects the automatic
+        creation of indices only. It does not affect the creation of data streams. **Routing**
+        By default, shard placement — or routing — is controlled by using a hash of the
+        document's ID value. For more explicit control, the value fed into the hash function
+        used by the router can be directly specified on a per-operation basis using the
+        `routing` parameter. When setting up explicit mapping, you can also use the `_routing`
+        field to direct the index operation to extract the routing value from the document
+        itself. This does come at the (very minimal) cost of an additional document parsing
+        pass. If the `_routing` mapping is defined and set to be required, the index
+        operation will fail if no routing value is provided or extracted. NOTE: Data
+        streams do not support custom routing unless they were created with the `allow_custom_routing`
+        setting enabled in the template. **Distributed** The index operation is directed
+        to the primary shard based on its route and performed on the actual node containing
+        this shard. After the primary shard completes the operation, if needed, the update
+        is distributed to applicable replicas. **Active shards** To improve the resiliency
+        of writes to the system, indexing operations can be configured to wait for a
+        certain number of active shard copies before proceeding with the operation. If
+        the requisite number of active shard copies are not available, then the write
+        operation must wait and retry, until either the requisite shard copies have started
+        or a timeout occurs. By default, write operations only wait for the primary shards
+        to be active before proceeding (that is to say `wait_for_active_shards` is `1`).
+        This default can be overridden in the index settings dynamically by setting `index.write.wait_for_active_shards`.
+        To alter this behavior per operation, use the `wait_for_active_shards request`
+        parameter. Valid values are all or any positive integer up to the total number
+        of configured copies per shard in the index (which is `number_of_replicas`+1).
+        Specifying a negative value or a number greater than the number of shard copies
+        will throw an error. For example, suppose you have a cluster of three nodes,
+        A, B, and C and you create an index index with the number of replicas set to
+        3 (resulting in 4 shard copies, one more copy than there are nodes). If you attempt
+        an indexing operation, by default the operation will only ensure the primary
+        copy of each shard is available before proceeding. This means that even if B
+        and C went down and A hosted the primary shard copies, the indexing operation
+        would still proceed with only one copy of the data. If `wait_for_active_shards`
+        is set on the request to `3` (and all three nodes are up), the indexing operation
+        will require 3 active shard copies before proceeding. This requirement should
+        be met because there are 3 active nodes in the cluster, each one holding a copy
+        of the shard. However, if you set `wait_for_active_shards` to `all` (or to `4`,
+        which is the same in this situation), the indexing operation will not proceed
+        as you do not have all 4 copies of each shard active in the index. The operation
+        will timeout unless a new node is brought up in the cluster to host the fourth
+        copy of the shard. It is important to note that this setting greatly reduces
+        the chances of the write operation not writing to the requisite number of shard
+        copies, but it does not completely eliminate the possibility, because this check
+        occurs before the write operation starts. After the write operation is underway,
+        it is still possible for replication to fail on any number of shard copies but
+        still succeed on the primary. The `_shards` section of the API response reveals
+        the number of shard copies on which replication succeeded and failed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-index_.html>`_
 
-        :param index: Name of the data stream or index to target. If the target doesn’t
+        :param index: The name of the data stream or index to target. If the target doesn't
             exist and matches the name or wildcard (`*`) pattern of an index template
             with a `data_stream` definition, this request creates the data stream. If
-            the target doesn’t exist and doesn’t match a data stream template, this request
+            the target doesn't exist and doesn’t match a data stream template, this request
             creates the index.
-        :param id: Unique identifier for the document.
+        :param id: A unique identifier for the document. To automatically generate a
+            document ID, use the `POST /<target>/_doc/` request format.
         :param document:
-        :param pipeline: ID of the pipeline to use to preprocess incoming documents.
-            If the index has a default ingest pipeline specified, then setting the value
-            to `_none` disables the default ingest pipeline for this request. If a final
-            pipeline is configured it will always run, regardless of the value of this
+        :param pipeline: The ID of the pipeline to use to preprocess incoming documents.
+            If the index has a default ingest pipeline specified, setting the value to
+            `_none` turns off the default ingest pipeline for this request. If a final
+            pipeline is configured, it will always run regardless of the value of this
             parameter.
         :param refresh: If `true`, Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` do nothing with refreshes.
-            Valid values: `true`, `false`, `wait_for`.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param timeout: Period the request waits for the following operations: automatic
-            index creation, dynamic mapping updates, waiting for active shards.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+            this operation visible to search. If `wait_for`, it waits for a refresh to
+            make this operation visible to search. If `false`, it does nothing with refreshes.
+        :param routing: A custom value that is used to route operations to a specific
+            shard.
+        :param timeout: The period the request waits for the following operations: automatic
+            index creation, dynamic mapping updates, waiting for active shards. Elasticsearch
+            waits for at least the specified timeout period before failing. The actual
+            wait time could be longer, particularly when multiple waits occur. This parameter
+            is useful for situations where the primary shard assigned to perform the
+            operation might not be available when the operation runs. Some reasons for
+            this might be that the primary shard is currently recovering from a gateway
+            or undergoing relocation. By default, the operation will wait on the primary
+            shard to become available for at least 1 minute before failing and responding
+            with an error. The actual wait time could be longer, particularly when multiple
+            waits occur.
+        :param version: The explicit version number for concurrency control. It must
+            be a non-negative long number.
+        :param version_type: The version type.
         :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to `all` or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            before proceeding with the operation. You can set it to `all` or any positive
+            integer up to the total number of shards in the index (`number_of_replicas+1`).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1221,29 +1302,57 @@ class Elasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete a document. Removes a JSON document from the specified index.
+        Delete a document. Remove a JSON document from the specified index. NOTE: You
+        cannot send deletion requests directly to a data stream. To delete a document
+        in a data stream, you must target the backing index containing the document.
+        **Optimistic concurrency control** Delete operations can be made conditional
+        and only be performed if the last modification to the document was assigned the
+        sequence number and primary term specified by the `if_seq_no` and `if_primary_term`
+        parameters. If a mismatch is detected, the operation will result in a `VersionConflictException`
+        and a status code of `409`. **Versioning** Each document indexed is versioned.
+        When deleting a document, the version can be specified to make sure the relevant
+        document you are trying to delete is actually being deleted and it has not changed
+        in the meantime. Every write operation run on a document, deletes included, causes
+        its version to be incremented. The version number of a deleted document remains
+        available for a short time after deletion to allow for control of concurrent
+        operations. The length of time for which a deleted document's version remains
+        available is determined by the `index.gc_deletes` index setting. **Routing**
+        If routing is used during indexing, the routing value also needs to be specified
+        to delete a document. If the `_routing` mapping is set to `required` and no routing
+        value is specified, the delete API throws a `RoutingMissingException` and rejects
+        the request. For example: ``` DELETE /my-index-000001/_doc/1?routing=shard-1
+        ``` This request deletes the document with ID 1, but it is routed based on the
+        user. The document is not deleted if the correct routing is not specified. **Distributed**
+        The delete operation gets hashed into a specific shard ID. It then gets redirected
+        into the primary shard within that ID group and replicated (if needed) to shard
+        replicas within that ID group.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-delete.html>`_
 
-        :param index: Name of the target index.
-        :param id: Unique identifier for the document.
+        :param index: The name of the target index.
+        :param id: A unique identifier for the document.
         :param if_primary_term: Only perform the operation if the document has this primary
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
         :param refresh: If `true`, Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` do nothing with refreshes.
-            Valid values: `true`, `false`, `wait_for`.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param timeout: Period to wait for active shards.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
-        :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to `all` or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            this operation visible to search. If `wait_for`, it waits for a refresh to
+            make this operation visible to search. If `false`, it does nothing with refreshes.
+        :param routing: A custom value used to route operations to a specific shard.
+        :param timeout: The period to wait for active shards. This parameter is useful
+            for situations where the primary shard assigned to perform the delete operation
+            might not be available when the delete operation runs. Some reasons for this
+            might be that the primary shard is currently recovering from a store or undergoing
+            relocation. By default, the delete operation will wait on the primary shard
+            to become available for up to 1 minute before failing and responding with
+            an error.
+        :param version: An explicit version number for concurrency control. It must match
+            the current version of the document for the request to succeed.
+        :param version_type: The version type.
+        :param wait_for_active_shards: The minimum number of shard copies that must be
+            active before proceeding with the operation. You can set it to `all` or any
+            positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1345,7 +1454,7 @@ class Elasticsearch(BaseClient):
         """
         Delete documents. Deletes documents that match the specified query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-delete-by-query.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams or indices, omit this
@@ -1526,7 +1635,7 @@ class Elasticsearch(BaseClient):
         takes effect immediately but rethrotting that slows down the query takes effect
         after completing the current batch to prevent scroll timeouts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-delete-by-query.html>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per
@@ -1572,7 +1681,7 @@ class Elasticsearch(BaseClient):
         """
         Delete a script or search template. Deletes a stored script or search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
 
         :param id: Identifier for the stored script or search template.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -1638,32 +1747,54 @@ class Elasticsearch(BaseClient):
         ] = None,
     ) -> HeadApiResponse:
         """
-        Check a document. Checks if a specified document exists.
+        Check a document. Verify that a document exists. For example, check to see if
+        a document with the `_id` 0 exists: ``` HEAD my-index-000001/_doc/0 ``` If the
+        document exists, the API returns a status code of `200 - OK`. If the document
+        doesn’t exist, the API returns `404 - Not Found`. **Versioning support** You
+        can use the `version` parameter to check the document only if its current version
+        is equal to the specified one. Internally, Elasticsearch has marked the old document
+        as deleted and added an entirely new document. The old version of the document
+        doesn't disappear immediately, although you won't be able to access it. Elasticsearch
+        cleans up deleted documents in the background as you continue to index more data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases. Supports
-            wildcards (`*`).
-        :param id: Identifier of the document.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param index: A comma-separated list of data streams, indices, and aliases. It
+            supports wildcards (`*`).
+        :param id: A unique document identifier.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas. If it is
+            set to `_local`, the operation will prefer to be run on a local allocated
+            shard when possible. If it is set to a custom value, the value is used to
+            guarantee that the same shards will be used for the same custom value. This
+            can help with "jumping values" when hitting different shards in different
+            refresh states. A sample value can be something like the web session ID or
+            the user name.
         :param realtime: If `true`, the request is real-time as opposed to near-real-time.
-        :param refresh: If `true`, Elasticsearch refreshes all shards involved in the
-            delete by query after the request completes.
-        :param routing: Target the specified primary shard.
-        :param source: `true` or `false` to return the `_source` field or not, or a list
-            of fields to return.
-        :param source_excludes: A comma-separated list of source fields to exclude in
-            the response.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
+        :param source_excludes: A comma-separated list of source fields to exclude from
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
         :param source_includes: A comma-separated list of source fields to include in
-            the response.
-        :param stored_fields: List of stored fields to return as part of a hit. If no
-            fields are specified, no stored fields are included in the response. If this
-            field is specified, the `_source` parameter defaults to false.
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
+        :param stored_fields: A comma-separated list of stored fields to return as part
+            of a hit. If no fields are specified, no stored fields are included in the
+            response. If this field is specified, the `_source` parameter defaults to
+            `false`.
         :param version: Explicit version number for concurrency control. The specified
             version must match the current version of the document for the request to
             succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1739,29 +1870,32 @@ class Elasticsearch(BaseClient):
         ] = None,
     ) -> HeadApiResponse:
         """
-        Check for a document source. Checks if a document's `_source` is stored.
+        Check for a document source. Check whether a document source exists in an index.
+        For example: ``` HEAD my-index-000001/_source/1 ``` A document's source is not
+        available if it is disabled in the mapping.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases. Supports
-            wildcards (`*`).
-        :param id: Identifier of the document.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param realtime: If true, the request is real-time as opposed to near-real-time.
-        :param refresh: If `true`, Elasticsearch refreshes all shards involved in the
-            delete by query after the request completes.
-        :param routing: Target the specified primary shard.
-        :param source: `true` or `false` to return the `_source` field or not, or a list
-            of fields to return.
+        :param index: A comma-separated list of data streams, indices, and aliases. It
+            supports wildcards (`*`).
+        :param id: A unique identifier for the document.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas.
+        :param realtime: If `true`, the request is real-time as opposed to near-real-time.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
         :param source_excludes: A comma-separated list of source fields to exclude in
             the response.
         :param source_includes: A comma-separated list of source fields to include in
             the response.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+        :param version: The version number for concurrency control. It must match the
+            current version of the document for the request to succeed.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -1842,7 +1976,7 @@ class Elasticsearch(BaseClient):
         Explain a document match result. Returns information about why a specific document
         matches, or doesn’t match, a query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-explain.html>`_
 
         :param index: Index names used to limit the request. Only a single index name
             can be provided to this parameter.
@@ -1965,7 +2099,7 @@ class Elasticsearch(BaseClient):
         field. For example, a runtime field with a type of keyword is returned the same
         as any other field that belongs to the `keyword` family.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-field-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-field-caps.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (*). To target all data streams
@@ -2079,36 +2213,78 @@ class Elasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get a document by its ID. Retrieves the document with the specified ID from an
-        index.
+        Get a document by its ID. Get a document and its source or stored fields from
+        an index. By default, this API is realtime and is not affected by the refresh
+        rate of the index (when data will become visible for search). In the case where
+        stored fields are requested with the `stored_fields` parameter and the document
+        has been updated but is not yet refreshed, the API will have to parse and analyze
+        the source to extract the stored fields. To turn off realtime behavior, set the
+        `realtime` parameter to false. **Source filtering** By default, the API returns
+        the contents of the `_source` field unless you have used the `stored_fields`
+        parameter or the `_source` field is turned off. You can turn off `_source` retrieval
+        by using the `_source` parameter: ``` GET my-index-000001/_doc/0?_source=false
+        ``` If you only need one or two fields from the `_source`, use the `_source_includes`
+        or `_source_excludes` parameters to include or filter out particular fields.
+        This can be helpful with large documents where partial retrieval can save on
+        network overhead Both parameters take a comma separated list of fields or wildcard
+        expressions. For example: ``` GET my-index-000001/_doc/0?_source_includes=*.id&_source_excludes=entities
+        ``` If you only want to specify includes, you can use a shorter notation: ```
+        GET my-index-000001/_doc/0?_source=*.id ``` **Routing** If routing is used during
+        indexing, the routing value also needs to be specified to retrieve a document.
+        For example: ``` GET my-index-000001/_doc/2?routing=user1 ``` This request gets
+        the document with ID 2, but it is routed based on the user. The document is not
+        fetched if the correct routing is not specified. **Distributed** The GET operation
+        is hashed into a specific shard ID. It is then redirected to one of the replicas
+        within that shard ID and returns the result. The replicas are the primary shard
+        and its replicas within that shard ID group. This means that the more replicas
+        you have, the better your GET scaling will be. **Versioning support** You can
+        use the `version` parameter to retrieve the document only if its current version
+        is equal to the specified one. Internally, Elasticsearch has marked the old document
+        as deleted and added an entirely new document. The old version of the document
+        doesn't disappear immediately, although you won't be able to access it. Elasticsearch
+        cleans up deleted documents in the background as you continue to index more data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Name of the index that contains the document.
-        :param id: Unique identifier of the document.
-        :param force_synthetic_source: Should this request force synthetic _source? Use
-            this to test if the mapping supports synthetic _source and to get a sense
-            of the worst case performance. Fetches with this enabled will be slower the
-            enabling synthetic source natively in the index.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param index: The name of the index that contains the document.
+        :param id: A unique document identifier.
+        :param force_synthetic_source: Indicates whether the request forces synthetic
+            `_source`. Use this paramater to test if the mapping supports synthetic `_source`
+            and to get a sense of the worst case performance. Fetches with this parameter
+            enabled will be slower than enabling synthetic source natively in the index.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas. If it is
+            set to `_local`, the operation will prefer to be run on a local allocated
+            shard when possible. If it is set to a custom value, the value is used to
+            guarantee that the same shards will be used for the same custom value. This
+            can help with "jumping values" when hitting different shards in different
+            refresh states. A sample value can be something like the web session ID or
+            the user name.
         :param realtime: If `true`, the request is real-time as opposed to near-real-time.
-        :param refresh: If true, Elasticsearch refreshes the affected shards to make
-            this operation visible to search. If false, do nothing with refreshes.
-        :param routing: Target the specified primary shard.
-        :param source: True or false to return the _source field or not, or a list of
-            fields to return.
-        :param source_excludes: A comma-separated list of source fields to exclude in
-            the response.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
+        :param source_excludes: A comma-separated list of source fields to exclude from
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
         :param source_includes: A comma-separated list of source fields to include in
-            the response.
-        :param stored_fields: List of stored fields to return as part of a hit. If no
-            fields are specified, no stored fields are included in the response. If this
-            field is specified, the `_source` parameter defaults to false.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: internal, external, external_gte.
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
+        :param stored_fields: A comma-separated list of stored fields to return as part
+            of a hit. If no fields are specified, no stored fields are included in the
+            response. If this field is specified, the `_source` parameter defaults to
+            `false`. Only leaf fields can be retrieved with the `stored_field` option.
+            Object fields can't be returned;​if specified, the request fails.
+        :param version: The version number for concurrency control. It must match the
+            current version of the document for the request to succeed.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2171,7 +2347,7 @@ class Elasticsearch(BaseClient):
         """
         Get a script or search template. Retrieves a stored script or search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
 
         :param id: Identifier for the stored script or search template.
         :param master_timeout: Specify timeout for connection to master
@@ -2213,7 +2389,7 @@ class Elasticsearch(BaseClient):
         """
         Get script contexts. Get a list of supported script contexts and their methods.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.16/painless-contexts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.17/painless-contexts.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_context"
@@ -2248,7 +2424,7 @@ class Elasticsearch(BaseClient):
         """
         Get script languages. Get a list of available script types, languages, and contexts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_language"
@@ -2301,29 +2477,34 @@ class Elasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get a document's source. Returns the source of a document.
+        Get a document's source. Get the source of a document. For example: ``` GET my-index-000001/_source/1
+        ``` You can use the source filtering parameters to control which parts of the
+        `_source` are returned: ``` GET my-index-000001/_source/1/?_source_includes=*.id&_source_excludes=entities
+        ```
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-get.html>`_
 
-        :param index: Name of the index that contains the document.
-        :param id: Unique identifier of the document.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param realtime: Boolean) If true, the request is real-time as opposed to near-real-time.
-        :param refresh: If true, Elasticsearch refreshes the affected shards to make
-            this operation visible to search. If false, do nothing with refreshes.
-        :param routing: Target the specified primary shard.
-        :param source: True or false to return the _source field or not, or a list of
-            fields to return.
+        :param index: The name of the index that contains the document.
+        :param id: A unique document identifier.
+        :param preference: The node or shard the operation should be performed on. By
+            default, the operation is randomized between the shard replicas.
+        :param realtime: If `true`, the request is real-time as opposed to near-real-time.
+        :param refresh: If `true`, the request refreshes the relevant shards before retrieving
+            the document. Setting it to `true` should be done after careful thought and
+            verification that this does not cause a heavy load on the system (and slow
+            down indexing).
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: Indicates whether to return the `_source` field (`true` or `false`)
+            or lists the fields to return.
         :param source_excludes: A comma-separated list of source fields to exclude in
             the response.
         :param source_includes: A comma-separated list of source fields to include in
             the response.
-        :param stored_fields:
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: internal, external, external_gte.
+        :param stored_fields: A comma-separated list of stored fields to return as part
+            of a hit.
+        :param version: The version number for concurrency control. It must match the
+            current version of the document for the request to succeed.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2405,7 +2586,7 @@ class Elasticsearch(BaseClient):
         for health status, set verbose to false to disable the more expensive analysis
         logic.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/health-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/health-api.html>`_
 
         :param feature: A feature of the cluster, as returned by the top-level health
             report API.
@@ -2478,44 +2659,170 @@ class Elasticsearch(BaseClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Index a document. Adds a JSON document to the specified data stream or index
-        and makes it searchable. If the target is an index and the document already exists,
-        the request updates the document and increments its version.
+        Create or update a document in an index. Add a JSON document to the specified
+        data stream or index and make it searchable. If the target is an index and the
+        document already exists, the request updates the document and increments its
+        version. NOTE: You cannot use this API to send update requests for existing documents
+        in a data stream. If the Elasticsearch security features are enabled, you must
+        have the following index privileges for the target data stream, index, or index
+        alias: * To add or overwrite a document using the `PUT /<target>/_doc/<_id>`
+        request format, you must have the `create`, `index`, or `write` index privilege.
+        * To add a document using the `POST /<target>/_doc/` request format, you must
+        have the `create_doc`, `create`, `index`, or `write` index privilege. * To automatically
+        create a data stream or index with this API request, you must have the `auto_configure`,
+        `create_index`, or `manage` index privilege. Automatic data stream creation requires
+        a matching index template with data stream enabled. NOTE: Replica shards might
+        not all be started when an indexing operation returns successfully. By default,
+        only the primary is required. Set `wait_for_active_shards` to change this default
+        behavior. **Automatically create data streams and indices** If the request's
+        target doesn't exist and matches an index template with a `data_stream` definition,
+        the index operation automatically creates the data stream. If the target doesn't
+        exist and doesn't match a data stream template, the operation automatically creates
+        the index and applies any matching index templates. NOTE: Elasticsearch includes
+        several built-in index templates. To avoid naming collisions with these templates,
+        refer to index pattern documentation. If no mapping exists, the index operation
+        creates a dynamic mapping. By default, new fields and objects are automatically
+        added to the mapping if needed. Automatic index creation is controlled by the
+        `action.auto_create_index` setting. If it is `true`, any index can be created
+        automatically. You can modify this setting to explicitly allow or block automatic
+        creation of indices that match specified patterns or set it to `false` to turn
+        off automatic index creation entirely. Specify a comma-separated list of patterns
+        you want to allow or prefix each pattern with `+` or `-` to indicate whether
+        it should be allowed or blocked. When a list is specified, the default behaviour
+        is to disallow. NOTE: The `action.auto_create_index` setting affects the automatic
+        creation of indices only. It does not affect the creation of data streams. **Optimistic
+        concurrency control** Index operations can be made conditional and only be performed
+        if the last modification to the document was assigned the sequence number and
+        primary term specified by the `if_seq_no` and `if_primary_term` parameters. If
+        a mismatch is detected, the operation will result in a `VersionConflictException`
+        and a status code of `409`. **Routing** By default, shard placement — or routing
+        — is controlled by using a hash of the document's ID value. For more explicit
+        control, the value fed into the hash function used by the router can be directly
+        specified on a per-operation basis using the `routing` parameter. When setting
+        up explicit mapping, you can also use the `_routing` field to direct the index
+        operation to extract the routing value from the document itself. This does come
+        at the (very minimal) cost of an additional document parsing pass. If the `_routing`
+        mapping is defined and set to be required, the index operation will fail if no
+        routing value is provided or extracted. NOTE: Data streams do not support custom
+        routing unless they were created with the `allow_custom_routing` setting enabled
+        in the template. **Distributed** The index operation is directed to the primary
+        shard based on its route and performed on the actual node containing this shard.
+        After the primary shard completes the operation, if needed, the update is distributed
+        to applicable replicas. **Active shards** To improve the resiliency of writes
+        to the system, indexing operations can be configured to wait for a certain number
+        of active shard copies before proceeding with the operation. If the requisite
+        number of active shard copies are not available, then the write operation must
+        wait and retry, until either the requisite shard copies have started or a timeout
+        occurs. By default, write operations only wait for the primary shards to be active
+        before proceeding (that is to say `wait_for_active_shards` is `1`). This default
+        can be overridden in the index settings dynamically by setting `index.write.wait_for_active_shards`.
+        To alter this behavior per operation, use the `wait_for_active_shards request`
+        parameter. Valid values are all or any positive integer up to the total number
+        of configured copies per shard in the index (which is `number_of_replicas`+1).
+        Specifying a negative value or a number greater than the number of shard copies
+        will throw an error. For example, suppose you have a cluster of three nodes,
+        A, B, and C and you create an index index with the number of replicas set to
+        3 (resulting in 4 shard copies, one more copy than there are nodes). If you attempt
+        an indexing operation, by default the operation will only ensure the primary
+        copy of each shard is available before proceeding. This means that even if B
+        and C went down and A hosted the primary shard copies, the indexing operation
+        would still proceed with only one copy of the data. If `wait_for_active_shards`
+        is set on the request to `3` (and all three nodes are up), the indexing operation
+        will require 3 active shard copies before proceeding. This requirement should
+        be met because there are 3 active nodes in the cluster, each one holding a copy
+        of the shard. However, if you set `wait_for_active_shards` to `all` (or to `4`,
+        which is the same in this situation), the indexing operation will not proceed
+        as you do not have all 4 copies of each shard active in the index. The operation
+        will timeout unless a new node is brought up in the cluster to host the fourth
+        copy of the shard. It is important to note that this setting greatly reduces
+        the chances of the write operation not writing to the requisite number of shard
+        copies, but it does not completely eliminate the possibility, because this check
+        occurs before the write operation starts. After the write operation is underway,
+        it is still possible for replication to fail on any number of shard copies but
+        still succeed on the primary. The `_shards` section of the API response reveals
+        the number of shard copies on which replication succeeded and failed. **No operation
+        (noop) updates** When updating a document by using this API, a new version of
+        the document is always created even if the document hasn't changed. If this isn't
+        acceptable use the `_update` API with `detect_noop` set to `true`. The `detect_noop`
+        option isn't available on this API because it doesn’t fetch the old source and
+        isn't able to compare it against the new source. There isn't a definitive rule
+        for when noop updates aren't acceptable. It's a combination of lots of factors
+        like how frequently your data source sends updates that are actually noops and
+        how many queries per second Elasticsearch runs on the shard receiving the updates.
+        **Versioning** Each indexed document is given a version number. By default, internal
+        versioning is used that starts at 1 and increments with each update, deletes
+        included. Optionally, the version number can be set to an external value (for
+        example, if maintained in a database). To enable this functionality, `version_type`
+        should be set to `external`. The value provided must be a numeric, long value
+        greater than or equal to 0, and less than around `9.2e+18`. NOTE: Versioning
+        is completely real time, and is not affected by the near real time aspects of
+        search operations. If no version is provided, the operation runs without any
+        version checks. When using the external version type, the system checks to see
+        if the version number passed to the index request is greater than the version
+        of the currently stored document. If true, the document will be indexed and the
+        new version number used. If the value provided is less than or equal to the stored
+        document's version number, a version conflict will occur and the index operation
+        will fail. For example: ``` PUT my-index-000001/_doc/1?version=2&version_type=external
+        { "user": { "id": "elkbee" } } In this example, the operation will succeed since
+        the supplied version of 2 is higher than the current document version of 1. If
+        the document was already updated and its version was set to 2 or higher, the
+        indexing command will fail and result in a conflict (409 HTTP status code). A
+        nice side effect is that there is no need to maintain strict ordering of async
+        indexing operations run as a result of changes to a source database, as long
+        as version numbers from the source database are used. Even the simple case of
+        updating the Elasticsearch index using data from a database is simplified if
+        external versioning is used, as only the latest version will be used if the index
+        operations arrive out of order.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-index_.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-index_.html>`_
 
-        :param index: Name of the data stream or index to target.
+        :param index: The name of the data stream or index to target. If the target doesn't
+            exist and matches the name or wildcard (`*`) pattern of an index template
+            with a `data_stream` definition, this request creates the data stream. If
+            the target doesn't exist and doesn't match a data stream template, this request
+            creates the index. You can check for existing targets with the resolve index
+            API.
         :param document:
-        :param id: Unique identifier for the document.
+        :param id: A unique identifier for the document. To automatically generate a
+            document ID, use the `POST /<target>/_doc/` request format and omit this
+            parameter.
         :param if_primary_term: Only perform the operation if the document has this primary
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
-        :param op_type: Set to create to only index the document if it does not already
+        :param op_type: Set to `create` to only index the document if it does not already
             exist (put if absent). If a document with the specified `_id` already exists,
-            the indexing operation will fail. Same as using the `<index>/_create` endpoint.
-            Valid values: `index`, `create`. If document id is specified, it defaults
-            to `index`. Otherwise, it defaults to `create`.
-        :param pipeline: ID of the pipeline to use to preprocess incoming documents.
+            the indexing operation will fail. The behavior is the same as using the `<index>/_create`
+            endpoint. If a document ID is specified, this paramater defaults to `index`.
+            Otherwise, it defaults to `create`. If the request targets a data stream,
+            an `op_type` of `create` is required.
+        :param pipeline: The ID of the pipeline to use to preprocess incoming documents.
             If the index has a default ingest pipeline specified, then setting the value
             to `_none` disables the default ingest pipeline for this request. If a final
             pipeline is configured it will always run, regardless of the value of this
             parameter.
         :param refresh: If `true`, Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` do nothing with refreshes.
-            Valid values: `true`, `false`, `wait_for`.
+            this operation visible to search. If `wait_for`, it waits for a refresh to
+            make this operation visible to search. If `false`, it does nothing with refreshes.
         :param require_alias: If `true`, the destination must be an index alias.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param timeout: Period the request waits for the following operations: automatic
-            index creation, dynamic mapping updates, waiting for active shards.
-        :param version: Explicit version number for concurrency control. The specified
-            version must match the current version of the document for the request to
-            succeed.
-        :param version_type: Specific version type: `external`, `external_gte`.
+        :param routing: A custom value that is used to route operations to a specific
+            shard.
+        :param timeout: The period the request waits for the following operations: automatic
+            index creation, dynamic mapping updates, waiting for active shards. This
+            parameter is useful for situations where the primary shard assigned to perform
+            the operation might not be available when the operation runs. Some reasons
+            for this might be that the primary shard is currently recovering from a gateway
+            or undergoing relocation. By default, the operation will wait on the primary
+            shard to become available for at least 1 minute before failing and responding
+            with an error. The actual wait time could be longer, particularly when multiple
+            waits occur.
+        :param version: An explicit version number for concurrency control. It must be
+            a non-negative long number.
+        :param version_type: The version type.
         :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to all or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            before proceeding with the operation. You can set it to `all` or any positive
+            integer up to the total number of shards in the index (`number_of_replicas+1`).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -2591,7 +2898,7 @@ class Elasticsearch(BaseClient):
         """
         Get cluster info. Get basic build, version, and cluster information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rest-api-root.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rest-api-root.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/"
@@ -2656,7 +2963,7 @@ class Elasticsearch(BaseClient):
         The kNN search API supports restricting the search using a filter. The search
         will return the top k documents that also match the filter query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             to perform the operation on all indices
@@ -2760,7 +3067,7 @@ class Elasticsearch(BaseClient):
         IDs in the request body. To ensure fast responses, this multi get (mget) API
         responds with partial results if one or more shards fail.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-multi-get.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-multi-get.html>`_
 
         :param index: Name of the index to retrieve documents from when `ids` are specified,
             or when a document in the `docs` array does not specify an index.
@@ -2887,7 +3194,7 @@ class Elasticsearch(BaseClient):
         Each newline character may be preceded by a carriage return `\\r`. When sending
         requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-multi-search.html>`_
 
         :param searches:
         :param index: Comma-separated list of data streams, indices, and index aliases
@@ -3019,7 +3326,7 @@ class Elasticsearch(BaseClient):
         """
         Run multiple templated searches.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-multi-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-multi-search.html>`_
 
         :param search_templates:
         :param index: Comma-separated list of data streams, indices, and aliases to search.
@@ -3118,7 +3425,7 @@ class Elasticsearch(BaseClient):
         with all the fetched termvectors. Each element has the structure provided by
         the termvectors API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-multi-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-multi-termvectors.html>`_
 
         :param index: Name of the index that contains the documents.
         :param docs: Array of existing or artificial documents.
@@ -3238,7 +3545,7 @@ class Elasticsearch(BaseClient):
         A point in time must be opened explicitly before being used in search requests.
         The `keep_alive` parameter tells Elasticsearch how long it should persist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/point-in-time-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/point-in-time-api.html>`_
 
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
@@ -3326,7 +3633,7 @@ class Elasticsearch(BaseClient):
         Create or update a script or search template. Creates or updates a stored script
         or search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-scripting.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-scripting.html>`_
 
         :param id: Identifier for the stored script or search template. Must be unique
             within the cluster.
@@ -3412,7 +3719,7 @@ class Elasticsearch(BaseClient):
         Evaluate ranked search results. Evaluate the quality of ranked search results
         over a set of typical search queries.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-rank-eval.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-rank-eval.html>`_
 
         :param requests: A set of typical search requests, together with their provided
             ratings.
@@ -3504,33 +3811,191 @@ class Elasticsearch(BaseClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Reindex documents. Copies documents from a source to a destination. The source
-        can be any existing index, alias, or data stream. The destination must differ
-        from the source. For example, you cannot reindex a data stream into itself.
+        Reindex documents. Copy documents from a source to a destination. You can copy
+        all documents to the destination index or reindex a subset of the documents.
+        The source can be any existing index, alias, or data stream. The destination
+        must differ from the source. For example, you cannot reindex a data stream into
+        itself. IMPORTANT: Reindex requires `_source` to be enabled for all documents
+        in the source. The destination should be configured as wanted before calling
+        the reindex API. Reindex does not copy the settings from the source or its associated
+        template. Mappings, shard counts, and replicas, for example, must be configured
+        ahead of time. If the Elasticsearch security features are enabled, you must have
+        the following security privileges: * The `read` index privilege for the source
+        data stream, index, or alias. * The `write` index privilege for the destination
+        data stream, index, or index alias. * To automatically create a data stream or
+        index with a reindex API request, you must have the `auto_configure`, `create_index`,
+        or `manage` index privilege for the destination data stream, index, or alias.
+        * If reindexing from a remote cluster, the `source.remote.user` must have the
+        `monitor` cluster privilege and the `read` index privilege for the source data
+        stream, index, or alias. If reindexing from a remote cluster, you must explicitly
+        allow the remote host in the `reindex.remote.whitelist` setting. Automatic data
+        stream creation requires a matching index template with data stream enabled.
+        The `dest` element can be configured like the index API to control optimistic
+        concurrency control. Omitting `version_type` or setting it to `internal` causes
+        Elasticsearch to blindly dump documents into the destination, overwriting any
+        that happen to have the same ID. Setting `version_type` to `external` causes
+        Elasticsearch to preserve the `version` from the source, create any documents
+        that are missing, and update any documents that have an older version in the
+        destination than they do in the source. Setting `op_type` to `create` causes
+        the reindex API to create only missing documents in the destination. All existing
+        documents will cause a version conflict. IMPORTANT: Because data streams are
+        append-only, any reindex request to a destination data stream must have an `op_type`
+        of `create`. A reindex can only add new documents to a destination data stream.
+        It cannot update existing documents in a destination data stream. By default,
+        version conflicts abort the reindex process. To continue reindexing if there
+        are conflicts, set the `conflicts` request body property to `proceed`. In this
+        case, the response includes a count of the version conflicts that were encountered.
+        Note that the handling of other error types is unaffected by the `conflicts`
+        property. Additionally, if you opt to count version conflicts, the operation
+        could attempt to reindex more documents from the source than `max_docs` until
+        it has successfully indexed `max_docs` documents into the target or it has gone
+        through every document in the source query. NOTE: The reindex API makes no effort
+        to handle ID collisions. The last document written will "win" but the order isn't
+        usually predictable so it is not a good idea to rely on this behavior. Instead,
+        make sure that IDs are unique by using a script. **Running reindex asynchronously**
+        If the request contains `wait_for_completion=false`, Elasticsearch performs some
+        preflight checks, launches the request, and returns a task you can use to cancel
+        or get the status of the task. Elasticsearch creates a record of this task as
+        a document at `_tasks/<task_id>`. **Reindex from multiple sources** If you have
+        many sources to reindex it is generally better to reindex them one at a time
+        rather than using a glob pattern to pick up multiple sources. That way you can
+        resume the process if there are any errors by removing the partially completed
+        source and starting over. It also makes parallelizing the process fairly simple:
+        split the list of sources to reindex and run each list in parallel. For example,
+        you can use a bash script like this: ``` for index in i1 i2 i3 i4 i5; do curl
+        -HContent-Type:application/json -XPOST localhost:9200/_reindex?pretty -d'{ "source":
+        { "index": "'$index'" }, "dest": { "index": "'$index'-reindexed" } }' done ```
+        **Throttling** Set `requests_per_second` to any positive decimal number (`1.4`,
+        `6`, `1000`, for example) to throttle the rate at which reindex issues batches
+        of index operations. Requests are throttled by padding each batch with a wait
+        time. To turn off throttling, set `requests_per_second` to `-1`. The throttling
+        is done by waiting between batches so that the scroll that reindex uses internally
+        can be given a timeout that takes into account the padding. The padding time
+        is the difference between the batch size divided by the `requests_per_second`
+        and the time spent writing. By default the batch size is `1000`, so if `requests_per_second`
+        is set to `500`: ``` target_time = 1000 / 500 per second = 2 seconds wait_time
+        = target_time - write_time = 2 seconds - .5 seconds = 1.5 seconds ``` Since the
+        batch is issued as a single bulk request, large batch sizes cause Elasticsearch
+        to create many requests and then wait for a while before starting the next set.
+        This is "bursty" instead of "smooth". **Slicing** Reindex supports sliced scroll
+        to parallelize the reindexing process. This parallelization can improve efficiency
+        and provide a convenient way to break the request down into smaller parts. NOTE:
+        Reindexing from remote clusters does not support manual or automatic slicing.
+        You can slice a reindex request manually by providing a slice ID and total number
+        of slices to each request. You can also let reindex automatically parallelize
+        by using sliced scroll to slice on `_id`. The `slices` parameter specifies the
+        number of slices to use. Adding `slices` to the reindex request just automates
+        the manual process, creating sub-requests which means it has some quirks: * You
+        can see these requests in the tasks API. These sub-requests are "child" tasks
+        of the task for the request with slices. * Fetching the status of the task for
+        the request with `slices` only contains the status of completed slices. * These
+        sub-requests are individually addressable for things like cancellation and rethrottling.
+        * Rethrottling the request with `slices` will rethrottle the unfinished sub-request
+        proportionally. * Canceling the request with `slices` will cancel each sub-request.
+        * Due to the nature of `slices`, each sub-request won't get a perfectly even
+        portion of the documents. All documents will be addressed, but some slices may
+        be larger than others. Expect larger slices to have a more even distribution.
+        * Parameters like `requests_per_second` and `max_docs` on a request with `slices`
+        are distributed proportionally to each sub-request. Combine that with the previous
+        point about distribution being uneven and you should conclude that using `max_docs`
+        with `slices` might not result in exactly `max_docs` documents being reindexed.
+        * Each sub-request gets a slightly different snapshot of the source, though these
+        are all taken at approximately the same time. If slicing automatically, setting
+        `slices` to `auto` will choose a reasonable number for most indices. If slicing
+        manually or otherwise tuning automatic slicing, use the following guidelines.
+        Query performance is most efficient when the number of slices is equal to the
+        number of shards in the index. If that number is large (for example, `500`),
+        choose a lower number as too many slices will hurt performance. Setting slices
+        higher than the number of shards generally does not improve efficiency and adds
+        overhead. Indexing performance scales linearly across available resources with
+        the number of slices. Whether query or indexing performance dominates the runtime
+        depends on the documents being reindexed and cluster resources. **Modify documents
+        during reindexing** Like `_update_by_query`, reindex operations support a script
+        that modifies the document. Unlike `_update_by_query`, the script is allowed
+        to modify the document's metadata. Just as in `_update_by_query`, you can set
+        `ctx.op` to change the operation that is run on the destination. For example,
+        set `ctx.op` to `noop` if your script decides that the document doesn’t have
+        to be indexed in the destination. This "no operation" will be reported in the
+        `noop` counter in the response body. Set `ctx.op` to `delete` if your script
+        decides that the document must be deleted from the destination. The deletion
+        will be reported in the `deleted` counter in the response body. Setting `ctx.op`
+        to anything else will return an error, as will setting any other field in `ctx`.
+        Think of the possibilities! Just be careful; you are able to change: * `_id`
+        * `_index` * `_version` * `_routing` Setting `_version` to `null` or clearing
+        it from the `ctx` map is just like not sending the version in an indexing request.
+        It will cause the document to be overwritten in the destination regardless of
+        the version on the target or the version type you use in the reindex API. **Reindex
+        from remote** Reindex supports reindexing from a remote Elasticsearch cluster.
+        The `host` parameter must contain a scheme, host, port, and optional path. The
+        `username` and `password` parameters are optional and when they are present the
+        reindex operation will connect to the remote Elasticsearch node using basic authentication.
+        Be sure to use HTTPS when using basic authentication or the password will be
+        sent in plain text. There are a range of settings available to configure the
+        behavior of the HTTPS connection. When using Elastic Cloud, it is also possible
+        to authenticate against the remote cluster through the use of a valid API key.
+        Remote hosts must be explicitly allowed with the `reindex.remote.whitelist` setting.
+        It can be set to a comma delimited list of allowed remote host and port combinations.
+        Scheme is ignored; only the host and port are used. For example: ``` reindex.remote.whitelist:
+        [otherhost:9200, another:9200, 127.0.10.*:9200, localhost:*"] ``` The list of
+        allowed hosts must be configured on any nodes that will coordinate the reindex.
+        This feature should work with remote clusters of any version of Elasticsearch.
+        This should enable you to upgrade from any version of Elasticsearch to the current
+        version by reindexing from a cluster of the old version. WARNING: Elasticsearch
+        does not support forward compatibility across major versions. For example, you
+        cannot reindex from a 7.x cluster into a 6.x cluster. To enable queries sent
+        to older versions of Elasticsearch, the `query` parameter is sent directly to
+        the remote host without validation or modification. NOTE: Reindexing from remote
+        clusters does not support manual or automatic slicing. Reindexing from a remote
+        server uses an on-heap buffer that defaults to a maximum size of 100mb. If the
+        remote index includes very large documents you'll need to use a smaller batch
+        size. It is also possible to set the socket read timeout on the remote connection
+        with the `socket_timeout` field and the connection timeout with the `connect_timeout`
+        field. Both default to 30 seconds. **Configuring SSL parameters** Reindex from
+        remote supports configurable SSL settings. These must be specified in the `elasticsearch.yml`
+        file, with the exception of the secure settings, which you add in the Elasticsearch
+        keystore. It is not possible to configure SSL in the body of the reindex request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-reindex.html>`_
 
         :param dest: The destination you are copying to.
         :param source: The source you are copying from.
-        :param conflicts: Set to proceed to continue reindexing even if there are conflicts.
-        :param max_docs: The maximum number of documents to reindex.
+        :param conflicts: Indicates whether to continue reindexing even when there are
+            conflicts.
+        :param max_docs: The maximum number of documents to reindex. By default, all
+            documents are reindexed. If it is a value less then or equal to `scroll_size`,
+            a scroll will not be used to retrieve the results for the operation. If `conflicts`
+            is set to `proceed`, the reindex operation could attempt to reindex more
+            documents from the source than `max_docs` until it has successfully indexed
+            `max_docs` documents into the target or it has gone through every document
+            in the source query.
         :param refresh: If `true`, the request refreshes affected shards to make this
             operation visible to search.
         :param requests_per_second: The throttle for this request in sub-requests per
-            second. Defaults to no throttle.
+            second. By default, there is no throttle.
         :param require_alias: If `true`, the destination must be an index alias.
         :param script: The script to run to update the document source or metadata when
             reindexing.
-        :param scroll: Specifies how long a consistent view of the index should be maintained
-            for scrolled search.
+        :param scroll: The period of time that a consistent view of the index should
+            be maintained for scrolled search.
         :param size:
-        :param slices: The number of slices this task should be divided into. Defaults
-            to 1 slice, meaning the task isn’t sliced into subtasks.
-        :param timeout: Period each indexing waits for automatic index creation, dynamic
-            mapping updates, and waiting for active shards.
+        :param slices: The number of slices this task should be divided into. It defaults
+            to one slice, which means the task isn't sliced into subtasks. Reindex supports
+            sliced scroll to parallelize the reindexing process. This parallelization
+            can improve efficiency and provide a convenient way to break the request
+            down into smaller parts. NOTE: Reindexing from remote clusters does not support
+            manual or automatic slicing. If set to `auto`, Elasticsearch chooses the
+            number of slices to use. This setting will use one slice per shard, up to
+            a certain limit. If there are multiple sources, it will choose the number
+            of slices based on the index or backing index with the smallest number of
+            shards.
+        :param timeout: The period each indexing waits for automatic index creation,
+            dynamic mapping updates, and waiting for active shards. By default, Elasticsearch
+            waits for at least one minute before failing. The actual wait time could
+            be longer, particularly when multiple waits occur.
         :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operation. Set to `all` or any positive integer
-            up to the total number of shards in the index (`number_of_replicas+1`).
+            before proceeding with the operation. Set it to `all` or any positive integer
+            up to the total number of shards in the index (`number_of_replicas+1`). The
+            default value is one, which means it waits for each primary shard to be active.
         :param wait_for_completion: If `true`, the request blocks until the operation
             is complete.
         """
@@ -3603,13 +4068,17 @@ class Elasticsearch(BaseClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Throttle a reindex operation. Change the number of requests per second for a
-        particular reindex operation.
+        particular reindex operation. For example: ``` POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1
+        ``` Rethrottling that speeds up the query takes effect immediately. Rethrottling
+        that slows down the query will take effect after completing the current batch.
+        This behavior prevents scroll timeouts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-reindex.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-reindex.html>`_
 
-        :param task_id: Identifier for the task.
+        :param task_id: The task identifier, which can be found by using the tasks API.
         :param requests_per_second: The throttle for this request in sub-requests per
-            second.
+            second. It can be either `-1` to turn off throttling or any decimal number
+            like `1.7` or `12` to throttle to that level.
         """
         if task_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'task_id'")
@@ -3656,7 +4125,7 @@ class Elasticsearch(BaseClient):
         """
         Render a search template. Render a search template as a search request body.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/render-search-template-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/render-search-template-api.html>`_
 
         :param id: ID of the search template to render. If no `source` is specified,
             this or the `id` request body parameter is required.
@@ -3725,7 +4194,7 @@ class Elasticsearch(BaseClient):
         """
         Run a script. Runs a script and returns a result.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.16/painless-execute-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/painless/8.17/painless-execute-api.html>`_
 
         :param context: The context that the script should run in.
         :param context_setup: Additional parameters for the `context`.
@@ -3798,7 +4267,7 @@ class Elasticsearch(BaseClient):
         of the index at the time of the initial search request. Subsequent indexing or
         document changes only affect later search and scroll requests.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-request-body.html#request-body-search-scroll>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-request-body.html#request-body-search-scroll>`_
 
         :param scroll_id: Scroll ID of the search.
         :param rest_total_hits_as_int: If true, the API response’s hit.total property
@@ -3990,7 +4459,7 @@ class Elasticsearch(BaseClient):
         can provide search queries using the `q` query string parameter or the request
         body. If both are specified, only the query parameter is used.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-search.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams and indices, omit this
@@ -4420,7 +4889,7 @@ class Elasticsearch(BaseClient):
         """
         Search a vector tile. Search a vector tile for geospatial values.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-vector-tile-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-vector-tile-api.html>`_
 
         :param index: Comma-separated list of data streams, indices, or aliases to search
         :param field: Field containing geospatial data to return
@@ -4578,7 +5047,7 @@ class Elasticsearch(BaseClient):
         optimizations with routing and shard preferences. When filtered aliases are used,
         the filter is returned as part of the indices section.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-shards.html>`_
 
         :param index: Returns the indices and shards that a search request would be executed
             against.
@@ -4682,7 +5151,7 @@ class Elasticsearch(BaseClient):
         """
         Run a search with a search template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-template.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (*).
@@ -4822,7 +5291,7 @@ class Elasticsearch(BaseClient):
         are actually deleted. Until that happens, the terms enum API will return terms
         from these documents.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-terms-enum.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-terms-enum.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             to search. Wildcard (*) expressions are supported.
@@ -4921,7 +5390,7 @@ class Elasticsearch(BaseClient):
         Get term vector information. Get information and statistics about terms in the
         fields of a particular document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-termvectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-termvectors.html>`_
 
         :param index: Name of the index that contains the document.
         :param id: Unique identifier of the document.
@@ -5061,46 +5530,60 @@ class Elasticsearch(BaseClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Update a document. Updates a document by running a script or passing a partial
-        document.
+        Update a document. Update a document by running a script or passing a partial
+        document. If the Elasticsearch security features are enabled, you must have the
+        `index` or `write` index privilege for the target index or index alias. The script
+        can update, delete, or skip modifying the document. The API also supports passing
+        a partial document, which is merged into the existing document. To fully replace
+        an existing document, use the index API. This operation: * Gets the document
+        (collocated with the shard) from the index. * Runs the specified script. * Indexes
+        the result. The document must still be reindexed, but using this API removes
+        some network roundtrips and reduces chances of version conflicts between the
+        GET and the index operation. The `_source` field must be enabled to use this
+        API. In addition to `_source`, you can access the following variables through
+        the `ctx` map: `_index`, `_type`, `_id`, `_version`, `_routing`, and `_now` (the
+        current timestamp).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-update.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-update.html>`_
 
-        :param index: The name of the index
-        :param id: Document ID
-        :param detect_noop: Set to false to disable setting 'result' in the response
-            to 'noop' if no change to the document occurred.
-        :param doc: A partial update to an existing document.
-        :param doc_as_upsert: Set to true to use the contents of 'doc' as the value of
-            'upsert'
+        :param index: The name of the target index. By default, the index is created
+            automatically if it doesn't exist.
+        :param id: A unique identifier for the document to be updated.
+        :param detect_noop: If `true`, the `result` in the response is set to `noop`
+            (no operation) when there are no changes to the document.
+        :param doc: A partial update to an existing document. If both `doc` and `script`
+            are specified, `doc` is ignored.
+        :param doc_as_upsert: If `true`, use the contents of 'doc' as the value of 'upsert'.
+            NOTE: Using ingest pipelines with `doc_as_upsert` is not supported.
         :param if_primary_term: Only perform the operation if the document has this primary
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
         :param lang: The script language.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
-            this operation visible to search, if 'wait_for' then wait for a refresh to
-            make this operation visible to search, if 'false' do nothing with refreshes.
-        :param require_alias: If true, the destination must be an index alias.
-        :param retry_on_conflict: Specify how many times should the operation be retried
+            this operation visible to search. If 'wait_for', it waits for a refresh to
+            make this operation visible to search. If 'false', it does nothing with refreshes.
+        :param require_alias: If `true`, the destination must be an index alias.
+        :param retry_on_conflict: The number of times the operation should be retried
             when a conflict occurs.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param script: Script to execute to update the document.
-        :param scripted_upsert: Set to true to execute the script whether or not the
-            document exists.
-        :param source: Set to false to disable source retrieval. You can also specify
-            a comma-separated list of the fields you want to retrieve.
-        :param source_excludes: Specify the source fields you want to exclude.
-        :param source_includes: Specify the source fields you want to retrieve.
-        :param timeout: Period to wait for dynamic mapping updates and active shards.
-            This guarantees Elasticsearch waits for at least the timeout before failing.
-            The actual wait time could be longer, particularly when multiple waits occur.
+        :param routing: A custom value used to route operations to a specific shard.
+        :param script: The script to run to update the document.
+        :param scripted_upsert: If `true`, run the script whether or not the document
+            exists.
+        :param source: If `false`, turn off source retrieval. You can also specify a
+            comma-separated list of the fields you want to retrieve.
+        :param source_excludes: The source fields you want to exclude.
+        :param source_includes: The source fields you want to retrieve.
+        :param timeout: The period to wait for the following operations: dynamic mapping
+            updates and waiting for active shards. Elasticsearch waits for at least the
+            timeout period before failing. The actual wait time could be longer, particularly
+            when multiple waits occur.
         :param upsert: If the document does not already exist, the contents of 'upsert'
-            are inserted as a new document. If the document exists, the 'script' is executed.
-        :param wait_for_active_shards: The number of shard copies that must be active
-            before proceeding with the operations. Set to 'all' or any positive integer
-            up to the total number of shards in the index (number_of_replicas+1). Defaults
-            to 1 meaning the primary shard.
+            are inserted as a new document. If the document exists, the 'script' is run.
+        :param wait_for_active_shards: The number of copies of each shard that must be
+            active before proceeding with the operation. Set to 'all' or any positive
+            integer up to the total number of shards in the index (`number_of_replicas`+1).
+            The default value of `1` means it waits for each primary shard to be active.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5230,7 +5713,7 @@ class Elasticsearch(BaseClient):
         is specified, performs an update on every document in the data stream or index
         without modifying the source, which is useful for picking up mapping changes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-update-by-query.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams or indices, omit this
@@ -5429,7 +5912,7 @@ class Elasticsearch(BaseClient):
         takes effect immediately but rethrotting that slows down the query takes effect
         after completing the current batch to prevent scroll timeouts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/docs-update-by-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/docs-update-by-query.html>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per

--- a/elasticsearch/_sync/client/async_search.py
+++ b/elasticsearch/_sync/client/async_search.py
@@ -42,7 +42,7 @@ class AsyncSearchClient(NamespacedClient):
         the authenticated user that submitted the original search request; users that
         have the `cancel_task` cluster privilege.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -90,7 +90,7 @@ class AsyncSearchClient(NamespacedClient):
         the results of a specific async search is restricted to the user or API key that
         submitted it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         :param keep_alive: Specifies how long the async search should be available in
@@ -154,7 +154,7 @@ class AsyncSearchClient(NamespacedClient):
         security features are enabled, use of this API is restricted to the `monitoring_user`
         role.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param id: A unique identifier for the async search.
         :param keep_alive: Specifies how long the async search needs to be available.
@@ -336,7 +336,7 @@ class AsyncSearchClient(NamespacedClient):
         can be set by changing the `search.max_async_search_response_size` cluster level
         setting.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/async-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/async-search.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices

--- a/elasticsearch/_sync/client/autoscaling.py
+++ b/elasticsearch/_sync/client/autoscaling.py
@@ -42,7 +42,7 @@ class AutoscalingClient(NamespacedClient):
         by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes.
         Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-delete-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-delete-autoscaling-policy.html>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -102,7 +102,7 @@ class AutoscalingClient(NamespacedClient):
         capacity was required. This information is provided for diagnosis only. Do not
         use this information to make autoscaling decisions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-get-autoscaling-capacity.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -147,7 +147,7 @@ class AutoscalingClient(NamespacedClient):
         Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes.
         Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-get-autoscaling-capacity.html>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -200,7 +200,7 @@ class AutoscalingClient(NamespacedClient):
         use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on
         Kubernetes. Direct use is not supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/autoscaling-put-autoscaling-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/autoscaling-put-autoscaling-policy.html>`_
 
         :param name: the name of the autoscaling policy
         :param policy:

--- a/elasticsearch/_sync/client/cat.py
+++ b/elasticsearch/_sync/client/cat.py
@@ -57,18 +57,20 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get aliases. Retrieves the cluster’s index aliases, including filter and routing
-        information. The API does not return data stream aliases. CAT APIs are only intended
+        Get aliases. Get the cluster's index aliases, including filter and routing information.
+        This API does not return data stream aliases. IMPORTANT: CAT APIs are only intended
         for human consumption using the command line or the Kibana console. They are
         not intended for use by applications. For application consumption, use the aliases
         API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-alias.html>`_
 
         :param name: A comma-separated list of aliases to retrieve. Supports wildcards
             (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. It supports comma-separated
+            values, such as `open,hidden`.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -78,7 +80,10 @@ class CatClient(NamespacedClient):
             the local cluster state. If `false` the list of selected nodes are computed
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. To indicated that the request should never timeout,
+            you can set it to `-1`.
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
@@ -147,13 +152,14 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Provides a snapshot of the number of shards allocated to each data node and their
-        disk space. IMPORTANT: cat APIs are only intended for human consumption using
-        the command line or Kibana console. They are not intended for use by applications.
+        Get shard allocation information. Get a snapshot of the number of shards allocated
+        to each data node and their disk space. IMPORTANT: CAT APIs are only intended
+        for human consumption using the command line or Kibana console. They are not
+        intended for use by applications.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-allocation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-allocation.html>`_
 
-        :param node_id: Comma-separated list of node identifiers or names used to limit
+        :param node_id: A comma-separated list of node identifiers or names used to limit
             the returned information.
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -231,17 +237,17 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get component templates. Returns information about component templates in a cluster.
+        Get component templates. Get information about component templates in a cluster.
         Component templates are building blocks for constructing index templates that
-        specify index mappings, settings, and aliases. CAT APIs are only intended for
-        human consumption using the command line or Kibana console. They are not intended
-        for use by applications. For application consumption, use the get component template
-        API.
+        specify index mappings, settings, and aliases. IMPORTANT: CAT APIs are only intended
+        for human consumption using the command line or Kibana console. They are not
+        intended for use by applications. For application consumption, use the get component
+        template API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-component-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-component-templates.html>`_
 
-        :param name: The name of the component template. Accepts wildcard expressions.
-            If omitted, all component templates are returned.
+        :param name: The name of the component template. It accepts wildcard expressions.
+            If it is omitted, all component templates are returned.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
         :param h: List of columns to appear in the response. Supports simple wildcards.
@@ -251,7 +257,7 @@ class CatClient(NamespacedClient):
             the local cluster state. If `false` the list of selected nodes are computed
             from the cluster state of the master node. In both cases the coordinating
             node will send requests for further information to each selected node.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param master_timeout: The period to wait for a connection to the master node.
         :param s: List of columns that determine how the table should be sorted. Sorting
             defaults to ascending and can be changed by setting `:asc` or `:desc` as
             a suffix to the column name.
@@ -313,17 +319,17 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get a document count. Provides quick access to a document count for a data stream,
+        Get a document count. Get quick access to a document count for a data stream,
         an index, or an entire cluster. The document count only includes live documents,
-        not deleted documents which have not yet been removed by the merge process. CAT
-        APIs are only intended for human consumption using the command line or Kibana
+        not deleted documents which have not yet been removed by the merge process. IMPORTANT:
+        CAT APIs are only intended for human consumption using the command line or Kibana
         console. They are not intended for use by applications. For application consumption,
         use the count API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-count.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-count.html>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases used
-            to limit the request. Supports wildcards (`*`). To target all data streams
+        :param index: A comma-separated list of data streams, indices, and aliases used
+            to limit the request. It supports wildcards (`*`). To target all data streams
             and indices, omit this parameter or use `*` or `_all`.
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -390,12 +396,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns the amount of heap memory currently used by the field data cache on every
-        data node in the cluster. IMPORTANT: cat APIs are only intended for human consumption
-        using the command line or Kibana console. They are not intended for use by applications.
-        For application consumption, use the nodes stats API.
+        Get field data cache information. Get the amount of heap memory currently used
+        by the field data cache on every data node in the cluster. IMPORTANT: cat APIs
+        are only intended for human consumption using the command line or Kibana console.
+        They are not intended for use by applications. For application consumption, use
+        the nodes stats API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-fielddata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-fielddata.html>`_
 
         :param fields: Comma-separated list of fields used to limit returned information.
             To retrieve all fields, omit this parameter.
@@ -467,19 +474,19 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns the health status of a cluster, similar to the cluster health API. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the cluster health API. This API is often used to check malfunctioning clusters.
-        To help you track cluster health alongside log files and alerting systems, the
-        API returns timestamps in two formats: `HH:MM:SS`, which is human-readable but
-        includes no date information; `Unix epoch time`, which is machine-sortable and
-        includes date information. The latter format is useful for cluster recoveries
-        that take multiple days. You can use the cat health API to verify cluster health
-        across multiple nodes. You also can use the API to track the recovery of a large
-        cluster over a longer period of time.
+        Get the cluster health status. IMPORTANT: CAT APIs are only intended for human
+        consumption using the command line or Kibana console. They are not intended for
+        use by applications. For application consumption, use the cluster health API.
+        This API is often used to check malfunctioning clusters. To help you track cluster
+        health alongside log files and alerting systems, the API returns timestamps in
+        two formats: `HH:MM:SS`, which is human-readable but includes no date information;
+        `Unix epoch time`, which is machine-sortable and includes date information. The
+        latter format is useful for cluster recoveries that take multiple days. You can
+        use the cat health API to verify cluster health across multiple nodes. You also
+        can use the API to track the recovery of a large cluster over a longer period
+        of time.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-health.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -531,9 +538,9 @@ class CatClient(NamespacedClient):
     @_rewrite_parameters()
     def help(self) -> TextApiResponse:
         """
-        Get CAT help. Returns help for the CAT APIs.
+        Get CAT help. Get help for the CAT APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_cat"
@@ -582,7 +589,7 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get index information. Returns high-level information about indices in a cluster,
+        Get index information. Get high-level information about indices in a cluster,
         including backing indices for data streams. Use this request to get the following
         information for each index in a cluster: - shard count - document count - deleted
         document count - primary store size - total store size of all shards, including
@@ -593,7 +600,7 @@ class CatClient(NamespacedClient):
         using the command line or Kibana console. They are not intended for use by applications.
         For application consumption, use an index endpoint.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-indices.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-indices.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -684,12 +691,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the master node, including the ID, bound IP address,
-        and name. IMPORTANT: cat APIs are only intended for human consumption using the
-        command line or Kibana console. They are not intended for use by applications.
-        For application consumption, use the nodes info API.
+        Get master node information. Get information about the master node, including
+        the ID, bound IP address, and name. IMPORTANT: cat APIs are only intended for
+        human consumption using the command line or Kibana console. They are not intended
+        for use by applications. For application consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-master.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-master.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -858,13 +865,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get data frame analytics jobs. Returns configuration and usage information about
-        data frame analytics jobs. CAT APIs are only intended for human consumption using
-        the Kibana console or command line. They are not intended for use by applications.
+        Get data frame analytics jobs. Get configuration and usage information about
+        data frame analytics jobs. IMPORTANT: CAT APIs are only intended for human consumption
+        using the Kibana console or command line. They are not intended for use by applications.
         For application consumption, use the get data frame analytics jobs statistics
         API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-dfanalytics.html>`_
 
         :param id: The ID of the data frame analytics to fetch
         :param allow_no_match: Whether to ignore if a wildcard expression matches no
@@ -1020,14 +1027,15 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get datafeeds. Returns configuration and usage information about datafeeds. This
+        Get datafeeds. Get configuration and usage information about datafeeds. This
         API returns a maximum of 10,000 datafeeds. If the Elasticsearch security features
         are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`
-        cluster privileges to use this API. CAT APIs are only intended for human consumption
-        using the Kibana console or command line. They are not intended for use by applications.
-        For application consumption, use the get datafeed statistics API.
+        cluster privileges to use this API. IMPORTANT: CAT APIs are only intended for
+        human consumption using the Kibana console or command line. They are not intended
+        for use by applications. For application consumption, use the get datafeed statistics
+        API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-datafeeds.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-datafeeds.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed.
@@ -1381,15 +1389,15 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get anomaly detection jobs. Returns configuration and usage information for anomaly
+        Get anomaly detection jobs. Get configuration and usage information for anomaly
         detection jobs. This API returns a maximum of 10,000 jobs. If the Elasticsearch
         security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`,
-        or `manage` cluster privileges to use this API. CAT APIs are only intended for
-        human consumption using the Kibana console or command line. They are not intended
-        for use by applications. For application consumption, use the get anomaly detection
-        job statistics API.
+        or `manage` cluster privileges to use this API. IMPORTANT: CAT APIs are only
+        intended for human consumption using the Kibana console or command line. They
+        are not intended for use by applications. For application consumption, use the
+        get anomaly detection job statistics API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-anomaly-detectors.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-anomaly-detectors.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param allow_no_match: Specifies what to do when the request: * Contains wildcard
@@ -1565,12 +1573,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get trained models. Returns configuration and usage information about inference
-        trained models. CAT APIs are only intended for human consumption using the Kibana
-        console or command line. They are not intended for use by applications. For application
-        consumption, use the get trained models statistics API.
+        Get trained models. Get configuration and usage information about inference trained
+        models. IMPORTANT: CAT APIs are only intended for human consumption using the
+        Kibana console or command line. They are not intended for use by applications.
+        For application consumption, use the get trained models statistics API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-trained-model.html>`_
 
         :param model_id: A unique identifier for the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -1656,12 +1664,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about custom node attributes. IMPORTANT: cat APIs are only
-        intended for human consumption using the command line or Kibana console. They
-        are not intended for use by applications. For application consumption, use the
-        nodes info API.
+        Get node attribute information. Get information about custom node attributes.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-nodeattrs.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-nodeattrs.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1737,12 +1745,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the nodes in a cluster. IMPORTANT: cat APIs are only
-        intended for human consumption using the command line or Kibana console. They
-        are not intended for use by applications. For application consumption, use the
-        nodes info API.
+        Get node information. Get information about the nodes in a cluster. IMPORTANT:
+        cat APIs are only intended for human consumption using the command line or Kibana
+        console. They are not intended for use by applications. For application consumption,
+        use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-nodes.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-nodes.html>`_
 
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -1822,12 +1830,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns cluster-level changes that have not yet been executed. IMPORTANT: cat
-        APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the pending cluster tasks API.
+        Get pending task information. Get information about cluster-level changes that
+        have not yet taken effect. IMPORTANT: cat APIs are only intended for human consumption
+        using the command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the pending cluster tasks API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-pending-tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-pending-tasks.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1900,12 +1908,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns a list of plugins running on each node of a cluster. IMPORTANT: cat APIs
-        are only intended for human consumption using the command line or Kibana console.
-        They are not intended for use by applications. For application consumption, use
-        the nodes info API.
+        Get plugin information. Get a list of plugins running on each node of a cluster.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-plugins.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-plugins.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1984,16 +1992,16 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about ongoing and completed shard recoveries. Shard recovery
-        is the process of initializing a shard copy, such as restoring a primary shard
-        from a snapshot or syncing a replica shard from a primary shard. When a shard
-        recovery completes, the recovered shard is available for search and indexing.
-        For data streams, the API returns information about the stream’s backing indices.
-        IMPORTANT: cat APIs are only intended for human consumption using the command
-        line or Kibana console. They are not intended for use by applications. For application
-        consumption, use the index recovery API.
+        Get shard recovery information. Get information about ongoing and completed shard
+        recoveries. Shard recovery is the process of initializing a shard copy, such
+        as restoring a primary shard from a snapshot or syncing a replica shard from
+        a primary shard. When a shard recovery completes, the recovered shard is available
+        for search and indexing. For data streams, the API returns information about
+        the stream’s backing indices. IMPORTANT: cat APIs are only intended for human
+        consumption using the command line or Kibana console. They are not intended for
+        use by applications. For application consumption, use the index recovery API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-recovery.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2074,12 +2082,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns the snapshot repositories for a cluster. IMPORTANT: cat APIs are only
-        intended for human consumption using the command line or Kibana console. They
-        are not intended for use by applications. For application consumption, use the
-        get snapshot repository API.
+        Get snapshot repository information. Get a list of snapshot repositories for
+        a cluster. IMPORTANT: cat APIs are only intended for human consumption using
+        the command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the get snapshot repository API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-repositories.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-repositories.html>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -2152,13 +2160,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns low-level information about the Lucene segments in index shards. For
-        data streams, the API returns information about the backing indices. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the index segments API.
+        Get segment information. Get low-level information about the Lucene segments
+        in index shards. For data streams, the API returns information about the backing
+        indices. IMPORTANT: cat APIs are only intended for human consumption using the
+        command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the index segments API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-segments.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2244,12 +2252,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the shards in a cluster. For data streams, the API
-        returns information about the backing indices. IMPORTANT: cat APIs are only intended
-        for human consumption using the command line or Kibana console. They are not
-        intended for use by applications.
+        Get shard information. Get information about the shards in a cluster. For data
+        streams, the API returns information about the backing indices. IMPORTANT: cat
+        APIs are only intended for human consumption using the command line or Kibana
+        console. They are not intended for use by applications.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-shards.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-shards.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2330,13 +2338,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about the snapshots stored in one or more repositories. A
-        snapshot is a backup of an index or running Elasticsearch cluster. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the get snapshot API.
+        Get snapshot information. Get information about the snapshots stored in one or
+        more repositories. A snapshot is a backup of an index or running Elasticsearch
+        cluster. IMPORTANT: cat APIs are only intended for human consumption using the
+        command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the get snapshot API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-snapshots.html>`_
 
         :param repository: A comma-separated list of snapshot repositories used to limit
             the request. Accepts wildcard expressions. `_all` returns all repositories.
@@ -2422,12 +2430,12 @@ class CatClient(NamespacedClient):
         wait_for_completion: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about tasks currently executing in the cluster. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the task management API.
+        Get task information. Get information about tasks currently running in the cluster.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the task management API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param actions: The task action names, which are used to limit the response.
         :param detailed: If `true`, the response includes detailed information about
@@ -2513,13 +2521,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns information about index templates in a cluster. You can use index templates
-        to apply index settings and field mappings to new indices at creation. IMPORTANT:
-        cat APIs are only intended for human consumption using the command line or Kibana
-        console. They are not intended for use by applications. For application consumption,
-        use the get index template API.
+        Get index template information. Get information about the index templates in
+        a cluster. You can use index templates to apply index settings and field mappings
+        to new indices at creation. IMPORTANT: cat APIs are only intended for human consumption
+        using the command line or Kibana console. They are not intended for use by applications.
+        For application consumption, use the get index template API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-templates.html>`_
 
         :param name: The name of the template to return. Accepts wildcard expressions.
             If omitted, all templates are returned.
@@ -2599,13 +2607,13 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Returns thread pool statistics for each node in a cluster. Returned information
-        includes all built-in thread pools and custom thread pools. IMPORTANT: cat APIs
-        are only intended for human consumption using the command line or Kibana console.
-        They are not intended for use by applications. For application consumption, use
-        the nodes info API.
+        Get thread pool statistics. Get thread pool statistics for each node in a cluster.
+        Returned information includes all built-in thread pools and custom thread pools.
+        IMPORTANT: cat APIs are only intended for human consumption using the command
+        line or Kibana console. They are not intended for use by applications. For application
+        consumption, use the nodes info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-thread-pool.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-thread-pool.html>`_
 
         :param thread_pool_patterns: A comma-separated list of thread pool names used
             to limit the request. Accepts wildcard expressions.
@@ -2853,12 +2861,12 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get transforms. Returns configuration and usage information about transforms.
+        Get transform information. Get configuration and usage information about transforms.
         CAT APIs are only intended for human consumption using the Kibana console or
         command line. They are not intended for use by applications. For application
         consumption, use the get transform statistics API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cat-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cat-transforms.html>`_
 
         :param transform_id: A transform identifier or a wildcard expression. If you
             do not specify one of these options, the API returns information for all

--- a/elasticsearch/_sync/client/ccr.py
+++ b/elasticsearch/_sync/client/ccr.py
@@ -40,7 +40,7 @@ class CcrClient(NamespacedClient):
         Delete auto-follow patterns. Delete a collection of cross-cluster replication
         auto-follow patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-delete-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-delete-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -122,7 +122,7 @@ class CcrClient(NamespacedClient):
         cross-cluster replication starts replicating operations from the leader index
         to the follower index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-put-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-put-follow.html>`_
 
         :param index: The name of the follower index.
         :param leader_index: The name of the index in the leader cluster to follow.
@@ -249,7 +249,7 @@ class CcrClient(NamespacedClient):
         index names, replication options, and whether the follower indices are active
         or paused.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-follow-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-follow-info.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -296,7 +296,7 @@ class CcrClient(NamespacedClient):
         shard-level stats about the "following tasks" associated with each shard for
         the specified indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-follow-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-follow-stats.html>`_
 
         :param index: A comma-separated list of index patterns; use `_all` to perform
             the operation on all indices
@@ -370,7 +370,7 @@ class CcrClient(NamespacedClient):
         API is to handle the case of failure to remove the following retention leases
         after the unfollow API is invoked.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-forget-follower.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-forget-follower.html>`_
 
         :param index: the name of the leader index for which specified follower retention
             leases should be removed
@@ -431,7 +431,7 @@ class CcrClient(NamespacedClient):
         """
         Get auto-follow patterns. Get cross-cluster replication auto-follow patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-auto-follow-pattern.html>`_
 
         :param name: Specifies the auto-follow pattern collection that you want to retrieve.
             If you do not specify a name, the API returns information for all collections.
@@ -486,7 +486,7 @@ class CcrClient(NamespacedClient):
         patterns. Remote indices that were created while the pattern was paused will
         also be followed, unless they have been deleted or closed in the interim.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-pause-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-pause-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern that should pause discovering
             new indices to follow.
@@ -534,7 +534,7 @@ class CcrClient(NamespacedClient):
         resume following with the resume follower API. You can pause and resume a follower
         index to change the configuration of the following task.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-pause-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-pause-follow.html>`_
 
         :param index: The name of the follower index that should pause following its
             leader index.
@@ -620,7 +620,7 @@ class CcrClient(NamespacedClient):
         that were configured automatically before updating an auto-follow pattern will
         remain unchanged even if they do not match against the new patterns.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-put-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-put-auto-follow-pattern.html>`_
 
         :param name: The name of the collection of auto-follow patterns.
         :param remote_cluster: The remote cluster containing the leader indices to match
@@ -752,7 +752,7 @@ class CcrClient(NamespacedClient):
         Remote indices created while the pattern was paused will also be followed unless
         they have been deleted or closed in the interim.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-resume-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-resume-auto-follow-pattern.html>`_
 
         :param name: The name of the auto follow pattern to resume discovering new indices
             to follow.
@@ -825,7 +825,7 @@ class CcrClient(NamespacedClient):
         to failures during following tasks. When this API returns, the follower index
         will resume fetching operations from the leader index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-resume-follow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-resume-follow.html>`_
 
         :param index: The name of the follow index to resume following.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -913,7 +913,7 @@ class CcrClient(NamespacedClient):
         Get cross-cluster replication stats. This API returns stats about auto-following
         and the same shard-level stats as the get follower stats API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-get-stats.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param timeout: Period to wait for a response. If no response is received before
@@ -964,7 +964,7 @@ class CcrClient(NamespacedClient):
         regular index to a follower index. Converting a follower index to a regular index
         is an irreversible operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ccr-post-unfollow.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ccr-post-unfollow.html>`_
 
         :param index: The name of the follower index that should be turned into a regular
             index.

--- a/elasticsearch/_sync/client/cluster.py
+++ b/elasticsearch/_sync/client/cluster.py
@@ -53,7 +53,7 @@ class ClusterClient(NamespacedClient):
         or why a shard continues to remain on its current node when you might expect
         otherwise.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-allocation-explain.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-allocation-explain.html>`_
 
         :param current_node: Specifies the node ID or the name of the node to only explain
             a shard that is currently located on the specified node.
@@ -126,7 +126,7 @@ class ClusterClient(NamespacedClient):
         Delete component templates. Component templates are building blocks for constructing
         index templates that specify index mappings, settings, and aliases.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Comma-separated list or wildcard expression of component template
             names used to limit the request.
@@ -178,7 +178,7 @@ class ClusterClient(NamespacedClient):
         Clear cluster voting config exclusions. Remove master-eligible nodes from the
         voting configuration exclusion list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/voting-config-exclusions.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
@@ -229,7 +229,7 @@ class ClusterClient(NamespacedClient):
         Check component templates. Returns information about whether a particular component
         template exists.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (*) expressions are supported.
@@ -284,7 +284,7 @@ class ClusterClient(NamespacedClient):
         """
         Get component templates. Get information about component templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -348,7 +348,7 @@ class ClusterClient(NamespacedClient):
         Get cluster-wide settings. By default, it returns only settings that have been
         explicitly defined.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-get-settings.html>`_
 
         :param flat_settings: If `true`, returns settings in flat format.
         :param include_defaults: If `true`, returns default cluster settings from the
@@ -439,7 +439,7 @@ class ClusterClient(NamespacedClient):
         high watermark health level. The cluster status is controlled by the worst index
         status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-health.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-health.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (`*`) are supported. To target
@@ -543,7 +543,7 @@ class ClusterClient(NamespacedClient):
         """
         Get cluster info. Returns basic information about the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-info.html>`_
 
         :param target: Limits the information returned to the specific target. Supports
             a comma-separated list, such as http,ingest.
@@ -592,7 +592,7 @@ class ClusterClient(NamespacedClient):
         index command causes a cluster state update, the activity of this task might
         be reported by both task api and pending cluster tasks API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-pending.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-pending.html>`_
 
         :param local: If `true`, the request retrieves information from the local node
             only. If `false`, information is retrieved from the master node.
@@ -667,7 +667,7 @@ class ClusterClient(NamespacedClient):
         master-ineligible nodes or when removing fewer than half of the master-eligible
         nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/voting-config-exclusions.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param node_ids: A comma-separated list of the persistent ids of the nodes to
@@ -746,7 +746,7 @@ class ClusterClient(NamespacedClient):
         template to a data stream or index. To be applied, a component template must
         be included in an index template's `composed_of` list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-component-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-component-template.html>`_
 
         :param name: Name of the component template to create. Elasticsearch includes
             the following built-in component templates: `logs-mappings`; `logs-settings`;
@@ -854,7 +854,7 @@ class ClusterClient(NamespacedClient):
         settings can clear unexpectedly, resulting in a potentially undesired cluster
         configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-update-settings.html>`_
 
         :param flat_settings: Return settings in flat format (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
@@ -910,7 +910,7 @@ class ClusterClient(NamespacedClient):
         This API returns connection and endpoint information keyed by the configured
         remote cluster alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-remote-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-remote-info.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_remote/info"
@@ -973,7 +973,7 @@ class ClusterClient(NamespacedClient):
         API with the `?retry_failed` URI query parameter, which will attempt a single
         retry round for these shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-reroute.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-reroute.html>`_
 
         :param commands: Defines the commands to perform.
         :param dry_run: If true, then the request simulates the operation. It will calculate
@@ -1081,7 +1081,7 @@ class ClusterClient(NamespacedClient):
         external monitoring tools. Instead, obtain the information you require using
         other more stable cluster APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-state.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-state.html>`_
 
         :param metric: Limit the information returned to the specified metrics
         :param index: A comma-separated list of index names; use `_all` or empty string
@@ -1167,7 +1167,7 @@ class ClusterClient(NamespacedClient):
         usage) and information about the current nodes that form the cluster (number,
         roles, os, jvm versions, memory usage, cpu and installed plugins).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-stats.html>`_
 
         :param node_id: Comma-separated list of node filters used to limit returned information.
             Defaults to all nodes in the cluster.

--- a/elasticsearch/_sync/client/connector.py
+++ b/elasticsearch/_sync/client/connector.py
@@ -46,7 +46,7 @@ class ConnectorClient(NamespacedClient):
         Check in a connector. Update the `last_seen` field in the connector and set it
         to the current timestamp.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/check-in-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/check-in-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be checked in
         """
@@ -91,7 +91,7 @@ class ConnectorClient(NamespacedClient):
         ingest pipelines, or data indices associated with the connector. These need to
         be removed manually.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be deleted
         :param delete_sync_jobs: A flag indicating if associated sync jobs should be
@@ -136,7 +136,7 @@ class ConnectorClient(NamespacedClient):
         """
         Get a connector. Get the details about a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector
         """
@@ -232,7 +232,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector last sync stats. Update the fields related to the last sync
         of a connector. This action is used for analytics and monitoring.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-last-sync-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-last-sync-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param last_access_control_sync_error:
@@ -327,7 +327,7 @@ class ConnectorClient(NamespacedClient):
         """
         Get all connectors. Get information about all connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-connector-api.html>`_
 
         :param connector_name: A comma-separated list of connector names to fetch connector
             documents for
@@ -406,7 +406,7 @@ class ConnectorClient(NamespacedClient):
         a managed service on Elastic Cloud. Self-managed connectors (Connector clients)
         are self-managed on your infrastructure.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-connector-api.html>`_
 
         :param description:
         :param index_name:
@@ -485,7 +485,7 @@ class ConnectorClient(NamespacedClient):
         """
         Create or update a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-connector-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-connector-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be created or
             updated. ID is auto-generated if not provided.
@@ -558,7 +558,7 @@ class ConnectorClient(NamespacedClient):
         connector service is then responsible for setting the status of connector sync
         jobs to cancelled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cancel-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cancel-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -607,7 +607,7 @@ class ConnectorClient(NamespacedClient):
         on your own infrastructure. This service runs automatically on Elastic Cloud
         for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/check-in-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/check-in-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be checked in.
@@ -665,7 +665,7 @@ class ConnectorClient(NamespacedClient):
         service on your own infrastructure. This service runs automatically on Elastic
         Cloud for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/claim-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/claim-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param worker_hostname: The host name of the current system that will run the
@@ -723,7 +723,7 @@ class ConnectorClient(NamespacedClient):
         Delete a connector sync job. Remove a connector sync job and its associated data.
         This is a destructive action that is not recoverable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be deleted
@@ -774,7 +774,7 @@ class ConnectorClient(NamespacedClient):
         you need to deploy the Elastic connector service on your own infrastructure.
         This service runs automatically on Elastic Cloud for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/set-connector-sync-job-error-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/set-connector-sync-job-error-api.html>`_
 
         :param connector_sync_job_id: The unique identifier for the connector sync job.
         :param error: The error for the connector sync job error field.
@@ -825,7 +825,7 @@ class ConnectorClient(NamespacedClient):
         """
         Get a connector sync job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-connector-sync-job-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -895,7 +895,7 @@ class ConnectorClient(NamespacedClient):
         Get all connector sync jobs. Get information about all stored connector sync
         jobs listed by their creation date in ascending order.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-connector-sync-jobs-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-connector-sync-jobs-api.html>`_
 
         :param connector_id: A connector id to fetch connector sync jobs for
         :param from_: Starting offset (default: 0)
@@ -958,7 +958,7 @@ class ConnectorClient(NamespacedClient):
         Create a connector sync job. Create a connector sync job document in the internal
         index and initialize its counters and timestamps with default values.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-connector-sync-job-api.html>`_
 
         :param id: The id of the associated connector
         :param job_type:
@@ -1031,7 +1031,7 @@ class ConnectorClient(NamespacedClient):
         service on your own infrastructure. This service runs automatically on Elastic
         Cloud for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/set-connector-sync-job-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/set-connector-sync-job-stats-api.html>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param deleted_document_count: The number of documents the sync job deleted.
@@ -1111,7 +1111,7 @@ class ConnectorClient(NamespacedClient):
         Activate the connector draft filter. Activates the valid draft filtering for
         a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-filtering-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         """
@@ -1161,7 +1161,7 @@ class ConnectorClient(NamespacedClient):
         secret ID is required only for Elastic managed (native) connectors. Self-managed
         connectors (connector clients) do not use this field.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-api-key-id-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-api-key-id-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param api_key_id:
@@ -1217,7 +1217,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector configuration. Update the configuration field in the connector
         document.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-configuration-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-configuration-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param configuration:
@@ -1274,7 +1274,7 @@ class ConnectorClient(NamespacedClient):
         to error. Otherwise, if the error is reset to null, the connector status is updated
         to connected.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-error-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-error-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param error:
@@ -1334,7 +1334,7 @@ class ConnectorClient(NamespacedClient):
         on your own infrastructure. This service runs automatically on Elastic Cloud
         for Elastic managed connectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-features-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-features-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated.
         :param features:
@@ -1392,7 +1392,7 @@ class ConnectorClient(NamespacedClient):
         is activated once validated by the running Elastic connector service. The filtering
         property is used to configure sync rules (both basic and advanced) for a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-filtering-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param advanced_snippet:
@@ -1450,7 +1450,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector draft filtering validation. Update the draft filtering validation
         info for a connector.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-filtering-validation-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-filtering-validation-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param validation:
@@ -1504,7 +1504,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector index name. Update the `index_name` field of a connector,
         specifying the index where the data ingested by the connector is stored.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-index-name-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-index-name-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param index_name:
@@ -1558,7 +1558,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector name and description.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-name-description-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-name-description-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param description:
@@ -1612,7 +1612,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector is_native flag.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-native-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-native-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param is_native:
@@ -1666,7 +1666,7 @@ class ConnectorClient(NamespacedClient):
         Update the connector pipeline. When you create a new connector, the configuration
         of an ingest pipeline is populated with default settings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-pipeline-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param pipeline:
@@ -1719,7 +1719,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector scheduling.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-scheduling-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-scheduling-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param scheduling:
@@ -1772,7 +1772,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector service type.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-service-type-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-service-type-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param service_type:
@@ -1832,7 +1832,7 @@ class ConnectorClient(NamespacedClient):
         """
         Update the connector status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-connector-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-connector-status-api.html>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param status:

--- a/elasticsearch/_sync/client/dangling_indices.py
+++ b/elasticsearch/_sync/client/dangling_indices.py
@@ -44,7 +44,7 @@ class DanglingIndicesClient(NamespacedClient):
         For example, this can happen if you delete more than `cluster.indices.tombstones.size`
         indices while an Elasticsearch node is offline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/dangling-index-delete.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/dangling-index-delete.html>`_
 
         :param index_uuid: The UUID of the index to delete. Use the get dangling indices
             API to find the UUID.
@@ -103,7 +103,7 @@ class DanglingIndicesClient(NamespacedClient):
         For example, this can happen if you delete more than `cluster.indices.tombstones.size`
         indices while an Elasticsearch node is offline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/dangling-index-import.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/dangling-index-import.html>`_
 
         :param index_uuid: The UUID of the index to import. Use the get dangling indices
             API to locate the UUID.
@@ -162,7 +162,7 @@ class DanglingIndicesClient(NamespacedClient):
         indices while an Elasticsearch node is offline. Use this API to list dangling
         indices, which you can then import or delete.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/dangling-indices-list.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/dangling-indices-list.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_dangling"

--- a/elasticsearch/_sync/client/enrich.py
+++ b/elasticsearch/_sync/client/enrich.py
@@ -39,7 +39,7 @@ class EnrichClient(NamespacedClient):
         """
         Delete an enrich policy. Deletes an existing enrich policy and its enrich index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-enrich-policy-api.html>`_
 
         :param name: Enrich policy to delete.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -84,7 +84,7 @@ class EnrichClient(NamespacedClient):
         """
         Run an enrich policy. Create the enrich index for an existing enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/execute-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/execute-enrich-policy-api.html>`_
 
         :param name: Enrich policy to execute.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -132,7 +132,7 @@ class EnrichClient(NamespacedClient):
         """
         Get an enrich policy. Returns information about an enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-enrich-policy-api.html>`_
 
         :param name: Comma-separated list of enrich policy names used to limit the request.
             To return information for all enrich policies, omit this parameter.
@@ -186,7 +186,7 @@ class EnrichClient(NamespacedClient):
         """
         Create an enrich policy. Creates an enrich policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-enrich-policy-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-enrich-policy-api.html>`_
 
         :param name: Name of the enrich policy to create or update.
         :param geo_match: Matches enrich data to incoming documents based on a `geo_shape`
@@ -244,7 +244,7 @@ class EnrichClient(NamespacedClient):
         Get enrich stats. Returns enrich coordinator statistics and information about
         enrich policies that are currently executing.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/enrich-stats-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/enrich-stats-api.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_sync/client/eql.py
+++ b/elasticsearch/_sync/client/eql.py
@@ -39,7 +39,7 @@ class EqlClient(NamespacedClient):
         Delete an async EQL search. Delete an async EQL search or a stored synchronous
         EQL search. The API also deletes results for the search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/eql-search-api.html>`_
 
         :param id: Identifier for the search to delete. A search ID is provided in the
             EQL search API's response for an async search. A search ID is also provided
@@ -86,7 +86,7 @@ class EqlClient(NamespacedClient):
         Get async EQL search results. Get the current status and available results for
         an async EQL search or a stored synchronous EQL search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-eql-search-api.html>`_
 
         :param id: Identifier for the search.
         :param keep_alive: Period for which the search and its results are stored on
@@ -137,7 +137,7 @@ class EqlClient(NamespacedClient):
         Get the async EQL status. Get the current status for an async EQL search or a
         stored synchronous EQL search without returning results.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-eql-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-eql-status-api.html>`_
 
         :param id: Identifier for the search.
         """
@@ -233,7 +233,7 @@ class EqlClient(NamespacedClient):
         query. EQL assumes each document in a data stream or index corresponds to an
         event.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/eql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/eql-search-api.html>`_
 
         :param index: The name of the index to scope the operation
         :param query: EQL query you wish to run.

--- a/elasticsearch/_sync/client/esql.py
+++ b/elasticsearch/_sync/client/esql.py
@@ -78,7 +78,7 @@ class EsqlClient(NamespacedClient):
         The API accepts the same parameters and request body as the synchronous query
         API, along with additional async related properties.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-async-query-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-async-query-api.html>`_
 
         :param query: The ES|QL query API accepts an ES|QL query string in the query
             parameter, runs it, and returns the results.
@@ -189,7 +189,7 @@ class EsqlClient(NamespacedClient):
         authenticated user that submitted the original query request * Users with the
         `cancel_task` cluster privilege
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-async-query-delete-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-async-query-delete-api.html>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -240,7 +240,7 @@ class EsqlClient(NamespacedClient):
         features are enabled, only the user who first submitted the ES|QL query can retrieve
         the results using this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-async-query-get-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-async-query-get-api.html>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -334,7 +334,7 @@ class EsqlClient(NamespacedClient):
         Run an ES|QL query. Get search results for an ES|QL (Elasticsearch query language)
         query.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/esql-rest.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/esql-rest.html>`_
 
         :param query: The ES|QL query API accepts an ES|QL query string in the query
             parameter, runs it, and returns the results.

--- a/elasticsearch/_sync/client/features.py
+++ b/elasticsearch/_sync/client/features.py
@@ -48,7 +48,7 @@ class FeaturesClient(NamespacedClient):
         this API and recognized as a valid feature state by the create snapshot API,
         the plugin that defines that feature must be installed on the master node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-features-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-features-api.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -102,7 +102,7 @@ class FeaturesClient(NamespacedClient):
         on the master node if you have any doubts about which plugins are installed on
         individual nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-snapshots.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_sync/client/fleet.py
+++ b/elasticsearch/_sync/client/fleet.py
@@ -49,7 +49,7 @@ class FleetClient(NamespacedClient):
         Returns the current global checkpoints for an index. This API is design for internal
         use by the fleet server project.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-global-checkpoints.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-global-checkpoints.html>`_
 
         :param index: A single index or index alias that resolves to a single index.
         :param checkpoints: A comma separated list of previous global checkpoints. When

--- a/elasticsearch/_sync/client/graph.py
+++ b/elasticsearch/_sync/client/graph.py
@@ -54,7 +54,7 @@ class GraphClient(NamespacedClient):
         from one more vertices of interest. You can exclude vertices that have already
         been returned.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/graph-explore-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/graph-explore-api.html>`_
 
         :param index: Name of the index.
         :param connections: Specifies or more fields from which you want to extract terms

--- a/elasticsearch/_sync/client/ilm.py
+++ b/elasticsearch/_sync/client/ilm.py
@@ -42,7 +42,7 @@ class IlmClient(NamespacedClient):
         If the policy is being used to manage any indices, the request fails and returns
         an error.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-delete-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -98,7 +98,7 @@ class IlmClient(NamespacedClient):
         lifecycle state, provides the definition of the running phase, and information
         about any failures.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-explain-lifecycle.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to target.
             Supports wildcards (`*`). To target all data streams and indices, use `*`
@@ -156,7 +156,7 @@ class IlmClient(NamespacedClient):
         """
         Get lifecycle policies.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-get-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -207,7 +207,7 @@ class IlmClient(NamespacedClient):
         """
         Get the ILM status. Get the current index lifecycle management status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-get-status.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ilm/status"
@@ -259,7 +259,7 @@ class IlmClient(NamespacedClient):
         stop ILM and get ILM status APIs to wait until the reported operation mode is
         `STOPPED`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-migrate-to-data-tiers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-migrate-to-data-tiers.html>`_
 
         :param dry_run: If true, simulates the migration from node attributes based allocation
             filters to data tiers, but does not perform the migration. This provides
@@ -333,7 +333,7 @@ class IlmClient(NamespacedClient):
         specified in the ILM policy are considered valid. An index cannot move to a step
         that is not part of its policy.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-move-to-step.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-move-to-step.html>`_
 
         :param index: The name of the index whose lifecycle step is to change
         :param current_step: The step that the index is expected to be in.
@@ -398,7 +398,7 @@ class IlmClient(NamespacedClient):
         and the policy version is incremented. NOTE: Only the latest version of the policy
         is stored, you cannot revert to previous versions.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-put-lifecycle.html>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -458,7 +458,7 @@ class IlmClient(NamespacedClient):
         Remove policies from an index. Remove the assigned lifecycle policies from an
         index or a data stream's backing indices. It also stops managing the indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-remove-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-remove-policy.html>`_
 
         :param index: The name of the index to remove policy on
         """
@@ -501,7 +501,7 @@ class IlmClient(NamespacedClient):
         and runs the step. Use the explain lifecycle state API to determine whether an
         index is in the ERROR step.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-retry-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-retry-policy.html>`_
 
         :param index: The name of the indices (comma-separated) whose failed lifecycle
             step is to be retry
@@ -545,7 +545,7 @@ class IlmClient(NamespacedClient):
         stopped. ILM is started automatically when the cluster is formed. Restarting
         ILM is necessary only when it has been stopped using the stop ILM API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-start.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -597,7 +597,7 @@ class IlmClient(NamespacedClient):
         might continue to run until in-progress operations complete and the plugin can
         be safely stopped. Use the get ILM status API to check whether ILM is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ilm-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ilm-stop.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and

--- a/elasticsearch/_sync/client/indices.py
+++ b/elasticsearch/_sync/client/indices.py
@@ -58,7 +58,7 @@ class IndicesClient(NamespacedClient):
         Add an index block. Limits the operations allowed on an index by blocking specific
         operation types.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/index-modules-blocks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-modules-blocks.html>`_
 
         :param index: A comma separated list of indices to add a block to
         :param block: The block to add (one of read, write, read_only or metadata)
@@ -150,7 +150,7 @@ class IndicesClient(NamespacedClient):
         of tokens gets generated, an error occurs. The `_analyze` endpoint without a
         specified index will always use `10000` as its limit.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-analyze.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-analyze.html>`_
 
         :param index: Index used to derive the analyzer. If specified, the `analyzer`
             or field parameter overrides this value. If no index is specified or the
@@ -255,7 +255,7 @@ class IndicesClient(NamespacedClient):
         `query`, or `request` parameters. To clear the cache only of specific fields,
         use the `fields` parameter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-clearcache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-clearcache.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -377,7 +377,7 @@ class IndicesClient(NamespacedClient):
         a new index to clone the shards to, the wait for active shards setting on index
         creation applies to the clone index action as well.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-clone-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-clone-index.html>`_
 
         :param index: Name of the source index to clone.
         :param target: Name of the target index to create.
@@ -482,7 +482,7 @@ class IndicesClient(NamespacedClient):
         can cause problems in managed environments. Closing indices can be turned off
         with the cluster settings API by setting `cluster.indices.close.enable` to `false`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-close.html>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -582,7 +582,7 @@ class IndicesClient(NamespacedClient):
         setting `index.write.wait_for_active_shards`. Note that changing this setting
         will also affect the `wait_for_active_shards` value on all subsequent write operations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-create-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-create-index.html>`_
 
         :param index: Name of the index you wish to create.
         :param aliases: Aliases for the index.
@@ -656,7 +656,7 @@ class IndicesClient(NamespacedClient):
         Create a data stream. Creates a data stream. You must have a matching index template
         with data stream enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Name of the data stream, which must meet the following criteria:
             Lowercase only; Cannot include `\\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`,
@@ -717,7 +717,7 @@ class IndicesClient(NamespacedClient):
         """
         Get data stream stats. Retrieves statistics for one or more data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Comma-separated list of data streams used to limit the request.
             Wildcard expressions (`*`) are supported. To target all data streams in a
@@ -782,7 +782,7 @@ class IndicesClient(NamespacedClient):
         delete the index, you must roll over the data stream so a new write index is
         created. You can then use the delete index API to delete the previous write index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-index.html>`_
 
         :param index: Comma-separated list of indices to delete. You cannot specify index
             aliases. By default, this parameter does not support wildcards (`*`) or `_all`.
@@ -852,7 +852,7 @@ class IndicesClient(NamespacedClient):
         """
         Delete an alias. Removes a data stream or index from an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-alias.html>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`).
@@ -917,7 +917,7 @@ class IndicesClient(NamespacedClient):
         Delete data stream lifecycles. Removes the data stream lifecycle from a data
         stream, rendering it not managed by the data stream lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-delete-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-delete-lifecycle.html>`_
 
         :param name: A comma-separated list of data streams of which the data stream
             lifecycle will be deleted; use `*` to get all data streams
@@ -977,7 +977,7 @@ class IndicesClient(NamespacedClient):
         """
         Delete data streams. Deletes one or more data streams and their backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Comma-separated list of data streams to delete. Wildcard (`*`) expressions
             are supported.
@@ -1032,7 +1032,7 @@ class IndicesClient(NamespacedClient):
         then there is no wildcard support and the provided names should match completely
         with existing templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-template.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1084,7 +1084,7 @@ class IndicesClient(NamespacedClient):
         """
         Delete a legacy index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-delete-template-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-delete-template-v1.html>`_
 
         :param name: The name of the legacy index template to delete. Wildcard (`*`)
             expressions are supported.
@@ -1156,7 +1156,7 @@ class IndicesClient(NamespacedClient):
         The stored size of the `_id` field is likely underestimated while the `_source`
         field is overestimated.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-disk-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-disk-usage.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. It’s recommended to execute this API with a single
@@ -1237,7 +1237,7 @@ class IndicesClient(NamespacedClient):
         are supported. Neither field nor document level security can be defined on the
         source index. The source index must be read only (`index.blocks.write: true`).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-downsample-data-stream.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-downsample-data-stream.html>`_
 
         :param index: Name of the time series index to downsample.
         :param target_index: Name of the index to create.
@@ -1305,7 +1305,7 @@ class IndicesClient(NamespacedClient):
         """
         Check indices. Check if one or more indices, index aliases, or data streams exist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-exists.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-exists.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases. Supports
             wildcards (`*`).
@@ -1383,7 +1383,7 @@ class IndicesClient(NamespacedClient):
         """
         Check aliases. Checks if one or more data stream or index aliases exist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-aliases.html>`_
 
         :param name: Comma-separated list of aliases to check. Supports wildcards (`*`).
         :param index: Comma-separated list of data streams or indices used to limit the
@@ -1453,7 +1453,7 @@ class IndicesClient(NamespacedClient):
         """
         Check index templates. Check whether index templates exist.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/index-templates.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-templates.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1506,7 +1506,7 @@ class IndicesClient(NamespacedClient):
         templates, which are deprecated and will be replaced by the composable templates
         introduced in Elasticsearch 7.8.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-template-exists-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-template-exists-v1.html>`_
 
         :param name: A comma-separated list of index template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -1563,7 +1563,7 @@ class IndicesClient(NamespacedClient):
         creation, time since rollover, the lifecycle configuration managing the index,
         or any errors encountered during lifecycle execution.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-explain-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-explain-lifecycle.html>`_
 
         :param index: The name of the index to explain
         :param include_defaults: indicates if the API should return the default values
@@ -1631,7 +1631,7 @@ class IndicesClient(NamespacedClient):
         in the index. A given request will increment each count by a maximum value of
         1, even if the request accesses the same field multiple times.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/field-usage-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/field-usage-stats.html>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -1725,7 +1725,7 @@ class IndicesClient(NamespacedClient):
         documents then a successful response indicates that Elasticsearch has flushed
         all the documents that were indexed before the flush API was called.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-flush.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-flush.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to flush.
             Supports wildcards (`*`). To flush all data streams and indices, omit this
@@ -1850,7 +1850,7 @@ class IndicesClient(NamespacedClient):
         searches. For example: ``` POST /.ds-my-data-stream-2099.03.07-000001/_forcemerge?max_num_segments=1
         ```
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-forcemerge.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-forcemerge.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -1944,7 +1944,7 @@ class IndicesClient(NamespacedClient):
         Get index information. Get information about one or more indices. For data streams,
         the API returns information about the stream’s backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-index.html>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported.
@@ -2033,7 +2033,7 @@ class IndicesClient(NamespacedClient):
         """
         Get aliases. Retrieves information for one or more data stream or index aliases.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-alias.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-alias.html>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`). To target all data streams and indices,
@@ -2116,7 +2116,7 @@ class IndicesClient(NamespacedClient):
         Get data stream lifecycles. Retrieves the data stream lifecycle configuration
         of one or more data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-get-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-get-lifecycle.html>`_
 
         :param name: Comma-separated list of data streams to limit the request. Supports
             wildcards (`*`). To target all data streams, omit this parameter or use `*`
@@ -2171,7 +2171,7 @@ class IndicesClient(NamespacedClient):
         Get data stream lifecycle stats. Get statistics about the data streams that are
         managed by a data stream lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-get-lifecycle-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-get-lifecycle-stats.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_lifecycle/stats"
@@ -2218,7 +2218,7 @@ class IndicesClient(NamespacedClient):
         """
         Get data streams. Retrieves information about one or more data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Comma-separated list of data stream names used to limit the request.
             Wildcard (`*`) expressions are supported. If omitted, all data streams are
@@ -2296,7 +2296,7 @@ class IndicesClient(NamespacedClient):
         This API is useful if you don't need a complete mapping or if an index mapping
         contains a large number of fields.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-field-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-field-mapping.html>`_
 
         :param fields: Comma-separated list or wildcard expression of fields used to
             limit returned information. Supports wildcards (`*`).
@@ -2373,7 +2373,7 @@ class IndicesClient(NamespacedClient):
         """
         Get index templates. Get information about one or more index templates.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-template.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -2447,7 +2447,7 @@ class IndicesClient(NamespacedClient):
         Get mapping definitions. For data streams, the API retrieves mappings for the
         stream’s backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-mapping.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2532,7 +2532,7 @@ class IndicesClient(NamespacedClient):
         Get index settings. Get setting information for one or more indices. For data
         streams, it returns setting information for the stream's backing indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-settings.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2621,7 +2621,7 @@ class IndicesClient(NamespacedClient):
         This documentation is about legacy index templates, which are deprecated and
         will be replaced by the composable templates introduced in Elasticsearch 7.8.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-get-template-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-get-template-v1.html>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (`*`) expressions are supported. To return all index templates,
@@ -2687,7 +2687,7 @@ class IndicesClient(NamespacedClient):
         with the same name. The indices for the alias become hidden backing indices for
         the stream. The write index for the alias becomes the write index for the stream.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: Name of the index alias to convert to a data stream.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -2740,7 +2740,7 @@ class IndicesClient(NamespacedClient):
         Update data streams. Performs one or more data stream modification actions in
         a single atomic operation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param actions: Actions to perform.
         """
@@ -2820,7 +2820,7 @@ class IndicesClient(NamespacedClient):
         setting on index creation applies to the `_open` and `_close` index actions as
         well.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-open-close.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-open-close.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). By default, you must explicitly
@@ -2906,7 +2906,7 @@ class IndicesClient(NamespacedClient):
         a matching index template is created. This will affect the lifecycle management
         of the data stream and interfere with the data stream size and retention.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams.html>`_
 
         :param name: The name of the data stream
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -2968,7 +2968,7 @@ class IndicesClient(NamespacedClient):
         """
         Create or update an alias. Adds a data stream or index to an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-aliases.html>`_
 
         :param index: Comma-separated list of data streams or indices to add. Supports
             wildcards (`*`). Wildcard patterns that match both data streams and indices
@@ -3070,7 +3070,7 @@ class IndicesClient(NamespacedClient):
         Update data stream lifecycles. Update the data stream lifecycle of the specified
         data streams.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/data-streams-put-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/data-streams-put-lifecycle.html>`_
 
         :param name: Comma-separated list of data streams used to limit the request.
             Supports wildcards (`*`). To target all data streams use `*` or `_all`.
@@ -3189,7 +3189,7 @@ class IndicesClient(NamespacedClient):
         default new `dynamic_templates` entries are appended onto the end. If an entry
         already exists with the same key, then it is overwritten by the new definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-put-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-put-template.html>`_
 
         :param name: Index or template name
         :param allow_auto_create: This setting overrides the value of the `action.auto_create_index`
@@ -3373,7 +3373,7 @@ class IndicesClient(NamespacedClient):
         invalidate data already indexed under the old field name. Instead, add an alias
         field to create an alternate field name.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-put-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-put-mapping.html>`_
 
         :param index: A comma-separated list of index names the mapping should be added
             to (supports wildcards); use `_all` or omit to add the mapping on all indices.
@@ -3516,7 +3516,7 @@ class IndicesClient(NamespacedClient):
         existing data. To change the analyzer for existing backing indices, you must
         create a new data stream and reindex your data into it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-update-settings.html>`_
 
         :param settings:
         :param index: Comma-separated list of data streams, indices, and aliases used
@@ -3637,7 +3637,7 @@ class IndicesClient(NamespacedClient):
         and higher orders overriding them. NOTE: Multiple matching templates with the
         same order value will result in a non-deterministic merging order.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-templates-v1.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-templates-v1.html>`_
 
         :param name: The name of the template
         :param aliases: Aliases for the index.
@@ -3738,7 +3738,7 @@ class IndicesClient(NamespacedClient):
         onto a different node then the information about the original recovery will not
         be shown in the recovery API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-recovery.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-recovery.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -3812,7 +3812,7 @@ class IndicesClient(NamespacedClient):
         query parameter option. This option ensures the indexing operation waits for
         a periodic refresh before running the search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-refresh.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-refresh.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -3896,7 +3896,7 @@ class IndicesClient(NamespacedClient):
         a shard replica--before using this API. This ensures the synonym file is updated
         everywhere in the cluster in case shards are relocated in the future.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-reload-analyzers.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-reload-analyzers.html>`_
 
         :param index: A comma-separated list of index names to reload analyzers for
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -3991,7 +3991,7 @@ class IndicesClient(NamespacedClient):
         errors will be shown.) * A remote cluster is an older version that does not support
         the feature you want to use in your search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-resolve-cluster-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-resolve-cluster-api.html>`_
 
         :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
             and data streams to resolve. Resources on remote clusters can be specified
@@ -4065,7 +4065,7 @@ class IndicesClient(NamespacedClient):
         Resolve indices. Resolve the names and/or index patterns for indices, aliases,
         and data streams. Multiple patterns and remote clusters are supported.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-resolve-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-resolve-index-api.html>`_
 
         :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
             and data streams to resolve. Resources on remote clusters can be specified
@@ -4164,7 +4164,7 @@ class IndicesClient(NamespacedClient):
         If you create the index on May 6, 2099, the index's name is `my-index-2099.05.06-000001`.
         If you roll over the alias on May 7, 2099, the new index's name is `my-index-2099.05.07-000002`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-rollover-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-rollover-index.html>`_
 
         :param alias: Name of the data stream or index alias to roll over.
         :param new_index: Name of the index to create. Supports date math. Data streams
@@ -4271,7 +4271,7 @@ class IndicesClient(NamespacedClient):
         shards. For data streams, the API returns information about the stream's backing
         indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-segments.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-segments.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4357,7 +4357,7 @@ class IndicesClient(NamespacedClient):
         information only for primary shards that are unassigned or have one or more unassigned
         replica shards.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-shards-stores.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-shards-stores.html>`_
 
         :param index: List of data streams, indices, and aliases used to limit the request.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -4460,7 +4460,7 @@ class IndicesClient(NamespacedClient):
         must have sufficient free disk space to accommodate a second copy of the existing
         index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-shrink-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-shrink-index.html>`_
 
         :param index: Name of the source index to shrink.
         :param target: Name of the target index to create.
@@ -4536,7 +4536,7 @@ class IndicesClient(NamespacedClient):
         Simulate an index. Get the index configuration that would be applied to the specified
         index from an existing index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-simulate-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-simulate-index.html>`_
 
         :param name: Name of the index to simulate
         :param include_defaults: If true, returns all relevant default configurations
@@ -4614,7 +4614,7 @@ class IndicesClient(NamespacedClient):
         Simulate an index template. Get the index configuration that would be applied
         by a particular index template.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-simulate-template.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-simulate-template.html>`_
 
         :param name: Name of the index template to simulate. To test a template configuration
             before you add it to the cluster, omit this parameter and specify the template
@@ -4769,7 +4769,7 @@ class IndicesClient(NamespacedClient):
         in the source index. * The node handling the split process must have sufficient
         free disk space to accommodate a second copy of the existing index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-split-index.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-split-index.html>`_
 
         :param index: Name of the source index to split.
         :param target: Name of the target index to create.
@@ -4868,7 +4868,7 @@ class IndicesClient(NamespacedClient):
         cleared. Although the shard is no longer part of the node, that node retains
         any node-level statistics to which the shard contributed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-stats.html>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -4972,7 +4972,7 @@ class IndicesClient(NamespacedClient):
         Unfreeze an index. When a frozen index is unfrozen, the index goes through the
         normal recovery process and becomes writeable again.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/unfreeze-index-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/unfreeze-index-api.html>`_
 
         :param index: Identifier for the index.
         :param allow_no_indices: If `false`, the request returns an error if any wildcard
@@ -5046,7 +5046,7 @@ class IndicesClient(NamespacedClient):
         """
         Create or update an alias. Adds a data stream or index to an alias.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/indices-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/indices-aliases.html>`_
 
         :param actions: Actions to perform.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -5121,7 +5121,7 @@ class IndicesClient(NamespacedClient):
         """
         Validate a query. Validates a query without running it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-validate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-validate.html>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to search.
             Supports wildcards (`*`). To search all data streams or indices, omit this

--- a/elasticsearch/_sync/client/inference.py
+++ b/elasticsearch/_sync/client/inference.py
@@ -46,7 +46,7 @@ class InferenceClient(NamespacedClient):
         """
         Delete an inference endpoint
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-inference-api.html>`_
 
         :param inference_id: The inference Id
         :param task_type: The task type
@@ -111,7 +111,7 @@ class InferenceClient(NamespacedClient):
         """
         Get an inference endpoint
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-inference-api.html>`_
 
         :param task_type: The task type
         :param inference_id: The inference Id
@@ -174,7 +174,7 @@ class InferenceClient(NamespacedClient):
         """
         Perform inference on the service
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/post-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/post-inference-api.html>`_
 
         :param inference_id: The inference Id
         :param input: Inference input. Either a string or an array of strings.
@@ -271,7 +271,7 @@ class InferenceClient(NamespacedClient):
         to use these models or if you want to use non-NLP models, use the machine learning
         trained model APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-inference-api.html>`_
 
         :param inference_id: The inference Id
         :param inference_config:
@@ -350,7 +350,7 @@ class InferenceClient(NamespacedClient):
         or if you want to use non-NLP models, use the machine learning trained model
         APIs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-inference-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-inference-api.html>`_
 
         :param inference_id: The unique identifier of the inference endpoint.
         :param inference_config:

--- a/elasticsearch/_sync/client/ingest.py
+++ b/elasticsearch/_sync/client/ingest.py
@@ -41,7 +41,7 @@ class IngestClient(NamespacedClient):
         Delete GeoIP database configurations. Delete one or more IP geolocation database
         configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-geoip-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-geoip-database-api.html>`_
 
         :param id: A comma-separated list of geoip database configurations to delete
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -92,7 +92,7 @@ class IngestClient(NamespacedClient):
         """
         Delete IP geolocation database configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-ip-location-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-ip-location-database-api.html>`_
 
         :param id: A comma-separated list of IP location database configurations.
         :param master_timeout: The period to wait for a connection to the master node.
@@ -145,7 +145,7 @@ class IngestClient(NamespacedClient):
         """
         Delete pipelines. Delete one or more ingest pipelines.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-pipeline-api.html>`_
 
         :param id: Pipeline ID or wildcard expression of pipeline IDs used to limit the
             request. To delete all ingest pipelines in a cluster, use a value of `*`.
@@ -195,7 +195,7 @@ class IngestClient(NamespacedClient):
         Get GeoIP statistics. Get download statistics for GeoIP2 databases that are used
         with the GeoIP processor.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/geoip-processor.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/geoip-processor.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ingest/geoip/stats"
@@ -232,7 +232,7 @@ class IngestClient(NamespacedClient):
         Get GeoIP database configurations. Get information about one or more IP geolocation
         database configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-geoip-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-geoip-database-api.html>`_
 
         :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
             (`*`) expressions are supported. To get all database configurations, omit
@@ -278,7 +278,7 @@ class IngestClient(NamespacedClient):
         """
         Get IP geolocation database configurations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-ip-location-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-ip-location-database-api.html>`_
 
         :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
             (`*`) expressions are supported. To get all database configurations, omit
@@ -332,7 +332,7 @@ class IngestClient(NamespacedClient):
         Get pipelines. Get information about one or more ingest pipelines. This API returns
         a local reference of the pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-pipeline-api.html>`_
 
         :param id: Comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions
             are supported. To get all ingest pipelines, omit this parameter or use `*`.
@@ -386,7 +386,7 @@ class IngestClient(NamespacedClient):
         as the grok pattern you expect will match. A grok pattern is like a regular expression
         that supports aliased expressions that can be reused.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/grok-processor.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/grok-processor.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ingest/processor/grok"
@@ -430,7 +430,7 @@ class IngestClient(NamespacedClient):
         Create or update a GeoIP database configuration. Refer to the create or update
         IP geolocation database configuration API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-geoip-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-geoip-database-api.html>`_
 
         :param id: ID of the database configuration to create or update.
         :param maxmind: The configuration necessary to identify which IP geolocation
@@ -502,7 +502,7 @@ class IngestClient(NamespacedClient):
         """
         Create or update an IP geolocation database configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-ip-location-database-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-ip-location-database-api.html>`_
 
         :param id: The database configuration identifier.
         :param configuration:
@@ -584,7 +584,7 @@ class IngestClient(NamespacedClient):
         """
         Create or update a pipeline. Changes made using this API take effect immediately.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ingest.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ingest.html>`_
 
         :param id: ID of the ingest pipeline to create or update.
         :param deprecated: Marks this ingest pipeline as deprecated. When a deprecated
@@ -678,7 +678,7 @@ class IngestClient(NamespacedClient):
         You can either specify an existing pipeline to use with the provided documents
         or supply a pipeline definition in the body of the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/simulate-pipeline-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/simulate-pipeline-api.html>`_
 
         :param docs: Sample documents to test in the pipeline.
         :param id: Pipeline to test. If you don’t specify a `pipeline` in the request

--- a/elasticsearch/_sync/client/license.py
+++ b/elasticsearch/_sync/client/license.py
@@ -41,7 +41,7 @@ class LicenseClient(NamespacedClient):
         to Basic. If the operator privileges feature is enabled, only operator users
         can use this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-license.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param timeout: Period to wait for a response. If no response is received before
@@ -90,7 +90,7 @@ class LicenseClient(NamespacedClient):
         Not Found` response. If you receive an unexpected 404 response after cluster
         startup, wait a short period and retry the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-license.html>`_
 
         :param accept_enterprise: If `true`, this parameter returns enterprise for Enterprise
             license types. If `false`, this parameter returns platinum for both platinum
@@ -136,7 +136,7 @@ class LicenseClient(NamespacedClient):
         """
         Get the basic license status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-basic-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-basic-status.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/basic_status"
@@ -171,7 +171,7 @@ class LicenseClient(NamespacedClient):
         """
         Get the trial status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-trial-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-trial-status.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/trial_status"
@@ -221,7 +221,7 @@ class LicenseClient(NamespacedClient):
         TLS on the transport networking layer before you install the license. If the
         operator privileges feature is enabled, only operator users can use this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-license.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-license.html>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:
@@ -290,7 +290,7 @@ class LicenseClient(NamespacedClient):
         parameter set to `true`. To check the status of your basic license, use the get
         basic license API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-basic.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-basic.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
@@ -345,7 +345,7 @@ class LicenseClient(NamespacedClient):
         however, request an extended trial at https://www.elastic.co/trialextension.
         To check the status of your trial, use the get trial status API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-trial.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-trial.html>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)

--- a/elasticsearch/_sync/client/logstash.py
+++ b/elasticsearch/_sync/client/logstash.py
@@ -40,7 +40,7 @@ class LogstashClient(NamespacedClient):
         Management. If the request succeeds, you receive an empty response with an appropriate
         status code.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/logstash-api-delete-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/logstash-api-delete-pipeline.html>`_
 
         :param id: An identifier for the pipeline.
         """
@@ -80,7 +80,7 @@ class LogstashClient(NamespacedClient):
         """
         Get Logstash pipelines. Get pipelines that are used for Logstash Central Management.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/logstash-api-get-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/logstash-api-get-pipeline.html>`_
 
         :param id: A comma-separated list of pipeline identifiers.
         """
@@ -128,7 +128,7 @@ class LogstashClient(NamespacedClient):
         Create or update a Logstash pipeline. Create a pipeline that is used for Logstash
         Central Management. If the specified pipeline exists, it is replaced.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/logstash-api-put-pipeline.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/logstash-api-put-pipeline.html>`_
 
         :param id: An identifier for the pipeline.
         :param pipeline:

--- a/elasticsearch/_sync/client/migration.py
+++ b/elasticsearch/_sync/client/migration.py
@@ -41,7 +41,7 @@ class MigrationClient(NamespacedClient):
         in the next major version. TIP: This APIs is designed for indirect use by the
         Upgrade Assistant. You are strongly recommended to use the Upgrade Assistant.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/migration-api-deprecation.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/migration-api-deprecation.html>`_
 
         :param index: Comma-separate list of data streams or indices to check. Wildcard
             (*) expressions are supported.
@@ -88,7 +88,7 @@ class MigrationClient(NamespacedClient):
         in progress. TIP: This API is designed for indirect use by the Upgrade Assistant.
         You are strongly recommended to use the Upgrade Assistant.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/feature-migration-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/feature-migration-api.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"
@@ -127,7 +127,7 @@ class MigrationClient(NamespacedClient):
         unavailable during the migration process. TIP: The API is designed for indirect
         use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/feature-migration-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/feature-migration-api.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -42,7 +42,7 @@ class MlClient(NamespacedClient):
         may be cached on that individual node. Calling this API clears the caches without
         restarting the deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-trained-model-deployment-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-trained-model-deployment-cache.html>`_
 
         :param model_id: The unique identifier of the trained model.
         """
@@ -102,7 +102,7 @@ class MlClient(NamespacedClient):
         force parameters as the close job request. When a datafeed that has a specified
         end date stops, it automatically closes its associated job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-close-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-close-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. You can close multiple anomaly detection
@@ -164,7 +164,7 @@ class MlClient(NamespacedClient):
         Delete a calendar. Removes all scheduled events from a calendar, then deletes
         it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         """
@@ -205,7 +205,7 @@ class MlClient(NamespacedClient):
         """
         Delete events from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param event_id: Identifier for the scheduled event. You can obtain this identifier
@@ -253,7 +253,7 @@ class MlClient(NamespacedClient):
         """
         Delete anomaly jobs from a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -302,7 +302,7 @@ class MlClient(NamespacedClient):
         """
         Delete a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param force: If `true`, it deletes a job that is not stopped; this method is
@@ -350,7 +350,7 @@ class MlClient(NamespacedClient):
         """
         Delete a datafeed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -408,7 +408,7 @@ class MlClient(NamespacedClient):
         expired data for all anomaly detection jobs by using _all, by specifying * as
         the <job_id>, or by omitting the <job_id>.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-expired-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-expired-data.html>`_
 
         :param job_id: Identifier for an anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression.
@@ -469,7 +469,7 @@ class MlClient(NamespacedClient):
         delete the filter. You must update or delete the job before you can delete the
         filter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         """
@@ -515,7 +515,7 @@ class MlClient(NamespacedClient):
         in the forecast jobs API. The delete forecast API enables you to delete one or
         more forecasts before they expire.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param forecast_id: A comma-separated list of forecast identifiers. If you do
@@ -587,7 +587,7 @@ class MlClient(NamespacedClient):
         delete datafeed API with the same timeout and force parameters as the delete
         job request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -643,7 +643,7 @@ class MlClient(NamespacedClient):
         that snapshot, first revert to a different one. To identify the active model
         snapshot, refer to the `model_snapshot_id` in the results from the get jobs API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-delete-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-delete-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -692,7 +692,7 @@ class MlClient(NamespacedClient):
         Delete an unreferenced trained model. The request deletes a trained inference
         model that is not referenced by an ingest pipeline.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param force: Forcefully deletes a trained model that is referenced by ingest
@@ -743,7 +743,7 @@ class MlClient(NamespacedClient):
         to a trained model. If the model alias is missing or refers to a model other
         than the one identified by the `model_id`, this API returns an error.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-trained-models-aliases.html>`_
 
         :param model_id: The trained model ID to which the model alias refers.
         :param model_alias: The model alias to delete.
@@ -800,7 +800,7 @@ class MlClient(NamespacedClient):
         an anomaly detection job model. It is based on analysis configuration details
         for the job and cardinality estimates for the fields it references.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-apis.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-apis.html>`_
 
         :param analysis_config: For a list of the properties that you can specify in
             the `analysis_config` component of the body of this API.
@@ -868,7 +868,7 @@ class MlClient(NamespacedClient):
         for use on indexes created by data frame analytics. Evaluation requires both
         a ground truth field and an analytics result field to be present.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/evaluate-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/evaluate-dfanalytics.html>`_
 
         :param evaluation: Defines the type of evaluation you want to perform.
         :param index: Defines the `index` in which the evaluation will be performed.
@@ -948,7 +948,7 @@ class MlClient(NamespacedClient):
         setting later on. If you have object fields or fields that are excluded via source
         filtering, they are not included in the explanation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/explain-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/explain-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -1055,7 +1055,7 @@ class MlClient(NamespacedClient):
         and persists the model state to disk and the job must be opened again before
         analyzing further data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-flush-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-flush-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param advance_time: Refer to the description for the `advance_time` query parameter.
@@ -1126,7 +1126,7 @@ class MlClient(NamespacedClient):
         for a job that has an `over_field_name` in its configuration. Forcasts predict
         future behavior based on historical data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-forecast.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-forecast.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must be open
             when you create a forecast; otherwise, an error occurs.
@@ -1209,7 +1209,7 @@ class MlClient(NamespacedClient):
         Get anomaly detection job results for buckets. The API presents a chronological
         view of the records, grouped by bucket.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-bucket.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-bucket.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timestamp: The timestamp of a single bucket result. If you do not specify
@@ -1304,7 +1304,7 @@ class MlClient(NamespacedClient):
         """
         Get info about events in calendars.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1370,7 +1370,7 @@ class MlClient(NamespacedClient):
         """
         Get calendar configuration info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1443,7 +1443,7 @@ class MlClient(NamespacedClient):
         """
         Get anomaly detection job results for categories.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-category.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-category.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param category_id: Identifier for the category, which is unique in the job.
@@ -1527,7 +1527,7 @@ class MlClient(NamespacedClient):
         multiple data frame analytics jobs in a single API request by using a comma-separated
         list of data frame analytics jobs or a wildcard expression.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1599,7 +1599,7 @@ class MlClient(NamespacedClient):
         """
         Get data frame analytics jobs usage info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-dfanalytics-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-dfanalytics-stats.html>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1669,7 +1669,7 @@ class MlClient(NamespacedClient):
         the only information you receive is the `datafeed_id` and the `state`. This API
         returns a maximum of 10,000 datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-datafeed-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-datafeed-stats.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1729,7 +1729,7 @@ class MlClient(NamespacedClient):
         `*` as the `<feed_id>`, or by omitting the `<feed_id>`. This API returns a maximum
         of 10,000 datafeeds.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1792,7 +1792,7 @@ class MlClient(NamespacedClient):
         """
         Get filters. You can get a single filter or all filters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param from_: Skips the specified number of filters.
@@ -1856,7 +1856,7 @@ class MlClient(NamespacedClient):
         that have contributed to, or are to blame for, the anomalies. Influencer results
         are available only if an `influencer_field_name` is specified in the job configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-influencer.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-influencer.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: If true, the results are sorted in descending order.
@@ -1937,7 +1937,7 @@ class MlClient(NamespacedClient):
         """
         Get anomaly detection jobs usage info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-job-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs, or a wildcard expression. If
@@ -1998,7 +1998,7 @@ class MlClient(NamespacedClient):
         detection jobs by using `_all`, by specifying `*` as the `<job_id>`, or by omitting
         the `<job_id>`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. If you do not specify one of these
@@ -2061,7 +2061,7 @@ class MlClient(NamespacedClient):
         jobs and trained models are using memory, on each node, both within the JVM heap,
         and natively, outside of the JVM.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-ml-memory.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-ml-memory.html>`_
 
         :param node_id: The names of particular nodes in the cluster to target. For example,
             `nodeId1,nodeId2` or `ml:true`
@@ -2116,7 +2116,7 @@ class MlClient(NamespacedClient):
         """
         Get anomaly detection job model snapshot upgrade usage info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-job-model-snapshot-upgrade-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job-model-snapshot-upgrade-stats.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2187,7 +2187,7 @@ class MlClient(NamespacedClient):
         """
         Get model snapshots info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2300,7 +2300,7 @@ class MlClient(NamespacedClient):
         its default), the `overall_score` is the maximum `overall_score` of the overall
         buckets that have a span equal to the jobs' largest bucket span.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-overall-buckets.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-overall-buckets.html>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs or groups, or a wildcard expression.
@@ -2405,7 +2405,7 @@ class MlClient(NamespacedClient):
         found in each bucket, which relates to the number of time series being modeled
         and the number of detectors.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-get-record.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-record.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: Refer to the description for the `desc` query parameter.
@@ -2501,7 +2501,7 @@ class MlClient(NamespacedClient):
         """
         Get trained model configuration info.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             You can get information for multiple trained models in a single API request
@@ -2589,7 +2589,7 @@ class MlClient(NamespacedClient):
         models in a single API request by using a comma-separated list of model IDs or
         a wildcard expression.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-trained-models-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-trained-models-stats.html>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             It can be a comma-separated list or a wildcard expression.
@@ -2652,7 +2652,7 @@ class MlClient(NamespacedClient):
         """
         Evaluate a trained model.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/infer-trained-model.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/infer-trained-model.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param docs: An array of objects to pass to the model for inference. The objects
@@ -2714,7 +2714,7 @@ class MlClient(NamespacedClient):
         what those defaults are. It also provides information about the maximum size
         of machine learning jobs that could run in the current cluster configuration.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-ml-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-ml-info.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ml/info"
@@ -2759,7 +2759,7 @@ class MlClient(NamespacedClient):
         job is ready to resume its analysis from where it left off, once new data is
         received.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-open-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-open-job.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timeout: Refer to the description for the `timeout` query parameter.
@@ -2813,7 +2813,7 @@ class MlClient(NamespacedClient):
         """
         Add scheduled events to the calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-post-calendar-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-post-calendar-event.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param events: A list of one of more scheduled events. The event’s start and
@@ -2871,7 +2871,7 @@ class MlClient(NamespacedClient):
         data can be accepted from only a single connection at a time. It is not currently
         possible to post data to multiple jobs using wildcards or a comma-separated list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-post-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-post-data.html>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must have a
             state of open to receive and process the data.
@@ -2935,7 +2935,7 @@ class MlClient(NamespacedClient):
         Preview features used by data frame analytics. Previews the extracted features
         used by a data frame analytics config.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/preview-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/preview-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job.
         :param config: A data frame analytics config as described in create data frame
@@ -3005,7 +3005,7 @@ class MlClient(NamespacedClient):
         that accurately reflects the behavior of the datafeed, use the appropriate credentials.
         You can also use secondary authorization headers to supply the credentials.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-preview-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-preview-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3081,7 +3081,7 @@ class MlClient(NamespacedClient):
         """
         Create a calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-calendar.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-calendar.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param description: A description of the calendar.
@@ -3135,7 +3135,7 @@ class MlClient(NamespacedClient):
         """
         Add anomaly detection job to calendar.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-calendar-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-calendar-job.html>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -3216,7 +3216,7 @@ class MlClient(NamespacedClient):
         parameters, hyperparameter optimization occurs. It determines a value for each
         of the undefined parameters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3400,7 +3400,7 @@ class MlClient(NamespacedClient):
         directly to the `.ml-config` index. Do not give users `write` privileges on the
         `.ml-config` index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3559,7 +3559,7 @@ class MlClient(NamespacedClient):
         more anomaly detection jobs. Specifically, filters are referenced in the `custom_rules`
         property of detector configuration objects.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param description: A description of the filter.
@@ -3658,7 +3658,7 @@ class MlClient(NamespacedClient):
         have read index privileges on the source index. If you include a `datafeed_config`
         but do not provide a query, the datafeed uses `{"match_all": {"boost": 1}}`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-put-job.html>`_
 
         :param job_id: The identifier for the anomaly detection job. This identifier
             can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and
@@ -3863,7 +3863,7 @@ class MlClient(NamespacedClient):
         Create a trained model. Enable you to supply a trained model that is not created
         by data frame analytics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-models.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-models.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param compressed_definition: The compressed (GZipped and Base64 encoded) inference
@@ -3977,7 +3977,7 @@ class MlClient(NamespacedClient):
         common between the old and new trained models for the model alias, the API returns
         a warning.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-models-aliases.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-models-aliases.html>`_
 
         :param model_id: The identifier for the trained model that the alias refers to.
         :param model_alias: The alias to create or update. This value cannot end in numbers.
@@ -4035,7 +4035,7 @@ class MlClient(NamespacedClient):
         """
         Create part of a trained model definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-model-definition-part.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-model-definition-part.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param part: The definition part number. When the definition is loaded for inference
@@ -4114,7 +4114,7 @@ class MlClient(NamespacedClient):
         processing (NLP) models. The vocabulary is stored in the index as described in
         `inference_config.*.vocabulary` of the trained model definition.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-trained-model-vocabulary.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-trained-model-vocabulary.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
@@ -4172,7 +4172,7 @@ class MlClient(NamespacedClient):
         job is ready to start over as if it had just been created. It is not currently
         possible to reset multiple jobs using wildcards or a comma separated list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-reset-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-reset-job.html>`_
 
         :param job_id: The ID of the job to reset.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -4232,7 +4232,7 @@ class MlClient(NamespacedClient):
         For example, you might consider reverting to a saved snapshot after Black Friday
         or a critical system failure.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-revert-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-revert-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: You can specify `empty` as the <snapshot_id>. Reverting to
@@ -4302,7 +4302,7 @@ class MlClient(NamespacedClient):
         the current value for the upgrade_mode setting by using the get machine learning
         info API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-set-upgrade-mode.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-set-upgrade-mode.html>`_
 
         :param enabled: When `true`, it enables `upgrade_mode` which temporarily halts
             all job and datafeed tasks and prohibits new job and datafeed tasks from
@@ -4357,7 +4357,7 @@ class MlClient(NamespacedClient):
         exists, it is used as is. You can therefore set up the destination index in advance
         with custom settings and mappings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4419,7 +4419,7 @@ class MlClient(NamespacedClient):
         headers when you created or updated the datafeed, those credentials are used
         instead.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-start-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-start-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -4489,7 +4489,7 @@ class MlClient(NamespacedClient):
         Start a trained model deployment. It allocates the model to every machine learning
         node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
@@ -4573,7 +4573,7 @@ class MlClient(NamespacedClient):
         Stop data frame analytics jobs. A data frame analytics job can be started and
         stopped multiple times throughout its lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/stop-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/stop-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4639,7 +4639,7 @@ class MlClient(NamespacedClient):
         Stop datafeeds. A datafeed that is stopped ceases to retrieve data from Elasticsearch.
         A datafeed can be started and stopped multiple times throughout its lifecycle.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-stop-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-stop-datafeed.html>`_
 
         :param datafeed_id: Identifier for the datafeed. You can stop multiple datafeeds
             in a single API request by using a comma-separated list of datafeeds or a
@@ -4701,7 +4701,7 @@ class MlClient(NamespacedClient):
         """
         Stop a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/stop-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/stop-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -4766,7 +4766,7 @@ class MlClient(NamespacedClient):
         """
         Update a data frame analytics job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-dfanalytics.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-dfanalytics.html>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4878,7 +4878,7 @@ class MlClient(NamespacedClient):
         query using those same roles. If you provide secondary authorization headers,
         those credentials are used instead.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-datafeed.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-datafeed.html>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -5042,7 +5042,7 @@ class MlClient(NamespacedClient):
         Update a filter. Updates the description of a filter, adds items, or removes
         items from the list.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-filter.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-filter.html>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param add_items: The items to add to the filter.
@@ -5133,7 +5133,7 @@ class MlClient(NamespacedClient):
         Update an anomaly detection job. Updates certain properties of an anomaly detection
         job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-job.html>`_
 
         :param job_id: Identifier for the job.
         :param allow_lazy_open: Advanced configuration option. Specifies whether this
@@ -5261,7 +5261,7 @@ class MlClient(NamespacedClient):
         """
         Update a snapshot. Updates certain properties of a snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-update-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-update-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -5322,7 +5322,7 @@ class MlClient(NamespacedClient):
         """
         Update a trained model deployment.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-trained-model-deployment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-trained-model-deployment.html>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
@@ -5388,7 +5388,7 @@ class MlClient(NamespacedClient):
         a time and the upgraded snapshot cannot be the current snapshot of the anomaly
         detection job.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/ml-upgrade-job-model-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-upgrade-job-model-snapshot.html>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -5464,7 +5464,7 @@ class MlClient(NamespacedClient):
         """
         Validate an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/machine-learning/8.16/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.17/ml-jobs.html>`_
 
         :param analysis_config:
         :param analysis_limits:
@@ -5534,7 +5534,7 @@ class MlClient(NamespacedClient):
         """
         Validate an anomaly detection job.
 
-        `<https://www.elastic.co/guide/en/machine-learning/8.16/ml-jobs.html>`_
+        `<https://www.elastic.co/guide/en/machine-learning/8.17/ml-jobs.html>`_
 
         :param detector:
         """

--- a/elasticsearch/_sync/client/monitoring.py
+++ b/elasticsearch/_sync/client/monitoring.py
@@ -45,7 +45,7 @@ class MonitoringClient(NamespacedClient):
         Send monitoring data. This API is used by the monitoring features to send monitoring
         data.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/monitor-elasticsearch-cluster.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/monitor-elasticsearch-cluster.html>`_
 
         :param interval: Collection interval (e.g., '10s' or '10000ms') of the payload
         :param operations:

--- a/elasticsearch/_sync/client/nodes.py
+++ b/elasticsearch/_sync/client/nodes.py
@@ -47,7 +47,7 @@ class NodesClient(NamespacedClient):
         Clear the archived repositories metering. Clear the archived repositories metering
         information in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-repositories-metering-archive-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-repositories-metering-archive-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -100,7 +100,7 @@ class NodesClient(NamespacedClient):
         over a period of time. Additionally, the information exposed by this API is volatile,
         meaning that it will not be present after node restarts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-repositories-metering-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-repositories-metering-api.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -154,7 +154,7 @@ class NodesClient(NamespacedClient):
         node in the cluster. The output is plain text with a breakdown of the top hot
         threads for each node.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-hot-threads.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-hot-threads.html>`_
 
         :param node_id: List of node IDs or names used to limit returned information.
         :param ignore_idle_threads: If true, known idle threads (e.g. waiting in a socket
@@ -224,7 +224,7 @@ class NodesClient(NamespacedClient):
         Get node information. By default, the API returns all attributes and core settings
         for cluster nodes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-info.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-info.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -299,7 +299,7 @@ class NodesClient(NamespacedClient):
         by locally accessing the API and passing the node-specific Elasticsearch keystore
         password.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/secure-settings.html#reloadable-secure-settings>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/secure-settings.html#reloadable-secure-settings>`_
 
         :param node_id: The names of particular nodes in the cluster to target.
         :param secure_settings_password: The password for the Elasticsearch keystore.
@@ -370,7 +370,7 @@ class NodesClient(NamespacedClient):
         Get node statistics. Get statistics for nodes in a cluster. By default, all stats
         are returned. You can limit the returned information by using metrics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-stats.html>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -482,7 +482,7 @@ class NodesClient(NamespacedClient):
         """
         Get feature usage information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/cluster-nodes-usage.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/cluster-nodes-usage.html>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting

--- a/elasticsearch/_sync/client/query_rules.py
+++ b/elasticsearch/_sync/client/query_rules.py
@@ -41,7 +41,7 @@ class QueryRulesClient(NamespacedClient):
         action that is only recoverable by re-adding the same rule with the create or
         update query rule API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-query-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-query-rule.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to delete
@@ -90,7 +90,7 @@ class QueryRulesClient(NamespacedClient):
         Delete a query ruleset. Remove a query ruleset and its associated data. This
         is a destructive action that is not recoverable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to delete
         """
@@ -131,7 +131,7 @@ class QueryRulesClient(NamespacedClient):
         """
         Get a query rule. Get details about a query rule within a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-query-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-query-rule.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to retrieve
@@ -179,7 +179,7 @@ class QueryRulesClient(NamespacedClient):
         """
         Get a query ruleset. Get details about a query ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset
         """
@@ -222,7 +222,7 @@ class QueryRulesClient(NamespacedClient):
         """
         Get all query rulesets. Get summarized information about the query rulesets.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-query-rulesets.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-query-rulesets.html>`_
 
         :param from_: The offset from the first result to fetch.
         :param size: The maximum number of results to retrieve.
@@ -281,7 +281,7 @@ class QueryRulesClient(NamespacedClient):
         than 100 documents, only the first 100 documents are pinned in the order they
         are specified in the ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-query-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-query-rule.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to be created or updated.
@@ -366,7 +366,7 @@ class QueryRulesClient(NamespacedClient):
         rules pin more than 100 documents, only the first 100 documents are pinned in
         the order they are specified in the ruleset.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated.
@@ -420,7 +420,7 @@ class QueryRulesClient(NamespacedClient):
         Test a query ruleset. Evaluate match criteria against a query ruleset to identify
         the rules that would match that criteria.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/test-query-ruleset.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/test-query-ruleset.html>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated

--- a/elasticsearch/_sync/client/rollup.py
+++ b/elasticsearch/_sync/client/rollup.py
@@ -58,7 +58,7 @@ class RollupClient(NamespacedClient):
         index. For example: ``` POST my_rollup_index/_delete_by_query { "query": { "term":
         { "_rollup.id": "the_rollup_job_id" } } } ```
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-delete-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-delete-job.html>`_
 
         :param id: Identifier for the job.
         """
@@ -103,7 +103,7 @@ class RollupClient(NamespacedClient):
         any details about it. For details about a historical rollup job, the rollup capabilities
         API may be more useful.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-get-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-get-job.html>`_
 
         :param id: Identifier for the rollup job. If it is `_all` or omitted, the API
             returns all rollup jobs.
@@ -156,7 +156,7 @@ class RollupClient(NamespacedClient):
         the first question, what fields were rolled up, what aggregations can be performed,
         and where does the data live?
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-get-rollup-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-get-rollup-caps.html>`_
 
         :param id: Index, indices or index-pattern to return rollup capabilities for.
             `_all` may be used to fetch rollup capabilities from all jobs.
@@ -206,7 +206,7 @@ class RollupClient(NamespacedClient):
         via a pattern)? * What target indices were rolled up, what fields were used in
         those rollups, and what aggregations can be performed on each job?
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-get-rollup-index-caps.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-get-rollup-index-caps.html>`_
 
         :param index: Data stream or index to check for rollup capabilities. Wildcard
             (`*`) expressions are supported.
@@ -278,7 +278,7 @@ class RollupClient(NamespacedClient):
         and what metrics to collect for each group. Jobs are created in a `STOPPED` state.
         You can start them with the start rollup jobs API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-put-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-put-job.html>`_
 
         :param id: Identifier for the rollup job. This can be any alphanumeric string
             and uniquely identifies the data that is associated with the rollup job.
@@ -413,7 +413,7 @@ class RollupClient(NamespacedClient):
         During the merging process, if there is any overlap in buckets between the two
         responses, the buckets from the non-rollup index are used.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-search.html>`_
 
         :param index: A comma-separated list of data streams and indices used to limit
             the request. This parameter has the following rules: * At least one data
@@ -487,7 +487,7 @@ class RollupClient(NamespacedClient):
         Start rollup jobs. If you try to start a job that does not exist, an exception
         occurs. If you try to start a job that is already started, nothing happens.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-start-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-start-job.html>`_
 
         :param id: Identifier for the rollup job.
         """
@@ -537,7 +537,7 @@ class RollupClient(NamespacedClient):
         moved to STOPPED or the specified time has elapsed. If the specified time elapses
         without the job moving to STOPPED, a timeout exception occurs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/rollup-stop-job.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/rollup-stop-job.html>`_
 
         :param id: Identifier for the rollup job.
         :param timeout: If `wait_for_completion` is `true`, the API blocks for (at maximum)

--- a/elasticsearch/_sync/client/search_application.py
+++ b/elasticsearch/_sync/client/search_application.py
@@ -46,7 +46,7 @@ class SearchApplicationClient(NamespacedClient):
         Delete a search application. Remove a search application and its associated alias.
         Indices attached to the search application are not removed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-search-application.html>`_
 
         :param name: The name of the search application to delete
         """
@@ -88,7 +88,7 @@ class SearchApplicationClient(NamespacedClient):
         Delete a behavioral analytics collection. The associated data stream is also
         deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-analytics-collection.html>`_
 
         :param name: The name of the analytics collection to be deleted
         """
@@ -129,7 +129,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Get search application details.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-search-application.html>`_
 
         :param name: The name of the search application
         """
@@ -170,7 +170,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Get behavioral analytics collections.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-analytics-collection.html>`_
 
         :param name: A list of analytics collections to limit the returned information
         """
@@ -218,7 +218,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Get search applications. Get information about search applications.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/list-search-applications.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/list-search-applications.html>`_
 
         :param from_: Starting offset.
         :param q: Query in the Lucene query string syntax.
@@ -271,7 +271,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Create a behavioral analytics collection event.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/post-analytics-collection-event.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/post-analytics-collection-event.html>`_
 
         :param collection_name: The name of the behavioral analytics collection.
         :param event_type: The analytics event type.
@@ -335,7 +335,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Create or update a search application.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-search-application.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-search-application.html>`_
 
         :param name: The name of the search application to be created or updated.
         :param search_application:
@@ -389,7 +389,7 @@ class SearchApplicationClient(NamespacedClient):
         """
         Create a behavioral analytics collection.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-analytics-collection.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-analytics-collection.html>`_
 
         :param name: The name of the analytics collection to be created or updated.
         """
@@ -441,7 +441,7 @@ class SearchApplicationClient(NamespacedClient):
         generated and run by calling the search application search API. You must have
         `read` privileges on the backing alias of the search application.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-application-render-query.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-application-render-query.html>`_
 
         :param name: The name of the search application to render teh query for.
         :param params:
@@ -503,7 +503,7 @@ class SearchApplicationClient(NamespacedClient):
         the search application or default template. Unspecified template parameters are
         assigned their default values if applicable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/search-application-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/search-application-search.html>`_
 
         :param name: The name of the search application to be searched.
         :param params: Query parameters specific to this request, which will override

--- a/elasticsearch/_sync/client/searchable_snapshots.py
+++ b/elasticsearch/_sync/client/searchable_snapshots.py
@@ -47,7 +47,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         Get cache statistics. Get statistics about the shared cache for partially mounted
         indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-cache-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-cache-stats.html>`_
 
         :param node_id: The names of the nodes in the cluster to target.
         :param master_timeout:
@@ -105,7 +105,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         Clear the cache. Clear indices and data streams from the shared cache for partially
         mounted indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-clear-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-clear-cache.html>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             clear from the cache. It supports wildcards (`*`).
@@ -180,7 +180,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         this API for snapshots managed by index lifecycle management (ILM). Manually
         mounting ILM-managed snapshots can interfere with ILM processes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-mount-snapshot.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-mount-snapshot.html>`_
 
         :param repository: The name of the repository containing the snapshot of the
             index to mount.
@@ -265,7 +265,7 @@ class SearchableSnapshotsClient(NamespacedClient):
         """
         Get searchable snapshot statistics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/searchable-snapshots-api-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/searchable-snapshots-api-stats.html>`_
 
         :param index: A comma-separated list of data streams and indices to retrieve
             statistics for.

--- a/elasticsearch/_sync/client/security.py
+++ b/elasticsearch/_sync/client/security.py
@@ -60,7 +60,7 @@ class SecurityClient(NamespacedClient):
         the document if it was disabled. Any updates do not change existing content for
         either the `labels` or `data` fields.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-activate-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-activate-user-profile.html>`_
 
         :param grant_type: The type of grant.
         :param access_token: The user's Elasticsearch access token or JWT. Both `access`
@@ -124,7 +124,7 @@ class SecurityClient(NamespacedClient):
         and information about the realms that authenticated and authorized the user.
         If the user cannot be authenticated, this API returns a 401 status code.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-authenticate.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_authenticate"
@@ -168,7 +168,7 @@ class SecurityClient(NamespacedClient):
         manage roles, rather than using file-based role management. The bulk delete roles
         API cannot delete roles that are defined in roles files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-bulk-delete-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-bulk-delete-role.html>`_
 
         :param names: An array of role names to delete
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -226,7 +226,7 @@ class SecurityClient(NamespacedClient):
         way to manage roles, rather than using file-based role management. The bulk create
         or update roles API cannot update roles that are defined in roles files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-bulk-put-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-bulk-put-role.html>`_
 
         :param roles: A dictionary of role name to RoleDescriptor objects to add or update
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -298,7 +298,7 @@ class SecurityClient(NamespacedClient):
         the requested changes and did not require an update, and error details for any
         failed update.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-bulk-update-api-keys.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-bulk-update-api-keys.html>`_
 
         :param ids: The API key identifiers.
         :param expiration: Expiration time for the API keys. By default, API keys never
@@ -373,7 +373,7 @@ class SecurityClient(NamespacedClient):
         Change passwords. Change the passwords of users in the native realm and built-in
         users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-change-password.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-change-password.html>`_
 
         :param username: The user whose password you want to change. If you do not specify
             this parameter, the password is changed for the current user.
@@ -436,7 +436,7 @@ class SecurityClient(NamespacedClient):
         Clear the API key cache. Evict a subset of all entries from the API key cache.
         The cache is also automatically cleared on state changes of the security index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-api-key-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-api-key-cache.html>`_
 
         :param ids: Comma-separated list of API key IDs to evict from the API key cache.
             To evict all API keys, use `*`. Does not support other wildcard patterns.
@@ -479,9 +479,10 @@ class SecurityClient(NamespacedClient):
         cache. The cache is also automatically cleared for applications that have their
         privileges updated.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-privilege-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-privilege-cache.html>`_
 
-        :param application: A comma-separated list of application names
+        :param application: A comma-separated list of applications. To clear all applications,
+            use an asterism (`*`). It does not support other wildcard patterns.
         """
         if application in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'application'")
@@ -519,12 +520,19 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Clear the user cache. Evict users from the user cache. You can completely clear
-        the cache or evict specific users.
+        the cache or evict specific users. User credentials are cached in memory on each
+        node to avoid connecting to a remote authentication service or hitting the disk
+        for every incoming request. There are realm settings that you can use to configure
+        the user cache. For more information, refer to the documentation about controlling
+        the user cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-cache.html>`_
 
-        :param realms: Comma-separated list of realms to clear
-        :param usernames: Comma-separated list of usernames to clear from the cache
+        :param realms: A comma-separated list of realms. To clear all realms, use an
+            asterisk (`*`). It does not support other wildcard patterns.
+        :param usernames: A comma-separated list of the users to clear from the cache.
+            If you do not specify this parameter, the API evicts all users from the user
+            cache.
         """
         if realms in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'realms'")
@@ -564,9 +572,11 @@ class SecurityClient(NamespacedClient):
         """
         Clear the roles cache. Evict roles from the native role cache.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-role-cache.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-role-cache.html>`_
 
-        :param name: Role name
+        :param name: A comma-separated list of roles to evict from the role cache. To
+            evict all roles, use an asterisk (`*`). It does not support other wildcard
+            patterns.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -605,13 +615,20 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Clear service account token caches. Evict a subset of all entries from the service
-        account token caches.
+        account token caches. Two separate caches exist for service account tokens: one
+        cache for tokens backed by the `service_tokens` file, and another for tokens
+        backed by the `.security` index. This API clears matching entries from both caches.
+        The cache for service account tokens backed by the `.security` index is cleared
+        automatically on state changes of the security index. The cache for tokens backed
+        by the `service_tokens` file is cleared automatically on file changes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-clear-service-token-caches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-clear-service-token-caches.html>`_
 
-        :param namespace: An identifier for the namespace
-        :param service: An identifier for the service name
-        :param name: A comma-separated list of service token names
+        :param namespace: The namespace, which is a top-level grouping of service accounts.
+        :param service: The name of the service, which must be unique within its namespace.
+        :param name: A comma-separated list of token names to evict from the service
+            account token caches. Use a wildcard (`*`) to evict all tokens that belong
+            to a service account. It does not support other wildcard patterns.
         """
         if namespace in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'namespace'")
@@ -665,30 +682,40 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Create an API key. Create an API key for access without requiring basic authentication.
-        A successful request returns a JSON structure that contains the API key, its
-        unique id, and its name. If applicable, it also returns expiration information
-        for the API key in milliseconds. NOTE: By default, API keys never expire. You
-        can specify expiration information when you create the API keys.
+        IMPORTANT: If the credential that is used to authenticate this request is an
+        API key, the derived API key cannot have any privileges. If you specify privileges,
+        the API returns an error. A successful request returns a JSON structure that
+        contains the API key, its unique id, and its name. If applicable, it also returns
+        expiration information for the API key in milliseconds. NOTE: By default, API
+        keys never expire. You can specify expiration information when you create the
+        API keys. The API keys are created by the Elasticsearch API key service, which
+        is automatically enabled. To configure or turn off the API key service, refer
+        to API key service setting documentation.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-create-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-create-api-key.html>`_
 
-        :param expiration: Expiration time for the API key. By default, API keys never
-            expire.
+        :param expiration: The expiration time for the API key. By default, API keys
+            never expire.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
             It supports nested data structure. Within the metadata object, keys beginning
             with `_` are reserved for system usage.
-        :param name: Specifies the name for this API key.
+        :param name: A name for the API key.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
-        :param role_descriptors: An array of role descriptors for this API key. This
-            parameter is optional. When it is not specified or is an empty array, then
-            the API key will have a point in time snapshot of permissions of the authenticated
-            user. If you supply role descriptors then the resultant permissions would
-            be an intersection of API keys permissions and authenticated user’s permissions
-            thereby limiting the access scope for API keys. The structure of role descriptor
-            is the same as the request for create role API. For more details, see create
-            or update roles API.
+        :param role_descriptors: An array of role descriptors for this API key. When
+            it is not specified or it is an empty array, the API key will have a point
+            in time snapshot of permissions of the authenticated user. If you supply
+            role descriptors, the resultant permissions are an intersection of API keys
+            permissions and the authenticated user's permissions thereby limiting the
+            access scope for API keys. The structure of role descriptor is the same as
+            the request for the create role API. For more details, refer to the create
+            or update roles API. NOTE: Due to the way in which this permission intersection
+            is calculated, it is not possible to create an API key that is a child of
+            another API key, unless the derived key is created without any privileges.
+            In this case, you must explicitly specify a role descriptor with no privileges.
+            The derived API key can be used for authentication; it will not have authority
+            to call Elasticsearch APIs.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/api_key"
@@ -757,7 +784,7 @@ class SecurityClient(NamespacedClient):
         API key API. Attempting to update them with the update REST API key API or the
         bulk update REST API keys API will result in an error.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-create-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-create-cross-cluster-api-key.html>`_
 
         :param access: The access to be granted to this API key. The access is composed
             of permissions for cross-cluster search and cross-cluster replication. At
@@ -825,13 +852,21 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Create a service account token. Create a service accounts token for access without
-        requiring basic authentication.
+        requiring basic authentication. NOTE: Service account tokens never expire. You
+        must actively delete them if they are no longer needed.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-create-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-create-service-token.html>`_
 
-        :param namespace: An identifier for the namespace
-        :param service: An identifier for the service name
-        :param name: An identifier for the token name
+        :param namespace: The name of the namespace, which is a top-level grouping of
+            service accounts.
+        :param service: The name of the service.
+        :param name: The name for the service account token. If omitted, a random name
+            will be generated. Token names must be at least one and no more than 256
+            characters. They can contain alphanumeric characters (a-z, A-Z, 0-9), dashes
+            (`-`), and underscores (`_`), but cannot begin with an underscore. NOTE:
+            Token names must be unique in the context of the associated service account.
+            They must also be globally unique with their fully qualified names, which
+            are comprised of the service account principal and token name, such as `<namespace>/<service>/<token-name>`.
         :param refresh: If `true` then refresh the affected shards to make this operation
             visible to search, if `wait_for` (the default) then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -909,7 +944,7 @@ class SecurityClient(NamespacedClient):
         the TLS authentication and this API translates that authentication into an Elasticsearch
         access token.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delegate-pki-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delegate-pki-authentication.html>`_
 
         :param x509_certificate_chain: The X509Certificate chain, which is represented
             as an ordered string array. Each string in the array is a base64-encoded
@@ -963,12 +998,16 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete application privileges.
+        Delete application privileges. To use this API, you must have one of the following
+        privileges: * The `manage_security` cluster privilege (or a greater privilege
+        such as `all`). * The "Manage Application Privileges" global privilege for the
+        application being referenced in the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-privilege.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-privilege.html>`_
 
-        :param application: Application name
-        :param name: Privilege name
+        :param application: The name of the application. Application privileges are always
+            associated with exactly one application.
+        :param name: The name of the privilege.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1019,11 +1058,14 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete roles. Delete roles in the native realm.
+        Delete roles. Delete roles in the native realm. The role management APIs are
+        generally the preferred way to manage roles, rather than using file-based role
+        management. The delete roles API cannot remove roles that are defined in roles
+        files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-role.html>`_
 
-        :param name: Role name
+        :param name: The name of the role.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1067,11 +1109,16 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Delete role mappings.
+        Delete role mappings. Role mappings define which roles are assigned to each user.
+        The role mapping APIs are generally the preferred way to manage role mappings
+        rather than using role mapping files. The delete role mappings API cannot remove
+        role mappings that are defined in role mapping files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-role-mapping.html>`_
 
-        :param name: Role-mapping name
+        :param name: The distinct name that identifies the role mapping. The name is
+            used solely as an identifier to facilitate interaction via the API; it does
+            not affect the behavior of the mapping in any way.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1120,11 +1167,11 @@ class SecurityClient(NamespacedClient):
         Delete service account tokens. Delete service account tokens for a service in
         a specified namespace.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-service-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-service-token.html>`_
 
-        :param namespace: An identifier for the namespace
-        :param service: An identifier for the service name
-        :param name: An identifier for the token name
+        :param namespace: The namespace, which is a top-level grouping of service accounts.
+        :param service: The service name.
+        :param name: The name of the service account token.
         :param refresh: If `true` then refresh the affected shards to make this operation
             visible to search, if `wait_for` (the default) then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1178,9 +1225,9 @@ class SecurityClient(NamespacedClient):
         """
         Delete users. Delete users from the native realm.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-delete-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-delete-user.html>`_
 
-        :param username: username
+        :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1224,11 +1271,12 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Disable users. Disable users in the native realm.
+        Disable users. Disable users in the native realm. By default, when you create
+        users, they are enabled. You can use this API to revoke a user's access to Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-disable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-disable-user.html>`_
 
-        :param username: The username of the user to disable
+        :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1282,7 +1330,7 @@ class SecurityClient(NamespacedClient):
         API to disable a user profile so it’s not visible in these searches. To re-enable
         a disabled user profile, use the enable user profile API .
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-disable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-disable-user-profile.html>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1328,11 +1376,12 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Enable users. Enable users in the native realm.
+        Enable users. Enable users in the native realm. By default, when you create users,
+        they are enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-enable-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-enable-user.html>`_
 
-        :param username: The username of the user to enable
+        :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
@@ -1385,7 +1434,7 @@ class SecurityClient(NamespacedClient):
         profile searches. If you later disable the user profile, you can use the enable
         user profile API to make the profile visible in these searches again.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-enable-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-enable-user-profile.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1428,9 +1477,12 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Enroll Kibana. Enable a Kibana instance to configure itself for communication
-        with a secured Elasticsearch cluster.
+        with a secured Elasticsearch cluster. NOTE: This API is currently intended for
+        internal use only by Kibana. Kibana uses this API internally to configure itself
+        for communications with an Elasticsearch cluster that already has security features
+        enabled.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-kibana-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-kibana-enrollment.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/kibana"
@@ -1464,9 +1516,13 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Enroll a node. Enroll a new node to allow it to join an existing cluster with
-        security features enabled.
+        security features enabled. The response contains all the necessary information
+        for the joining node to bootstrap discovery and security related settings so
+        that it can successfully join the cluster. The response contains key and certificate
+        material that allows the caller to generate valid signed certificates for the
+        HTTP layer of all nodes in the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-node-enrollment.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-node-enrollment.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/node"
@@ -1513,7 +1569,7 @@ class SecurityClient(NamespacedClient):
         privileges (including `manage_security`), this API returns all API keys regardless
         of ownership.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-api-key.html>`_
 
         :param active_only: A boolean flag that can be used to query API keys that are
             currently active. An API key is considered active if it is neither invalidated,
@@ -1588,7 +1644,7 @@ class SecurityClient(NamespacedClient):
         Get builtin privileges. Get the list of cluster privileges and index privileges
         that are available in this version of Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-builtin-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-builtin-privileges.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/privilege/_builtin"
@@ -1623,12 +1679,18 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get application privileges.
+        Get application privileges. To use this API, you must have one of the following
+        privileges: * The `read_security` cluster privilege (or a greater privilege such
+        as `manage_security` or `all`). * The "Manage Application Privileges" global
+        privilege for the application being referenced in the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-privileges.html>`_
 
-        :param application: Application name
-        :param name: Privilege name
+        :param application: The name of the application. Application privileges are always
+            associated with exactly one application. If you do not specify this parameter,
+            the API returns information about all privileges for all applications.
+        :param name: The name of the privilege. If you do not specify this parameter,
+            the API returns information about all privileges for the requested application.
         """
         __path_parts: t.Dict[str, str]
         if application not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
@@ -1674,7 +1736,7 @@ class SecurityClient(NamespacedClient):
         the preferred way to manage roles, rather than using file-based role management.
         The get roles API cannot retrieve roles that are defined in roles files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-role.html>`_
 
         :param name: The name of the role. You can specify multiple roles as a comma-separated
             list. If you do not specify this parameter, the API returns information about
@@ -1722,7 +1784,7 @@ class SecurityClient(NamespacedClient):
         rather than using role mapping files. The get role mappings API cannot retrieve
         role mappings that are defined in role mapping files.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-role-mapping.html>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1769,14 +1831,15 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Get service accounts. Get a list of service accounts that match the provided
-        path parameters.
+        path parameters. NOTE: Currently, only the `elastic/fleet-server` service account
+        is available.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-service-accounts.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-service-accounts.html>`_
 
-        :param namespace: Name of the namespace. Omit this parameter to retrieve information
-            about all service accounts. If you omit this parameter, you must also omit
-            the `service` parameter.
-        :param service: Name of the service name. Omit this parameter to retrieve information
+        :param namespace: The name of the namespace. Omit this parameter to retrieve
+            information about all service accounts. If you omit this parameter, you must
+            also omit the `service` parameter.
+        :param service: The service name. Omit this parameter to retrieve information
             about all service accounts that belong to the specified `namespace`.
         """
         __path_parts: t.Dict[str, str]
@@ -1820,12 +1883,19 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get service account credentials.
+        Get service account credentials. To use this API, you must have at least the
+        `read_security` cluster privilege (or a greater privilege such as `manage_service_account`
+        or `manage_security`). The response includes service account tokens that were
+        created with the create service account tokens API as well as file-backed tokens
+        from all nodes of the cluster. NOTE: For tokens backed by the `service_tokens`
+        file, the API collects them from all nodes of the cluster. Tokens with the same
+        name from different nodes are assumed to be the same token and are only counted
+        once towards the total number of service tokens.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-service-credentials.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-service-credentials.html>`_
 
-        :param namespace: Name of the namespace.
-        :param service: Name of the service name.
+        :param namespace: The name of the namespace.
+        :param service: The service name.
         """
         if namespace in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'namespace'")
@@ -1867,9 +1937,11 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Get security index settings. Get the user-configurable settings for the security
-        internal index (`.security` and associated indices).
+        internal index (`.security` and associated indices). Only a subset of the index
+        settings — those that are user-configurable—will be shown. This includes: * `index.auto_expand_replicas`
+        * `index.number_of_replicas`
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-settings.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -1932,15 +2004,39 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Get a token. Create a bearer token for access without requiring basic authentication.
+        The tokens are created by the Elasticsearch Token Service, which is automatically
+        enabled when you configure TLS on the HTTP interface. Alternatively, you can
+        explicitly enable the `xpack.security.authc.token.enabled` setting. When you
+        are running in production mode, a bootstrap check prevents you from enabling
+        the token service unless you also enable TLS on the HTTP interface. The get token
+        API takes the same parameters as a typical OAuth 2.0 token API except for the
+        use of a JSON request body. A successful get token API call returns a JSON structure
+        that contains the access token, the amount of time (seconds) that the token expires
+        in, the type, and the scope if available. The tokens returned by the get token
+        API have a finite period of time for which they are valid and after that time
+        period, they can no longer be used. That time period is defined by the `xpack.security.authc.token.timeout`
+        setting. If you want to invalidate a token immediately, you can do so by using
+        the invalidate token API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-token.html>`_
 
-        :param grant_type:
-        :param kerberos_ticket:
-        :param password:
-        :param refresh_token:
-        :param scope:
-        :param username:
+        :param grant_type: The type of grant. Supported grant types are: `password`,
+            `_kerberos`, `client_credentials`, and `refresh_token`.
+        :param kerberos_ticket: The base64 encoded kerberos ticket. If you specify the
+            `_kerberos` grant type, this parameter is required. This parameter is not
+            valid with any other supported grant type.
+        :param password: The user's password. If you specify the `password` grant type,
+            this parameter is required. This parameter is not valid with any other supported
+            grant type.
+        :param refresh_token: The string that was returned when you created the token,
+            which enables you to extend its life. If you specify the `refresh_token`
+            grant type, this parameter is required. This parameter is not valid with
+            any other supported grant type.
+        :param scope: The scope of the token. Currently tokens are only issued for a
+            scope of FULL regardless of the value sent with the request.
+        :param username: The username that identifies the user. If you specify the `password`
+            grant type, this parameter is required. This parameter is not valid with
+            any other supported grant type.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/oauth2/token"
@@ -1992,13 +2088,13 @@ class SecurityClient(NamespacedClient):
         """
         Get users. Get information about users in the native realm and built-in users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-user.html>`_
 
         :param username: An identifier for the user. You can specify multiple usernames
             as a comma-separated list. If you omit this parameter, the API retrieves
             information about all users.
-        :param with_profile_uid: If true will return the User Profile ID for a user,
-            if any.
+        :param with_profile_uid: Determines whether to retrieve the user profile UID,
+            if it exists, for the users.
         """
         __path_parts: t.Dict[str, str]
         if username not in SKIP_IN_PATH:
@@ -2041,9 +2137,12 @@ class SecurityClient(NamespacedClient):
         username: t.Optional[t.Union[None, str]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Get user privileges.
+        Get user privileges. Get the security privileges for the logged in user. All
+        users can use this API, but only to determine their own privileges. To check
+        the privileges of other users, you must use the run as feature. To check whether
+        a user has a specific list of privileges, use the has privileges API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-user-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-user-privileges.html>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -2097,7 +2196,7 @@ class SecurityClient(NamespacedClient):
         applications should not call this API directly. Elastic reserves the right to
         change or remove this feature in future releases without prior notice.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-get-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-get-user-profile.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: A comma-separated list of filters for the `data` field of the profile
@@ -2162,28 +2261,30 @@ class SecurityClient(NamespacedClient):
         Grant an API key. Create an API key on behalf of another user. This API is similar
         to the create API keys API, however it creates the API key for a user that is
         different than the user that runs the API. The caller must have authentication
-        credentials (either an access token, or a username and password) for the user
-        on whose behalf the API key will be created. It is not possible to use this API
-        to create an API key without that user’s credentials. The user, for whom the
-        authentication credentials is provided, can optionally "run as" (impersonate)
-        another user. In this case, the API key will be created on behalf of the impersonated
-        user. This API is intended be used by applications that need to create and manage
-        API keys for end users, but cannot guarantee that those users have permission
-        to create API keys on their own behalf. A successful grant API key API call returns
-        a JSON structure that contains the API key, its unique id, and its name. If applicable,
+        credentials for the user on whose behalf the API key will be created. It is not
+        possible to use this API to create an API key without that user's credentials.
+        The supported user authentication credential types are: * username and password
+        * Elasticsearch access tokens * JWTs The user, for whom the authentication credentials
+        is provided, can optionally "run as" (impersonate) another user. In this case,
+        the API key will be created on behalf of the impersonated user. This API is intended
+        be used by applications that need to create and manage API keys for end users,
+        but cannot guarantee that those users have permission to create API keys on their
+        own behalf. The API keys are created by the Elasticsearch API key service, which
+        is automatically enabled. A successful grant API key API call returns a JSON
+        structure that contains the API key, its unique id, and its name. If applicable,
         it also returns expiration information for the API key in milliseconds. By default,
         API keys never expire. You can specify expiration information when you create
         the API keys.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-grant-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-grant-api-key.html>`_
 
-        :param api_key: Defines the API key.
+        :param api_key: The API key.
         :param grant_type: The type of grant. Supported grant types are: `access_token`,
             `password`.
-        :param access_token: The user’s access token. If you specify the `access_token`
+        :param access_token: The user's access token. If you specify the `access_token`
             grant type, this parameter is required. It is not valid with other grant
             types.
-        :param password: The user’s password. If you specify the `password` grant type,
+        :param password: The user's password. If you specify the `password` grant type,
             this parameter is required. It is not valid with other grant types.
         :param run_as: The name of the user to be impersonated.
         :param username: The user name that identifies the user. If you specify the `password`
@@ -2315,9 +2416,10 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Check user privileges. Determine whether the specified user has a specified list
-        of privileges.
+        of privileges. All users can use this API, but only to determine their own privileges.
+        To check the privileges of other users, you must use the run as feature.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-has-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-has-privileges.html>`_
 
         :param user: Username
         :param application:
@@ -2381,7 +2483,7 @@ class SecurityClient(NamespacedClient):
         applications should not call this API directly. Elastic reserves the right to
         change or remove this feature in future releases without prior notice.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-has-privileges-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-has-privileges-user-profile.html>`_
 
         :param privileges: An object containing all the privileges to be checked.
         :param uids: A list of profile IDs. The privileges are checked for associated
@@ -2442,29 +2544,33 @@ class SecurityClient(NamespacedClient):
         key or grant API key APIs. Invalidated API keys fail authentication, but they
         can still be viewed using the get API key information and query API key information
         APIs, for at least the configured retention period, until they are automatically
-        deleted. The `manage_api_key` privilege allows deleting any API keys. The `manage_own_api_key`
-        only allows deleting API keys that are owned by the user. In addition, with the
-        `manage_own_api_key` privilege, an invalidation request must be issued in one
-        of the three formats: - Set the parameter `owner=true`. - Or, set both `username`
-        and `realm_name` to match the user’s identity. - Or, if the request is issued
-        by an API key, that is to say an API key invalidates itself, specify its ID in
-        the `ids` field.
+        deleted. To use this API, you must have at least the `manage_security`, `manage_api_key`,
+        or `manage_own_api_key` cluster privileges. The `manage_security` privilege allows
+        deleting any API key, including both REST and cross cluster API keys. The `manage_api_key`
+        privilege allows deleting any REST API key, but not cross cluster API keys. The
+        `manage_own_api_key` only allows deleting REST API keys that are owned by the
+        user. In addition, with the `manage_own_api_key` privilege, an invalidation request
+        must be issued in one of the three formats: - Set the parameter `owner=true`.
+        - Or, set both `username` and `realm_name` to match the user's identity. - Or,
+        if the request is issued by an API key, that is to say an API key invalidates
+        itself, specify its ID in the `ids` field.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-invalidate-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-invalidate-api-key.html>`_
 
         :param id:
         :param ids: A list of API key ids. This parameter cannot be used with any of
             `name`, `realm_name`, or `username`.
         :param name: An API key name. This parameter cannot be used with any of `ids`,
             `realm_name` or `username`.
-        :param owner: Can be used to query API keys owned by the currently authenticated
-            user. The `realm_name` or `username` parameters cannot be specified when
-            this parameter is set to `true` as they are assumed to be the currently authenticated
-            ones.
+        :param owner: Query API keys owned by the currently authenticated user. The `realm_name`
+            or `username` parameters cannot be specified when this parameter is set to
+            `true` as they are assumed to be the currently authenticated ones. NOTE:
+            At least one of `ids`, `name`, `username`, and `realm_name` must be specified
+            if `owner` is `false`.
         :param realm_name: The name of an authentication realm. This parameter cannot
             be used with either `ids` or `name`, or when `owner` flag is set to `true`.
         :param username: The username of a user. This parameter cannot be used with either
-            `ids` or `name`, or when `owner` flag is set to `true`.
+            `ids` or `name` or when `owner` flag is set to `true`.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/api_key"
@@ -2524,14 +2630,21 @@ class SecurityClient(NamespacedClient):
         longer be used. The time period is defined by the `xpack.security.authc.token.timeout`
         setting. The refresh tokens returned by the get token API are only valid for
         24 hours. They can also be used exactly once. If you want to invalidate one or
-        more access or refresh tokens immediately, use this invalidate token API.
+        more access or refresh tokens immediately, use this invalidate token API. NOTE:
+        While all parameters are optional, at least one of them is required. More specifically,
+        either one of `token` or `refresh_token` parameters is required. If none of these
+        two are specified, then `realm_name` and/or `username` need to be specified.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-invalidate-token.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-invalidate-token.html>`_
 
-        :param realm_name:
-        :param refresh_token:
-        :param token:
-        :param username:
+        :param realm_name: The name of an authentication realm. This parameter cannot
+            be used with either `refresh_token` or `token`.
+        :param refresh_token: A refresh token. This parameter cannot be used if any of
+            `refresh_token`, `realm_name`, or `username` are used.
+        :param token: An access token. This parameter cannot be used if any of `refresh_token`,
+            `realm_name`, or `username` are used.
+        :param username: The username of a user. This parameter cannot be used with either
+            `refresh_token` or `token`.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/oauth2/token"
@@ -2589,7 +2702,7 @@ class SecurityClient(NamespacedClient):
         are used internally by Kibana in order to provide OpenID Connect based authentication,
         but can also be used by other, custom web applications or other clients.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-oidc-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-oidc-authenticate.html>`_
 
         :param nonce: Associate a client session with an ID token and mitigate replay
             attacks. This value needs to be the same as the one that was provided to
@@ -2670,7 +2783,7 @@ class SecurityClient(NamespacedClient):
         Connect based authentication, but can also be used by other, custom web applications
         or other clients.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-oidc-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-oidc-logout.html>`_
 
         :param access_token: The access token to be invalidated.
         :param refresh_token: The refresh token to be invalidated.
@@ -2733,7 +2846,7 @@ class SecurityClient(NamespacedClient):
         Connect based authentication, but can also be used by other, custom web applications
         or other clients.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-oidc-prepare-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-oidc-prepare-authentication.html>`_
 
         :param iss: In the case of a third party initiated single sign on, this is the
             issuer identifier for the OP that the RP is to send the authentication request
@@ -2808,9 +2921,22 @@ class SecurityClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Create or update application privileges.
+        Create or update application privileges. To use this API, you must have one of
+        the following privileges: * The `manage_security` cluster privilege (or a greater
+        privilege such as `all`). * The "Manage Application Privileges" global privilege
+        for the application being referenced in the request. Application names are formed
+        from a prefix, with an optional suffix that conform to the following rules: *
+        The prefix must begin with a lowercase ASCII letter. * The prefix must contain
+        only ASCII letters or digits. * The prefix must be at least 3 characters long.
+        * If the suffix exists, it must begin with either a dash `-` or `_`. * The suffix
+        cannot contain any of the following characters: `\\`, `/`, `*`, `?`, `"`, `<`,
+        `>`, `|`, `,`, `*`. * No part of the name can contain whitespace. Privilege names
+        must begin with a lowercase ASCII letter and must contain only ASCII letters
+        and digits along with the characters `_`, `-`, and `.`. Action names can contain
+        any number of printable ASCII characters and must contain at least one of the
+        following characters: `/`, `*`, `:`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-privileges.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-privileges.html>`_
 
         :param privileges:
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -2959,7 +3085,7 @@ class SecurityClient(NamespacedClient):
         The create or update roles API cannot update roles that are defined in roles
         files. File-based role management is not available in Elastic Serverless.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-role.html>`_
 
         :param name: The name of the role.
         :param applications: A list of application privilege entries.
@@ -2976,7 +3102,10 @@ class SecurityClient(NamespacedClient):
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
         :param remote_cluster: A list of remote cluster permissions entries.
-        :param remote_indices: A list of remote indices permissions entries.
+        :param remote_indices: A list of remote indices permissions entries. NOTE: Remote
+            indices are effective for remote clusters configured with the API key based
+            model. They have no effect for remote clusters configured with the certificate
+            based model.
         :param run_as: A list of users that the owners of this role can impersonate.
             *Note*: in Serverless, the run-as feature is disabled. For API compatibility,
             you can still specify an empty `run_as` field, but a non-empty list will
@@ -3071,21 +3200,45 @@ class SecurityClient(NamespacedClient):
         that are granted to those users. The role mapping APIs are generally the preferred
         way to manage role mappings rather than using role mapping files. The create
         or update role mappings API cannot update role mappings that are defined in role
-        mapping files. This API does not create roles. Rather, it maps users to existing
-        roles. Roles can be created by using the create or update roles API or roles
-        files.
+        mapping files. NOTE: This API does not create roles. Rather, it maps users to
+        existing roles. Roles can be created by using the create or update roles API
+        or roles files. **Role templates** The most common use for role mappings is to
+        create a mapping from a known value on the user to a fixed role name. For example,
+        all users in the `cn=admin,dc=example,dc=com` LDAP group should be given the
+        superuser role in Elasticsearch. The `roles` field is used for this purpose.
+        For more complex needs, it is possible to use Mustache templates to dynamically
+        determine the names of the roles that should be granted to the user. The `role_templates`
+        field is used for this purpose. NOTE: To use role templates successfully, the
+        relevant scripting feature must be enabled. Otherwise, all attempts to create
+        a role mapping with role templates fail. All of the user fields that are available
+        in the role mapping rules are also available in the role templates. Thus it is
+        possible to assign a user to a role that reflects their username, their groups,
+        or the name of the realm to which they authenticated. By default a template is
+        evaluated to produce a single string that is the name of the role which should
+        be assigned to the user. If the format of the template is set to "json" then
+        the template is expected to produce a JSON string or an array of JSON strings
+        for the role names.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-role-mapping.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-role-mapping.html>`_
 
-        :param name: Role-mapping name
-        :param enabled:
-        :param metadata:
+        :param name: The distinct name that identifies the role mapping. The name is
+            used solely as an identifier to facilitate interaction via the API; it does
+            not affect the behavior of the mapping in any way.
+        :param enabled: Mappings that have `enabled` set to `false` are ignored when
+            role mapping is performed.
+        :param metadata: Additional metadata that helps define which roles are assigned
+            to each user. Within the metadata object, keys beginning with `_` are reserved
+            for system usage.
         :param refresh: If `true` (the default) then refresh the affected shards to make
             this operation visible to search, if `wait_for` then wait for a refresh to
             make this operation visible to search, if `false` then do nothing with refreshes.
-        :param role_templates:
-        :param roles:
-        :param rules:
+        :param role_templates: A list of Mustache templates that will be evaluated to
+            determine the roles names that should granted to the users that match the
+            role mapping rules. Exactly one of `roles` or `role_templates` must be specified.
+        :param roles: A list of role names that are granted to the users that match the
+            role mapping rules. Exactly one of `roles` or `role_templates` must be specified.
+        :param rules: The rules that determine which users should be matched by the mapping.
+            A rule is a logical condition that is expressed by using a JSON DSL.
         :param run_as:
         """
         if name in SKIP_IN_PATH:
@@ -3160,23 +3313,38 @@ class SecurityClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Create or update users. A password is required for adding a new user but is optional
-        when updating an existing user. To change a user’s password without updating
-        any other fields, use the change password API.
+        Create or update users. Add and update users in the native realm. A password
+        is required for adding a new user but is optional when updating an existing user.
+        To change a user's password without updating any other fields, use the change
+        password API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-put-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-put-user.html>`_
 
-        :param username: The username of the User
-        :param email:
-        :param enabled:
-        :param full_name:
-        :param metadata:
-        :param password:
-        :param password_hash:
-        :param refresh: If `true` (the default) then refresh the affected shards to make
-            this operation visible to search, if `wait_for` then wait for a refresh to
-            make this operation visible to search, if `false` then do nothing with refreshes.
-        :param roles:
+        :param username: An identifier for the user. NOTE: Usernames must be at least
+            1 and no more than 507 characters. They can contain alphanumeric characters
+            (a-z, A-Z, 0-9), spaces, punctuation, and printable symbols in the Basic
+            Latin (ASCII) block. Leading or trailing whitespace is not allowed.
+        :param email: The email of the user.
+        :param enabled: Specifies whether the user is enabled.
+        :param full_name: The full name of the user.
+        :param metadata: Arbitrary metadata that you want to associate with the user.
+        :param password: The user's password. Passwords must be at least 6 characters
+            long. When adding a user, one of `password` or `password_hash` is required.
+            When updating an existing user, the password is optional, so that other fields
+            on the user (such as their roles) may be updated without modifying the user's
+            password
+        :param password_hash: A hash of the user's password. This must be produced using
+            the same hashing algorithm as has been configured for password storage. For
+            more details, see the explanation of the `xpack.security.authc.password_hashing.algorithm`
+            setting in the user cache and password hash algorithm documentation. Using
+            this parameter allows the client to pre-hash the password for performance
+            and/or confidentiality reasons. The `password` parameter and the `password_hash`
+            parameter cannot be used in the same request.
+        :param refresh: Valid values are `true`, `false`, and `wait_for`. These values
+            have the same meaning as in the index API, but the default value for this
+            API is true.
+        :param roles: A set of roles the user has. The roles determine the user's access
+            permissions. To create a user without any roles, specify an empty list (`[]`).
         """
         if username in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'username'")
@@ -3260,9 +3428,14 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Find API keys with a query. Get a paginated list of API keys and their information.
-        You can optionally filter the results with a query.
+        You can optionally filter the results with a query. To use this API, you must
+        have at least the `manage_own_api_key` or the `read_security` cluster privileges.
+        If you have only the `manage_own_api_key` privilege, this API returns only the
+        API keys that you own. If you have the `read_security`, `manage_api_key`, or
+        greater privileges (including `manage_security`), this API returns all API keys
+        regardless of ownership.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-query-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-query-api-key.html>`_
 
         :param aggregations: Any aggregations to run over the corpus of returned API
             keys. Aggregations and queries work together. Aggregations are computed only
@@ -3276,30 +3449,39 @@ class SecurityClient(NamespacedClient):
             `terms`, `range`, `date_range`, `missing`, `cardinality`, `value_count`,
             `composite`, `filter`, and `filters`. Additionally, aggregations only run
             over the same subset of fields that query works with.
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the `search_after` parameter.
+        :param from_: The starting document offset. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
         :param query: A query to filter which API keys to return. If the query parameter
             is missing, it is equivalent to a `match_all` query. The query supports a
             subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,
             `ids`, `prefix`, `wildcard`, `exists`, `range`, and `simple_query_string`.
             You can query the following public information associated with an API key:
             `id`, `type`, `name`, `creation`, `expiration`, `invalidated`, `invalidation`,
-            `username`, `realm`, and `metadata`.
-        :param search_after: Search after definition
-        :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the `from` and `size` parameters. To page through
-            more hits, use the `search_after` parameter.
-        :param sort: Other than `id`, all public fields of an API key are eligible for
-            sorting. In addition, sort can also be applied to the `_doc` field to sort
-            by index order.
+            `username`, `realm`, and `metadata`. NOTE: The queryable string values associated
+            with API keys are internally mapped as keywords. Consequently, if no `analyzer`
+            parameter is specified for a `match` query, then the provided match query
+            string is interpreted as a single keyword value. Such a match query is hence
+            equivalent to a `term` query.
+        :param search_after: The search after definition.
+        :param size: The number of hits to return. It must not be negative. The `size`
+            parameter can be set to `0`, in which case no API key matches are returned,
+            only the aggregation results. By default, you cannot page through more than
+            10,000 hits using the `from` and `size` parameters. To page through more
+            hits, use the `search_after` parameter.
+        :param sort: The sort definition. Other than `id`, all public fields of an API
+            key are eligible for sorting. In addition, sort can also be applied to the
+            `_doc` field to sort by index order.
         :param typed_keys: Determines whether aggregation names are prefixed by their
             respective types in the response.
         :param with_limited_by: Return the snapshot of the owner user's role descriptors
             associated with the API key. An API key's actual permission is the intersection
-            of its assigned role descriptors and the owner user's role descriptors.
-        :param with_profile_uid: Determines whether to also retrieve the profile uid,
-            for the API key owner principal, if it exists.
+            of its assigned role descriptors and the owner user's role descriptors (effectively
+            limited by it). An API key cannot retrieve any API key’s limited-by role
+            descriptors (including itself) unless it has `manage_api_key` or higher privileges.
+        :param with_profile_uid: Determines whether to also retrieve the profile UID
+            for the API key owner principal. If it exists, the profile UID is returned
+            under the `profile_uid` response field for each API key.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_query/api_key"
@@ -3386,26 +3568,30 @@ class SecurityClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Find roles with a query. Get roles in a paginated manner. You can optionally
-        filter the results with a query.
+        Find roles with a query. Get roles in a paginated manner. The role management
+        APIs are generally the preferred way to manage roles, rather than using file-based
+        role management. The query roles API does not retrieve roles that are defined
+        in roles files, nor built-in ones. You can optionally filter the results with
+        a query. Also, the results can be paginated and sorted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-query-role.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-query-role.html>`_
 
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the `search_after` parameter.
+        :param from_: The starting document offset. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
         :param query: A query to filter which roles to return. If the query parameter
             is missing, it is equivalent to a `match_all` query. The query supports a
             subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,
             `ids`, `prefix`, `wildcard`, `exists`, `range`, and `simple_query_string`.
             You can query the following information associated with roles: `name`, `description`,
-            `metadata`, `applications.application`, `applications.privileges`, `applications.resources`.
-        :param search_after: Search after definition
-        :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the `from` and `size` parameters. To page through
-            more hits, use the `search_after` parameter.
-        :param sort: All public fields of a role are eligible for sorting. In addition,
-            sort can also be applied to the `_doc` field to sort by index order.
+            `metadata`, `applications.application`, `applications.privileges`, and `applications.resources`.
+        :param search_after: The search after definition.
+        :param size: The number of hits to return. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
+        :param sort: The sort definition. You can sort on `username`, `roles`, or `enabled`.
+            In addition, sort can also be applied to the `_doc` field to sort by index
+            order.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_query/role"
@@ -3473,27 +3659,30 @@ class SecurityClient(NamespacedClient):
     ) -> ObjectApiResponse[t.Any]:
         """
         Find users with a query. Get information for users in a paginated manner. You
-        can optionally filter the results with a query.
+        can optionally filter the results with a query. NOTE: As opposed to the get user
+        API, built-in users are excluded from the result. This API is only for native
+        users.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-query-user.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-query-user.html>`_
 
-        :param from_: Starting document offset. By default, you cannot page through more
-            than 10,000 hits using the from and size parameters. To page through more
-            hits, use the `search_after` parameter.
+        :param from_: The starting document offset. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
         :param query: A query to filter which users to return. If the query parameter
             is missing, it is equivalent to a `match_all` query. The query supports a
             subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,
             `ids`, `prefix`, `wildcard`, `exists`, `range`, and `simple_query_string`.
             You can query the following information associated with user: `username`,
-            `roles`, `enabled`
-        :param search_after: Search after definition
-        :param size: The number of hits to return. By default, you cannot page through
-            more than 10,000 hits using the `from` and `size` parameters. To page through
-            more hits, use the `search_after` parameter.
-        :param sort: Fields eligible for sorting are: username, roles, enabled In addition,
-            sort can also be applied to the `_doc` field to sort by index order.
-        :param with_profile_uid: If true will return the User Profile ID for the users
-            in the query result, if any.
+            `roles`, `enabled`, `full_name`, and `email`.
+        :param search_after: The search after definition
+        :param size: The number of hits to return. It must not be negative. By default,
+            you cannot page through more than 10,000 hits using the `from` and `size`
+            parameters. To page through more hits, use the `search_after` parameter.
+        :param sort: The sort definition. Fields eligible for sorting are: `username`,
+            `roles`, `enabled`. In addition, sort can also be applied to the `_doc` field
+            to sort by index order.
+        :param with_profile_uid: Determines whether to retrieve the user profile UID,
+            if it exists, for the users.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_query/user"
@@ -3565,7 +3754,7 @@ class SecurityClient(NamespacedClient):
         Elasticsearch access and refresh tokens, which can be used for authentication
         against Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-authenticate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-authenticate.html>`_
 
         :param content: The SAML response as it was sent by the user's browser, usually
             a Base64 encoded XML document.
@@ -3636,7 +3825,7 @@ class SecurityClient(NamespacedClient):
         of this API must prepare the request accordingly so that this API can handle
         either of them.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-complete-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-complete-logout.html>`_
 
         :param ids: A JSON array with all the valid SAML Request Ids that the caller
             of the API has for the current user.
@@ -3710,7 +3899,7 @@ class SecurityClient(NamespacedClient):
         to that specific SAML principal and provides a URL that contains a SAML LogoutResponse
         message. Thus the user can be redirected back to their IdP.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-invalidate.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-invalidate.html>`_
 
         :param query_string: The query part of the URL that the user was redirected to
             by the SAML IdP to initiate the Single Logout. This query should include
@@ -3784,7 +3973,7 @@ class SecurityClient(NamespacedClient):
         a URL to redirect the user to the IdP that contains a SAML logout request (starting
         an SP-initiated SAML Single Logout).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-logout.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-logout.html>`_
 
         :param token: The access token that was returned as a response to calling the
             SAML authenticate API. Alternatively, the most recent token that was received
@@ -3854,7 +4043,7 @@ class SecurityClient(NamespacedClient):
         request. The caller of this API needs to store this identifier as it needs to
         be used in a following step of the authentication process.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-prepare-authentication.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-prepare-authentication.html>`_
 
         :param acs: The Assertion Consumer Service URL that matches the one of the SAML
             realms in Elasticsearch. The realm is used to generate the authentication
@@ -3913,7 +4102,7 @@ class SecurityClient(NamespacedClient):
         This API generates Service Provider metadata based on the configuration of a
         SAML realm in Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-saml-sp-metadata.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-saml-sp-metadata.html>`_
 
         :param realm_name: The name of the SAML realm in Elasticsearch.
         """
@@ -3964,7 +4153,7 @@ class SecurityClient(NamespacedClient):
         Elastic reserves the right to change or remove this feature in future releases
         without prior notice.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-suggest-user-profile.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-suggest-user-profile.html>`_
 
         :param data: A comma-separated list of filters for the `data` field of the profile
             document. To return all content use `data=*`. To return a subset of content,
@@ -4033,38 +4222,44 @@ class SecurityClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Update an API key. Updates attributes of an existing API key. Users can only
-        update API keys that they created or that were granted to them. Use this API
-        to update API keys created by the create API Key or grant API Key APIs. If you
-        need to apply the same update to many API keys, you can use bulk update API Keys
-        to reduce overhead. It’s not possible to update expired API keys, or API keys
-        that have been invalidated by invalidate API Key. This API supports updates to
-        an API key’s access scope and metadata. The access scope of an API key is derived
-        from the `role_descriptors` you specify in the request, and a snapshot of the
-        owner user’s permissions at the time of the request. The snapshot of the owner’s
-        permissions is updated automatically on every call. If you don’t specify `role_descriptors`
-        in the request, a call to this API might still change the API key’s access scope.
-        This change can occur if the owner user’s permissions have changed since the
-        API key was created or last modified. To update another user’s API key, use the
-        `run_as` feature to submit a request on behalf of another user. IMPORTANT: It’s
-        not possible to use an API key as the authentication credential for this API.
-        To update an API key, the owner user’s credentials are required.
+        Update an API key. Update attributes of an existing API key. This API supports
+        updates to an API key's access scope, expiration, and metadata. To use this API,
+        you must have at least the `manage_own_api_key` cluster privilege. Users can
+        only update API keys that they created or that were granted to them. To update
+        another user’s API key, use the `run_as` feature to submit a request on behalf
+        of another user. IMPORTANT: It's not possible to use an API key as the authentication
+        credential for this API. The owner user’s credentials are required. Use this
+        API to update API keys created by the create API key or grant API Key APIs. If
+        you need to apply the same update to many API keys, you can use the bulk update
+        API keys API to reduce overhead. It's not possible to update expired API keys
+        or API keys that have been invalidated by the invalidate API key API. The access
+        scope of an API key is derived from the `role_descriptors` you specify in the
+        request and a snapshot of the owner user's permissions at the time of the request.
+        The snapshot of the owner's permissions is updated automatically on every call.
+        IMPORTANT: If you don't specify `role_descriptors` in the request, a call to
+        this API might still change the API key's access scope. This change can occur
+        if the owner user's permissions have changed since the API key was created or
+        last modified.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-api-key.html>`_
 
         :param id: The ID of the API key to update.
-        :param expiration: Expiration time for the API key.
+        :param expiration: The expiration time for the API key. By default, API keys
+            never expire. This property can be omitted to leave the expiration unchanged.
         :param metadata: Arbitrary metadata that you want to associate with the API key.
-            It supports nested data structure. Within the metadata object, keys beginning
-            with _ are reserved for system usage.
-        :param role_descriptors: An array of role descriptors for this API key. This
-            parameter is optional. When it is not specified or is an empty array, then
-            the API key will have a point in time snapshot of permissions of the authenticated
-            user. If you supply role descriptors then the resultant permissions would
-            be an intersection of API keys permissions and authenticated user’s permissions
-            thereby limiting the access scope for API keys. The structure of role descriptor
-            is the same as the request for create role API. For more details, see create
-            or update roles API.
+            It supports a nested data structure. Within the metadata object, keys beginning
+            with `_` are reserved for system usage. When specified, this value fully
+            replaces the metadata previously associated with the API key.
+        :param role_descriptors: The role descriptors to assign to this API key. The
+            API key's effective permissions are an intersection of its assigned privileges
+            and the point in time snapshot of permissions of the owner user. You can
+            assign new privileges by specifying them in this parameter. To remove assigned
+            privileges, you can supply an empty `role_descriptors` parameter, that is
+            to say, an empty object `{}`. If an API key has no assigned privileges, it
+            inherits the owner user's full permissions. The snapshot of the owner's permissions
+            is always updated, whether you supply the `role_descriptors` parameter or
+            not. The structure of a role descriptor is the same as the request for the
+            create API keys API.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -4133,7 +4328,7 @@ class SecurityClient(NamespacedClient):
         API keys, which should be updated by either the update API key or bulk update
         API keys API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-cross-cluster-api-key.html>`_
 
         :param id: The ID of the cross-cluster API key to update.
         :param access: The access to be granted to this API key. The access is composed
@@ -4205,12 +4400,14 @@ class SecurityClient(NamespacedClient):
         """
         Update security index settings. Update the user-configurable settings for the
         security internal index (`.security` and associated indices). Only a subset of
-        settings are allowed to be modified, for example `index.auto_expand_replicas`
-        and `index.number_of_replicas`. If a specific index is not in use on the system
-        and settings are provided for it, the request will be rejected. This API does
-        not yet support configuring the settings for indices before they are in use.
+        settings are allowed to be modified. This includes `index.auto_expand_replicas`
+        and `index.number_of_replicas`. NOTE: If `index.auto_expand_replicas` is set,
+        `index.number_of_replicas` will be ignored during updates. If a specific index
+        is not in use on the system and settings are provided for it, the request will
+        be rejected. This API does not yet support configuring the settings for indices
+        before they are in use.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-settings.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -4291,7 +4488,7 @@ class SecurityClient(NamespacedClient):
         data, content is namespaced by the top-level fields. The `update_profile_data`
         global privilege grants privileges for updating only the allowed namespaces.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-update-user-profile-data.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-update-user-profile-data.html>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: Non-searchable data that you want to associate with the user profile.

--- a/elasticsearch/_sync/client/shutdown.py
+++ b/elasticsearch/_sync/client/shutdown.py
@@ -50,7 +50,7 @@ class ShutdownClient(NamespacedClient):
         and Elastic Cloud on Kubernetes. Direct use is not supported. If the operator
         privileges feature is enabled, you must be an operator to use this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-shutdown.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-shutdown.html>`_
 
         :param node_id: The node id of node to be removed from the shutdown state
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -108,7 +108,7 @@ class ShutdownClient(NamespacedClient):
         the operator privileges feature is enabled, you must be an operator to use this
         API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-shutdown.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-shutdown.html>`_
 
         :param node_id: Which node for which to retrieve the shutdown status
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -182,7 +182,7 @@ class ShutdownClient(NamespacedClient):
         IMPORTANT: This API does NOT terminate the Elasticsearch process. Monitor the
         node shutdown status to determine when it is safe to stop Elasticsearch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-shutdown.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-shutdown.html>`_
 
         :param node_id: The node identifier. This parameter is not validated against
             the cluster's active nodes. This enables you to register a node for shut

--- a/elasticsearch/_sync/client/simulate.py
+++ b/elasticsearch/_sync/client/simulate.py
@@ -87,7 +87,7 @@ class SimulateClient(NamespacedClient):
         This can be used to replace existing pipeline definitions or to create new ones.
         The pipeline substitutions are used only within this request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/simulate-ingest-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/simulate-ingest-api.html>`_
 
         :param docs: Sample documents to test in the pipeline.
         :param index: The index to simulate ingesting into. This value can be overridden

--- a/elasticsearch/_sync/client/slm.py
+++ b/elasticsearch/_sync/client/slm.py
@@ -42,7 +42,7 @@ class SlmClient(NamespacedClient):
         prevents any future snapshots from being taken but does not cancel in-progress
         snapshots or remove previously-taken snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-delete-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-delete-policy.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to remove
         :param master_timeout: The period to wait for a connection to the master node.
@@ -96,7 +96,7 @@ class SlmClient(NamespacedClient):
         applied according to its schedule, but you might want to manually run a policy
         before performing an upgrade or other maintenance.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-execute-lifecycle.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-execute-lifecycle.html>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to be executed
         :param master_timeout: The period to wait for a connection to the master node.
@@ -148,7 +148,7 @@ class SlmClient(NamespacedClient):
         removal of snapshots that are expired according to the snapshot lifecycle policy
         retention rules. The retention policy is normally applied according to its schedule.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-execute-retention.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-execute-retention.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -197,7 +197,7 @@ class SlmClient(NamespacedClient):
         Get policy information. Get snapshot lifecycle policy definitions and information
         about the latest snapshot attempts.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-get-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-get-policy.html>`_
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         :param master_timeout: The period to wait for a connection to the master node.
@@ -251,7 +251,7 @@ class SlmClient(NamespacedClient):
         Get snapshot lifecycle management statistics. Get global and policy-level statistics
         about actions taken by snapshot lifecycle management.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-get-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-get-stats.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -298,7 +298,7 @@ class SlmClient(NamespacedClient):
         """
         Get the snapshot lifecycle management status.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-get-status.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-get-status.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -358,7 +358,7 @@ class SlmClient(NamespacedClient):
         policy already exists, this request increments the policy version. Only the latest
         version of a policy is stored.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-put-policy.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-put-policy.html>`_
 
         :param policy_id: The identifier for the snapshot lifecycle policy you want to
             create or update.
@@ -441,7 +441,7 @@ class SlmClient(NamespacedClient):
         automatically when a cluster is formed. Manually starting SLM is necessary only
         if it has been stopped using the stop SLM API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-start.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -498,7 +498,7 @@ class SlmClient(NamespacedClient):
         complete and it can be safely stopped. Use the get snapshot lifecycle management
         status API to see if SLM is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/slm-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/slm-api-stop.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/_sync/client/snapshot.py
+++ b/elasticsearch/_sync/client/snapshot.py
@@ -47,7 +47,7 @@ class SnapshotClient(NamespacedClient):
         Clean up the snapshot repository. Trigger the review of the contents of a snapshot
         repository and delete any stale data not referenced by existing snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clean-up-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clean-up-snapshot-repo-api.html>`_
 
         :param name: Snapshot repository to clean up.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -101,7 +101,7 @@ class SnapshotClient(NamespacedClient):
         Clone a snapshot. Clone part of all of a snapshot into another snapshot in the
         same repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clone-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clone-snapshot-api.html>`_
 
         :param repository: A repository name
         :param snapshot: The name of the snapshot to clone from
@@ -181,7 +181,7 @@ class SnapshotClient(NamespacedClient):
         """
         Create a snapshot. Take a snapshot of a cluster or of data streams and indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/create-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/create-snapshot-api.html>`_
 
         :param repository: Repository for the snapshot.
         :param snapshot: Name of the snapshot. Must be unique in the repository.
@@ -289,7 +289,7 @@ class SnapshotClient(NamespacedClient):
         be writeable. Ensure there are no cluster blocks (for example, `cluster.blocks.read_only`
         and `clsuter.blocks.read_only_allow_delete` settings) that prevent write access.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/modules-snapshots.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/modules-snapshots.html>`_
 
         :param name: A repository name
         :param repository:
@@ -349,7 +349,7 @@ class SnapshotClient(NamespacedClient):
         """
         Delete snapshots.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-snapshot-api.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -402,7 +402,7 @@ class SnapshotClient(NamespacedClient):
         removes only the reference to the location where the repository is storing the
         snapshots. The snapshots themselves are left untouched and in place.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-snapshot-repo-api.html>`_
 
         :param name: Name of the snapshot repository to unregister. Wildcard (`*`) patterns
             are supported.
@@ -476,7 +476,7 @@ class SnapshotClient(NamespacedClient):
         """
         Get snapshot information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-snapshot-api.html>`_
 
         :param repository: Comma-separated list of snapshot repository names used to
             limit the request. Wildcard (*) expressions are supported.
@@ -588,7 +588,7 @@ class SnapshotClient(NamespacedClient):
         """
         Get snapshot repository information.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-snapshot-repo-api.html>`_
 
         :param name: A comma-separated list of repository names
         :param local: Return local information, do not retrieve the state from master
@@ -763,7 +763,7 @@ class SnapshotClient(NamespacedClient):
         Some operations also verify the behavior on small blobs with sizes other than
         8 bytes.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/repo-analysis-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/repo-analysis-api.html>`_
 
         :param name: The name of the repository.
         :param blob_count: The total number of blobs to write to the repository during
@@ -899,7 +899,7 @@ class SnapshotClient(NamespacedClient):
         in future versions. NOTE: This API may not work correctly in a mixed-version
         cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/verify-repo-integrity-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/verify-repo-integrity-api.html>`_
 
         :param name: A repository name
         :param blob_thread_pool_concurrency: Number of threads to use for reading blob
@@ -1009,7 +1009,7 @@ class SnapshotClient(NamespacedClient):
         or Workplace Search, you must restore the Enterprise Search encryption key before
         you restore the snapshot.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/restore-snapshot-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/restore-snapshot-api.html>`_
 
         :param repository: A repository name
         :param snapshot: A snapshot name
@@ -1113,7 +1113,7 @@ class SnapshotClient(NamespacedClient):
         These requests can also tax machine resources and, when using cloud storage,
         incur high processing costs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-snapshot-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-snapshot-status-api.html>`_
 
         :param repository: A repository name
         :param snapshot: A comma-separated list of snapshot names
@@ -1173,7 +1173,7 @@ class SnapshotClient(NamespacedClient):
         Verify a snapshot repository. Check for common misconfigurations in a snapshot
         repository.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/verify-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/verify-snapshot-repo-api.html>`_
 
         :param name: A repository name
         :param master_timeout: Explicit operation timeout for connection to master node

--- a/elasticsearch/_sync/client/sql.py
+++ b/elasticsearch/_sync/client/sql.py
@@ -41,7 +41,7 @@ class SqlClient(NamespacedClient):
         """
         Clear an SQL search cursor.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/clear-sql-cursor-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/clear-sql-cursor-api.html>`_
 
         :param cursor: Cursor to clear.
         """
@@ -90,7 +90,7 @@ class SqlClient(NamespacedClient):
         a search: * Users with the `cancel_task` cluster privilege. * The user who first
         submitted the search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-async-sql-search-api.html>`_
 
         :param id: The identifier for the search.
         """
@@ -139,7 +139,7 @@ class SqlClient(NamespacedClient):
         features are enabled, only the user who first submitted the SQL search can retrieve
         the search using this API.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-sql-search-api.html>`_
 
         :param id: The identifier for the search.
         :param delimiter: The separator for CSV results. The API supports this parameter
@@ -198,7 +198,7 @@ class SqlClient(NamespacedClient):
         Get the async SQL search status. Get the current status of an async SQL search
         or a stored synchronous SQL search.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-async-sql-search-status-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-async-sql-search-status-api.html>`_
 
         :param id: The identifier for the search.
         """
@@ -283,7 +283,7 @@ class SqlClient(NamespacedClient):
         """
         Get SQL search results. Run an SQL request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/sql-search-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/sql-search-api.html>`_
 
         :param allow_partial_search_results: If `true`, the response has partial results
             when there are shard request timeouts or shard failures. If `false`, the
@@ -406,7 +406,7 @@ class SqlClient(NamespacedClient):
         API request containing Query DSL. It accepts the same request body parameters
         as the SQL search API, excluding `cursor`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/sql-translate-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/sql-translate-api.html>`_
 
         :param query: The SQL query to run.
         :param fetch_size: The maximum number of rows (or entries) to return in one response.

--- a/elasticsearch/_sync/client/ssl.py
+++ b/elasticsearch/_sync/client/ssl.py
@@ -53,7 +53,7 @@ class SslClient(NamespacedClient):
         the API output includes all certificates in that store, even though some of the
         certificates might not be in active use within the cluster.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/security-api-ssl.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/security-api-ssl.html>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ssl/certificates"

--- a/elasticsearch/_sync/client/synonyms.py
+++ b/elasticsearch/_sync/client/synonyms.py
@@ -52,7 +52,7 @@ class SynonymsClient(NamespacedClient):
         finished, you can delete the index. When the synonyms set is not used in analyzers,
         you will be able to delete it.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-synonyms-set.html>`_
 
         :param id: The synonyms set identifier to delete.
         """
@@ -93,7 +93,7 @@ class SynonymsClient(NamespacedClient):
         """
         Delete a synonym rule. Delete a synonym rule from a synonym set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-synonym-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-synonym-rule.html>`_
 
         :param set_id: The ID of the synonym set to update.
         :param rule_id: The ID of the synonym rule to delete.
@@ -143,7 +143,7 @@ class SynonymsClient(NamespacedClient):
         """
         Get a synonym set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-synonyms-set.html>`_
 
         :param id: The synonyms set identifier to retrieve.
         :param from_: The starting offset for query rules to retrieve.
@@ -190,7 +190,7 @@ class SynonymsClient(NamespacedClient):
         """
         Get a synonym rule. Get a synonym rule from a synonym set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-synonym-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-synonym-rule.html>`_
 
         :param set_id: The ID of the synonym set to retrieve the synonym rule from.
         :param rule_id: The ID of the synonym rule to retrieve.
@@ -239,7 +239,7 @@ class SynonymsClient(NamespacedClient):
         """
         Get all synonym sets. Get a summary of all defined synonym sets.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-synonyms-set.html>`_
 
         :param from_: The starting offset for synonyms sets to retrieve.
         :param size: The maximum number of synonyms sets to retrieve.
@@ -293,7 +293,7 @@ class SynonymsClient(NamespacedClient):
         equivalent to invoking the reload search analyzers API for all indices that use
         the synonyms set.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-synonyms-set.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-synonyms-set.html>`_
 
         :param id: The ID of the synonyms set to be created or updated.
         :param synonyms_set: The synonym rules definitions for the synonyms set.
@@ -349,7 +349,7 @@ class SynonymsClient(NamespacedClient):
         When you update a synonym rule, all analyzers using the synonyms set will be
         reloaded automatically to reflect the new rule.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-synonym-rule.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-synonym-rule.html>`_
 
         :param set_id: The ID of the synonym set.
         :param rule_id: The ID of the synonym rule to be updated or created.

--- a/elasticsearch/_sync/client/tasks.py
+++ b/elasticsearch/_sync/client/tasks.py
@@ -61,7 +61,7 @@ class TasksClient(NamespacedClient):
         threads API to obtain detailed information about the work the system is doing
         instead of completing the cancelled task.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param task_id: The task identifier.
         :param actions: A comma-separated list or wildcard expression of actions that
@@ -126,7 +126,7 @@ class TasksClient(NamespacedClient):
         task identifier is not found, a 404 response code indicates that there are no
         resources that match the request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param task_id: The task identifier.
         :param timeout: The period to wait for a response. If no response is received
@@ -203,7 +203,7 @@ class TasksClient(NamespacedClient):
         initiated by the REST request. The `X-Opaque-Id` in the children `headers` is
         the child task of the task that was initiated by the REST request.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/tasks.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/tasks.html>`_
 
         :param actions: A comma-separated list or wildcard expression of actions used
             to limit the request. For example, you can use `cluser:*` to retrieve all

--- a/elasticsearch/_sync/client/text_structure.py
+++ b/elasticsearch/_sync/client/text_structure.py
@@ -70,7 +70,7 @@ class TextStructureClient(NamespacedClient):
         `explain` query parameter and an explanation will appear in the response. It
         helps determine why the returned structure was chosen.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/find-field-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/find-field-structure.html>`_
 
         :param field: The field that should be analyzed.
         :param index: The name of the index that contains the analyzed field.
@@ -255,7 +255,7 @@ class TextStructureClient(NamespacedClient):
         an explanation will appear in the response. It helps determine why the returned
         structure was chosen.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/find-message-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/find-message-structure.html>`_
 
         :param messages: The list of messages you want to analyze.
         :param column_names: If the format is `delimited`, you can specify the column
@@ -427,7 +427,7 @@ class TextStructureClient(NamespacedClient):
         However, you can optionally override some of the decisions about the text structure
         by specifying one or more query parameters.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/find-structure.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/find-structure.html>`_
 
         :param text_files:
         :param charset: The text's character set. It must be a character set that is
@@ -611,7 +611,7 @@ class TextStructureClient(NamespacedClient):
         indicates whether the lines match the pattern together with the offsets and lengths
         of the matched substrings.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/test-grok-pattern.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/test-grok-pattern.html>`_
 
         :param grok_pattern: The Grok pattern to run on the text.
         :param text: The lines of text to run the Grok pattern on.

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -41,7 +41,7 @@ class TransformClient(NamespacedClient):
         """
         Delete a transform. Deletes a transform.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/delete-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/delete-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param delete_dest_index: If this value is true, the destination index is deleted
@@ -101,7 +101,7 @@ class TransformClient(NamespacedClient):
         """
         Get transforms. Retrieves configuration information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-transform.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -170,7 +170,7 @@ class TransformClient(NamespacedClient):
         """
         Get transform stats. Retrieves usage information for transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/get-transform-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-transform-stats.html>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -256,7 +256,7 @@ class TransformClient(NamespacedClient):
         These values are determined based on the field types of the source index and
         the transform aggregations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/preview-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/preview-transform.html>`_
 
         :param transform_id: Identifier for the transform to preview. If you specify
             this path parameter, you cannot provide transform configuration details in
@@ -393,7 +393,7 @@ class TransformClient(NamespacedClient):
         If you used transforms prior to 7.5, also do not give users any privileges on
         `.data-frame-internal*` indices.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/put-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/put-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -496,7 +496,7 @@ class TransformClient(NamespacedClient):
         it; alternatively, use the `force` query parameter. If the destination index
         was created by the transform, it is deleted.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/reset-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/reset-transform.html>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -552,7 +552,7 @@ class TransformClient(NamespacedClient):
         the transform will be processed again at now + frequency unless _schedule_now
         API is called again in the meantime.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/schedule-now-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/schedule-now-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param timeout: Controls the time to wait for the scheduling to take place
@@ -616,7 +616,7 @@ class TransformClient(NamespacedClient):
         privileges on the source and destination indices, the transform fails when it
         attempts unauthorized operations.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/start-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/start-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param from_: Restricts the set of transformed entities to those changed after
@@ -670,7 +670,7 @@ class TransformClient(NamespacedClient):
         """
         Stop transforms. Stops one or more transforms.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/stop-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/stop-transform.html>`_
 
         :param transform_id: Identifier for the transform. To stop multiple transforms,
             use a comma-separated list or a wildcard expression. To stop all transforms,
@@ -770,7 +770,7 @@ class TransformClient(NamespacedClient):
         which roles the user who updated it had at the time of update and runs with those
         privileges.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/update-transform.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/update-transform.html>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -864,7 +864,7 @@ class TransformClient(NamespacedClient):
         example, from 7.16 to 8.0 – it is recommended to upgrade transforms before upgrading
         the cluster. You may want to perform a recent cluster backup prior to the upgrade.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/upgrade-transforms.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/upgrade-transforms.html>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_sync/client/watcher.py
+++ b/elasticsearch/_sync/client/watcher.py
@@ -46,7 +46,7 @@ class WatcherClient(NamespacedClient):
         `ack.state` is reset to `awaits_successful_execution`. This happens when the
         condition of the watch is not met (the condition evaluates to false).
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-ack-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-ack-watch.html>`_
 
         :param watch_id: The watch identifier.
         :param action_id: A comma-separated list of the action identifiers to acknowledge.
@@ -98,7 +98,7 @@ class WatcherClient(NamespacedClient):
         """
         Activate a watch. A watch can be either active or inactive.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-activate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-activate-watch.html>`_
 
         :param watch_id: The watch identifier.
         """
@@ -138,7 +138,7 @@ class WatcherClient(NamespacedClient):
         """
         Deactivate a watch. A watch can be either active or inactive.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-deactivate-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-deactivate-watch.html>`_
 
         :param watch_id: The watch identifier.
         """
@@ -184,7 +184,7 @@ class WatcherClient(NamespacedClient):
         delete document API When Elasticsearch security features are enabled, make sure
         no write privileges are granted to anyone for the `.watches` index.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-delete-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-delete-watch.html>`_
 
         :param id: The watch identifier.
         """
@@ -267,7 +267,7 @@ class WatcherClient(NamespacedClient):
         that called the API will be used as a base, instead of the information who stored
         the watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-execute-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-execute-watch.html>`_
 
         :param id: The watch identifier.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -352,7 +352,7 @@ class WatcherClient(NamespacedClient):
         Only a subset of settings are shown, for example `index.auto_expand_replicas`
         and `index.number_of_replicas`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-get-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-get-settings.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -394,7 +394,7 @@ class WatcherClient(NamespacedClient):
         """
         Get a watch.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-get-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-get-watch.html>`_
 
         :param id: The watch identifier.
         """
@@ -468,7 +468,7 @@ class WatcherClient(NamespacedClient):
         for which the user that stored the watch has privileges. If the user is able
         to read index `a`, but not index `b`, the same will apply when the watch runs.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-put-watch.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-put-watch.html>`_
 
         :param id: The identifier for the watch.
         :param actions: The list of actions that will be run if the condition matches.
@@ -578,7 +578,7 @@ class WatcherClient(NamespacedClient):
         filter watches by a query. Note that only the `_id` and `metadata.*` fields are
         queryable or sortable.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-query-watches.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-query-watches.html>`_
 
         :param from_: The offset from the first result to fetch. It must be non-negative.
         :param query: A query that filters the watches to be returned.
@@ -649,7 +649,7 @@ class WatcherClient(NamespacedClient):
         """
         Start the watch service. Start the Watcher service if it is not already running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-start.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-start.html>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -711,7 +711,7 @@ class WatcherClient(NamespacedClient):
         Get Watcher statistics. This API always returns basic metrics. You retrieve more
         metrics by using the metric parameter.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-stats.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-stats.html>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -758,7 +758,7 @@ class WatcherClient(NamespacedClient):
         """
         Stop the watch service. Stop the Watcher service if it is running.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-stop.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-stop.html>`_
 
         :param master_timeout: The period to wait for the master node. If the master
             node is not available before the timeout expires, the request fails and returns
@@ -812,7 +812,7 @@ class WatcherClient(NamespacedClient):
         (`.watches`). Only a subset of settings can be modified. This includes `index.auto_expand_replicas`
         and `index.number_of_replicas`.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/watcher-api-update-settings.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/watcher-api-update-settings.html>`_
 
         :param index_auto_expand_replicas:
         :param index_number_of_replicas:

--- a/elasticsearch/_sync/client/xpack.py
+++ b/elasticsearch/_sync/client/xpack.py
@@ -48,7 +48,7 @@ class XPackClient(NamespacedClient):
         installed license. * Feature information for the features that are currently
         enabled and available under the current license.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/info-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/info-api.html>`_
 
         :param accept_enterprise: If this param is used it must be set to true
         :param categories: A comma-separated list of the information categories to include
@@ -94,7 +94,7 @@ class XPackClient(NamespacedClient):
         enabled and available under the current license. The API also provides some usage
         statistics.
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.16/usage-api.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/usage-api.html>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-py/pull/2756, the docs build failure is expected and will be fixed by the next pull request.