### PR TITLE
fix flaky integration test

### DIFF
--- a/test_elasticsearch/test_dsl/test_integration/test_examples/_async/test_vectors.py
+++ b/test_elasticsearch/test_dsl/test_integration/test_examples/_async/test_vectors.py
@@ -22,7 +22,6 @@ from unittest import SkipTest
 import pytest
 
 from elasticsearch import AsyncElasticsearch
-from test_elasticsearch.test_dsl.async_sleep import sleep
 
 from ..async_examples import vectors
 
@@ -48,9 +47,6 @@ async def test_vector_search(
     mocker.patch.object(vectors, "SentenceTransformer", new=MockModel)
 
     await vectors.create()
-    for i in range(10):
-        results = await (await vectors.search("Welcome to our team!")).execute()
-        if len(results.hits) > 0:
-            break
-        await sleep(0.1)
+    await vectors.WorkplaceDoc._index.refresh()
+    results = await (await vectors.search("Welcome to our team!")).execute()
     assert results[0].name == "New Employee Onboarding Guide"

--- a/test_elasticsearch/test_dsl/test_integration/test_examples/_sync/test_vectors.py
+++ b/test_elasticsearch/test_dsl/test_integration/test_examples/_sync/test_vectors.py
@@ -22,7 +22,6 @@ from unittest import SkipTest
 import pytest
 
 from elasticsearch import Elasticsearch
-from test_elasticsearch.test_dsl.sleep import sleep
 
 from ..examples import vectors
 
@@ -48,9 +47,6 @@ def test_vector_search(
     mocker.patch.object(vectors, "SentenceTransformer", new=MockModel)
 
     vectors.create()
-    for i in range(10):
-        results = (vectors.search("Welcome to our team!")).execute()
-        if len(results.hits) > 0:
-            break
-        sleep(0.1)
+    vectors.WorkplaceDoc._index.refresh()
+    results = (vectors.search("Welcome to our team!")).execute()
     assert results[0].name == "New Employee Onboarding Guide"


### PR DESCRIPTION
The DSL vectors test is missing a refresh on the index, which causes the test to occasionally give unexpected results.