### PR TITLE
github-action: Add AsciiDoc freeze warning

### DIFF
--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -2,7 +2,8 @@
 name: Comment on PR for .asciidoc changes
 
 on:
-  pull_request:
+  # We need to use pull_request_target to be able to comment on PRs from forks
+  pull_request_target:
     types:
       - synchronize
       - opened

--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -1,0 +1,20 @@
+---
+name: Comment on PR for .asciidoc changes
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+      - reopened
+    branches:
+      - main
+      - master
+      - "9.0"
+
+jobs:
+  comment-on-asciidoc-change:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: elastic/docs-builder/.github/workflows/comment-on-asciidoc-changes.yml@main


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Add a workflow that will comment on PRs with AsciiDoc changes.

## Why

During the migration to Elastic Docs v3, the Docs team will focus exclusively on migrating content.
To maintain consistency, prevent conflicts, and ensure a smoother transition we will freeze all AsciiDoc changes.

This means you will get a warning when you create AsciiDoc changes in your PRs.

   See https://github.com/elastic/docs-builder/issues/281 for details

If there are any questions, please reach out to the @elastic/docs-engineering
