### PR TITLE
Auto-generated code for main

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -628,6 +628,7 @@ class AsyncElasticsearch(BaseClient):
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
+        include_source_on_error: t.Optional[bool] = None,
         list_executed_pipelines: t.Optional[bool] = None,
         pipeline: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
@@ -730,11 +731,13 @@ class AsyncElasticsearch(BaseClient):
           The other two shards that make up the index do not participate in the <code>_bulk</code> request at all.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk>`_
 
         :param operations:
         :param index: The name of the data stream, index, or index alias to perform bulk
             actions on.
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param list_executed_pipelines: If `true`, the response will include the ingest
             pipelines that were run for each index or create.
         :param pipeline: The pipeline identifier to use to preprocess incoming documents.
@@ -792,6 +795,8 @@ class AsyncElasticsearch(BaseClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if list_executed_pipelines is not None:
             __query["list_executed_pipelines"] = list_executed_pipelines
         if pipeline is not None:
@@ -851,7 +856,7 @@ class AsyncElasticsearch(BaseClient):
           Clear the search context and results for a scrolling search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-clear-scroll>`_
 
         :param scroll_id: The scroll IDs to clear. To clear all scroll IDs, use `_all`.
         """
@@ -908,7 +913,7 @@ class AsyncElasticsearch(BaseClient):
           However, keeping points in time has a cost; close them as soon as they are no longer required for search requests.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time>`_
 
         :param id: The ID of the point-in-time.
         """
@@ -984,15 +989,15 @@ class AsyncElasticsearch(BaseClient):
 
           <p>Count search results.
           Get the number of documents matching a query.</p>
-          <p>The query can either be provided using a simple query string as a parameter or using the Query DSL defined within the request body.
-          The latter must be nested in a <code>query</code> key, which is the same as the search API.</p>
+          <p>The query can be provided either by using a simple query string as a parameter, or by defining Query DSL within the request body.
+          The query is optional. When no query is provided, the API uses <code>match_all</code> to count all the documents.</p>
           <p>The count API supports multi-target syntax. You can run a single count API search across multiple data streams and indices.</p>
           <p>The operation is broadcast across all shards.
           For each shard ID group, a replica is chosen and the search is run against it.
           This means that replicas increase the scalability of the count.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-count>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams and indices,
@@ -1027,10 +1032,10 @@ class AsyncElasticsearch(BaseClient):
             in the result.
         :param preference: The node or shard the operation should be performed on. By
             default, it is random.
-        :param q: The query in Lucene query string syntax.
-        :param query: Defines the search definition using the Query DSL. The query is
-            optional, and when not provided, it will use `match_all` to count all the
-            docs.
+        :param q: The query in Lucene query string syntax. This parameter cannot be used
+            with a request body.
+        :param query: Defines the search query using Query DSL. A request body query
+            cannot be used with the `q` query string parameter.
         :param routing: A custom value used to route operations to a specific shard.
         :param terminate_after: The maximum number of documents to collect for each shard.
             If a query reaches this limit, Elasticsearch terminates the query early.
@@ -1116,6 +1121,7 @@ class AsyncElasticsearch(BaseClient):
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
+        include_source_on_error: t.Optional[bool] = None,
         pipeline: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         refresh: t.Optional[
@@ -1188,7 +1194,7 @@ class AsyncElasticsearch(BaseClient):
           The <code>_shards</code> section of the API response reveals the number of shard copies on which replication succeeded and failed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-create>`_
 
         :param index: The name of the data stream or index to target. If the target doesn't
             exist and matches the name or wildcard (`*`) pattern of an index template
@@ -1198,6 +1204,8 @@ class AsyncElasticsearch(BaseClient):
         :param id: A unique identifier for the document. To automatically generate a
             document ID, use the `POST /<target>/_doc/` request format.
         :param document:
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param pipeline: The ID of the pipeline to use to preprocess incoming documents.
             If the index has a default ingest pipeline specified, setting the value to
             `_none` turns off the default ingest pipeline for this request. If a final
@@ -1246,6 +1254,8 @@ class AsyncElasticsearch(BaseClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if pipeline is not None:
             __query["pipeline"] = pipeline
         if pretty is not None:
@@ -1328,7 +1338,7 @@ class AsyncElasticsearch(BaseClient):
           It then gets redirected into the primary shard within that ID group and replicated (if needed) to shard replicas within that ID group.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete>`_
 
         :param index: The name of the target index.
         :param id: A unique identifier for the document.
@@ -1517,7 +1527,7 @@ class AsyncElasticsearch(BaseClient):
           The get task status API will continue to list the delete by query task until this task checks that it has been cancelled and terminates itself.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams or indices,
@@ -1714,7 +1724,7 @@ class AsyncElasticsearch(BaseClient):
           Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html#docs-delete-by-query-rethrottle>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query-rethrottle>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per
@@ -1764,14 +1774,16 @@ class AsyncElasticsearch(BaseClient):
           Deletes a stored script or search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-script>`_
 
-        :param id: Identifier for the stored script or search template.
-        :param master_timeout: Period to wait for a connection to the master node. If
-            no response is received before the timeout expires, the request fails and
-            returns an error.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param id: The identifier for the stored script or search template.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error. It can also be set to `-1` to indicate that the request
+            should never timeout.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error. It can
+            also be set to `-1` to indicate that the request should never timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -1846,7 +1858,7 @@ class AsyncElasticsearch(BaseClient):
           Elasticsearch cleans up deleted documents in the background as you continue to index more data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases. It
             supports wildcards (`*`).
@@ -1969,7 +1981,7 @@ class AsyncElasticsearch(BaseClient):
           <p>A document's source is not available if it is disabled in the mapping.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases. It
             supports wildcards (`*`).
@@ -2071,34 +2083,44 @@ class AsyncElasticsearch(BaseClient):
         .. raw:: html
 
           <p>Explain a document match result.
-          Returns information about why a specific document matches, or doesn’t match, a query.</p>
+          Get information about why a specific document matches, or doesn't match, a query.
+          It computes a score explanation for a query and a specific document.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-explain>`_
 
-        :param index: Index names used to limit the request. Only a single index name
-            can be provided to this parameter.
-        :param id: Defines the document ID.
+        :param index: Index names that are used to limit the request. Only a single index
+            name can be provided to this parameter.
+        :param id: The document identifier.
         :param analyze_wildcard: If `true`, wildcard and prefix queries are analyzed.
-        :param analyzer: Analyzer to use for the query string. This parameter can only
-            be used when the `q` query string parameter is specified.
+            This parameter can be used only when the `q` query string parameter is specified.
+        :param analyzer: The analyzer to use for the query string. This parameter can
+            be used only when the `q` query string parameter is specified.
         :param default_operator: The default operator for query string query: `AND` or
-            `OR`.
-        :param df: Field to use as default where no field prefix is given in the query
-            string.
+            `OR`. This parameter can be used only when the `q` query string parameter
+            is specified.
+        :param df: The field to use as default where no field prefix is given in the
+            query string. This parameter can be used only when the `q` query string parameter
+            is specified.
         :param lenient: If `true`, format-based query failures (such as providing text
-            to a numeric field) in the query string will be ignored.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param q: Query in the Lucene query string syntax.
+            to a numeric field) in the query string will be ignored. This parameter can
+            be used only when the `q` query string parameter is specified.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
+        :param q: The query in the Lucene query string syntax.
         :param query: Defines the search definition using the Query DSL.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param source: True or false to return the `_source` field or not, or a list
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: `True` or `false` to return the `_source` field or not or a list
             of fields to return.
         :param source_excludes: A comma-separated list of source fields to exclude from
-            the response.
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
         :param source_includes: A comma-separated list of source fields to include in
-            the response.
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
         :param stored_fields: A comma-separated list of stored fields to return in the
             response.
         """
@@ -2200,9 +2222,9 @@ class AsyncElasticsearch(BaseClient):
           For example, a runtime field with a type of keyword is returned the same as any other field that belongs to the <code>keyword</code> family.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-field-caps>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases used
+        :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (*). To target all data streams
             and indices, omit this parameter or use * or _all.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -2210,25 +2232,32 @@ class AsyncElasticsearch(BaseClient):
             This behavior applies even if the request targets other open indices. For
             example, a request targeting `foo*,bar*` returns an error if an index starts
             with foo but no index starts with bar.
-        :param expand_wildcards: Type of index that wildcard patterns can match. If the
-            request can target data streams, this argument determines whether wildcard
-            expressions match hidden data streams. Supports comma-separated values, such
-            as `open,hidden`.
-        :param fields: List of fields to retrieve capabilities for. Wildcard (`*`) expressions
-            are supported.
-        :param filters: An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. Supports comma-separated
+            values, such as `open,hidden`.
+        :param fields: A list of fields to retrieve capabilities for. Wildcard (`*`)
+            expressions are supported.
+        :param filters: A comma-separated list of filters to apply to the response.
         :param ignore_unavailable: If `true`, missing or closed indices are not included
             in the response.
         :param include_empty_fields: If false, empty fields are not included in the response.
         :param include_unmapped: If true, unmapped fields are included in the response.
-        :param index_filter: Allows to filter indices if the provided query rewrites
-            to match_none on every shard.
-        :param runtime_mappings: Defines ad-hoc runtime fields in the request similar
+        :param index_filter: Filter indices if the provided query rewrites to `match_none`
+            on every shard. IMPORTANT: The filtering is done on a best-effort basis,
+            it uses index statistics and mappings to rewrite queries to `match_none`
+            instead of fully running the request. For instance a range query over a date
+            field can rewrite to `match_none` if all documents within a shard (including
+            deleted documents) are outside of the provided range. However, not all queries
+            can rewrite to `match_none` so this API may return an index even if the provided
+            filter matches no document.
+        :param runtime_mappings: Define ad-hoc runtime fields in the request similar
             to the way it is done in search requests. These fields exist only as part
             of the query and take precedence over fields defined with the same name in
             the index mappings.
-        :param types: Only return results for fields that have one of the types in the
-            list
+        :param types: A comma-separated list of field types to include. Any fields that
+            do not match one of these types will be excluded from the results. It defaults
+            to empty, meaning that all field types are returned.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
@@ -2354,7 +2383,7 @@ class AsyncElasticsearch(BaseClient):
           Elasticsearch cleans up deleted documents in the background as you continue to index more data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: The name of the index that contains the document.
         :param id: A unique document identifier.
@@ -2461,10 +2490,13 @@ class AsyncElasticsearch(BaseClient):
           Retrieves a stored script or search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get-script>`_
 
-        :param id: Identifier for the stored script or search template.
-        :param master_timeout: Specify timeout for connection to master
+        :param id: The identifier for the stored script or search template.
+        :param master_timeout: The period to wait for the master node. If the master
+            node is not available before the timeout expires, the request fails and returns
+            an error. It can also be set to `-1` to indicate that the request should
+            never timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -2507,7 +2539,7 @@ class AsyncElasticsearch(BaseClient):
           <p>Get a list of supported script contexts and their methods.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get-script-context>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_context"
@@ -2546,7 +2578,7 @@ class AsyncElasticsearch(BaseClient):
           <p>Get a list of available script types, languages, and contexts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get-script-languages>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_language"
@@ -2611,7 +2643,7 @@ class AsyncElasticsearch(BaseClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: The name of the index that contains the document.
         :param id: A unique document identifier.
@@ -2711,7 +2743,7 @@ class AsyncElasticsearch(BaseClient):
           When setting up automated polling of the API for health status, set verbose to false to disable the more expensive analysis logic.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/health-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-health-report>`_
 
         :param feature: A feature of the cluster, as returned by the top-level health
             report API.
@@ -2766,6 +2798,7 @@ class AsyncElasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         if_primary_term: t.Optional[int] = None,
         if_seq_no: t.Optional[int] = None,
+        include_source_on_error: t.Optional[bool] = None,
         op_type: t.Optional[t.Union[str, t.Literal["create", "index"]]] = None,
         pipeline: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
@@ -2875,7 +2908,7 @@ class AsyncElasticsearch(BaseClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-create>`_
 
         :param index: The name of the data stream or index to target. If the target doesn't
             exist and matches the name or wildcard (`*`) pattern of an index template
@@ -2891,6 +2924,8 @@ class AsyncElasticsearch(BaseClient):
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param op_type: Set to `create` to only index the document if it does not already
             exist (put if absent). If a document with the specified `_id` already exists,
             the indexing operation will fail. The behavior is the same as using the `<index>/_create`
@@ -2955,6 +2990,8 @@ class AsyncElasticsearch(BaseClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if op_type is not None:
             __query["op_type"] = op_type
         if pipeline is not None:
@@ -3003,7 +3040,7 @@ class AsyncElasticsearch(BaseClient):
           Get basic build, version, and cluster information.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rest-api-root.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-info>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/"
@@ -3069,30 +3106,37 @@ class AsyncElasticsearch(BaseClient):
           This means the results returned are not always the true k closest neighbors.</p>
           <p>The kNN search API supports restricting the search using a filter.
           The search will return the top k documents that also match the filter query.</p>
+          <p>A kNN search response has the exact same structure as a search API response.
+          However, certain sections have a meaning specific to kNN search:</p>
+          <ul>
+          <li>The document <code>_score</code> is determined by the similarity between the query and document vector.</li>
+          <li>The <code>hits.total</code> object contains the total number of nearest neighbor candidates considered, which is <code>num_candidates * num_shards</code>. The <code>hits.total.relation</code> will always be <code>eq</code>, indicating an exact value.</li>
+          </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/knn-search-api.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
-            to perform the operation on all indices
-        :param knn: kNN query to execute
+            to perform the operation on all indices.
+        :param knn: The kNN query to run.
         :param docvalue_fields: The request returns doc values for field names matching
-            these patterns in the hits.fields property of the response. Accepts wildcard
-            (*) patterns.
+            these patterns in the `hits.fields` property of the response. It accepts
+            wildcard (`*`) patterns.
         :param fields: The request returns values for field names matching these patterns
-            in the hits.fields property of the response. Accepts wildcard (*) patterns.
-        :param filter: Query to filter the documents that can match. The kNN search will
-            return the top `k` documents that also match this filter. The value can be
-            a single query or a list of queries. If `filter` isn't provided, all documents
-            are allowed to match.
-        :param routing: A comma-separated list of specific routing values
+            in the `hits.fields` property of the response. It accepts wildcard (`*`)
+            patterns.
+        :param filter: A query to filter the documents that can match. The kNN search
+            will return the top `k` documents that also match this filter. The value
+            can be a single query or a list of queries. If `filter` isn't provided, all
+            documents are allowed to match.
+        :param routing: A comma-separated list of specific routing values.
         :param source: Indicates which source fields are returned for matching documents.
-            These fields are returned in the hits._source property of the search response.
-        :param stored_fields: List of stored fields to return as part of a hit. If no
-            fields are specified, no stored fields are included in the response. If this
-            field is specified, the _source parameter defaults to false. You can pass
-            _source: true to return both source fields and stored fields in the search
-            response.
+            These fields are returned in the `hits._source` property of the search response.
+        :param stored_fields: A list of stored fields to return as part of a hit. If
+            no fields are specified, no stored fields are included in the response. If
+            this field is specified, the `_source` parameter defaults to `false`. You
+            can pass `_source: true` to return both source fields and stored fields in
+            the search response.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3176,9 +3220,17 @@ class AsyncElasticsearch(BaseClient):
           <p>Get multiple JSON documents by ID from one or more indices.
           If you specify an index in the request URI, you only need to specify the document IDs in the request body.
           To ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.</p>
+          <p><strong>Filter source fields</strong></p>
+          <p>By default, the <code>_source</code> field is returned for every document (if stored).
+          Use the <code>_source</code> and <code>_source_include</code> or <code>source_exclude</code> attributes to filter what fields are returned for a particular document.
+          You can include the <code>_source</code>, <code>_source_includes</code>, and <code>_source_excludes</code> query parameters in the request URI to specify the defaults to use when there are no per-document instructions.</p>
+          <p><strong>Get stored fields</strong></p>
+          <p>Use the <code>stored_fields</code> attribute to specify the set of stored fields you want to retrieve.
+          Any requested fields that are not stored are ignored.
+          You can include the <code>stored_fields</code> query parameter in the request URI to specify the defaults to use when there are no per-document instructions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-mget>`_
 
         :param index: Name of the index to retrieve documents from when `ids` are specified,
             or when a document in the `docs` array does not specify an index.
@@ -3313,7 +3365,7 @@ class AsyncElasticsearch(BaseClient):
           When sending requests to this endpoint the <code>Content-Type</code> header should be set to <code>application/x-ndjson</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-msearch>`_
 
         :param searches:
         :param index: Comma-separated list of data streams, indices, and index aliases
@@ -3446,22 +3498,32 @@ class AsyncElasticsearch(BaseClient):
         .. raw:: html
 
           <p>Run multiple templated searches.</p>
+          <p>Run multiple templated searches with a single request.
+          If you are providing a text file or text input to <code>curl</code>, use the <code>--data-binary</code> flag instead of <code>-d</code> to preserve newlines.
+          For example:</p>
+          <pre><code>$ cat requests
+          { &quot;index&quot;: &quot;my-index&quot; }
+          { &quot;id&quot;: &quot;my-search-template&quot;, &quot;params&quot;: { &quot;query_string&quot;: &quot;hello world&quot;, &quot;from&quot;: 0, &quot;size&quot;: 10 }}
+          { &quot;index&quot;: &quot;my-other-index&quot; }
+          { &quot;id&quot;: &quot;my-other-search-template&quot;, &quot;params&quot;: { &quot;query_type&quot;: &quot;match_all&quot; }}
+
+          $ curl -H &quot;Content-Type: application/x-ndjson&quot; -XGET localhost:9200/_msearch/template --data-binary &quot;@requests&quot;; echo
+          </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-msearch-template>`_
 
         :param search_templates:
-        :param index: Comma-separated list of data streams, indices, and aliases to search.
-            Supports wildcards (`*`). To search all data streams and indices, omit this
-            parameter or use `*`.
+        :param index: A comma-separated list of data streams, indices, and aliases to
+            search. It supports wildcards (`*`). To search all data streams and indices,
+            omit this parameter or use `*`.
         :param ccs_minimize_roundtrips: If `true`, network round-trips are minimized
             for cross-cluster search requests.
-        :param max_concurrent_searches: Maximum number of concurrent searches the API
-            can run.
+        :param max_concurrent_searches: The maximum number of concurrent searches the
+            API can run.
         :param rest_total_hits_as_int: If `true`, the response returns `hits.total` as
             an integer. If `false`, it returns `hits.total` as an object.
-        :param search_type: The type of the search operation. Available options: `query_then_fetch`,
-            `dfs_query_then_fetch`.
+        :param search_type: The type of the search operation.
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
@@ -3544,34 +3606,38 @@ class AsyncElasticsearch(BaseClient):
         .. raw:: html
 
           <p>Get multiple term vectors.</p>
-          <p>You can specify existing documents by index and ID or provide artificial documents in the body of the request.
+          <p>Get multiple term vectors with a single request.
+          You can specify existing documents by index and ID or provide artificial documents in the body of the request.
           You can specify the index in the request body or request URI.
           The response contains a <code>docs</code> array with all the fetched termvectors.
           Each element has the structure provided by the termvectors API.</p>
+          <p><strong>Artificial documents</strong></p>
+          <p>You can also use <code>mtermvectors</code> to generate term vectors for artificial documents provided in the body of the request.
+          The mapping used is determined by the specified <code>_index</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-mtermvectors>`_
 
-        :param index: Name of the index that contains the documents.
-        :param docs: Array of existing or artificial documents.
+        :param index: The name of the index that contains the documents.
+        :param docs: An array of existing or artificial documents.
         :param field_statistics: If `true`, the response includes the document count,
             sum of document frequencies, and sum of total term frequencies.
-        :param fields: Comma-separated list or wildcard expressions of fields to include
-            in the statistics. Used as the default list unless a specific field list
-            is provided in the `completion_fields` or `fielddata_fields` parameters.
-        :param ids: Simplified syntax to specify documents by their ID if they're in
+        :param fields: A comma-separated list or wildcard expressions of fields to include
+            in the statistics. It is used as the default list unless a specific field
+            list is provided in the `completion_fields` or `fielddata_fields` parameters.
+        :param ids: A simplified syntax to specify documents by their ID if they're in
             the same index.
         :param offsets: If `true`, the response includes term offsets.
         :param payloads: If `true`, the response includes term payloads.
         :param positions: If `true`, the response includes term positions.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
         :param realtime: If true, the request is real-time as opposed to near-real-time.
-        :param routing: Custom value used to route operations to a specific shard.
+        :param routing: A custom value used to route operations to a specific shard.
         :param term_statistics: If true, the response includes term frequency and document
             frequency.
         :param version: If `true`, returns the document version as part of a hit.
-        :param version_type: Specific version type.
+        :param version_type: The version type.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
@@ -3690,7 +3756,7 @@ class AsyncElasticsearch(BaseClient):
           You can check how many point-in-times (that is, search contexts) are open with the nodes stats API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time>`_
 
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
@@ -3784,20 +3850,21 @@ class AsyncElasticsearch(BaseClient):
           Creates or updates a stored script or search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-put-script>`_
 
-        :param id: Identifier for the stored script or search template. Must be unique
-            within the cluster.
-        :param script: Contains the script or search template, its parameters, and its
-            language.
-        :param context: Context in which the script or search template should run. To
-            prevent errors, the API immediately compiles the script or template in this
-            context.
-        :param master_timeout: Period to wait for a connection to the master node. If
-            no response is received before the timeout expires, the request fails and
-            returns an error.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param id: The identifier for the stored script or search template. It must be
+            unique within the cluster.
+        :param script: The script or search template, its parameters, and its language.
+        :param context: The context in which the script or search template should run.
+            To prevent errors, the API immediately compiles the script or template in
+            this context.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error. It can also be set to `-1` to indicate that the request
+            should never timeout.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error. It can
+            also be set to `-1` to indicate that the request should never timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -3873,11 +3940,11 @@ class AsyncElasticsearch(BaseClient):
           <p>Evaluate the quality of ranked search results over a set of typical search queries.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rank-eval>`_
 
         :param requests: A set of typical search requests, together with their provided
             ratings.
-        :param index: Comma-separated list of data streams, indices, and index aliases
+        :param index: A comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard (`*`) expressions are supported. To target
             all data streams and indices in a cluster, omit this parameter or use `_all`
             or `*`.
@@ -4105,7 +4172,7 @@ class AsyncElasticsearch(BaseClient):
           It is not possible to configure SSL in the body of the reindex request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex>`_
 
         :param dest: The destination you are copying to.
         :param source: The source you are copying from.
@@ -4229,7 +4296,7 @@ class AsyncElasticsearch(BaseClient):
           This behavior prevents scroll timeouts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex>`_
 
         :param task_id: The task identifier, which can be found by using the tasks API.
         :param requests_per_second: The throttle for this request in sub-requests per
@@ -4285,15 +4352,15 @@ class AsyncElasticsearch(BaseClient):
           <p>Render a search template as a search request body.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/render-search-template-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-render-search-template>`_
 
-        :param id: ID of the search template to render. If no `source` is specified,
+        :param id: The ID of the search template to render. If no `source` is specified,
             this or the `id` request body parameter is required.
         :param file:
         :param params: Key-value pairs used to replace Mustache variables in the template.
             The key is the variable name. The value is the variable value.
-        :param source: An inline search template. Supports the same parameters as the
-            search API's request body. These parameters also support Mustache variables.
+        :param source: An inline search template. It supports the same parameters as
+            the search API's request body. These parameters also support Mustache variables.
             If no `id` or `<templated-id>` is specified, this parameter is required.
         """
         __path_parts: t.Dict[str, str]
@@ -4452,13 +4519,13 @@ class AsyncElasticsearch(BaseClient):
           <p>IMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-scroll>`_
 
-        :param scroll_id: Scroll ID of the search.
+        :param scroll_id: The scroll ID of the search.
         :param rest_total_hits_as_int: If true, the API response’s hit.total property
             is returned as an integer. If false, the API response’s hit.total property
             is returned as an object.
-        :param scroll: Period to retain the search context for scrolling.
+        :param scroll: The period to retain the search context for scrolling.
         """
         if scroll_id is None and body is None:
             raise ValueError("Empty value passed for parameter 'scroll_id'")
@@ -4604,7 +4671,7 @@ class AsyncElasticsearch(BaseClient):
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         search_type: t.Optional[
             t.Union[str, t.Literal["dfs_query_then_fetch", "query_then_fetch"]]
@@ -4657,7 +4724,7 @@ class AsyncElasticsearch(BaseClient):
           This situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams and indices,
@@ -5093,53 +5160,373 @@ class AsyncElasticsearch(BaseClient):
         .. raw:: html
 
           <p>Search a vector tile.</p>
-          <p>Search a vector tile for geospatial values.</p>
+          <p>Search a vector tile for geospatial values.
+          Before using this API, you should be familiar with the Mapbox vector tile specification.
+          The API returns results as a binary mapbox vector tile.</p>
+          <p>Internally, Elasticsearch translates a vector tile search API request into a search containing:</p>
+          <ul>
+          <li>A <code>geo_bounding_box</code> query on the <code>&lt;field&gt;</code>. The query uses the <code>&lt;zoom&gt;/&lt;x&gt;/&lt;y&gt;</code> tile as a bounding box.</li>
+          <li>A <code>geotile_grid</code> or <code>geohex_grid</code> aggregation on the <code>&lt;field&gt;</code>. The <code>grid_agg</code> parameter determines the aggregation type. The aggregation uses the <code>&lt;zoom&gt;/&lt;x&gt;/&lt;y&gt;</code> tile as a bounding box.</li>
+          <li>Optionally, a <code>geo_bounds</code> aggregation on the <code>&lt;field&gt;</code>. The search only includes this aggregation if the <code>exact_bounds</code> parameter is <code>true</code>.</li>
+          <li>If the optional parameter <code>with_labels</code> is <code>true</code>, the internal search will include a dynamic runtime field that calls the <code>getLabelPosition</code> function of the geometry doc value. This enables the generation of new point features containing suggested geometry labels, so that, for example, multi-polygons will have only one label.</li>
+          </ul>
+          <p>For example, Elasticsearch may translate a vector tile search API request with a <code>grid_agg</code> argument of <code>geotile</code> and an <code>exact_bounds</code> argument of <code>true</code> into the following search</p>
+          <pre><code>GET my-index/_search
+          {
+            &quot;size&quot;: 10000,
+            &quot;query&quot;: {
+              &quot;geo_bounding_box&quot;: {
+                &quot;my-geo-field&quot;: {
+                  &quot;top_left&quot;: {
+                    &quot;lat&quot;: -40.979898069620134,
+                    &quot;lon&quot;: -45
+                  },
+                  &quot;bottom_right&quot;: {
+                    &quot;lat&quot;: -66.51326044311186,
+                    &quot;lon&quot;: 0
+                  }
+                }
+              }
+            },
+            &quot;aggregations&quot;: {
+              &quot;grid&quot;: {
+                &quot;geotile_grid&quot;: {
+                  &quot;field&quot;: &quot;my-geo-field&quot;,
+                  &quot;precision&quot;: 11,
+                  &quot;size&quot;: 65536,
+                  &quot;bounds&quot;: {
+                    &quot;top_left&quot;: {
+                      &quot;lat&quot;: -40.979898069620134,
+                      &quot;lon&quot;: -45
+                    },
+                    &quot;bottom_right&quot;: {
+                      &quot;lat&quot;: -66.51326044311186,
+                      &quot;lon&quot;: 0
+                    }
+                  }
+                }
+              },
+              &quot;bounds&quot;: {
+                &quot;geo_bounds&quot;: {
+                  &quot;field&quot;: &quot;my-geo-field&quot;,
+                  &quot;wrap_longitude&quot;: false
+                }
+              }
+            }
+          }
+          </code></pre>
+          <p>The API returns results as a binary Mapbox vector tile.
+          Mapbox vector tiles are encoded as Google Protobufs (PBF). By default, the tile contains three layers:</p>
+          <ul>
+          <li>A <code>hits</code> layer containing a feature for each <code>&lt;field&gt;</code> value matching the <code>geo_bounding_box</code> query.</li>
+          <li>An <code>aggs</code> layer containing a feature for each cell of the <code>geotile_grid</code> or <code>geohex_grid</code>. The layer only contains features for cells with matching data.</li>
+          <li>A meta layer containing:
+          <ul>
+          <li>A feature containing a bounding box. By default, this is the bounding box of the tile.</li>
+          <li>Value ranges for any sub-aggregations on the <code>geotile_grid</code> or <code>geohex_grid</code>.</li>
+          <li>Metadata for the search.</li>
+          </ul>
+          </li>
+          </ul>
+          <p>The API only returns features that can display at its zoom level.
+          For example, if a polygon feature has no area at its zoom level, the API omits it.
+          The API returns errors as UTF-8 encoded JSON.</p>
+          <p>IMPORTANT: You can specify several options for this API as either a query parameter or request body parameter.
+          If you specify both parameters, the query parameter takes precedence.</p>
+          <p><strong>Grid precision for geotile</strong></p>
+          <p>For a <code>grid_agg</code> of <code>geotile</code>, you can use cells in the <code>aggs</code> layer as tiles for lower zoom levels.
+          <code>grid_precision</code> represents the additional zoom levels available through these cells. The final precision is computed by as follows: <code>&lt;zoom&gt; + grid_precision</code>.
+          For example, if <code>&lt;zoom&gt;</code> is 7 and <code>grid_precision</code> is 8, then the <code>geotile_grid</code> aggregation will use a precision of 15.
+          The maximum final precision is 29.
+          The <code>grid_precision</code> also determines the number of cells for the grid as follows: <code>(2^grid_precision) x (2^grid_precision)</code>.
+          For example, a value of 8 divides the tile into a grid of 256 x 256 cells.
+          The <code>aggs</code> layer only contains features for cells with matching data.</p>
+          <p><strong>Grid precision for geohex</strong></p>
+          <p>For a <code>grid_agg</code> of <code>geohex</code>, Elasticsearch uses <code>&lt;zoom&gt;</code> and <code>grid_precision</code> to calculate a final precision as follows: <code>&lt;zoom&gt; + grid_precision</code>.</p>
+          <p>This precision determines the H3 resolution of the hexagonal cells produced by the <code>geohex</code> aggregation.
+          The following table maps the H3 resolution for each precision.
+          For example, if <code>&lt;zoom&gt;</code> is 3 and <code>grid_precision</code> is 3, the precision is 6.
+          At a precision of 6, hexagonal cells have an H3 resolution of 2.
+          If <code>&lt;zoom&gt;</code> is 3 and <code>grid_precision</code> is 4, the precision is 7.
+          At a precision of 7, hexagonal cells have an H3 resolution of 3.</p>
+          <table>
+          <thead>
+          <tr>
+          <th>Precision</th>
+          <th>Unique tile bins</th>
+          <th>H3 resolution</th>
+          <th>Unique hex bins</th>
+          <th>Ratio</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>1</td>
+          <td>4</td>
+          <td>0</td>
+          <td>122</td>
+          <td>30.5</td>
+          </tr>
+          <tr>
+          <td>2</td>
+          <td>16</td>
+          <td>0</td>
+          <td>122</td>
+          <td>7.625</td>
+          </tr>
+          <tr>
+          <td>3</td>
+          <td>64</td>
+          <td>1</td>
+          <td>842</td>
+          <td>13.15625</td>
+          </tr>
+          <tr>
+          <td>4</td>
+          <td>256</td>
+          <td>1</td>
+          <td>842</td>
+          <td>3.2890625</td>
+          </tr>
+          <tr>
+          <td>5</td>
+          <td>1024</td>
+          <td>2</td>
+          <td>5882</td>
+          <td>5.744140625</td>
+          </tr>
+          <tr>
+          <td>6</td>
+          <td>4096</td>
+          <td>2</td>
+          <td>5882</td>
+          <td>1.436035156</td>
+          </tr>
+          <tr>
+          <td>7</td>
+          <td>16384</td>
+          <td>3</td>
+          <td>41162</td>
+          <td>2.512329102</td>
+          </tr>
+          <tr>
+          <td>8</td>
+          <td>65536</td>
+          <td>3</td>
+          <td>41162</td>
+          <td>0.6280822754</td>
+          </tr>
+          <tr>
+          <td>9</td>
+          <td>262144</td>
+          <td>4</td>
+          <td>288122</td>
+          <td>1.099098206</td>
+          </tr>
+          <tr>
+          <td>10</td>
+          <td>1048576</td>
+          <td>4</td>
+          <td>288122</td>
+          <td>0.2747745514</td>
+          </tr>
+          <tr>
+          <td>11</td>
+          <td>4194304</td>
+          <td>5</td>
+          <td>2016842</td>
+          <td>0.4808526039</td>
+          </tr>
+          <tr>
+          <td>12</td>
+          <td>16777216</td>
+          <td>6</td>
+          <td>14117882</td>
+          <td>0.8414913416</td>
+          </tr>
+          <tr>
+          <td>13</td>
+          <td>67108864</td>
+          <td>6</td>
+          <td>14117882</td>
+          <td>0.2103728354</td>
+          </tr>
+          <tr>
+          <td>14</td>
+          <td>268435456</td>
+          <td>7</td>
+          <td>98825162</td>
+          <td>0.3681524172</td>
+          </tr>
+          <tr>
+          <td>15</td>
+          <td>1073741824</td>
+          <td>8</td>
+          <td>691776122</td>
+          <td>0.644266719</td>
+          </tr>
+          <tr>
+          <td>16</td>
+          <td>4294967296</td>
+          <td>8</td>
+          <td>691776122</td>
+          <td>0.1610666797</td>
+          </tr>
+          <tr>
+          <td>17</td>
+          <td>17179869184</td>
+          <td>9</td>
+          <td>4842432842</td>
+          <td>0.2818666889</td>
+          </tr>
+          <tr>
+          <td>18</td>
+          <td>68719476736</td>
+          <td>10</td>
+          <td>33897029882</td>
+          <td>0.4932667053</td>
+          </tr>
+          <tr>
+          <td>19</td>
+          <td>274877906944</td>
+          <td>11</td>
+          <td>237279209162</td>
+          <td>0.8632167343</td>
+          </tr>
+          <tr>
+          <td>20</td>
+          <td>1099511627776</td>
+          <td>11</td>
+          <td>237279209162</td>
+          <td>0.2158041836</td>
+          </tr>
+          <tr>
+          <td>21</td>
+          <td>4398046511104</td>
+          <td>12</td>
+          <td>1660954464122</td>
+          <td>0.3776573213</td>
+          </tr>
+          <tr>
+          <td>22</td>
+          <td>17592186044416</td>
+          <td>13</td>
+          <td>11626681248842</td>
+          <td>0.6609003122</td>
+          </tr>
+          <tr>
+          <td>23</td>
+          <td>70368744177664</td>
+          <td>13</td>
+          <td>11626681248842</td>
+          <td>0.165225078</td>
+          </tr>
+          <tr>
+          <td>24</td>
+          <td>281474976710656</td>
+          <td>14</td>
+          <td>81386768741882</td>
+          <td>0.2891438866</td>
+          </tr>
+          <tr>
+          <td>25</td>
+          <td>1125899906842620</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.5060018015</td>
+          </tr>
+          <tr>
+          <td>26</td>
+          <td>4503599627370500</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.1265004504</td>
+          </tr>
+          <tr>
+          <td>27</td>
+          <td>18014398509482000</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.03162511259</td>
+          </tr>
+          <tr>
+          <td>28</td>
+          <td>72057594037927900</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.007906278149</td>
+          </tr>
+          <tr>
+          <td>29</td>
+          <td>288230376151712000</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.001976569537</td>
+          </tr>
+          </tbody>
+          </table>
+          <p>Hexagonal cells don't align perfectly on a vector tile.
+          Some cells may intersect more than one vector tile.
+          To compute the H3 resolution for each precision, Elasticsearch compares the average density of hexagonal bins at each resolution with the average density of tile bins at each zoom level.
+          Elasticsearch uses the H3 resolution that is closest to the corresponding geotile density.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-mvt>`_
 
         :param index: Comma-separated list of data streams, indices, or aliases to search
         :param field: Field containing geospatial data to return
         :param zoom: Zoom level for the vector tile to search
         :param x: X coordinate for the vector tile to search
         :param y: Y coordinate for the vector tile to search
-        :param aggs: Sub-aggregations for the geotile_grid. Supports the following aggregation
-            types: - avg - cardinality - max - min - sum
-        :param buffer: Size, in pixels, of a clipping buffer outside the tile. This allows
-            renderers to avoid outline artifacts from geometries that extend past the
-            extent of the tile.
-        :param exact_bounds: If false, the meta layer’s feature is the bounding box of
-            the tile. If true, the meta layer’s feature is a bounding box resulting from
-            a geo_bounds aggregation. The aggregation runs on <field> values that intersect
-            the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting bounding
-            box may be larger than the vector tile.
-        :param extent: Size, in pixels, of a side of the tile. Vector tiles are square
+        :param aggs: Sub-aggregations for the geotile_grid. It supports the following
+            aggregation types: - `avg` - `boxplot` - `cardinality` - `extended stats`
+            - `max` - `median absolute deviation` - `min` - `percentile` - `percentile-rank`
+            - `stats` - `sum` - `value count` The aggregation names can't start with
+            `_mvt_`. The `_mvt_` prefix is reserved for internal aggregations.
+        :param buffer: The size, in pixels, of a clipping buffer outside the tile. This
+            allows renderers to avoid outline artifacts from geometries that extend past
+            the extent of the tile.
+        :param exact_bounds: If `false`, the meta layer's feature is the bounding box
+            of the tile. If `true`, the meta layer's feature is a bounding box resulting
+            from a `geo_bounds` aggregation. The aggregation runs on <field> values that
+            intersect the `<zoom>/<x>/<y>` tile with `wrap_longitude` set to `false`.
+            The resulting bounding box may be larger than the vector tile.
+        :param extent: The size, in pixels, of a side of the tile. Vector tiles are square
             with equal sides.
-        :param fields: Fields to return in the `hits` layer. Supports wildcards (`*`).
-            This parameter does not support fields with array values. Fields with array
-            values may return inconsistent results.
-        :param grid_agg: Aggregation used to create a grid for the `field`.
+        :param fields: The fields to return in the `hits` layer. It supports wildcards
+            (`*`). This parameter does not support fields with array values. Fields with
+            array values may return inconsistent results.
+        :param grid_agg: The aggregation used to create a grid for the `field`.
         :param grid_precision: Additional zoom levels available through the aggs layer.
-            For example, if <zoom> is 7 and grid_precision is 8, you can zoom in up to
-            level 15. Accepts 0-8. If 0, results don’t include the aggs layer.
+            For example, if `<zoom>` is `7` and `grid_precision` is `8`, you can zoom
+            in up to level 15. Accepts 0-8. If 0, results don't include the aggs layer.
         :param grid_type: Determines the geometry type for features in the aggs layer.
-            In the aggs layer, each feature represents a geotile_grid cell. If 'grid'
-            each feature is a Polygon of the cells bounding box. If 'point' each feature
+            In the aggs layer, each feature represents a `geotile_grid` cell. If `grid,
+            each feature is a polygon of the cells bounding box. If `point`, each feature
             is a Point that is the centroid of the cell.
-        :param query: Query DSL used to filter documents for the search.
+        :param query: The query DSL used to filter documents for the search.
         :param runtime_mappings: Defines one or more runtime fields in the search request.
             These fields take precedence over mapped fields with the same name.
-        :param size: Maximum number of features to return in the hits layer. Accepts
-            0-10000. If 0, results don’t include the hits layer.
-        :param sort: Sorts features in the hits layer. By default, the API calculates
-            a bounding box for each feature. It sorts features based on this box’s diagonal
+        :param size: The maximum number of features to return in the hits layer. Accepts
+            0-10000. If 0, results don't include the hits layer.
+        :param sort: Sort the features in the hits layer. By default, the API calculates
+            a bounding box for each feature. It sorts features based on this box's diagonal
             length, from longest to shortest.
-        :param track_total_hits: Number of hits matching the query to count accurately.
+        :param track_total_hits: The number of hits matching the query to count accurately.
             If `true`, the exact number of hits is returned at the cost of some performance.
             If `false`, the response does not include the total number of hits matching
             the query.
         :param with_labels: If `true`, the hits and aggs layers will contain additional
             point features representing suggested label positions for the original features.
+            * `Point` and `MultiPoint` features will have one of the points selected.
+            * `Polygon` and `MultiPolygon` features will have a single point generated,
+            either the centroid, if it is within the polygon, or another point within
+            the polygon selected from the sorted triangle-tree. * `LineString` features
+            will likewise provide a roughly central point selected from the triangle-tree.
+            * The aggregation results will provide one central point for each aggregation
+            bucket. All attributes from the original features will also be copied to
+            the new label features. In addition, the new features will be distinguishable
+            using the tag `_mvt_label_position`.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5254,13 +5641,15 @@ class AsyncElasticsearch(BaseClient):
           <p>Get the search shards.</p>
           <p>Get the indices and shards that a search request would be run against.
           This information can be useful for working out issues or planning optimizations with routing and shard preferences.
-          When filtered aliases are used, the filter is returned as part of the indices section.</p>
+          When filtered aliases are used, the filter is returned as part of the <code>indices</code> section.</p>
+          <p>If the Elasticsearch security features are enabled, you must have the <code>view_index_metadata</code> or <code>manage</code> index privilege for the target data stream, index, or alias.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-shards>`_
 
-        :param index: Returns the indices and shards that a search request would be executed
-            against.
+        :param index: A comma-separated list of data streams, indices, and aliases to
+            search. It supports wildcards (`*`). To search all data streams and indices,
+            omit this parameter or use `*` or `_all`.
         :param allow_no_indices: If `false`, the request returns an error if any wildcard
             expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
@@ -5274,10 +5663,13 @@ class AsyncElasticsearch(BaseClient):
             a missing or closed index.
         :param local: If `true`, the request retrieves information from the local node
             only.
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param routing: Custom value used to route operations to a specific shard.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. IT can also be set to `-1` to indicate that the
+            request should never timeout.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
+        :param routing: A custom value used to route operations to a specific shard.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
@@ -5364,10 +5756,10 @@ class AsyncElasticsearch(BaseClient):
           <p>Run a search with a search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-template>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases to search.
-            Supports wildcards (*).
+        :param index: A comma-separated list of data streams, indices, and aliases to
+            search. It supports wildcards (`*`).
         :param allow_no_indices: If `false`, the request returns an error if any wildcard
             expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
@@ -5375,32 +5767,34 @@ class AsyncElasticsearch(BaseClient):
             with `foo` but no index starts with `bar`.
         :param ccs_minimize_roundtrips: If `true`, network round-trips are minimized
             for cross-cluster search requests.
-        :param expand_wildcards: Type of index that wildcard patterns can match. If the
-            request can target data streams, this argument determines whether wildcard
-            expressions match hidden data streams. Supports comma-separated values, such
-            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. Supports comma-separated
+            values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`,
+            `hidden`, `none`.
         :param explain: If `true`, returns detailed information about score calculation
-            as part of each hit.
-        :param id: ID of the search template to use. If no source is specified, this
-            parameter is required.
+            as part of each hit. If you specify both this and the `explain` query parameter,
+            the API uses only the query parameter.
+        :param id: The ID of the search template to use. If no `source` is specified,
+            this parameter is required.
         :param ignore_throttled: If `true`, specified concrete, expanded, or aliased
             indices are not included in the response when throttled.
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
         :param params: Key-value pairs used to replace Mustache variables in the template.
             The key is the variable name. The value is the variable value.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
         :param profile: If `true`, the query execution is profiled.
-        :param rest_total_hits_as_int: If true, hits.total are rendered as an integer
-            in the response.
-        :param routing: Custom value used to route operations to a specific shard.
+        :param rest_total_hits_as_int: If `true`, `hits.total` is rendered as an integer
+            in the response. If `false`, it is rendered as an object.
+        :param routing: A custom value used to route operations to a specific shard.
         :param scroll: Specifies how long a consistent view of the index should be maintained
             for scrolled search.
         :param search_type: The type of the search operation.
         :param source: An inline search template. Supports the same parameters as the
-            search API's request body. Also supports Mustache variables. If no id is
-            specified, this parameter is required.
+            search API's request body. It also supports Mustache variables. If no `id`
+            is specified, this parameter is required.
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
@@ -5498,30 +5892,35 @@ class AsyncElasticsearch(BaseClient):
 
           <p>Get terms in an index.</p>
           <p>Discover terms that match a partial string in an index.
-          This &quot;terms enum&quot; API is designed for low-latency look-ups used in auto-complete scenarios.</p>
-          <p>If the <code>complete</code> property in the response is false, the returned terms set may be incomplete and should be treated as approximate.
-          This can occur due to a few reasons, such as a request timeout or a node error.</p>
-          <p>NOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.</p>
+          This API is designed for low-latency look-ups used in auto-complete scenarios.</p>
+          <blockquote>
+          <p>info
+          The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-terms-enum.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-terms-enum>`_
 
-        :param index: Comma-separated list of data streams, indices, and index aliases
-            to search. Wildcard (*) expressions are supported.
+        :param index: A comma-separated list of data streams, indices, and index aliases
+            to search. Wildcard (`*`) expressions are supported. To search all data streams
+            or indices, omit this parameter or use `*` or `_all`.
         :param field: The string to match at the start of indexed terms. If not provided,
             all terms in the field are considered.
-        :param case_insensitive: When true the provided search string is matched against
+        :param case_insensitive: When `true`, the provided search string is matched against
             index terms without case sensitivity.
-        :param index_filter: Allows to filter an index shard if the provided query rewrites
-            to match_none.
-        :param search_after:
-        :param size: How many matching terms to return.
-        :param string: The string after which terms in the index should be returned.
-            Allows for a form of pagination if the last result from one request is passed
-            as the search_after parameter for a subsequent request.
-        :param timeout: The maximum length of time to spend collecting results. Defaults
-            to "1s" (one second). If the timeout is exceeded the complete flag set to
-            false in the response and the results may be partial or empty.
+        :param index_filter: Filter an index shard if the provided query rewrites to
+            `match_none`.
+        :param search_after: The string after which terms in the index should be returned.
+            It allows for a form of pagination if the last result from one request is
+            passed as the `search_after` parameter for a subsequent request.
+        :param size: The number of matching terms to return.
+        :param string: The string to match at the start of indexed terms. If it is not
+            provided, all terms in the field are considered. > info > The prefix string
+            cannot be larger than the largest possible keyword value, which is Lucene's
+            term byte-length limit of 32766.
+        :param timeout: The maximum length of time to spend collecting results. If the
+            timeout is exceeded the `complete` flag set to `false` in the response and
+            the results may be partial or empty.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5604,32 +6003,73 @@ class AsyncElasticsearch(BaseClient):
 
           <p>Get term vector information.</p>
           <p>Get information and statistics about terms in the fields of a particular document.</p>
+          <p>You can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.
+          You can specify the fields you are interested in through the <code>fields</code> parameter or by adding the fields to the request body.
+          For example:</p>
+          <pre><code>GET /my-index-000001/_termvectors/1?fields=message
+          </code></pre>
+          <p>Fields can be specified using wildcards, similar to the multi match query.</p>
+          <p>Term vectors are real-time by default, not near real-time.
+          This can be changed by setting <code>realtime</code> parameter to <code>false</code>.</p>
+          <p>You can request three types of values: <em>term information</em>, <em>term statistics</em>, and <em>field statistics</em>.
+          By default, all term information and field statistics are returned for all fields but term statistics are excluded.</p>
+          <p><strong>Term information</strong></p>
+          <ul>
+          <li>term frequency in the field (always returned)</li>
+          <li>term positions (<code>positions: true</code>)</li>
+          <li>start and end offsets (<code>offsets: true</code>)</li>
+          <li>term payloads (<code>payloads: true</code>), as base64 encoded bytes</li>
+          </ul>
+          <p>If the requested information wasn't stored in the index, it will be computed on the fly if possible.
+          Additionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.</p>
+          <blockquote>
+          <p>warn
+          Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.</p>
+          </blockquote>
+          <p><strong>Behaviour</strong></p>
+          <p>The term and field statistics are not accurate.
+          Deleted documents are not taken into account.
+          The information is only retrieved for the shard the requested document resides in.
+          The term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.
+          By default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.
+          Use <code>routing</code> only to hit a particular shard.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-termvectors>`_
 
-        :param index: Name of the index that contains the document.
-        :param id: Unique identifier of the document.
+        :param index: The name of the index that contains the document.
+        :param id: A unique identifier for the document.
         :param doc: An artificial document (a document not present in the index) for
             which you want to retrieve term vectors.
-        :param field_statistics: If `true`, the response includes the document count,
-            sum of document frequencies, and sum of total term frequencies.
-        :param fields: Comma-separated list or wildcard expressions of fields to include
-            in the statistics. Used as the default list unless a specific field list
-            is provided in the `completion_fields` or `fielddata_fields` parameters.
-        :param filter: Filter terms based on their tf-idf scores.
+        :param field_statistics: If `true`, the response includes: * The document count
+            (how many documents contain this field). * The sum of document frequencies
+            (the sum of document frequencies for all terms in this field). * The sum
+            of total term frequencies (the sum of total term frequencies of each term
+            in this field).
+        :param fields: A comma-separated list or wildcard expressions of fields to include
+            in the statistics. It is used as the default list unless a specific field
+            list is provided in the `completion_fields` or `fielddata_fields` parameters.
+        :param filter: Filter terms based on their tf-idf scores. This could be useful
+            in order find out a good characteristic vector of a document. This feature
+            works in a similar manner to the second phase of the More Like This Query.
         :param offsets: If `true`, the response includes term offsets.
         :param payloads: If `true`, the response includes term payloads.
-        :param per_field_analyzer: Overrides the default per-field analyzer.
+        :param per_field_analyzer: Override the default per-field analyzer. This is useful
+            in order to generate term vectors in any fashion, especially when using artificial
+            documents. When providing an analyzer for a field that already stores term
+            vectors, the term vectors will be regenerated.
         :param positions: If `true`, the response includes term positions.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
         :param realtime: If true, the request is real-time as opposed to near-real-time.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param term_statistics: If `true`, the response includes term frequency and document
-            frequency.
+        :param routing: A custom value that is used to route operations to a specific
+            shard.
+        :param term_statistics: If `true`, the response includes: * The total term frequency
+            (how often a term occurs in all documents). * The document frequency (the
+            number of documents containing the current term). By default these values
+            are not returned since term statistics can have a serious performance impact.
         :param version: If `true`, returns the document version as part of a hit.
-        :param version_type: Specific version type.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5725,6 +6165,7 @@ class AsyncElasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         if_primary_term: t.Optional[int] = None,
         if_seq_no: t.Optional[int] = None,
+        include_source_on_error: t.Optional[bool] = None,
         lang: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         refresh: t.Optional[
@@ -5765,7 +6206,7 @@ class AsyncElasticsearch(BaseClient):
           In addition to <code>_source</code>, you can access the following variables through the <code>ctx</code> map: <code>_index</code>, <code>_type</code>, <code>_id</code>, <code>_version</code>, <code>_routing</code>, and <code>_now</code> (the current timestamp).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update>`_
 
         :param index: The name of the target index. By default, the index is created
             automatically if it doesn't exist.
@@ -5780,6 +6221,8 @@ class AsyncElasticsearch(BaseClient):
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param lang: The script language.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
             this operation visible to search. If 'wait_for', it waits for a refresh to
@@ -5824,6 +6267,8 @@ class AsyncElasticsearch(BaseClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if lang is not None:
             __query["lang"] = lang
         if pretty is not None:
@@ -5999,7 +6444,7 @@ class AsyncElasticsearch(BaseClient):
           This API enables you to only modify the source of matching documents; you cannot move them.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update-by-query>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams or indices,
@@ -6219,7 +6664,7 @@ class AsyncElasticsearch(BaseClient):
           Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html#docs-update-by-query-rethrottle>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update-by-query-rethrottle>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per

--- a/elasticsearch/_async/client/async_search.py
+++ b/elasticsearch/_async/client/async_search.py
@@ -44,7 +44,7 @@ class AsyncSearchClient(NamespacedClient):
           If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the <code>cancel_task</code> cluster privilege.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -94,11 +94,11 @@ class AsyncSearchClient(NamespacedClient):
           If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param id: A unique identifier for the async search.
-        :param keep_alive: Specifies how long the async search should be available in
-            the cluster. When not specified, the `keep_alive` set with the corresponding
+        :param keep_alive: The length of time that the async search should be available
+            in the cluster. When not specified, the `keep_alive` set with the corresponding
             submit async request will be used. Otherwise, it is possible to override
             the value and extend the validity of the request. When this period expires,
             the search, if still running, is cancelled. If the search is completed, its
@@ -157,13 +157,17 @@ class AsyncSearchClient(NamespacedClient):
 
           <p>Get the async search status.</p>
           <p>Get the status of a previously submitted async search request given its identifier, without retrieving search results.
-          If the Elasticsearch security features are enabled, use of this API is restricted to the <code>monitoring_user</code> role.</p>
+          If the Elasticsearch security features are enabled, the access to the status of a specific async search is restricted to:</p>
+          <ul>
+          <li>The user or API key that submitted the original async search request.</li>
+          <li>Users that have the <code>monitor</code> cluster privilege or greater privileges.</li>
+          </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param id: A unique identifier for the async search.
-        :param keep_alive: Specifies how long the async search needs to be available.
+        :param keep_alive: The length of time that the async search needs to be available.
             Ongoing async searches and any saved search results are deleted after this
             period.
         """
@@ -294,7 +298,7 @@ class AsyncSearchClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         search_type: t.Optional[
             t.Union[str, t.Literal["dfs_query_then_fetch", "query_then_fetch"]]
@@ -341,7 +345,7 @@ class AsyncSearchClient(NamespacedClient):
           The maximum allowed size for a stored async search response can be set by changing the <code>search.max_async_search_response_size</code> cluster level setting.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices

--- a/elasticsearch/_async/client/autoscaling.py
+++ b/elasticsearch/_async/client/autoscaling.py
@@ -44,7 +44,7 @@ class AutoscalingClient(NamespacedClient):
           <p>NOTE: This feature is designed for indirect use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes. Direct use is not supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-delete-autoscaling-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-delete-autoscaling-policy>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -104,7 +104,7 @@ class AutoscalingClient(NamespacedClient):
           Do not use this information to make autoscaling decisions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-get-autoscaling-capacity>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -151,7 +151,7 @@ class AutoscalingClient(NamespacedClient):
           <p>NOTE: This feature is designed for indirect use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes. Direct use is not supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-get-autoscaling-capacity>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -206,7 +206,7 @@ class AutoscalingClient(NamespacedClient):
           <p>NOTE: This feature is designed for indirect use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes. Direct use is not supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-put-autoscaling-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-put-autoscaling-policy>`_
 
         :param name: the name of the autoscaling policy
         :param policy:

--- a/elasticsearch/_async/client/cat.py
+++ b/elasticsearch/_async/client/cat.py
@@ -64,7 +64,7 @@ class CatClient(NamespacedClient):
           <p>IMPORTANT: CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-aliases>`_
 
         :param name: A comma-separated list of aliases to retrieve. Supports wildcards
             (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
@@ -154,7 +154,7 @@ class CatClient(NamespacedClient):
           <p>IMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-allocation>`_
 
         :param node_id: A comma-separated list of node identifiers or names used to limit
             the returned information.
@@ -243,7 +243,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use the get component template API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-component-templates>`_
 
         :param name: The name of the component template. It accepts wildcard expressions.
             If it is omitted, all component templates are returned.
@@ -327,7 +327,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use the count API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-count>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. It supports wildcards (`*`). To target all data streams
@@ -405,7 +405,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use the nodes stats API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-fielddata>`_
 
         :param fields: Comma-separated list of fields used to limit returned information.
             To retrieve all fields, omit this parameter.
@@ -491,7 +491,7 @@ class CatClient(NamespacedClient):
           You also can use the API to track the recovery of a large cluster over a longer period of time.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-health>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -549,7 +549,7 @@ class CatClient(NamespacedClient):
           <p>Get help for the CAT APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-cat>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_cat"
@@ -616,7 +616,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use an index endpoint.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-indices>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -714,7 +714,7 @@ class CatClient(NamespacedClient):
           <p>IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-master>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -892,7 +892,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get data frame analytics jobs statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-data-frame-analytics>`_
 
         :param id: The ID of the data frame analytics to fetch
         :param allow_no_match: Whether to ignore if a wildcard expression matches no
@@ -1060,7 +1060,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get datafeed statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-datafeeds>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed.
@@ -1426,7 +1426,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get anomaly detection job statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-jobs>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param allow_no_match: Specifies what to do when the request: * Contains wildcard
@@ -1611,7 +1611,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get trained models statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-trained-models>`_
 
         :param model_id: A unique identifier for the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -1704,7 +1704,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-nodeattrs>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1787,7 +1787,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-nodes>`_
 
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -1874,7 +1874,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-pending-tasks>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1954,7 +1954,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-plugins>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -2042,7 +2042,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-recovery>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2130,7 +2130,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-repositories>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -2211,7 +2211,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-segments>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2305,7 +2305,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-shards>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2394,7 +2394,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-snapshots>`_
 
         :param repository: A comma-separated list of snapshot repositories used to limit
             the request. Accepts wildcard expressions. `_all` returns all repositories.
@@ -2487,7 +2487,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the task management API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-tasks>`_
 
         :param actions: The task action names, which are used to limit the response.
         :param detailed: If `true`, the response includes detailed information about
@@ -2581,7 +2581,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-templates>`_
 
         :param name: The name of the template to return. Accepts wildcard expressions.
             If omitted, all templates are returned.
@@ -2669,7 +2669,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-thread-pool>`_
 
         :param thread_pool_patterns: A comma-separated list of thread pool names used
             to limit the request. Accepts wildcard expressions.
@@ -2926,7 +2926,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get transform statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-transforms>`_
 
         :param transform_id: A transform identifier or a wildcard expression. If you
             do not specify one of these options, the API returns information for all

--- a/elasticsearch/_async/client/ccr.py
+++ b/elasticsearch/_async/client/ccr.py
@@ -39,14 +39,17 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete auto-follow patterns.
-          Delete a collection of cross-cluster replication auto-follow patterns.</p>
+          <p>Delete auto-follow patterns.</p>
+          <p>Delete a collection of cross-cluster replication auto-follow patterns.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-delete-auto-follow-pattern>`_
 
-        :param name: The name of the auto follow pattern.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The auto-follow pattern collection to delete.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -127,7 +130,7 @@ class CcrClient(NamespacedClient):
           When the API returns, the follower index exists and cross-cluster replication starts replicating operations from the leader index to the follower index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-follow>`_
 
         :param index: The name of the follower index.
         :param leader_index: The name of the index in the leader cluster to follow.
@@ -251,16 +254,18 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get follower information.
-          Get information about all cross-cluster replication follower indices.
+          <p>Get follower information.</p>
+          <p>Get information about all cross-cluster replication follower indices.
           For example, the results include follower index names, leader index names, replication options, and whether the follower indices are active or paused.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-follow-info>`_
 
-        :param index: A comma-separated list of index patterns; use `_all` to perform
-            the operation on all indices
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param index: A comma-delimited list of follower index patterns.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -301,17 +306,16 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get follower stats.
-          Get cross-cluster replication follower stats.
+          <p>Get follower stats.</p>
+          <p>Get cross-cluster replication follower stats.
           The API returns shard-level stats about the &quot;following tasks&quot; associated with each shard for the specified indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-follow-stats>`_
 
-        :param index: A comma-separated list of index patterns; use `_all` to perform
-            the operation on all indices
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param index: A comma-delimited list of index patterns.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -376,7 +380,7 @@ class CcrClient(NamespacedClient):
           The only purpose of this API is to handle the case of failure to remove the following retention leases after the unfollow API is invoked.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-forget-follower>`_
 
         :param index: the name of the leader index for which specified follower retention
             leases should be removed
@@ -437,15 +441,18 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get auto-follow patterns.
-          Get cross-cluster replication auto-follow patterns.</p>
+          <p>Get auto-follow patterns.</p>
+          <p>Get cross-cluster replication auto-follow patterns.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-get-auto-follow-pattern-1>`_
 
-        :param name: Specifies the auto-follow pattern collection that you want to retrieve.
-            If you do not specify a name, the API returns information for all collections.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The auto-follow pattern collection that you want to retrieve. If
+            you do not specify a name, the API returns information for all collections.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
@@ -489,8 +496,8 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Pause an auto-follow pattern.
-          Pause a cross-cluster replication auto-follow pattern.
+          <p>Pause an auto-follow pattern.</p>
+          <p>Pause a cross-cluster replication auto-follow pattern.
           When the API returns, the auto-follow pattern is inactive.
           New indices that are created on the remote cluster and match the auto-follow patterns are ignored.</p>
           <p>You can resume auto-following with the resume auto-follow pattern API.
@@ -498,11 +505,13 @@ class CcrClient(NamespacedClient):
           Remote indices that were created while the pattern was paused will also be followed, unless they have been deleted or closed in the interim.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-pause-auto-follow-pattern>`_
 
-        :param name: The name of the auto follow pattern that should pause discovering
-            new indices to follow.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The name of the auto-follow pattern to pause.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -543,18 +552,20 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Pause a follower.
-          Pause a cross-cluster replication follower index.
+          <p>Pause a follower.</p>
+          <p>Pause a cross-cluster replication follower index.
           The follower index will not fetch any additional operations from the leader index.
           You can resume following with the resume follower API.
           You can pause and resume a follower index to change the configuration of the following task.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-pause-follow>`_
 
-        :param index: The name of the follower index that should pause following its
-            leader index.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param index: The name of the follower index.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -637,7 +648,7 @@ class CcrClient(NamespacedClient):
           NOTE: Follower indices that were configured automatically before updating an auto-follow pattern will remain unchanged even if they do not match against the new patterns.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-put-auto-follow-pattern>`_
 
         :param name: The name of the collection of auto-follow patterns.
         :param remote_cluster: The remote cluster containing the leader indices to match
@@ -765,17 +776,19 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Resume an auto-follow pattern.
-          Resume a cross-cluster replication auto-follow pattern that was paused.
+          <p>Resume an auto-follow pattern.</p>
+          <p>Resume a cross-cluster replication auto-follow pattern that was paused.
           The auto-follow pattern will resume configuring following indices for newly created indices that match its patterns on the remote cluster.
           Remote indices created while the pattern was paused will also be followed unless they have been deleted or closed in the interim.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-resume-auto-follow-pattern>`_
 
-        :param name: The name of the auto follow pattern to resume discovering new indices
-            to follow.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The name of the auto-follow pattern to resume.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -847,7 +860,7 @@ class CcrClient(NamespacedClient):
           When this API returns, the follower index will resume fetching operations from the leader index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-resume-follow>`_
 
         :param index: The name of the follow index to resume following.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -934,15 +947,18 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get cross-cluster replication stats.
-          This API returns stats about auto-following and the same shard-level stats as the get follower stats API.</p>
+          <p>Get cross-cluster replication stats.</p>
+          <p>This API returns stats about auto-following and the same shard-level stats as the get follower stats API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-stats>`_
 
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ccr/stats"
@@ -983,18 +999,23 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Unfollow an index.
-          Convert a cross-cluster replication follower index to a regular index.
+          <p>Unfollow an index.</p>
+          <p>Convert a cross-cluster replication follower index to a regular index.
           The API stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication.
           The follower index must be paused and closed before you call the unfollow API.</p>
-          <p>NOTE: Currently cross-cluster replication does not support converting an existing regular index to a follower index. Converting a follower index to a regular index is an irreversible operation.</p>
+          <blockquote>
+          <p>info
+          Currently cross-cluster replication does not support converting an existing regular index to a follower index. Converting a follower index to a regular index is an irreversible operation.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-unfollow>`_
 
-        :param index: The name of the follower index that should be turned into a regular
-            index.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param index: The name of the follower index.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")

--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -54,7 +54,7 @@ class ClusterClient(NamespacedClient):
           This API can be very useful when attempting to diagnose why a shard is unassigned or why a shard continues to remain on its current node when you might expect otherwise.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-allocation-explain>`_
 
         :param current_node: Specifies the node ID or the name of the node to only explain
             a shard that is currently located on the specified node.
@@ -130,7 +130,7 @@ class ClusterClient(NamespacedClient):
           Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Comma-separated list or wildcard expression of component template
             names used to limit the request.
@@ -185,7 +185,7 @@ class ClusterClient(NamespacedClient):
           Remove master-eligible nodes from the voting configuration exclusion list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
@@ -239,7 +239,7 @@ class ClusterClient(NamespacedClient):
           Returns information about whether a particular component template exists.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (*) expressions are supported.
@@ -298,7 +298,7 @@ class ClusterClient(NamespacedClient):
           Get information about component templates.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -365,7 +365,7 @@ class ClusterClient(NamespacedClient):
           By default, it returns only settings that have been explicitly defined.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-get-settings>`_
 
         :param flat_settings: If `true`, returns settings in flat format.
         :param include_defaults: If `true`, returns default cluster settings from the
@@ -447,8 +447,8 @@ class ClusterClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get the cluster health status.
-          You can also use the API to get the health status of only specified data streams and indices.
+          <p>Get the cluster health status.</p>
+          <p>You can also use the API to get the health status of only specified data streams and indices.
           For data streams, the API retrieves the health status of the stream’s backing indices.</p>
           <p>The cluster health status is: green, yellow or red.
           On the shard level, a red status indicates that the specific shard is not allocated in the cluster. Yellow means that the primary shard is allocated but replicas are not. Green means that all shards are allocated.
@@ -457,7 +457,7 @@ class ClusterClient(NamespacedClient):
           The cluster status is controlled by the worst index status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-health>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (`*`) are supported. To target
@@ -565,7 +565,7 @@ class ClusterClient(NamespacedClient):
           Returns basic information about the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-info>`_
 
         :param target: Limits the information returned to the specific target. Supports
             a comma-separated list, such as http,ingest.
@@ -614,7 +614,7 @@ class ClusterClient(NamespacedClient):
           However, if a user-initiated task such as a create index command causes a cluster state update, the activity of this task might be reported by both task api and pending cluster tasks API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-pending-tasks>`_
 
         :param local: If `true`, the request retrieves information from the local node
             only. If `false`, information is retrieved from the master node.
@@ -680,7 +680,7 @@ class ClusterClient(NamespacedClient):
           They are not required when removing master-ineligible nodes or when removing fewer than half of the master-eligible nodes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param node_ids: A comma-separated list of the persistent ids of the nodes to
@@ -761,7 +761,7 @@ class ClusterClient(NamespacedClient):
           To be applied, a component template must be included in an index template's <code>composed_of</code> list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Name of the component template to create. Elasticsearch includes
             the following built-in component templates: `logs-mappings`; `logs-settings`;
@@ -850,8 +850,8 @@ class ClusterClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Update the cluster settings.
-          Configure and update dynamic settings on a running cluster.
+          <p>Update the cluster settings.</p>
+          <p>Configure and update dynamic settings on a running cluster.
           You can also configure dynamic settings locally on an unstarted or shut down node in <code>elasticsearch.yml</code>.</p>
           <p>Updates made with this API can be persistent, which apply across cluster restarts, or transient, which reset after a cluster restart.
           You can also reset transient or persistent settings by assigning them a null value.</p>
@@ -866,7 +866,7 @@ class ClusterClient(NamespacedClient):
           If a cluster becomes unstable, transient settings can clear unexpectedly, resulting in a potentially undesired cluster configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-settings>`_
 
         :param flat_settings: Return settings in flat format (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
@@ -920,12 +920,19 @@ class ClusterClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get remote cluster information.
-          Get all of the configured remote cluster information.
-          This API returns connection and endpoint information keyed by the configured remote cluster alias.</p>
+          <p>Get remote cluster information.</p>
+          <p>Get information about configured remote clusters.
+          The API returns connection and endpoint information keyed by the configured remote cluster alias.</p>
+          <blockquote>
+          <p>info
+          This API returns information that reflects current state on the local cluster.
+          The <code>connected</code> field does not necessarily reflect whether a remote cluster is down or unavailable, only whether there is currently an open connection to it.
+          Elasticsearch does not spontaneously try to reconnect to a disconnected remote cluster.
+          To trigger a reconnection, attempt a cross-cluster search, ES|QL cross-cluster search, or try the <a href="https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-resolve-cluster">resolve cluster endpoint</a>.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-remote-info>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_remote/info"
@@ -982,7 +989,7 @@ class ClusterClient(NamespacedClient):
           <p>Once the problem has been corrected, allocation can be manually retried by calling the reroute API with the <code>?retry_failed</code> URI query parameter, which will attempt a single retry round for these shards.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-reroute>`_
 
         :param commands: Defines the commands to perform.
         :param dry_run: If true, then the request simulates the operation. It will calculate
@@ -1087,7 +1094,7 @@ class ClusterClient(NamespacedClient):
           Instead, obtain the information you require using other more stable cluster APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-state>`_
 
         :param metric: Limit the information returned to the specified metrics
         :param index: A comma-separated list of index names; use `_all` or empty string
@@ -1175,7 +1182,7 @@ class ClusterClient(NamespacedClient):
           Get basic index metrics (shard numbers, store size, memory usage) and information about the current nodes that form the cluster (number, roles, os, jvm versions, memory usage, cpu and installed plugins).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-stats>`_
 
         :param node_id: Comma-separated list of node filters used to limit returned information.
             Defaults to all nodes in the cluster.

--- a/elasticsearch/_async/client/connector.py
+++ b/elasticsearch/_async/client/connector.py
@@ -49,7 +49,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the <code>last_seen</code> field in the connector and set it to the current timestamp.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/check-in-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-check-in>`_
 
         :param connector_id: The unique identifier of the connector to be checked in
         """
@@ -99,7 +99,7 @@ class ConnectorClient(NamespacedClient):
           These need to be removed manually.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-delete>`_
 
         :param connector_id: The unique identifier of the connector to be deleted
         :param delete_sync_jobs: A flag indicating if associated sync jobs should be
@@ -152,7 +152,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get the details about a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-get>`_
 
         :param connector_id: The unique identifier of the connector
         :param include_deleted: A flag to indicate if the desired connector should be
@@ -256,7 +256,7 @@ class ConnectorClient(NamespacedClient):
           This action is used for analytics and monitoring.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-last-sync-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-last-sync>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param last_access_control_sync_error:
@@ -356,7 +356,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get information about all connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-list>`_
 
         :param connector_name: A comma-separated list of connector names to fetch connector
             documents for
@@ -441,7 +441,7 @@ class ConnectorClient(NamespacedClient):
           Self-managed connectors (Connector clients) are self-managed on your infrastructure.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-put>`_
 
         :param description:
         :param index_name:
@@ -523,7 +523,7 @@ class ConnectorClient(NamespacedClient):
           <p>Create or update a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-put>`_
 
         :param connector_id: The unique identifier of the connector to be created or
             updated. ID is auto-generated if not provided.
@@ -598,7 +598,7 @@ class ConnectorClient(NamespacedClient):
           The connector service is then responsible for setting the status of connector sync jobs to cancelled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cancel-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-cancel>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -649,7 +649,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/check-in-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-check-in>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be checked in.
@@ -709,7 +709,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/claim-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-claim>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param worker_hostname: The host name of the current system that will run the
@@ -771,7 +771,7 @@ class ConnectorClient(NamespacedClient):
           This is a destructive action that is not recoverable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-delete>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be deleted
@@ -825,7 +825,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-error-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-error>`_
 
         :param connector_sync_job_id: The unique identifier for the connector sync job.
         :param error: The error for the connector sync job error field.
@@ -879,7 +879,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get a connector sync job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-get>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -952,7 +952,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get information about all stored connector sync jobs listed by their creation date in ascending order.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-connector-sync-jobs-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-list>`_
 
         :param connector_id: A connector id to fetch connector sync jobs for
         :param from_: Starting offset (default: 0)
@@ -1018,7 +1018,7 @@ class ConnectorClient(NamespacedClient):
           <p>Create a connector sync job document in the internal index and initialize its counters and timestamps with default values.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-post>`_
 
         :param id: The id of the associated connector
         :param job_type:
@@ -1094,7 +1094,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-stats-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-update-stats>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param deleted_document_count: The number of documents the sync job deleted.
@@ -1177,7 +1177,7 @@ class ConnectorClient(NamespacedClient):
           <p>Activates the valid draft filtering for a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-filtering>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         """
@@ -1230,7 +1230,7 @@ class ConnectorClient(NamespacedClient):
           Self-managed connectors (connector clients) do not use this field.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-api-key-id-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-api-key-id>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param api_key_id:
@@ -1289,7 +1289,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the configuration field in the connector document.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-configuration-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-configuration>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param configuration:
@@ -1349,7 +1349,7 @@ class ConnectorClient(NamespacedClient):
           Otherwise, if the error is reset to null, the connector status is updated to connected.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-error-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-error>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param error:
@@ -1417,7 +1417,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-features-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-features>`_
 
         :param connector_id: The unique identifier of the connector to be updated.
         :param features:
@@ -1478,7 +1478,7 @@ class ConnectorClient(NamespacedClient):
           The filtering property is used to configure sync rules (both basic and advanced) for a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-filtering>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param advanced_snippet:
@@ -1596,7 +1596,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the <code>index_name</code> field of a connector, specifying the index where the data ingested by the connector is stored.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-index-name-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-index-name>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param index_name:
@@ -1653,7 +1653,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector name and description.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-name-description-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-name>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param description:
@@ -1767,7 +1767,7 @@ class ConnectorClient(NamespacedClient):
           <p>When you create a new connector, the configuration of an ingest pipeline is populated with default settings.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-pipeline>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param pipeline:
@@ -1823,7 +1823,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector scheduling.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-scheduling-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-scheduling>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param scheduling:
@@ -1879,7 +1879,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector service type.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-service-type-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-service-type>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param service_type:
@@ -1942,7 +1942,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-status>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param status:

--- a/elasticsearch/_async/client/dangling_indices.py
+++ b/elasticsearch/_async/client/dangling_indices.py
@@ -46,7 +46,7 @@ class DanglingIndicesClient(NamespacedClient):
           For example, this can happen if you delete more than <code>cluster.indices.tombstones.size</code> indices while an Elasticsearch node is offline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-index-delete.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-dangling-indices-delete-dangling-index>`_
 
         :param index_uuid: The UUID of the index to delete. Use the get dangling indices
             API to find the UUID.
@@ -107,7 +107,7 @@ class DanglingIndicesClient(NamespacedClient):
           For example, this can happen if you delete more than <code>cluster.indices.tombstones.size</code> indices while an Elasticsearch node is offline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-index-import.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-dangling-indices-import-dangling-index>`_
 
         :param index_uuid: The UUID of the index to import. Use the get dangling indices
             API to locate the UUID.
@@ -168,7 +168,7 @@ class DanglingIndicesClient(NamespacedClient):
           <p>Use this API to list dangling indices, which you can then import or delete.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-indices-list.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-dangling-indices-list-dangling-indices>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_dangling"

--- a/elasticsearch/_async/client/enrich.py
+++ b/elasticsearch/_async/client/enrich.py
@@ -43,7 +43,7 @@ class EnrichClient(NamespacedClient):
           Deletes an existing enrich policy and its enrich index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-delete-policy>`_
 
         :param name: Enrich policy to delete.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -92,7 +92,7 @@ class EnrichClient(NamespacedClient):
           Create the enrich index for an existing enrich policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-execute-policy>`_
 
         :param name: Enrich policy to execute.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -144,7 +144,7 @@ class EnrichClient(NamespacedClient):
           Returns information about an enrich policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-get-policy>`_
 
         :param name: Comma-separated list of enrich policy names used to limit the request.
             To return information for all enrich policies, omit this parameter.
@@ -202,7 +202,7 @@ class EnrichClient(NamespacedClient):
           Creates an enrich policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-put-policy>`_
 
         :param name: Name of the enrich policy to create or update.
         :param geo_match: Matches enrich data to incoming documents based on a `geo_shape`
@@ -263,7 +263,7 @@ class EnrichClient(NamespacedClient):
           Returns enrich coordinator statistics and information about enrich policies that are currently executing.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-stats>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_async/client/eql.py
+++ b/elasticsearch/_async/client/eql.py
@@ -43,7 +43,7 @@ class EqlClient(NamespacedClient):
           The API also deletes results for the search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-delete>`_
 
         :param id: Identifier for the search to delete. A search ID is provided in the
             EQL search API's response for an async search. A search ID is also provided
@@ -93,7 +93,7 @@ class EqlClient(NamespacedClient):
           Get the current status and available results for an async EQL search or a stored synchronous EQL search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-get>`_
 
         :param id: Identifier for the search.
         :param keep_alive: Period for which the search and its results are stored on
@@ -147,7 +147,7 @@ class EqlClient(NamespacedClient):
           Get the current status for an async EQL search or a stored synchronous EQL search without returning results.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-get-status>`_
 
         :param id: Identifier for the search.
         """
@@ -246,13 +246,20 @@ class EqlClient(NamespacedClient):
           EQL assumes each document in a data stream or index corresponds to an event.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-search>`_
 
         :param index: The name of the index to scope the operation
         :param query: EQL query you wish to run.
         :param allow_no_indices:
-        :param allow_partial_search_results:
-        :param allow_partial_sequence_results:
+        :param allow_partial_search_results: Allow query execution also in case of shard
+            failures. If true, the query will keep running and will return results based
+            on the available shards. For sequences, the behavior can be further refined
+            using allow_partial_sequence_results
+        :param allow_partial_sequence_results: This flag applies only to sequences and
+            has effect only if allow_partial_search_results=true. If true, the sequence
+            query will return results based on the available shards, ignoring the others.
+            If false, the sequence query will return successfully, but will always have
+            empty results.
         :param case_sensitive:
         :param event_category_field: Field containing the event classification, such
             as process, file, or network.

--- a/elasticsearch/_async/client/esql.py
+++ b/elasticsearch/_async/client/esql.py
@@ -30,6 +30,7 @@ class EsqlClient(NamespacedClient):
             "query",
             "columnar",
             "filter",
+            "include_ccs_metadata",
             "locale",
             "params",
             "profile",
@@ -56,12 +57,11 @@ class EsqlClient(NamespacedClient):
             ]
         ] = None,
         human: t.Optional[bool] = None,
+        include_ccs_metadata: t.Optional[bool] = None,
         keep_alive: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         keep_on_completion: t.Optional[bool] = None,
         locale: t.Optional[str] = None,
-        params: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
-        ] = None,
+        params: t.Optional[t.Sequence[t.Union[None, bool, float, int, str]]] = None,
         pretty: t.Optional[bool] = None,
         profile: t.Optional[bool] = None,
         tables: t.Optional[
@@ -80,7 +80,7 @@ class EsqlClient(NamespacedClient):
           <p>The API accepts the same parameters and request body as the synchronous query API, along with additional async related properties.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-async-query>`_
 
         :param query: The ES|QL query API accepts an ES|QL query string in the query
             parameter, runs it, and returns the results.
@@ -97,6 +97,10 @@ class EsqlClient(NamespacedClient):
         :param filter: Specify a Query DSL query in the filter parameter to filter the
             set of documents that an ES|QL query runs on.
         :param format: A short version of the Accept header, for example `json` or `yaml`.
+        :param include_ccs_metadata: When set to `true` and performing a cross-cluster
+            query, the response will include an extra `_clusters` object with information
+            about the clusters that participated in the search along with info such as
+            shards count.
         :param keep_alive: The period for which the query and its results are stored
             in the cluster. The default period is five days. When this period expires,
             the query and its results are deleted, even if the query is still ongoing.
@@ -155,6 +159,8 @@ class EsqlClient(NamespacedClient):
                 __body["columnar"] = columnar
             if filter is not None:
                 __body["filter"] = filter
+            if include_ccs_metadata is not None:
+                __body["include_ccs_metadata"] = include_ccs_metadata
             if locale is not None:
                 __body["locale"] = locale
             if params is not None:
@@ -197,7 +203,7 @@ class EsqlClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-delete-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-async-query-delete>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -250,7 +256,7 @@ class EsqlClient(NamespacedClient):
           If the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can retrieve the results using this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-get-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-async-query-get>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -298,11 +304,67 @@ class EsqlClient(NamespacedClient):
             path_parts=__path_parts,
         )
 
+    @_rewrite_parameters()
+    async def async_query_stop(
+        self,
+        *,
+        id: str,
+        drop_null_columns: t.Optional[bool] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        .. raw:: html
+
+          <p>Stop async ES|QL query.</p>
+          <p>This API interrupts the query execution and returns the results so far.
+          If the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can stop it.</p>
+
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-stop-api.html>`_
+
+        :param id: The unique identifier of the query. A query ID is provided in the
+            ES|QL async query API response for a query that does not complete in the
+            designated time. A query ID is also provided when the request was submitted
+            with the `keep_on_completion` parameter set to `true`.
+        :param drop_null_columns: Indicates whether columns that are entirely `null`
+            will be removed from the `columns` and `values` portion of the results. If
+            `true`, the response will include an extra section under the name `all_columns`
+            which has the name of all the columns.
+        """
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        __path_parts: t.Dict[str, str] = {"id": _quote(id)}
+        __path = f'/_query/async/{__path_parts["id"]}/stop'
+        __query: t.Dict[str, t.Any] = {}
+        if drop_null_columns is not None:
+            __query["drop_null_columns"] = drop_null_columns
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        __headers = {"accept": "application/json"}
+        return await self.perform_request(  # type: ignore[return-value]
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="esql.async_query_stop",
+            path_parts=__path_parts,
+        )
+
     @_rewrite_parameters(
         body_fields=(
             "query",
             "columnar",
             "filter",
+            "include_ccs_metadata",
             "locale",
             "params",
             "profile",
@@ -329,10 +391,9 @@ class EsqlClient(NamespacedClient):
             ]
         ] = None,
         human: t.Optional[bool] = None,
+        include_ccs_metadata: t.Optional[bool] = None,
         locale: t.Optional[str] = None,
-        params: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
-        ] = None,
+        params: t.Optional[t.Sequence[t.Union[None, bool, float, int, str]]] = None,
         pretty: t.Optional[bool] = None,
         profile: t.Optional[bool] = None,
         tables: t.Optional[
@@ -364,6 +425,10 @@ class EsqlClient(NamespacedClient):
         :param filter: Specify a Query DSL query in the filter parameter to filter the
             set of documents that an ES|QL query runs on.
         :param format: A short version of the Accept header, e.g. json, yaml.
+        :param include_ccs_metadata: When set to `true` and performing a cross-cluster
+            query, the response will include an extra `_clusters` object with information
+            about the clusters that participated in the search along with info such as
+            shards count.
         :param locale:
         :param params: To avoid any attempts of hacking or code injection, extract the
             values in a separate list of parameters. Use question mark placeholders (?)
@@ -402,6 +467,8 @@ class EsqlClient(NamespacedClient):
                 __body["columnar"] = columnar
             if filter is not None:
                 __body["filter"] = filter
+            if include_ccs_metadata is not None:
+                __body["include_ccs_metadata"] = include_ccs_metadata
             if locale is not None:
                 __body["locale"] = locale
             if params is not None:

--- a/elasticsearch/_async/client/features.py
+++ b/elasticsearch/_async/client/features.py
@@ -48,7 +48,7 @@ class FeaturesClient(NamespacedClient):
           In order for a feature state to be listed in this API and recognized as a valid feature state by the create snapshot API, the plugin that defines that feature must be installed on the master node.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-features-get-features>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -102,7 +102,7 @@ class FeaturesClient(NamespacedClient):
           <p>IMPORTANT: The features installed on the node you submit this request to are the features that will be reset. Run on the master node if you have any doubts about which plugins are installed on individual nodes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-features-reset-features>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_async/client/fleet.py
+++ b/elasticsearch/_async/client/fleet.py
@@ -48,12 +48,12 @@ class FleetClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get global checkpoints.
-          Get the current global checkpoints for an index.
+          <p>Get global checkpoints.</p>
+          <p>Get the current global checkpoints for an index.
           This API is designed for internal use by the Fleet server project.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-global-checkpoints.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-fleet>`_
 
         :param index: A single index or index alias that resolves to a single index.
         :param checkpoints: A comma separated list of previous global checkpoints. When
@@ -143,6 +143,8 @@ class FleetClient(NamespacedClient):
           The API follows the same structure as the multi search API.
           However, similar to the Fleet search API, it supports the <code>wait_for_checkpoints</code> parameter.</p>
 
+
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-fleet-msearch>`_
 
         :param searches:
         :param index: A single target to search. If the target is an index alias, it
@@ -348,7 +350,7 @@ class FleetClient(NamespacedClient):
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         search_type: t.Optional[
             t.Union[str, t.Literal["dfs_query_then_fetch", "query_then_fetch"]]
@@ -390,6 +392,8 @@ class FleetClient(NamespacedClient):
           The purpose of the Fleet search API is to provide an API where the search will be run only
           after the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.</p>
 
+
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-fleet-search>`_
 
         :param index: A single target to search. If the target is an index alias, it
             must resolve to a single index.

--- a/elasticsearch/_async/client/graph.py
+++ b/elasticsearch/_async/client/graph.py
@@ -55,7 +55,7 @@ class GraphClient(NamespacedClient):
           You can exclude vertices that have already been returned.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-graph>`_
 
         :param index: Name of the index.
         :param connections: Specifies or more fields from which you want to extract terms

--- a/elasticsearch/_async/client/ilm.py
+++ b/elasticsearch/_async/client/ilm.py
@@ -44,7 +44,7 @@ class IlmClient(NamespacedClient):
           You cannot delete policies that are currently in use. If the policy is being used to manage any indices, the request fails and returns an error.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-delete-lifecycle>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -102,7 +102,7 @@ class IlmClient(NamespacedClient):
           <p>The response indicates when the index entered each lifecycle state, provides the definition of the running phase, and information about any failures.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-explain-lifecycle>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to target.
             Supports wildcards (`*`). To target all data streams and indices, use `*`
@@ -163,7 +163,7 @@ class IlmClient(NamespacedClient):
           <p>Get lifecycle policies.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-get-lifecycle>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -214,11 +214,11 @@ class IlmClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get the ILM status.
-          Get the current index lifecycle management status.</p>
+          <p>Get the ILM status.</p>
+          <p>Get the current index lifecycle management status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-get-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ilm/status"
@@ -252,6 +252,7 @@ class IlmClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         legacy_template_to_delete: t.Optional[str] = None,
+        master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         node_attribute: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         body: t.Optional[t.Dict[str, t.Any]] = None,
@@ -274,12 +275,16 @@ class IlmClient(NamespacedClient):
           Use the stop ILM and get ILM status APIs to wait until the reported operation mode is <code>STOPPED</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-migrate-to-data-tiers.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-migrate-to-data-tiers>`_
 
         :param dry_run: If true, simulates the migration from node attributes based allocation
             filters to data tiers, but does not perform the migration. This provides
             a way to retrieve the indices and ILM policies that need to be migrated.
         :param legacy_template_to_delete:
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error. It can also be set to `-1` to indicate that the request
+            should never timeout.
         :param node_attribute:
         """
         __path_parts: t.Dict[str, str] = {}
@@ -294,6 +299,8 @@ class IlmClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
         if not __body:
@@ -347,7 +354,7 @@ class IlmClient(NamespacedClient):
           An index cannot move to a step that is not part of its policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-move-to-step.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-move-to-step>`_
 
         :param index: The name of the index whose lifecycle step is to change
         :param current_step: The step that the index is expected to be in.
@@ -415,7 +422,7 @@ class IlmClient(NamespacedClient):
           <p>NOTE: Only the latest version of the policy is stored, you cannot revert to previous versions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-put-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-put-lifecycle>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -479,7 +486,7 @@ class IlmClient(NamespacedClient):
           It also stops managing the indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-remove-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-remove-policy>`_
 
         :param index: The name of the index to remove policy on
         """
@@ -525,7 +532,7 @@ class IlmClient(NamespacedClient):
           Use the explain lifecycle state API to determine whether an index is in the ERROR step.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-retry-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-retry>`_
 
         :param index: The name of the indices (comma-separated) whose failed lifecycle
             step is to be retry
@@ -573,7 +580,7 @@ class IlmClient(NamespacedClient):
           Restarting ILM is necessary only when it has been stopped using the stop ILM API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-start.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-start>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -627,7 +634,7 @@ class IlmClient(NamespacedClient):
           Use the get ILM status API to check whether ILM is running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-stop.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-stop>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and

--- a/elasticsearch/_async/client/indices.py
+++ b/elasticsearch/_async/client/indices.py
@@ -57,23 +57,40 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Add an index block.
-          Limits the operations allowed on an index by blocking specific operation types.</p>
+          <p>Add an index block.</p>
+          <p>Add an index block to an index.
+          Index blocks limit the operations allowed on an index by blocking specific operation types.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-add-block>`_
 
-        :param index: A comma separated list of indices to add a block to
-        :param block: The block to add (one of read, write, read_only or metadata)
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param index: A comma-separated list or wildcard expression of index names used
+            to limit the request. By default, you must explicitly name the indices you
+            are adding blocks to. To allow the adding of blocks to indices with `_all`,
+            `*`, or other wildcard expressions, change the `action.destructive_requires_name`
+            setting to `false`. You can update this setting in the `elasticsearch.yml`
+            file or by using the cluster update settings API.
+        :param block: The block type to add to the index.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. It supports comma-separated
+            values, such as `open,hidden`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: The period to wait for the master node. If the master
+            node is not available before the timeout expires, the request fails and returns
+            an error. It can also be set to `-1` to indicate that the request should
+            never timeout.
+        :param timeout: The period to wait for a response from all relevant nodes in
+            the cluster after updating the cluster metadata. If no response is received
+            before the timeout expires, the cluster metadata update still applies but
+            the response will indicate that it was not completely acknowledged. It can
+            also be set to `-1` to indicate that the request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -156,7 +173,7 @@ class IndicesClient(NamespacedClient):
           The <code>_analyze</code> endpoint without a specified index will always use <code>10000</code> as its limit.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-analyze>`_
 
         :param index: Index used to derive the analyzer. If specified, the `analyzer`
             or field parameter overrides this value. If no index is specified or the
@@ -310,7 +327,7 @@ class IndicesClient(NamespacedClient):
           To clear the cache only of specific fields, use the <code>fields</code> parameter.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-clear-cache>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -432,7 +449,7 @@ class IndicesClient(NamespacedClient):
           <p>Because the clone operation creates a new index to clone the shards to, the wait for active shards setting on index creation applies to the clone index action as well.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-clone>`_
 
         :param index: Name of the source index to clone.
         :param target: Name of the target index to create.
@@ -536,7 +553,7 @@ class IndicesClient(NamespacedClient):
           Closing indices can be turned off with the cluster settings API by setting <code>cluster.indices.close.enable</code> to <code>false</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-close.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-close>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -637,7 +654,7 @@ class IndicesClient(NamespacedClient):
           Note that changing this setting will also affect the <code>wait_for_active_shards</code> value on all subsequent write operations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create>`_
 
         :param index: Name of the index you wish to create.
         :param aliases: Aliases for the index.
@@ -710,12 +727,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Create a data stream.
-          Creates a data stream.
-          You must have a matching index template with data stream enabled.</p>
+          <p>Create a data stream.</p>
+          <p>You must have a matching index template with data stream enabled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create-data-stream>`_
 
         :param name: Name of the data stream, which must meet the following criteria:
             Lowercase only; Cannot include `\\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`,
@@ -841,11 +857,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data stream stats.
-          Retrieves statistics for one or more data streams.</p>
+          <p>Get data stream stats.</p>
+          <p>Get statistics for one or more data streams.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-data-streams-stats-1>`_
 
         :param name: Comma-separated list of data streams used to limit the request.
             Wildcard expressions (`*`) are supported. To target all data streams in a
@@ -914,7 +930,7 @@ class IndicesClient(NamespacedClient):
           You can then use the delete index API to delete the previous write index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete>`_
 
         :param index: Comma-separated list of indices to delete. You cannot specify index
             aliases. By default, this parameter does not support wildcards (`*`) or `_all`.
@@ -988,7 +1004,7 @@ class IndicesClient(NamespacedClient):
           Removes a data stream or index from an alias.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-alias.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-alias>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`).
@@ -1056,7 +1072,7 @@ class IndicesClient(NamespacedClient):
           Removes the data stream lifecycle from a data stream, rendering it not managed by the data stream lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-data-lifecycle>`_
 
         :param name: A comma-separated list of data streams of which the data stream
             lifecycle will be deleted; use `*` to get all data streams
@@ -1120,7 +1136,7 @@ class IndicesClient(NamespacedClient):
           Deletes one or more data streams and their backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-data-stream>`_
 
         :param name: Comma-separated list of data streams to delete. Wildcard (`*`) expressions
             are supported.
@@ -1178,7 +1194,7 @@ class IndicesClient(NamespacedClient):
           existing templates.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-index-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1233,7 +1249,7 @@ class IndicesClient(NamespacedClient):
           <p>Delete a legacy index template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-template>`_
 
         :param name: The name of the legacy index template to delete. Wildcard (`*`)
             expressions are supported.
@@ -1305,7 +1321,7 @@ class IndicesClient(NamespacedClient):
           The stored size of the <code>_id</code> field is likely underestimated while the <code>_source</code> field is overestimated.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-disk-usage>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. It’s recommended to execute this API with a single
@@ -1388,7 +1404,7 @@ class IndicesClient(NamespacedClient):
           The source index must be read only (<code>index.blocks.write: true</code>).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-downsample-data-stream.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-downsample>`_
 
         :param index: Name of the time series index to downsample.
         :param target_index: Name of the index to create.
@@ -1460,7 +1476,7 @@ class IndicesClient(NamespacedClient):
           Check if one or more indices, index aliases, or data streams exist.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases. Supports
             wildcards (`*`).
@@ -1538,11 +1554,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Check aliases.
-          Checks if one or more data stream or index aliases exist.</p>
+          <p>Check aliases.</p>
+          <p>Check if one or more data stream or index aliases exist.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-alias>`_
 
         :param name: Comma-separated list of aliases to check. Supports wildcards (`*`).
         :param index: Comma-separated list of data streams or indices used to limit the
@@ -1613,11 +1629,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Check index templates.
-          Check whether index templates exist.</p>
+          <p>Check index templates.</p>
+          <p>Check whether index templates exist.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-index-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1672,7 +1688,7 @@ class IndicesClient(NamespacedClient):
           <p>IMPORTANT: This documentation is about legacy index templates, which are deprecated and will be replaced by the composable templates introduced in Elasticsearch 7.8.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-template-exists-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-template>`_
 
         :param name: A comma-separated list of index template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -1730,7 +1746,7 @@ class IndicesClient(NamespacedClient):
           Get information about an index or data stream's current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-explain-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-explain-data-lifecycle>`_
 
         :param index: The name of the index to explain
         :param include_defaults: indicates if the API should return the default values
@@ -1800,7 +1816,7 @@ class IndicesClient(NamespacedClient):
           A given request will increment each count by a maximum value of 1, even if the request accesses the same field multiple times.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-field-usage-stats>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -1890,7 +1906,7 @@ class IndicesClient(NamespacedClient):
           If you call the flush API after indexing some documents then a successful response indicates that Elasticsearch has flushed all the documents that were indexed before the flush API was called.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-flush>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to flush.
             Supports wildcards (`*`). To flush all data streams and indices, omit this
@@ -2015,7 +2031,7 @@ class IndicesClient(NamespacedClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-forcemerge>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -2113,7 +2129,7 @@ class IndicesClient(NamespacedClient):
           stream’s backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported.
@@ -2206,7 +2222,7 @@ class IndicesClient(NamespacedClient):
           Retrieves information for one or more data stream or index aliases.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-alias.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-alias>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`). To target all data streams and indices,
@@ -2289,11 +2305,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data stream lifecycles.
-          Retrieves the data stream lifecycle configuration of one or more data streams.</p>
+          <p>Get data stream lifecycles.</p>
+          <p>Get the data stream lifecycle configuration of one or more data streams.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-lifecycle>`_
 
         :param name: Comma-separated list of data streams to limit the request. Supports
             wildcards (`*`). To target all data streams, omit this parameter or use `*`
@@ -2351,7 +2367,7 @@ class IndicesClient(NamespacedClient):
           Get statistics about the data streams that are managed by a data stream lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-lifecycle-stats>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_lifecycle/stats"
@@ -2398,11 +2414,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data streams.
-          Retrieves information about one or more data streams.</p>
+          <p>Get data streams.</p>
+          <p>Get information about one or more data streams.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-stream>`_
 
         :param name: Comma-separated list of data stream names used to limit the request.
             Wildcard (`*`) expressions are supported. If omitted, all data streams are
@@ -2471,7 +2487,6 @@ class IndicesClient(NamespacedClient):
         human: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
         include_defaults: t.Optional[bool] = None,
-        local: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -2483,7 +2498,7 @@ class IndicesClient(NamespacedClient):
           <p>This API is useful if you don't need a complete mapping or if an index mapping contains a large number of fields.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-mapping>`_
 
         :param fields: Comma-separated list or wildcard expression of fields used to
             limit returned information. Supports wildcards (`*`).
@@ -2500,8 +2515,6 @@ class IndicesClient(NamespacedClient):
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
         :param include_defaults: If `true`, return all default settings in the response.
-        :param local: If `true`, the request retrieves information from the local node
-            only.
         """
         if fields in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'fields'")
@@ -2529,8 +2542,6 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if include_defaults is not None:
             __query["include_defaults"] = include_defaults
-        if local is not None:
-            __query["local"] = local
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -2564,7 +2575,7 @@ class IndicesClient(NamespacedClient):
           Get information about one or more index templates.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-index-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -2641,7 +2652,7 @@ class IndicesClient(NamespacedClient):
           For data streams, the API retrieves mappings for the stream’s backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-mapping>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2775,7 +2786,7 @@ class IndicesClient(NamespacedClient):
           For data streams, it returns setting information for the stream's backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-settings>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2867,7 +2878,7 @@ class IndicesClient(NamespacedClient):
           <p>IMPORTANT: This documentation is about legacy index templates, which are deprecated and will be replaced by the composable templates introduced in Elasticsearch 7.8.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (`*`) expressions are supported. To return all index templates,
@@ -3130,7 +3141,7 @@ class IndicesClient(NamespacedClient):
           <p>Because opening or closing an index allocates its shards, the <code>wait_for_active_shards</code> setting on index creation applies to the <code>_open</code> and <code>_close</code> index actions as well.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-open>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). By default, you must explicitly
@@ -3357,14 +3368,15 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_name="lifecycle",
+        body_fields=("data_retention", "downsampling", "enabled"),
     )
     async def put_data_lifecycle(
         self,
         *,
         name: t.Union[str, t.Sequence[str]],
-        lifecycle: t.Optional[t.Mapping[str, t.Any]] = None,
-        body: t.Optional[t.Mapping[str, t.Any]] = None,
+        data_retention: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        downsampling: t.Optional[t.Mapping[str, t.Any]] = None,
+        enabled: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
             t.Union[
@@ -3379,6 +3391,7 @@ class IndicesClient(NamespacedClient):
         master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         .. raw:: html
@@ -3391,7 +3404,15 @@ class IndicesClient(NamespacedClient):
 
         :param name: Comma-separated list of data streams used to limit the request.
             Supports wildcards (`*`). To target all data streams use `*` or `_all`.
-        :param lifecycle:
+        :param data_retention: If defined, every document added to this data stream will
+            be stored at least for this time frame. Any time after this duration the
+            document could be deleted. When empty, every document in this data stream
+            will be stored indefinitely.
+        :param downsampling: The downsampling configuration to execute for the managed
+            backing index after rollover.
+        :param enabled: If defined, it turns data stream lifecycle on/off (`true`/`false`)
+            for this data stream. A data stream lifecycle that's disabled (enabled: `false`)
+            will have no effect on the data stream.
         :param expand_wildcards: Type of data stream that wildcard patterns can match.
             Supports comma-separated values, such as `open,hidden`. Valid values are:
             `all`, `hidden`, `open`, `closed`, `none`.
@@ -3403,15 +3424,10 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if lifecycle is None and body is None:
-            raise ValueError(
-                "Empty value passed for parameters 'lifecycle' and 'body', one of them should be set."
-            )
-        elif lifecycle is not None and body is not None:
-            raise ValueError("Cannot set both 'lifecycle' and 'body'")
         __path_parts: t.Dict[str, str] = {"name": _quote(name)}
         __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
@@ -3426,8 +3442,18 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        __body = lifecycle if lifecycle is not None else body
-        __headers = {"accept": "application/json", "content-type": "application/json"}
+        if not __body:
+            if data_retention is not None:
+                __body["data_retention"] = data_retention
+            if downsampling is not None:
+                __body["downsampling"] = downsampling
+            if enabled is not None:
+                __body["enabled"] = enabled
+        if not __body:
+            __body = None  # type: ignore[assignment]
+        __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
             "PUT",
             __path,
@@ -3633,10 +3659,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         dynamic_date_formats: t.Optional[t.Sequence[str]] = None,
         dynamic_templates: t.Optional[
-            t.Union[
-                t.Mapping[str, t.Mapping[str, t.Any]],
-                t.Sequence[t.Mapping[str, t.Mapping[str, t.Any]]],
-            ]
+            t.Sequence[t.Mapping[str, t.Mapping[str, t.Any]]]
         ] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
@@ -3688,7 +3711,7 @@ class IndicesClient(NamespacedClient):
           Instead, add an alias field to create an alternate field name.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping>`_
 
         :param index: A comma-separated list of index names the mapping should be added
             to (supports wildcards); use `_all` or omit to add the mapping on all indices.
@@ -3833,7 +3856,7 @@ class IndicesClient(NamespacedClient):
           To change the analyzer for existing backing indices, you must create a new data stream and reindex your data into it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-settings>`_
 
         :param settings:
         :param index: Comma-separated list of data streams, indices, and aliases used
@@ -3954,7 +3977,7 @@ class IndicesClient(NamespacedClient):
           NOTE: Multiple matching templates with the same order value will result in a non-deterministic merging order.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-template>`_
 
         :param name: The name of the template
         :param aliases: Aliases for the index.
@@ -4056,7 +4079,7 @@ class IndicesClient(NamespacedClient):
           This means that if a shard copy completes a recovery and then Elasticsearch relocates it onto a different node then the information about the original recovery will not be shown in the recovery API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-recovery>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4130,7 +4153,7 @@ class IndicesClient(NamespacedClient):
           This option ensures the indexing operation waits for a periodic refresh before running the search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-refresh>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4213,7 +4236,7 @@ class IndicesClient(NamespacedClient):
           This ensures the synonym file is updated everywhere in the cluster in case shards are relocated in the future.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-reload-search-analyzers>`_
 
         :param index: A comma-separated list of index names to reload analyzers for
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -4257,7 +4280,7 @@ class IndicesClient(NamespacedClient):
     async def resolve_cluster(
         self,
         *,
-        name: t.Union[str, t.Sequence[str]],
+        name: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
@@ -4273,19 +4296,20 @@ class IndicesClient(NamespacedClient):
         ignore_throttled: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         .. raw:: html
 
-          <p>Resolve the cluster.
-          Resolve the specified index expressions to return information about each cluster, including the local cluster, if included.
-          Multiple patterns and remote clusters are supported.</p>
+          <p>Resolve the cluster.</p>
+          <p>Resolve the specified index expressions to return information about each cluster, including the local &quot;querying&quot; cluster, if included.
+          If no index expression is provided, the API will return information about all the remote clusters that are configured on the querying cluster.</p>
           <p>This endpoint is useful before doing a cross-cluster search in order to determine which remote clusters should be included in a search.</p>
           <p>You use the same index expression with this endpoint as you would for cross-cluster search.
           Index and cluster exclusions are also supported with this endpoint.</p>
           <p>For each cluster in the index expression, information is returned about:</p>
           <ul>
-          <li>Whether the querying (&quot;local&quot;) cluster is currently connected to each remote cluster in the index expression scope.</li>
+          <li>Whether the querying (&quot;local&quot;) cluster is currently connected to each remote cluster specified in the index expression. Note that this endpoint actively attempts to contact the remote clusters, unlike the <code>remote/info</code> endpoint.</li>
           <li>Whether each remote cluster is configured with <code>skip_unavailable</code> as <code>true</code> or <code>false</code>.</li>
           <li>Whether there are any indices, aliases, or data streams on that cluster that match the index expression.</li>
           <li>Whether the search is likely to have errors returned when you do the cross-cluster search (including any authorization errors if you do not have permission to query the index).</li>
@@ -4293,7 +4317,13 @@ class IndicesClient(NamespacedClient):
           </ul>
           <p>For example, <code>GET /_resolve/cluster/my-index-*,cluster*:my-index-*</code> returns information about the local cluster and all remotely configured clusters that start with the alias <code>cluster*</code>.
           Each cluster returns information about whether it has any indices, aliases or data streams that match <code>my-index-*</code>.</p>
-          <p><strong>Advantages of using this endpoint before a cross-cluster search</strong></p>
+          <h2>Note on backwards compatibility</h2>
+          <p>The ability to query without an index expression was added in version 8.18, so when
+          querying remote clusters older than that, the local cluster will send the index
+          expression <code>dummy*</code> to those remote clusters. Thus, if an errors occur, you may see a reference
+          to that index expression even though you didn't request it. If it causes a problem, you can
+          instead include an index expression like <code>*:*</code> to bypass the issue.</p>
+          <h2>Advantages of using this endpoint before a cross-cluster search</h2>
           <p>You may want to exclude a cluster or index from a search when:</p>
           <ul>
           <li>A remote cluster is not currently connected and is configured with <code>skip_unavailable=false</code>. Running a cross-cluster search under those conditions will cause the entire search to fail.</li>
@@ -4301,31 +4331,60 @@ class IndicesClient(NamespacedClient):
           <li>The index expression (combined with any query parameters you specify) will likely cause an exception to be thrown when you do the search. In these cases, the &quot;error&quot; field in the <code>_resolve/cluster</code> response will be present. (This is also where security/permission errors will be shown.)</li>
           <li>A remote cluster is an older version that does not support the feature you want to use in your search.</li>
           </ul>
+          <h2>Test availability of remote clusters</h2>
+          <p>The <code>remote/info</code> endpoint is commonly used to test whether the &quot;local&quot; cluster (the cluster being queried) is connected to its remote clusters, but it does not necessarily reflect whether the remote cluster is available or not.
+          The remote cluster may be available, while the local cluster is not currently connected to it.</p>
+          <p>You can use the <code>_resolve/cluster</code> API to attempt to reconnect to remote clusters.
+          For example with <code>GET _resolve/cluster</code> or <code>GET _resolve/cluster/*:*</code>.
+          The <code>connected</code> field in the response will indicate whether it was successful.
+          If a connection was (re-)established, this will also cause the <code>remote/info</code> endpoint to now indicate a connected status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-cluster-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-resolve-cluster>`_
 
-        :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
-            and data streams to resolve. Resources on remote clusters can be specified
-            using the `<cluster>`:`<name>` syntax.
+        :param name: A comma-separated list of names or index patterns for the indices,
+            aliases, and data streams to resolve. Resources on remote clusters can be
+            specified using the `<cluster>`:`<name>` syntax. Index and cluster exclusions
+            (e.g., `-cluster1:*`) are also supported. If no index expression is specified,
+            information about all remote clusters configured on the local cluster is
+            returned without doing any index matching
         :param allow_no_indices: If false, the request returns an error if any wildcard
-            expression, index alias, or _all value targets only missing or closed indices.
+            expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
-            example, a request targeting foo*,bar* returns an error if an index starts
-            with foo but no index starts with bar.
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`. NOTE: This option is only supported
+            when specifying an index expression. You will get an error if you specify
+            index options to the `_resolve/cluster` API endpoint that takes no index
+            expression.
         :param expand_wildcards: Type of index that wildcard patterns can match. If the
             request can target data streams, this argument determines whether wildcard
             expressions match hidden data streams. Supports comma-separated values, such
             as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-        :param ignore_throttled: If true, concrete, expanded or aliased indices are ignored
-            when frozen. Defaults to false.
+            NOTE: This option is only supported when specifying an index expression.
+            You will get an error if you specify index options to the `_resolve/cluster`
+            API endpoint that takes no index expression.
+        :param ignore_throttled: If true, concrete, expanded, or aliased indices are
+            ignored when frozen. NOTE: This option is only supported when specifying
+            an index expression. You will get an error if you specify index options to
+            the `_resolve/cluster` API endpoint that takes no index expression.
         :param ignore_unavailable: If false, the request returns an error if it targets
-            a missing or closed index. Defaults to false.
+            a missing or closed index. NOTE: This option is only supported when specifying
+            an index expression. You will get an error if you specify index options to
+            the `_resolve/cluster` API endpoint that takes no index expression.
+        :param timeout: The maximum time to wait for remote clusters to respond. If a
+            remote cluster does not respond within this timeout period, the API response
+            will show the cluster as not connected and include an error message that
+            the request timed out. The default timeout is unset and the query can take
+            as long as the networking layer is configured to wait for remote clusters
+            that are not responding (typically 30 seconds).
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path_parts: t.Dict[str, str] = {"name": _quote(name)}
-        __path = f'/_resolve/cluster/{__path_parts["name"]}'
+        __path_parts: t.Dict[str, str]
+        if name not in SKIP_IN_PATH:
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_resolve/cluster/{__path_parts["name"]}'
+        else:
+            __path_parts = {}
+            __path = "/_resolve/cluster"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -4343,6 +4402,8 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if pretty is not None:
             __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "GET",
@@ -4381,7 +4442,7 @@ class IndicesClient(NamespacedClient):
           Multiple patterns and remote clusters are supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-resolve-index>`_
 
         :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
             and data streams to resolve. Resources on remote clusters can be specified
@@ -4482,7 +4543,7 @@ class IndicesClient(NamespacedClient):
           If you roll over the alias on May 7, 2099, the new index's name is <code>my-index-2099.05.07-000002</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-rollover>`_
 
         :param alias: Name of the data stream or index alias to roll over.
         :param new_index: Name of the index to create. Supports date math. Data streams
@@ -4591,7 +4652,7 @@ class IndicesClient(NamespacedClient):
           For data streams, the API returns information about the stream's backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-segments>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4680,7 +4741,7 @@ class IndicesClient(NamespacedClient):
           <p>By default, the API returns store information only for primary shards that are unassigned or have one or more unassigned replica shards.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-shard-stores>`_
 
         :param index: List of data streams, indices, and aliases used to limit the request.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -4782,7 +4843,7 @@ class IndicesClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-shrink>`_
 
         :param index: Name of the source index to shrink.
         :param target: Name of the target index to create.
@@ -4861,7 +4922,7 @@ class IndicesClient(NamespacedClient):
           Get the index configuration that would be applied to the specified index from an existing index template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-simulate-index-template>`_
 
         :param name: Name of the index to simulate
         :param include_defaults: If true, returns all relevant default configurations
@@ -4942,7 +5003,7 @@ class IndicesClient(NamespacedClient):
           Get the index configuration that would be applied by a particular index template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-simulate-template>`_
 
         :param name: Name of the index template to simulate. To test a template configuration
             before you add it to the cluster, omit this parameter and specify the template
@@ -5110,7 +5171,7 @@ class IndicesClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-split>`_
 
         :param index: Name of the source index to split.
         :param target: Name of the target index to create.
@@ -5212,7 +5273,7 @@ class IndicesClient(NamespacedClient):
           Although the shard is no longer part of the node, that node retains any node-level statistics to which the shard contributed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-stats>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices

--- a/elasticsearch/_async/client/inference.py
+++ b/elasticsearch/_async/client/inference.py
@@ -49,14 +49,14 @@ class InferenceClient(NamespacedClient):
           <p>Delete an inference endpoint</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-delete>`_
 
-        :param inference_id: The inference Id
+        :param inference_id: The inference identifier.
         :param task_type: The task type
-        :param dry_run: When true, the endpoint is not deleted, and a list of ingest
-            processors which reference this endpoint is returned
+        :param dry_run: When true, the endpoint is not deleted and a list of ingest processors
+            which reference this endpoint is returned.
         :param force: When true, the inference endpoint is forcefully deleted even if
-            it is still being used by ingest processors or semantic text fields
+            it is still being used by ingest processors or semantic text fields.
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
@@ -117,7 +117,7 @@ class InferenceClient(NamespacedClient):
           <p>Get an inference endpoint</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-get>`_
 
         :param task_type: The task type
         :param inference_id: The inference Id
@@ -180,18 +180,29 @@ class InferenceClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Perform inference on the service</p>
+          <p>Perform inference on the service.</p>
+          <p>This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.
+          It returns a response with the results of the tasks.
+          The inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.</p>
+          <blockquote>
+          <p>info
+          The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-inference>`_
 
-        :param inference_id: The inference Id
-        :param input: Inference input. Either a string or an array of strings.
-        :param task_type: The task type
-        :param query: Query input, required for rerank task. Not required for other tasks.
-        :param task_settings: Optional task settings
-        :param timeout: Specifies the amount of time to wait for the inference request
-            to complete.
+        :param inference_id: The unique identifier for the inference endpoint.
+        :param input: The text on which you want to perform the inference task. It can
+            be a single string or an array. > info > Inference endpoints for the `completion`
+            task type currently only support a single string as input.
+        :param task_type: The type of inference task that the model performs.
+        :param query: The query input, which is required only for the `rerank` task.
+            It is not required for other tasks.
+        :param task_settings: Task settings for the individual inference request. These
+            settings are specific to the task type you specified and override the task
+            settings specified when initializing the service.
+        :param timeout: The amount of time to wait for the inference request to complete.
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
@@ -277,7 +288,7 @@ class InferenceClient(NamespacedClient):
           However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put>`_
 
         :param inference_id: The inference Id
         :param inference_config:
@@ -354,7 +365,7 @@ class InferenceClient(NamespacedClient):
           However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-update>`_
 
         :param inference_id: The unique identifier of the inference endpoint.
         :param inference_config:

--- a/elasticsearch/_async/client/ingest.py
+++ b/elasticsearch/_async/client/ingest.py
@@ -40,18 +40,18 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete GeoIP database configurations.
-          Delete one or more IP geolocation database configurations.</p>
+          <p>Delete GeoIP database configurations.</p>
+          <p>Delete one or more IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-geoip-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-delete-geoip-database>`_
 
         :param id: A comma-separated list of geoip database configurations to delete
-        :param master_timeout: Period to wait for a connection to the master node. If
-            no response is received before the timeout expires, the request fails and
-            returns an error.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -98,7 +98,7 @@ class IngestClient(NamespacedClient):
           <p>Delete IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-ip-location-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-delete-ip-location-database>`_
 
         :param id: A comma-separated list of IP location database configurations.
         :param master_timeout: The period to wait for a connection to the master node.
@@ -155,7 +155,7 @@ class IngestClient(NamespacedClient):
           Delete one or more ingest pipelines.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-delete-pipeline>`_
 
         :param id: Pipeline ID or wildcard expression of pipeline IDs used to limit the
             request. To delete all ingest pipelines in a cluster, use a value of `*`.
@@ -244,15 +244,15 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get GeoIP database configurations.
-          Get information about one or more IP geolocation database configurations.</p>
+          <p>Get GeoIP database configurations.</p>
+          <p>Get information about one or more IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-geoip-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-get-geoip-database>`_
 
-        :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
-            (`*`) expressions are supported. To get all database configurations, omit
-            this parameter or use `*`.
+        :param id: A comma-separated list of database configuration IDs to retrieve.
+            Wildcard (`*`) expressions are supported. To get all database configurations,
+            omit this parameter or use `*`.
         """
         __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
@@ -297,7 +297,7 @@ class IngestClient(NamespacedClient):
           <p>Get IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ip-location-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-get-ip-location-database>`_
 
         :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
             (`*`) expressions are supported. To get all database configurations, omit
@@ -350,12 +350,12 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get pipelines.
-          Get information about one or more ingest pipelines.
+          <p>Get pipelines.</p>
+          <p>Get information about one or more ingest pipelines.
           This API returns a local reference of the pipeline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-get-pipeline>`_
 
         :param id: Comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions
             are supported. To get all ingest pipelines, omit this parameter or use `*`.
@@ -455,11 +455,11 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Create or update a GeoIP database configuration.
-          Refer to the create or update IP geolocation database configuration API.</p>
+          <p>Create or update a GeoIP database configuration.</p>
+          <p>Refer to the create or update IP geolocation database configuration API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-geoip-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-put-geoip-database>`_
 
         :param id: ID of the database configuration to create or update.
         :param maxmind: The configuration necessary to identify which IP geolocation
@@ -534,7 +534,7 @@ class IngestClient(NamespacedClient):
           <p>Create or update an IP geolocation database configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-ip-location-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-put-ip-location-database>`_
 
         :param id: The database configuration identifier.
         :param configuration:
@@ -712,17 +712,17 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Simulate a pipeline.
-          Run an ingest pipeline against a set of provided documents.
+          <p>Simulate a pipeline.</p>
+          <p>Run an ingest pipeline against a set of provided documents.
           You can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-simulate>`_
 
         :param docs: Sample documents to test in the pipeline.
-        :param id: Pipeline to test. If you don’t specify a `pipeline` in the request
+        :param id: The pipeline to test. If you don't specify a `pipeline` in the request
             body, this parameter is required.
-        :param pipeline: Pipeline to test. If you don’t specify the `pipeline` request
+        :param pipeline: The pipeline to test. If you don't specify the `pipeline` request
             path parameter, this parameter is required. If you specify both this and
             the request path parameter, the API only uses the request path parameter.
         :param verbose: If `true`, the response includes output data for each processor

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -39,16 +39,16 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete the license.
-          When the license expires, your subscription level reverts to Basic.</p>
+          <p>Delete the license.</p>
+          <p>When the license expires, your subscription level reverts to Basic.</p>
           <p>If the operator privileges feature is enabled, only operator users can use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-delete>`_
 
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license"
@@ -89,13 +89,16 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get license information.
-          Get information about your Elastic license including its type, its status, when it was issued, and when it expires.</p>
-          <p>NOTE: If the master node is generating a new cluster state, the get license API may return a <code>404 Not Found</code> response.
+          <p>Get license information.</p>
+          <p>Get information about your Elastic license including its type, its status, when it was issued, and when it expires.</p>
+          <blockquote>
+          <p>info
+          If the master node is generating a new cluster state, the get license API may return a <code>404 Not Found</code> response.
           If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-get>`_
 
         :param accept_enterprise: If `true`, this parameter returns enterprise for Enterprise
             license types. If `false`, this parameter returns platinum for both platinum
@@ -144,7 +147,7 @@ class LicenseClient(NamespacedClient):
           <p>Get the basic license status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-get-basic-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/basic_status"
@@ -182,7 +185,7 @@ class LicenseClient(NamespacedClient):
           <p>Get the trial status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-get-trial-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/trial_status"
@@ -225,8 +228,8 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Update the license.
-          You can update your license at runtime without shutting down your nodes.
+          <p>Update the license.</p>
+          <p>You can update your license at runtime without shutting down your nodes.
           License updates take effect immediately.
           If the license you are installing does not support all of the features that were available with your previous license, however, you are notified in the response.
           You must then re-submit the API request with the acknowledge parameter set to true.</p>
@@ -234,15 +237,15 @@ class LicenseClient(NamespacedClient):
           If the operator privileges feature is enabled, only operator users can use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:
         :param licenses: A sequence of one or more JSON documents containing the license
             information.
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license"
@@ -297,15 +300,15 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Start a basic license.
-          Start an indefinite basic license, which gives access to all the basic features.</p>
+          <p>Start a basic license.</p>
+          <p>Start an indefinite basic license, which gives access to all the basic features.</p>
           <p>NOTE: In order to start a basic license, you must not currently have a basic license.</p>
           <p>If the basic license does not support all of the features that are available with your current license, however, you are notified in the response.
           You must then re-submit the API request with the <code>acknowledge</code> parameter set to <code>true</code>.</p>
           <p>To check the status of your basic license, use the get basic license API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post-start-basic>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
@@ -362,7 +365,7 @@ class LicenseClient(NamespacedClient):
           <p>To check the status of your trial, use the get trial status API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post-start-trial>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)

--- a/elasticsearch/_async/client/logstash.py
+++ b/elasticsearch/_async/client/logstash.py
@@ -43,7 +43,7 @@ class LogstashClient(NamespacedClient):
           If the request succeeds, you receive an empty response with an appropriate status code.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-delete-pipeline.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-logstash-delete-pipeline>`_
 
         :param id: An identifier for the pipeline.
         """
@@ -87,7 +87,7 @@ class LogstashClient(NamespacedClient):
           Get pipelines that are used for Logstash Central Management.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-get-pipeline.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-logstash-get-pipeline>`_
 
         :param id: A comma-separated list of pipeline identifiers.
         """
@@ -139,7 +139,7 @@ class LogstashClient(NamespacedClient):
           If the specified pipeline exists, it is replaced.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-put-pipeline.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-logstash-put-pipeline>`_
 
         :param id: An identifier for the pipeline.
         :param pipeline:

--- a/elasticsearch/_async/client/migration.py
+++ b/elasticsearch/_async/client/migration.py
@@ -44,7 +44,7 @@ class MigrationClient(NamespacedClient):
           You are strongly recommended to use the Upgrade Assistant.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-deprecations>`_
 
         :param index: Comma-separate list of data streams or indices to check. Wildcard
             (*) expressions are supported.
@@ -94,7 +94,7 @@ class MigrationClient(NamespacedClient):
           You are strongly recommended to use the Upgrade Assistant.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/feature-migration-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-get-feature-upgrade-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"
@@ -136,7 +136,7 @@ class MigrationClient(NamespacedClient):
           <p>TIP: The API is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/feature-migration-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-get-feature-upgrade-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -38,14 +38,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Clear trained model deployment cache.
-          Cache will be cleared on all nodes where the trained model is assigned.
+          <p>Clear trained model deployment cache.</p>
+          <p>Cache will be cleared on all nodes where the trained model is assigned.
           A trained model deployment may have an inference cache enabled.
           As requests are handled by each allocated node, their responses may be cached on that individual node.
           Calling this API clears the caches without restarting the deployment.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-trained-model-deployment-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-clear-trained-model-deployment-cache>`_
 
         :param model_id: The unique identifier of the trained model.
         """
@@ -93,14 +93,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Close anomaly detection jobs.
-          A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.
+          <p>Close anomaly detection jobs.</p>
+          <p>A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.
           When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data.
           If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.
           When a datafeed that has a specified end date stops, it automatically closes its associated job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-close-job>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. You can close multiple anomaly detection
@@ -161,11 +161,11 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a calendar.
-          Removes all scheduled events from a calendar, then deletes it.</p>
+          <p>Delete a calendar.</p>
+          <p>Remove all scheduled events from a calendar, then delete it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-calendar>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         """
@@ -209,7 +209,7 @@ class MlClient(NamespacedClient):
           <p>Delete events from a calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-calendar-event>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param event_id: Identifier for the scheduled event. You can obtain this identifier
@@ -260,7 +260,7 @@ class MlClient(NamespacedClient):
           <p>Delete anomaly jobs from a calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-calendar-job>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -312,7 +312,7 @@ class MlClient(NamespacedClient):
           <p>Delete a data frame analytics job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job.
         :param force: If `true`, it deletes a job that is not stopped; this method is
@@ -363,7 +363,7 @@ class MlClient(NamespacedClient):
           <p>Delete a datafeed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -415,18 +415,18 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete expired ML data.
-          Deletes all job results, model snapshots and forecast data that have exceeded
+          <p>Delete expired ML data.</p>
+          <p>Delete all job results, model snapshots and forecast data that have exceeded
           their retention days period. Machine learning state documents that are not
           associated with any job are also deleted.
           You can limit the request to a single or set of anomaly detection jobs by
           using a job identifier, a group name, a comma-separated list of jobs, or a
           wildcard expression. You can delete expired data for all anomaly detection
-          jobs by using _all, by specifying * as the &lt;job_id&gt;, or by omitting the
-          &lt;job_id&gt;.</p>
+          jobs by using <code>_all</code>, by specifying <code>*</code> as the <code>&lt;job_id&gt;</code>, or by omitting the
+          <code>&lt;job_id&gt;</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-expired-data.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-expired-data>`_
 
         :param job_id: Identifier for an anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression.
@@ -485,12 +485,12 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a filter.
-          If an anomaly detection job references the filter, you cannot delete the
+          <p>Delete a filter.</p>
+          <p>If an anomaly detection job references the filter, you cannot delete the
           filter. You must update or delete the job before you can delete the filter.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-filter>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         """
@@ -533,14 +533,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete forecasts from a job.
-          By default, forecasts are retained for 14 days. You can specify a
+          <p>Delete forecasts from a job.</p>
+          <p>By default, forecasts are retained for 14 days. You can specify a
           different retention period with the <code>expires_in</code> parameter in the forecast
           jobs API. The delete forecast API enables you to delete one or more
           forecasts before they expire.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-forecast.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-forecast>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param forecast_id: A comma-separated list of forecast identifiers. If you do
@@ -607,8 +607,8 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete an anomaly detection job.
-          All job configuration, model state and results are deleted.
+          <p>Delete an anomaly detection job.</p>
+          <p>All job configuration, model state and results are deleted.
           It is not currently possible to delete multiple jobs using wildcards or a
           comma separated list. If you delete a job that has a datafeed, the request
           first tries to delete the datafeed. This behavior is equivalent to calling
@@ -616,7 +616,7 @@ class MlClient(NamespacedClient):
           delete job request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-job>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -670,13 +670,13 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a model snapshot.
-          You cannot delete the active model snapshot. To delete that snapshot, first
+          <p>Delete a model snapshot.</p>
+          <p>You cannot delete the active model snapshot. To delete that snapshot, first
           revert to a different one. To identify the active model snapshot, refer to
           the <code>model_snapshot_id</code> in the results from the get jobs API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-model-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -724,11 +724,11 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete an unreferenced trained model.
-          The request deletes a trained inference model that is not referenced by an ingest pipeline.</p>
+          <p>Delete an unreferenced trained model.</p>
+          <p>The request deletes a trained inference model that is not referenced by an ingest pipeline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-trained-model>`_
 
         :param model_id: The unique identifier of the trained model.
         :param force: Forcefully deletes a trained model that is referenced by ingest
@@ -777,13 +777,13 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a trained model alias.
-          This API deletes an existing model alias that refers to a trained model. If
+          <p>Delete a trained model alias.</p>
+          <p>This API deletes an existing model alias that refers to a trained model. If
           the model alias is missing or refers to a model other than the one identified
           by the <code>model_id</code>, this API returns an error.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models-aliases.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-trained-model-alias>`_
 
         :param model_id: The trained model ID to which the model alias refers.
         :param model_alias: The model alias to delete.
@@ -838,13 +838,13 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Estimate job model memory usage.
-          Makes an estimation of the memory usage for an anomaly detection job model.
-          It is based on analysis configuration details for the job and cardinality
+          <p>Estimate job model memory usage.</p>
+          <p>Make an estimation of the memory usage for an anomaly detection job model.
+          The estimate is based on analysis configuration details for the job and cardinality
           estimates for the fields it references.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-apis.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-estimate-model-memory>`_
 
         :param analysis_config: For a list of the properties that you can specify in
             the `analysis_config` component of the body of this API.
@@ -909,14 +909,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Evaluate data frame analytics.
-          The API packages together commonly used evaluation metrics for various types
+          <p>Evaluate data frame analytics.</p>
+          <p>The API packages together commonly used evaluation metrics for various types
           of machine learning features. This has been designed for use on indexes
           created by data frame analytics. Evaluation requires both a ground truth
           field and an analytics result field to be present.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-evaluate-data-frame>`_
 
         :param evaluation: Defines the type of evaluation you want to perform.
         :param index: Defines the `index` in which the evaluation will be performed.
@@ -990,8 +990,8 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Explain data frame analytics config.
-          This API provides explanations for a data frame analytics config that either
+          <p>Explain data frame analytics config.</p>
+          <p>This API provides explanations for a data frame analytics config that either
           exists already or one that has not been created yet. The following
           explanations are provided:</p>
           <ul>
@@ -1001,7 +1001,7 @@ class MlClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-explain-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -1112,7 +1112,7 @@ class MlClient(NamespacedClient):
           analyzing further data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-flush-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-flush-job>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param advance_time: Refer to the description for the `advance_time` query parameter.
@@ -1187,7 +1187,7 @@ class MlClient(NamespacedClient):
           based on historical data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-forecast.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-forecast>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must be open
             when you create a forecast; otherwise, an error occurs.
@@ -1273,7 +1273,7 @@ class MlClient(NamespacedClient):
           The API presents a chronological view of the records, grouped by bucket.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-bucket.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-buckets>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timestamp: The timestamp of a single bucket result. If you do not specify
@@ -1371,7 +1371,7 @@ class MlClient(NamespacedClient):
           <p>Get info about events in calendars.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-calendar-events>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1440,7 +1440,7 @@ class MlClient(NamespacedClient):
           <p>Get calendar configuration info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-calendars>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1516,7 +1516,7 @@ class MlClient(NamespacedClient):
           <p>Get anomaly detection job results for categories.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-category.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-categories>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param category_id: Identifier for the category, which is unique in the job.
@@ -1604,7 +1604,7 @@ class MlClient(NamespacedClient):
           wildcard expression.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1679,7 +1679,7 @@ class MlClient(NamespacedClient):
           <p>Get data frame analytics jobs usage info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-data-frame-analytics-stats>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1753,7 +1753,7 @@ class MlClient(NamespacedClient):
           This API returns a maximum of 10,000 datafeeds.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-datafeed-stats>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1817,7 +1817,7 @@ class MlClient(NamespacedClient):
           This API returns a maximum of 10,000 datafeeds.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-datafeeds>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1884,7 +1884,7 @@ class MlClient(NamespacedClient):
           You can get a single filter or all filters.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-filters>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param from_: Skips the specified number of filters.
@@ -1952,7 +1952,7 @@ class MlClient(NamespacedClient):
           <code>influencer_field_name</code> is specified in the job configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-influencer.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-influencers>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: If true, the results are sorted in descending order.
@@ -2036,7 +2036,7 @@ class MlClient(NamespacedClient):
           <p>Get anomaly detection jobs usage info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-job-stats>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs, or a wildcard expression. If
@@ -2100,7 +2100,7 @@ class MlClient(NamespacedClient):
           <code>_all</code>, by specifying <code>*</code> as the <code>&lt;job_id&gt;</code>, or by omitting the <code>&lt;job_id&gt;</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-jobs>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. If you do not specify one of these
@@ -2166,7 +2166,7 @@ class MlClient(NamespacedClient):
           on each node, both within the JVM heap, and natively, outside of the JVM.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-memory.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-memory-stats>`_
 
         :param node_id: The names of particular nodes in the cluster to target. For example,
             `nodeId1,nodeId2` or `ml:true`
@@ -2224,7 +2224,7 @@ class MlClient(NamespacedClient):
           <p>Get anomaly detection job model snapshot upgrade usage info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-model-snapshot-upgrade-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-model-snapshot-upgrade-stats>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2298,7 +2298,7 @@ class MlClient(NamespacedClient):
           <p>Get model snapshots info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-model-snapshots>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2418,7 +2418,7 @@ class MlClient(NamespacedClient):
           jobs' largest bucket span.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-overall-buckets.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-overall-buckets>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs or groups, or a wildcard expression.
@@ -2528,7 +2528,7 @@ class MlClient(NamespacedClient):
           number of detectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-record.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-records>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: Refer to the description for the `desc` query parameter.
@@ -2627,7 +2627,7 @@ class MlClient(NamespacedClient):
           <p>Get trained model configuration info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-trained-models>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             You can get information for multiple trained models in a single API request
@@ -2718,7 +2718,7 @@ class MlClient(NamespacedClient):
           models in a single API request by using a comma-separated list of model IDs or a wildcard expression.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-trained-models-stats>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             It can be a comma-separated list or a wildcard expression.
@@ -2784,7 +2784,7 @@ class MlClient(NamespacedClient):
           <p>Evaluate a trained model.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-infer-trained-model>`_
 
         :param model_id: The unique identifier of the trained model.
         :param docs: An array of objects to pass to the model for inference. The objects
@@ -2851,7 +2851,7 @@ class MlClient(NamespacedClient):
           cluster configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-info>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ml/info"
@@ -2891,8 +2891,8 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Open anomaly detection jobs.
-          An anomaly detection job must be opened to be ready to receive and analyze
+          <p>Open anomaly detection jobs.</p>
+          <p>An anomaly detection job must be opened to be ready to receive and analyze
           data. It can be opened and closed multiple times throughout its lifecycle.
           When you open a new job, it starts with an empty model.
           When you open an existing job, the most recent model state is automatically
@@ -2900,7 +2900,7 @@ class MlClient(NamespacedClient):
           new data is received.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-open-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-open-job>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timeout: Refer to the description for the `timeout` query parameter.
@@ -2957,7 +2957,7 @@ class MlClient(NamespacedClient):
           <p>Add scheduled events to the calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-calendar-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-post-calendar-events>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param events: A list of one of more scheduled events. The event’s start and
@@ -3018,7 +3018,7 @@ class MlClient(NamespacedClient):
           It is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-data.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-post-data>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must have a
             state of open to receive and process the data.
@@ -3082,10 +3082,10 @@ class MlClient(NamespacedClient):
         .. raw:: html
 
           <p>Preview features used by data frame analytics.
-          Previews the extracted features used by a data frame analytics config.</p>
+          Preview the extracted features used by a data frame analytics config.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-preview-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job.
         :param config: A data frame analytics config as described in create data frame
@@ -3158,7 +3158,7 @@ class MlClient(NamespacedClient):
           You can also use secondary authorization headers to supply the credentials.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-preview-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-preview-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3237,7 +3237,7 @@ class MlClient(NamespacedClient):
           <p>Create a calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-calendar>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param description: A description of the calendar.
@@ -3294,7 +3294,7 @@ class MlClient(NamespacedClient):
           <p>Add anomaly detection job to calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-calendar-job>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -3377,7 +3377,7 @@ class MlClient(NamespacedClient):
           <p>If you supply only a subset of the regression or classification parameters, hyperparameter optimization occurs. It determines a value for each of the undefined parameters.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3562,7 +3562,7 @@ class MlClient(NamespacedClient):
           directly to the <code>.ml-config</code> index. Do not give users <code>write</code> privileges on the <code>.ml-config</code> index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3724,7 +3724,7 @@ class MlClient(NamespacedClient):
           Specifically, filters are referenced in the <code>custom_rules</code> property of detector configuration objects.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-filter>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param description: A description of the filter.
@@ -3821,12 +3821,12 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Create an anomaly detection job.
-          If you include a <code>datafeed_config</code>, you must have read index privileges on the source index.
+          <p>Create an anomaly detection job.</p>
+          <p>If you include a <code>datafeed_config</code>, you must have read index privileges on the source index.
           If you include a <code>datafeed_config</code> but do not provide a query, the datafeed uses <code>{&quot;match_all&quot;: {&quot;boost&quot;: 1}}</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-job>`_
 
         :param job_id: The identifier for the anomaly detection job. This identifier
             can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and
@@ -4034,7 +4034,7 @@ class MlClient(NamespacedClient):
           Enable you to supply a trained model that is not created by data frame analytics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model>`_
 
         :param model_id: The unique identifier of the trained model.
         :param compressed_definition: The compressed (GZipped and Base64 encoded) inference
@@ -4155,7 +4155,7 @@ class MlClient(NamespacedClient):
           returns a warning.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models-aliases.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model-alias>`_
 
         :param model_id: The identifier for the trained model that the alias refers to.
         :param model_alias: The alias to create or update. This value cannot end in numbers.
@@ -4216,7 +4216,7 @@ class MlClient(NamespacedClient):
           <p>Create part of a trained model definition.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-definition-part.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model-definition-part>`_
 
         :param model_id: The unique identifier of the trained model.
         :param part: The definition part number. When the definition is loaded for inference
@@ -4298,7 +4298,7 @@ class MlClient(NamespacedClient):
           The vocabulary is stored in the index as described in <code>inference_config.*.vocabulary</code> of the trained model definition.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-vocabulary.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model-vocabulary>`_
 
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
@@ -4361,7 +4361,7 @@ class MlClient(NamespacedClient):
           comma separated list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-reset-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-reset-job>`_
 
         :param job_id: The ID of the job to reset.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -4425,7 +4425,7 @@ class MlClient(NamespacedClient):
           snapshot after Black Friday or a critical system failure.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-revert-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-revert-model-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: You can specify `empty` as the <snapshot_id>. Reverting to
@@ -4500,7 +4500,7 @@ class MlClient(NamespacedClient):
           machine learning info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-set-upgrade-mode.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-set-upgrade-mode>`_
 
         :param enabled: When `true`, it enables `upgrade_mode` which temporarily halts
             all job and datafeed tasks and prohibits new job and datafeed tasks from
@@ -4560,7 +4560,7 @@ class MlClient(NamespacedClient):
           the destination index in advance with custom settings and mappings.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-start-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4623,7 +4623,7 @@ class MlClient(NamespacedClient):
           authorization headers when you created or updated the datafeed, those credentials are used instead.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-start-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -4669,11 +4669,14 @@ class MlClient(NamespacedClient):
             path_parts=__path_parts,
         )
 
-    @_rewrite_parameters()
+    @_rewrite_parameters(
+        body_fields=("adaptive_allocations",),
+    )
     async def start_trained_model_deployment(
         self,
         *,
         model_id: str,
+        adaptive_allocations: t.Optional[t.Mapping[str, t.Any]] = None,
         cache_size: t.Optional[t.Union[int, str]] = None,
         deployment_id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -4688,6 +4691,7 @@ class MlClient(NamespacedClient):
         wait_for: t.Optional[
             t.Union[str, t.Literal["fully_allocated", "started", "starting"]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         .. raw:: html
@@ -4696,10 +4700,13 @@ class MlClient(NamespacedClient):
           It allocates the model to every machine learning node.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-start-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
+        :param adaptive_allocations: Adaptive allocations configuration. When enabled,
+            the number of allocations is set based on the current load. If adaptive_allocations
+            is enabled, do not set the number of allocations manually.
         :param cache_size: The inference cache size (in memory outside the JVM heap)
             per node for the model. The default value is the same size as the `model_size_bytes`.
             To disable the cache, `0b` can be provided.
@@ -4709,7 +4716,8 @@ class MlClient(NamespacedClient):
             model in memory but use a separate set of threads to evaluate the model.
             Increasing this value generally increases the throughput. If this setting
             is greater than the number of hardware threads it will automatically be changed
-            to a value less than the number of hardware threads.
+            to a value less than the number of hardware threads. If adaptive_allocations
+            is enabled, do not set this value, because it’s automatically set.
         :param priority: The deployment priority.
         :param queue_capacity: Specifies the number of inference requests that are allowed
             in the queue. After the number of requests exceeds this value, new requests
@@ -4729,6 +4737,7 @@ class MlClient(NamespacedClient):
         __path_parts: t.Dict[str, str] = {"model_id": _quote(model_id)}
         __path = f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/_start'
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if cache_size is not None:
             __query["cache_size"] = cache_size
         if deployment_id is not None:
@@ -4753,12 +4762,20 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         if wait_for is not None:
             __query["wait_for"] = wait_for
+        if not __body:
+            if adaptive_allocations is not None:
+                __body["adaptive_allocations"] = adaptive_allocations
+        if not __body:
+            __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
         return await self.perform_request(  # type: ignore[return-value]
             "POST",
             __path,
             params=__query,
             headers=__headers,
+            body=__body,
             endpoint_id="ml.start_trained_model_deployment",
             path_parts=__path_parts,
         )
@@ -4784,7 +4801,7 @@ class MlClient(NamespacedClient):
           throughout its lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-stop-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4854,7 +4871,7 @@ class MlClient(NamespacedClient):
           multiple times throughout its lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-stop-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-stop-datafeed>`_
 
         :param datafeed_id: Identifier for the datafeed. You can stop multiple datafeeds
             in a single API request by using a comma-separated list of datafeeds or a
@@ -4919,7 +4936,7 @@ class MlClient(NamespacedClient):
           <p>Stop a trained model deployment.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-stop-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -4987,7 +5004,7 @@ class MlClient(NamespacedClient):
           <p>Update a data frame analytics job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -5102,7 +5119,7 @@ class MlClient(NamespacedClient):
           those credentials are used instead.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -5269,7 +5286,7 @@ class MlClient(NamespacedClient):
           Updates the description of a filter, adds items, or removes items from the list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-filter>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param add_items: The items to add to the filter.
@@ -5363,7 +5380,7 @@ class MlClient(NamespacedClient):
           Updates certain properties of an anomaly detection job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-job>`_
 
         :param job_id: Identifier for the job.
         :param allow_lazy_open: Advanced configuration option. Specifies whether this
@@ -5495,7 +5512,7 @@ class MlClient(NamespacedClient):
           Updates certain properties of a snapshot.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-model-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -5540,12 +5557,13 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=("number_of_allocations",),
+        body_fields=("adaptive_allocations", "number_of_allocations"),
     )
     async def update_trained_model_deployment(
         self,
         *,
         model_id: str,
+        adaptive_allocations: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -5559,16 +5577,20 @@ class MlClient(NamespacedClient):
           <p>Update a trained model deployment.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-trained-model-deployment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
+        :param adaptive_allocations: Adaptive allocations configuration. When enabled,
+            the number of allocations is set based on the current load. If adaptive_allocations
+            is enabled, do not set the number of allocations manually.
         :param number_of_allocations: The number of model allocations on each node where
             the model is deployed. All allocations on a node share the same copy of the
             model in memory but use a separate set of threads to evaluate the model.
             Increasing this value generally increases the throughput. If this setting
             is greater than the number of hardware threads it will automatically be changed
-            to a value less than the number of hardware threads.
+            to a value less than the number of hardware threads. If adaptive_allocations
+            is enabled, do not set this value, because it’s automatically set.
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
@@ -5585,6 +5607,8 @@ class MlClient(NamespacedClient):
         if pretty is not None:
             __query["pretty"] = pretty
         if not __body:
+            if adaptive_allocations is not None:
+                __body["adaptive_allocations"] = adaptive_allocations
             if number_of_allocations is not None:
                 __body["number_of_allocations"] = number_of_allocations
         if not __body:
@@ -5619,7 +5643,7 @@ class MlClient(NamespacedClient):
         .. raw:: html
 
           <p>Upgrade a snapshot.
-          Upgrades an anomaly detection model snapshot to the latest major version.
+          Upgrade an anomaly detection model snapshot to the latest major version.
           Over time, older snapshot formats are deprecated and removed. Anomaly
           detection jobs support only snapshots that are from the current or previous
           major version.
@@ -5630,7 +5654,7 @@ class MlClient(NamespacedClient):
           job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-upgrade-job-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -5782,7 +5806,7 @@ class MlClient(NamespacedClient):
           <p>Validate an anomaly detection job.</p>
 
 
-        `<https://www.elastic.co/guide/en/machine-learning/master/ml-jobs.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch>`_
 
         :param detector:
         """

--- a/elasticsearch/_async/client/monitoring.py
+++ b/elasticsearch/_async/client/monitoring.py
@@ -48,7 +48,7 @@ class MonitoringClient(NamespacedClient):
           This API is used by the monitoring features to send monitoring data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch>`_
 
         :param interval: Collection interval (e.g., '10s' or '10000ms') of the payload
         :param operations:

--- a/elasticsearch/_async/client/nodes.py
+++ b/elasticsearch/_async/client/nodes.py
@@ -50,7 +50,7 @@ class NodesClient(NamespacedClient):
           Clear the archived repositories metering information in the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-repositories-metering-archive-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-clear-repositories-metering-archive>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -105,7 +105,7 @@ class NodesClient(NamespacedClient):
           Additionally, the information exposed by this API is volatile, meaning that it will not be present after node restarts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-repositories-metering-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-get-repositories-metering-info>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -162,7 +162,7 @@ class NodesClient(NamespacedClient):
           The output is plain text with a breakdown of the top hot threads for each node.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-hot-threads>`_
 
         :param node_id: List of node IDs or names used to limit returned information.
         :param ignore_idle_threads: If true, known idle threads (e.g. waiting in a socket
@@ -231,11 +231,11 @@ class NodesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get node information.
-          By default, the API returns all attributes and core settings for cluster nodes.</p>
+          <p>Get node information.</p>
+          <p>By default, the API returns all attributes and core settings for cluster nodes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-info>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -308,7 +308,7 @@ class NodesClient(NamespacedClient):
           Alternatively, you can reload the secure settings on each node by locally accessing the API and passing the node-specific Elasticsearch keystore password.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-reload-secure-settings>`_
 
         :param node_id: The names of particular nodes in the cluster to target.
         :param secure_settings_password: The password for the Elasticsearch keystore.
@@ -383,7 +383,7 @@ class NodesClient(NamespacedClient):
           By default, all stats are returned. You can limit the returned information by using metrics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -498,7 +498,7 @@ class NodesClient(NamespacedClient):
           <p>Get feature usage information.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-usage>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting

--- a/elasticsearch/_async/client/query_rules.py
+++ b/elasticsearch/_async/client/query_rules.py
@@ -44,7 +44,7 @@ class QueryRulesClient(NamespacedClient):
           This is a destructive action that is only recoverable by re-adding the same rule with the create or update query rule API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-delete-rule>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to delete
@@ -97,7 +97,7 @@ class QueryRulesClient(NamespacedClient):
           This is a destructive action that is not recoverable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-delete-ruleset>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to delete
         """
@@ -142,7 +142,7 @@ class QueryRulesClient(NamespacedClient):
           Get details about a query rule within a query ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-get-rule>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to retrieve
@@ -194,7 +194,7 @@ class QueryRulesClient(NamespacedClient):
           Get details about a query ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-get-ruleset>`_
 
         :param ruleset_id: The unique identifier of the query ruleset
         """
@@ -241,7 +241,7 @@ class QueryRulesClient(NamespacedClient):
           Get summarized information about the query rulesets.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-list-rulesets>`_
 
         :param from_: The offset from the first result to fetch.
         :param size: The maximum number of results to retrieve.
@@ -302,7 +302,7 @@ class QueryRulesClient(NamespacedClient):
           If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-put-rule>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to be created or updated.
@@ -389,7 +389,7 @@ class QueryRulesClient(NamespacedClient):
           If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-put-ruleset>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated.
@@ -446,7 +446,7 @@ class QueryRulesClient(NamespacedClient):
           Evaluate match criteria against a query ruleset to identify the rules that would match that criteria.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-test>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated

--- a/elasticsearch/_async/client/rollup.py
+++ b/elasticsearch/_async/client/rollup.py
@@ -67,7 +67,7 @@ class RollupClient(NamespacedClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-delete-job>`_
 
         :param id: Identifier for the job.
         """
@@ -115,7 +115,7 @@ class RollupClient(NamespacedClient):
           For details about a historical rollup job, the rollup capabilities API may be more useful.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-jobs>`_
 
         :param id: Identifier for the rollup job. If it is `_all` or omitted, the API
             returns all rollup jobs.
@@ -171,7 +171,7 @@ class RollupClient(NamespacedClient):
           </ol>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-rollup-caps>`_
 
         :param id: Index, indices or index-pattern to return rollup capabilities for.
             `_all` may be used to fetch rollup capabilities from all jobs.
@@ -225,7 +225,7 @@ class RollupClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-rollup-index-caps>`_
 
         :param index: Data stream or index to check for rollup capabilities. Wildcard
             (`*`) expressions are supported.
@@ -295,7 +295,7 @@ class RollupClient(NamespacedClient):
           <p>Jobs are created in a <code>STOPPED</code> state. You can start them with the start rollup jobs API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-put-job>`_
 
         :param id: Identifier for the rollup job. This can be any alphanumeric string
             and uniquely identifies the data that is associated with the rollup job.
@@ -443,7 +443,7 @@ class RollupClient(NamespacedClient):
           During the merging process, if there is any overlap in buckets between the two responses, the buckets from the non-rollup index are used.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-rollup-search>`_
 
         :param index: A comma-separated list of data streams and indices used to limit
             the request. This parameter has the following rules: * At least one data
@@ -521,7 +521,7 @@ class RollupClient(NamespacedClient):
           If you try to start a job that is already started, nothing happens.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-start-job>`_
 
         :param id: Identifier for the rollup job.
         """
@@ -575,7 +575,7 @@ class RollupClient(NamespacedClient):
           If the specified time elapses without the job moving to STOPPED, a timeout exception occurs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-stop-job>`_
 
         :param id: Identifier for the rollup job.
         :param timeout: If `wait_for_completion` is `true`, the API blocks for (at maximum)

--- a/elasticsearch/_async/client/search_application.py
+++ b/elasticsearch/_async/client/search_application.py
@@ -45,13 +45,13 @@ class SearchApplicationClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a search application.
-          Remove a search application and its associated alias. Indices attached to the search application are not removed.</p>
+          <p>Delete a search application.</p>
+          <p>Remove a search application and its associated alias. Indices attached to the search application are not removed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-search-application.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-delete>`_
 
-        :param name: The name of the search application to delete
+        :param name: The name of the search application to delete.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -94,7 +94,7 @@ class SearchApplicationClient(NamespacedClient):
           The associated data stream is also deleted.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-delete-behavioral-analytics>`_
 
         :param name: The name of the analytics collection to be deleted
         """
@@ -138,7 +138,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Get search application details.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get>`_
 
         :param name: The name of the search application
         """
@@ -182,7 +182,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Get behavioral analytics collections.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get-behavioral-analytics>`_
 
         :param name: A list of analytics collections to limit the returned information
         """
@@ -234,7 +234,7 @@ class SearchApplicationClient(NamespacedClient):
           Get information about search applications.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-search-applications.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get-behavioral-analytics>`_
 
         :param from_: Starting offset.
         :param q: Query in the Lucene query string syntax.
@@ -290,7 +290,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Create a behavioral analytics collection event.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/post-analytics-collection-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-post-behavioral-analytics-event>`_
 
         :param collection_name: The name of the behavioral analytics collection.
         :param event_type: The analytics event type.
@@ -357,7 +357,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Create or update a search application.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-put>`_
 
         :param name: The name of the search application to be created or updated.
         :param search_application:
@@ -414,7 +414,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Create a behavioral analytics collection.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-put-behavioral-analytics>`_
 
         :param name: The name of the analytics collection to be created or updated.
         """
@@ -467,7 +467,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>You must have <code>read</code> privileges on the backing alias of the search application.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-render-query.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-render-query>`_
 
         :param name: The name of the search application to render teh query for.
         :param params:
@@ -531,7 +531,7 @@ class SearchApplicationClient(NamespacedClient):
           Unspecified template parameters are assigned their default values if applicable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-search>`_
 
         :param name: The name of the search application to be searched.
         :param params: Query parameters specific to this request, which will override

--- a/elasticsearch/_async/client/searchable_snapshots.py
+++ b/elasticsearch/_async/client/searchable_snapshots.py
@@ -50,7 +50,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           Get statistics about the shared cache for partially mounted indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-cache-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-cache-stats>`_
 
         :param node_id: The names of the nodes in the cluster to target.
         :param master_timeout:
@@ -111,7 +111,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           Clear indices and data streams from the shared cache for partially mounted indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-clear-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-clear-cache>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             clear from the cache. It supports wildcards (`*`).
@@ -190,7 +190,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           Manually mounting ILM-managed snapshots can interfere with ILM processes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-mount>`_
 
         :param repository: The name of the repository containing the snapshot of the
             index to mount.
@@ -278,7 +278,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           <p>Get searchable snapshot statistics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-stats>`_
 
         :param index: A comma-separated list of data streams and indices to retrieve
             statistics for.

--- a/elasticsearch/_async/client/security.py
+++ b/elasticsearch/_async/client/security.py
@@ -58,7 +58,7 @@ class SecurityClient(NamespacedClient):
           Any updates do not change existing content for either the <code>labels</code> or <code>data</code> fields.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-activate-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-activate-user-profile>`_
 
         :param grant_type: The type of grant.
         :param access_token: The user's Elasticsearch access token or JWT. Both `access`
@@ -124,7 +124,7 @@ class SecurityClient(NamespacedClient):
           If the user cannot be authenticated, this API returns a 401 status code.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-authenticate>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_authenticate"
@@ -171,7 +171,7 @@ class SecurityClient(NamespacedClient):
           The bulk delete roles API cannot delete roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-bulk-delete-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-bulk-delete-role>`_
 
         :param names: An array of role names to delete
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -232,7 +232,7 @@ class SecurityClient(NamespacedClient):
           The bulk create or update roles API cannot update roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-bulk-put-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-bulk-put-role>`_
 
         :param roles: A dictionary of role name to RoleDescriptor objects to add or update
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -300,7 +300,7 @@ class SecurityClient(NamespacedClient):
           <p>A successful request returns a JSON structure that contains the IDs of all updated API keys, the IDs of API keys that already had the requested changes and did not require an update, and error details for any failed update.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-bulk-update-api-keys.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-bulk-update-api-keys>`_
 
         :param ids: The API key identifiers.
         :param expiration: Expiration time for the API keys. By default, API keys never
@@ -378,7 +378,7 @@ class SecurityClient(NamespacedClient):
           <p>Change the passwords of users in the native realm and built-in users.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-change-password.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-change-password>`_
 
         :param username: The user whose password you want to change. If you do not specify
             this parameter, the password is changed for the current user.
@@ -445,7 +445,7 @@ class SecurityClient(NamespacedClient):
           The cache is also automatically cleared on state changes of the security index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-api-key-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-api-key-cache>`_
 
         :param ids: Comma-separated list of API key IDs to evict from the API key cache.
             To evict all API keys, use `*`. Does not support other wildcard patterns.
@@ -491,7 +491,7 @@ class SecurityClient(NamespacedClient):
           The cache is also automatically cleared for applications that have their privileges updated.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-privilege-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-privileges>`_
 
         :param application: A comma-separated list of applications. To clear all applications,
             use an asterism (`*`). It does not support other wildcard patterns.
@@ -541,7 +541,7 @@ class SecurityClient(NamespacedClient):
           For more information, refer to the documentation about controlling the user cache.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-realms>`_
 
         :param realms: A comma-separated list of realms. To clear all realms, use an
             asterisk (`*`). It does not support other wildcard patterns.
@@ -591,7 +591,7 @@ class SecurityClient(NamespacedClient):
           <p>Evict roles from the native role cache.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-role-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-roles>`_
 
         :param name: A comma-separated list of roles to evict from the role cache. To
             evict all roles, use an asterisk (`*`). It does not support other wildcard
@@ -643,7 +643,7 @@ class SecurityClient(NamespacedClient):
           The cache for tokens backed by the <code>service_tokens</code> file is cleared automatically on file changes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-service-token-caches.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-service-tokens>`_
 
         :param namespace: The namespace, which is a top-level grouping of service accounts.
         :param service: The name of the service, which must be unique within its namespace.
@@ -715,7 +715,7 @@ class SecurityClient(NamespacedClient):
           To configure or turn off the API key service, refer to API key service setting documentation.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key>`_
 
         :param expiration: The expiration time for the API key. By default, API keys
             never expire.
@@ -805,7 +805,7 @@ class SecurityClient(NamespacedClient):
           Attempting to update them with the update REST API key API or the bulk update REST API keys API will result in an error.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key>`_
 
         :param access: The access to be granted to this API key. The access is composed
             of permissions for cross-cluster search and cross-cluster replication. At
@@ -880,7 +880,7 @@ class SecurityClient(NamespacedClient):
           You must actively delete them if they are no longer needed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-service-token>`_
 
         :param namespace: The name of the namespace, which is a top-level grouping of
             service accounts.
@@ -966,7 +966,7 @@ class SecurityClient(NamespacedClient):
           The proxy is trusted to have performed the TLS authentication and this API translates that authentication into an Elasticsearch access token.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delegate-pki-authentication.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delegate-pki>`_
 
         :param x509_certificate_chain: The X509Certificate chain, which is represented
             as an ordered string array. Each string in the array is a base64-encoded
@@ -1030,7 +1030,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-privilege.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-privileges>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application.
@@ -1093,7 +1093,7 @@ class SecurityClient(NamespacedClient):
           The delete roles API cannot remove roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-role>`_
 
         :param name: The name of the role.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1147,7 +1147,7 @@ class SecurityClient(NamespacedClient):
           The delete role mappings API cannot remove role mappings that are defined in role mapping files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-role-mapping>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1203,7 +1203,7 @@ class SecurityClient(NamespacedClient):
           <p>Delete service account tokens for a service in a specified namespace.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-service-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-service-token>`_
 
         :param namespace: The namespace, which is a top-level grouping of service accounts.
         :param service: The service name.
@@ -1265,7 +1265,7 @@ class SecurityClient(NamespacedClient):
           <p>Delete users from the native realm.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-user>`_
 
         :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1319,7 +1319,7 @@ class SecurityClient(NamespacedClient):
           You can use this API to revoke a user's access to Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-disable-user>`_
 
         :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1376,7 +1376,7 @@ class SecurityClient(NamespacedClient):
           To re-enable a disabled user profile, use the enable user profile API .</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-disable-user-profile>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1429,7 +1429,7 @@ class SecurityClient(NamespacedClient):
           By default, when you create users, they are enabled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enable-user>`_
 
         :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1486,7 +1486,7 @@ class SecurityClient(NamespacedClient):
           If you later disable the user profile, you can use the enable user profile API to make the profile visible in these searches again.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enable-user-profile>`_
 
         :param uid: A unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1536,7 +1536,7 @@ class SecurityClient(NamespacedClient):
           Kibana uses this API internally to configure itself for communications with an Elasticsearch cluster that already has security features enabled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enroll-kibana>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/kibana"
@@ -1577,7 +1577,7 @@ class SecurityClient(NamespacedClient):
           The response contains key and certificate material that allows the caller to generate valid signed certificates for the HTTP layer of all nodes in the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enroll-node>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/node"
@@ -1626,7 +1626,7 @@ class SecurityClient(NamespacedClient):
           If you have <code>read_security</code>, <code>manage_api_key</code> or greater privileges (including <code>manage_security</code>), this API returns all API keys regardless of ownership.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-api-key>`_
 
         :param active_only: A boolean flag that can be used to query API keys that are
             currently active. An API key is considered active if it is neither invalidated,
@@ -1704,7 +1704,7 @@ class SecurityClient(NamespacedClient):
           <p>Get the list of cluster privileges and index privileges that are available in this version of Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-builtin-privileges>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/privilege/_builtin"
@@ -1749,7 +1749,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-privileges>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -1805,7 +1805,7 @@ class SecurityClient(NamespacedClient):
           The get roles API cannot retrieve roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-role>`_
 
         :param name: The name of the role. You can specify multiple roles as a comma-separated
             list. If you do not specify this parameter, the API returns information about
@@ -1856,7 +1856,7 @@ class SecurityClient(NamespacedClient):
           The get role mappings API cannot retrieve role mappings that are defined in role mapping files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-role-mapping>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1909,7 +1909,7 @@ class SecurityClient(NamespacedClient):
           <p>NOTE: Currently, only the <code>elastic/fleet-server</code> service account is available.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-accounts.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-service-accounts>`_
 
         :param namespace: The name of the namespace. Omit this parameter to retrieve
             information about all service accounts. If you omit this parameter, you must
@@ -1967,7 +1967,7 @@ class SecurityClient(NamespacedClient):
           Tokens with the same name from different nodes are assumed to be the same token and are only counted once towards the total number of service tokens.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-credentials.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-service-credentials>`_
 
         :param namespace: The name of the namespace.
         :param service: The service name.
@@ -2023,7 +2023,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-settings>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -2099,7 +2099,7 @@ class SecurityClient(NamespacedClient):
           If you want to invalidate a token immediately, you can do so by using the invalidate token API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-token>`_
 
         :param grant_type: The type of grant. Supported grant types are: `password`,
             `_kerberos`, `client_credentials`, and `refresh_token`.
@@ -2173,7 +2173,7 @@ class SecurityClient(NamespacedClient):
           <p>Get information about users in the native realm and built-in users.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-user>`_
 
         :param username: An identifier for the user. You can specify multiple usernames
             as a comma-separated list. If you omit this parameter, the API retrieves
@@ -2231,7 +2231,7 @@ class SecurityClient(NamespacedClient):
           To check whether a user has a specific list of privileges, use the has privileges API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-user-privileges>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -2288,7 +2288,7 @@ class SecurityClient(NamespacedClient):
           Elastic reserves the right to change or remove this feature in future releases without prior notice.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-user-profile>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: A comma-separated list of filters for the `data` field of the profile
@@ -2372,7 +2372,7 @@ class SecurityClient(NamespacedClient):
           <p>By default, API keys never expire. You can specify expiration information when you create the API keys.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-grant-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-grant-api-key>`_
 
         :param api_key: The API key.
         :param grant_type: The type of grant. Supported grant types are: `access_token`,
@@ -2519,7 +2519,7 @@ class SecurityClient(NamespacedClient):
           To check the privileges of other users, you must use the run as feature.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-has-privileges>`_
 
         :param user: Username
         :param application:
@@ -2584,7 +2584,7 @@ class SecurityClient(NamespacedClient):
           Elastic reserves the right to change or remove this feature in future releases without prior notice.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-has-privileges-user-profile>`_
 
         :param privileges: An object containing all the privileges to be checked.
         :param uids: A list of profile IDs. The privileges are checked for associated
@@ -2658,7 +2658,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-invalidate-api-key>`_
 
         :param id:
         :param ids: A list of API key ids. This parameter cannot be used with any of
@@ -2742,7 +2742,7 @@ class SecurityClient(NamespacedClient):
           If none of these two are specified, then <code>realm_name</code> and/or <code>username</code> need to be specified.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-invalidate-token>`_
 
         :param realm_name: The name of an authentication realm. This parameter cannot
             be used with either `refresh_token` or `token`.
@@ -2810,7 +2810,7 @@ class SecurityClient(NamespacedClient):
           These APIs are used internally by Kibana in order to provide OpenID Connect based authentication, but can also be used by other, custom web applications or other clients.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-oidc-authenticate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-oidc-authenticate>`_
 
         :param nonce: Associate a client session with an ID token and mitigate replay
             attacks. This value needs to be the same as the one that was provided to
@@ -2890,7 +2890,7 @@ class SecurityClient(NamespacedClient):
           These APIs are used internally by Kibana in order to provide OpenID Connect based authentication, but can also be used by other, custom web applications or other clients.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-oidc-logout.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-oidc-logout>`_
 
         :param access_token: The access token to be invalidated.
         :param refresh_token: The refresh token to be invalidated.
@@ -2952,7 +2952,7 @@ class SecurityClient(NamespacedClient):
           These APIs are used internally by Kibana in order to provide OpenID Connect based authentication, but can also be used by other, custom web applications or other clients.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-oidc-prepare-authentication.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-oidc-prepare-authentication>`_
 
         :param iss: In the case of a third party initiated single sign on, this is the
             issuer identifier for the OP that the RP is to send the authentication request
@@ -3048,7 +3048,7 @@ class SecurityClient(NamespacedClient):
           <p>Action names can contain any number of printable ASCII characters and must contain at least one of the following characters: <code>/</code>, <code>*</code>, <code>:</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-privileges>`_
 
         :param privileges:
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -3200,7 +3200,7 @@ class SecurityClient(NamespacedClient):
           File-based role management is not available in Elastic Serverless.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role>`_
 
         :param name: The name of the role that is being created or updated. On Elasticsearch
             Serverless, the role name must begin with a letter or digit and can only
@@ -3335,7 +3335,7 @@ class SecurityClient(NamespacedClient):
           If the format of the template is set to &quot;json&quot; then the template is expected to produce a JSON string or an array of JSON strings for the role names.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role-mapping>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -3437,7 +3437,7 @@ class SecurityClient(NamespacedClient):
           To change a user's password without updating any other fields, use the change password API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-user>`_
 
         :param username: An identifier for the user. NOTE: Usernames must be at least
             1 and no more than 507 characters. They can contain alphanumeric characters
@@ -3531,7 +3531,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -3556,7 +3556,7 @@ class SecurityClient(NamespacedClient):
           If you have the <code>read_security</code>, <code>manage_api_key</code>, or greater privileges (including <code>manage_security</code>), this API returns all API keys regardless of ownership.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-query-api-keys>`_
 
         :param aggregations: Any aggregations to run over the corpus of returned API
             keys. Aggregations and queries work together. Aggregations are computed only
@@ -3677,7 +3677,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -3699,7 +3699,7 @@ class SecurityClient(NamespacedClient):
           Also, the results can be paginated and sorted.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-query-role>`_
 
         :param from_: The starting document offset. It must not be negative. By default,
             you cannot page through more than 10,000 hits using the `from` and `size`
@@ -3770,7 +3770,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -3792,7 +3792,7 @@ class SecurityClient(NamespacedClient):
           This API is only for native users.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-query-user>`_
 
         :param from_: The starting document offset. It must not be negative. By default,
             you cannot page through more than 10,000 hits using the `from` and `size`
@@ -3885,7 +3885,7 @@ class SecurityClient(NamespacedClient):
           This API endpoint essentially exchanges SAML responses that indicate successful authentication in the IdP for Elasticsearch access and refresh tokens, which can be used for authentication against Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-authenticate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-authenticate>`_
 
         :param content: The SAML response as it was sent by the user's browser, usually
             a Base64 encoded XML document.
@@ -3958,7 +3958,7 @@ class SecurityClient(NamespacedClient):
           The caller of this API must prepare the request accordingly so that this API can handle either of them.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-complete-logout.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-complete-logout>`_
 
         :param ids: A JSON array with all the valid SAML Request Ids that the caller
             of the API has for the current user.
@@ -4034,7 +4034,7 @@ class SecurityClient(NamespacedClient):
           Thus the user can be redirected back to their IdP.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-invalidate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-invalidate>`_
 
         :param query_string: The query part of the URL that the user was redirected to
             by the SAML IdP to initiate the Single Logout. This query should include
@@ -4109,7 +4109,7 @@ class SecurityClient(NamespacedClient):
           If the SAML realm in Elasticsearch is configured accordingly and the SAML IdP supports this, the Elasticsearch response contains a URL to redirect the user to the IdP that contains a SAML logout request (starting an SP-initiated SAML Single Logout).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-logout.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-logout>`_
 
         :param token: The access token that was returned as a response to calling the
             SAML authenticate API. Alternatively, the most recent token that was received
@@ -4179,7 +4179,7 @@ class SecurityClient(NamespacedClient):
           The caller of this API needs to store this identifier as it needs to be used in a following step of the authentication process.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-prepare-authentication.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-prepare-authentication>`_
 
         :param acs: The Assertion Consumer Service URL that matches the one of the SAML
             realms in Elasticsearch. The realm is used to generate the authentication
@@ -4240,7 +4240,7 @@ class SecurityClient(NamespacedClient):
           This API generates Service Provider metadata based on the configuration of a SAML realm in Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-sp-metadata.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-service-provider-metadata>`_
 
         :param realm_name: The name of the SAML realm in Elasticsearch.
         """
@@ -4293,7 +4293,7 @@ class SecurityClient(NamespacedClient):
           Elastic reserves the right to change or remove this feature in future releases without prior notice.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-suggest-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-suggest-user-profiles>`_
 
         :param data: A comma-separated list of filters for the `data` field of the profile
             document. To return all content use `data=*`. To return a subset of content,
@@ -4380,7 +4380,7 @@ class SecurityClient(NamespacedClient):
           This change can occur if the owner user's permissions have changed since the API key was created or last modified.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-api-key>`_
 
         :param id: The ID of the API key to update.
         :param expiration: The expiration time for the API key. By default, API keys
@@ -4468,7 +4468,7 @@ class SecurityClient(NamespacedClient):
           <p>NOTE: This API cannot update REST API keys, which should be updated by either the update API key or bulk update API keys API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-cross-cluster-api-key>`_
 
         :param id: The ID of the cross-cluster API key to update.
         :param access: The access to be granted to this API key. The access is composed
@@ -4547,7 +4547,7 @@ class SecurityClient(NamespacedClient):
           This API does not yet support configuring the settings for indices before they are in use.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-settings>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -4632,7 +4632,7 @@ class SecurityClient(NamespacedClient):
           The <code>update_profile_data</code> global privilege grants privileges for updating only the allowed namespaces.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-user-profile-data.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-user-profile-data>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: Non-searchable data that you want to associate with the user profile.

--- a/elasticsearch/_async/client/shutdown.py
+++ b/elasticsearch/_async/client/shutdown.py
@@ -53,7 +53,7 @@ class ShutdownClient(NamespacedClient):
           <p>If the operator privileges feature is enabled, you must be an operator to use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-shutdown.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-shutdown-delete-node>`_
 
         :param node_id: The node id of node to be removed from the shutdown state
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -112,7 +112,7 @@ class ShutdownClient(NamespacedClient):
           <p>If the operator privileges feature is enabled, you must be an operator to use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-shutdown.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-shutdown-get-node>`_
 
         :param node_id: Which node for which to retrieve the shutdown status
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -187,7 +187,7 @@ class ShutdownClient(NamespacedClient):
           Monitor the node shutdown status to determine when it is safe to stop Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-shutdown.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-shutdown-put-node>`_
 
         :param node_id: The node identifier. This parameter is not validated against
             the cluster's active nodes. This enables you to register a node for shut

--- a/elasticsearch/_async/client/simulate.py
+++ b/elasticsearch/_async/client/simulate.py
@@ -81,7 +81,7 @@ class SimulateClient(NamespacedClient):
           These will be used in place of the pipeline definitions that are already in the system. This can be used to replace existing pipeline definitions or to create new ones. The pipeline substitutions are used only within this request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-ingest-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-simulate-ingest>`_
 
         :param docs: Sample documents to test in the pipeline.
         :param index: The index to simulate ingesting into. This value can be overridden

--- a/elasticsearch/_async/client/slm.py
+++ b/elasticsearch/_async/client/slm.py
@@ -45,7 +45,7 @@ class SlmClient(NamespacedClient):
           This operation prevents any future snapshots from being taken but does not cancel in-progress snapshots or remove previously-taken snapshots.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-delete-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-delete-lifecycle>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to remove
         :param master_timeout: The period to wait for a connection to the master node.
@@ -101,7 +101,7 @@ class SlmClient(NamespacedClient):
           The snapshot policy is normally applied according to its schedule, but you might want to manually run a policy before performing an upgrade or other maintenance.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-execute-lifecycle>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to be executed
         :param master_timeout: The period to wait for a connection to the master node.
@@ -156,7 +156,7 @@ class SlmClient(NamespacedClient):
           The retention policy is normally applied according to its schedule.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-execute-retention>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -208,7 +208,7 @@ class SlmClient(NamespacedClient):
           Get snapshot lifecycle policy definitions and information about the latest snapshot attempts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-get-lifecycle>`_
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         :param master_timeout: The period to wait for a connection to the master node.
@@ -265,7 +265,7 @@ class SlmClient(NamespacedClient):
           Get global and policy-level statistics about actions taken by snapshot lifecycle management.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-get-stats>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -315,7 +315,7 @@ class SlmClient(NamespacedClient):
           <p>Get the snapshot lifecycle management status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-get-status>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -379,7 +379,7 @@ class SlmClient(NamespacedClient):
           Only the latest version of a policy is stored.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-put-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-put-lifecycle>`_
 
         :param policy_id: The identifier for the snapshot lifecycle policy you want to
             create or update.
@@ -465,7 +465,7 @@ class SlmClient(NamespacedClient):
           Manually starting SLM is necessary only if it has been stopped using the stop SLM API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-start>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -523,7 +523,7 @@ class SlmClient(NamespacedClient):
           Use the get snapshot lifecycle management status API to see if SLM is running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-stop>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/_async/client/snapshot.py
+++ b/elasticsearch/_async/client/snapshot.py
@@ -50,7 +50,7 @@ class SnapshotClient(NamespacedClient):
           Trigger the review of the contents of a snapshot repository and delete any stale data not referenced by existing snapshots.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-cleanup-repository>`_
 
         :param name: The name of the snapshot repository to clean up.
         :param master_timeout: The period to wait for a connection to the master node.
@@ -115,7 +115,7 @@ class SnapshotClient(NamespacedClient):
           Clone part of all of a snapshot into another snapshot in the same repository.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clone-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-clone>`_
 
         :param repository: The name of the snapshot repository that both source and target
             snapshot belong to.
@@ -216,7 +216,7 @@ class SnapshotClient(NamespacedClient):
           Take a snapshot of a cluster or of data streams and indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-create>`_
 
         :param repository: The name of the repository for the snapshot.
         :param snapshot: The name of the snapshot. It supportes date math. It must be
@@ -343,7 +343,7 @@ class SnapshotClient(NamespacedClient):
           If both parameters are specified, only the query parameter is used.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-create-repository>`_
 
         :param name: The name of the snapshot repository to register or update.
         :param repository:
@@ -415,7 +415,7 @@ class SnapshotClient(NamespacedClient):
           <p>Delete snapshots.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-delete>`_
 
         :param repository: The name of the repository to delete a snapshot from.
         :param snapshot: A comma-separated list of snapshot names to delete. It also
@@ -474,7 +474,7 @@ class SnapshotClient(NamespacedClient):
           The snapshots themselves are left untouched and in place.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-delete-repository>`_
 
         :param name: The ame of the snapshot repositories to unregister. Wildcard (`*`)
             patterns are supported.
@@ -560,7 +560,7 @@ class SnapshotClient(NamespacedClient):
           Snapshots concurrently created may be seen during an iteration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-get>`_
 
         :param repository: A comma-separated list of snapshot repository names used to
             limit the request. Wildcard (`*`) expressions are supported.
@@ -686,7 +686,7 @@ class SnapshotClient(NamespacedClient):
           <p>Get snapshot repository information.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-get-repository>`_
 
         :param name: A comma-separated list of snapshot repository names used to limit
             the request. Wildcard (`*`) expressions are supported including combining
@@ -830,7 +830,7 @@ class SnapshotClient(NamespacedClient):
           Some operations also verify the behavior on small blobs with sizes other than 8 bytes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/repo-analysis-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-repository-analyze>`_
 
         :param name: The name of the repository.
         :param blob_count: The total number of blobs to write to the repository during
@@ -963,7 +963,7 @@ class SnapshotClient(NamespacedClient):
           The response body format is therefore not considered stable and may be different in newer versions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/verify-repo-integrity-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-repository-verify-integrity>`_
 
         :param name: The name of the snapshot repository.
         :param blob_thread_pool_concurrency: If `verify_blob_contents` is `true`, this
@@ -1085,7 +1085,7 @@ class SnapshotClient(NamespacedClient):
           <p>If your snapshot contains data from App Search or Workplace Search, you must restore the Enterprise Search encryption key before you restore the snapshot.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/restore-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-restore>`_
 
         :param repository: The name of the repository to restore a snapshot from.
         :param snapshot: The name of the snapshot to restore.
@@ -1235,7 +1235,7 @@ class SnapshotClient(NamespacedClient):
           These requests can also tax machine resources and, when using cloud storage, incur high processing costs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-snapshot-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-status>`_
 
         :param repository: The snapshot repository name used to limit the request. It
             supports wildcards (`*`) if `<snapshot>` isn't specified.
@@ -1303,7 +1303,7 @@ class SnapshotClient(NamespacedClient):
           Check for common misconfigurations in a snapshot repository.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/verify-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-verify-repository>`_
 
         :param name: The name of the snapshot repository to verify.
         :param master_timeout: The period to wait for the master node. If the master

--- a/elasticsearch/_async/client/sql.py
+++ b/elasticsearch/_async/client/sql.py
@@ -44,7 +44,7 @@ class SqlClient(NamespacedClient):
           <p>Clear an SQL search cursor.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-sql-cursor-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-clear-cursor>`_
 
         :param cursor: Cursor to clear.
         """
@@ -99,7 +99,7 @@ class SqlClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-async-sql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-delete-async>`_
 
         :param id: The identifier for the search.
         """
@@ -150,7 +150,7 @@ class SqlClient(NamespacedClient):
           <p>If the Elasticsearch security features are enabled, only the user who first submitted the SQL search can retrieve the search using this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-get-async>`_
 
         :param id: The identifier for the search.
         :param delimiter: The separator for CSV results. The API supports this parameter
@@ -212,7 +212,7 @@ class SqlClient(NamespacedClient):
           Get the current status of an async SQL search or a stored synchronous SQL search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-get-async-status>`_
 
         :param id: The identifier for the search.
         """
@@ -301,7 +301,7 @@ class SqlClient(NamespacedClient):
           Run an SQL request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-query>`_
 
         :param allow_partial_search_results: If `true`, the response has partial results
             when there are shard request timeouts or shard failures. If `false`, the
@@ -427,7 +427,7 @@ class SqlClient(NamespacedClient):
           It accepts the same request body parameters as the SQL search API, excluding <code>cursor</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-translate>`_
 
         :param query: The SQL query to run.
         :param fetch_size: The maximum number of rows (or entries) to return in one response.

--- a/elasticsearch/_async/client/ssl.py
+++ b/elasticsearch/_async/client/ssl.py
@@ -52,7 +52,7 @@ class SslClient(NamespacedClient):
           <p>If Elasticsearch is configured to use a keystore or truststore, the API output includes all certificates in that store, even though some of the certificates might not be in active use within the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ssl-certificates>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ssl/certificates"

--- a/elasticsearch/_async/client/synonyms.py
+++ b/elasticsearch/_async/client/synonyms.py
@@ -53,7 +53,7 @@ class SynonymsClient(NamespacedClient):
           When the synonyms set is not used in analyzers, you will be able to delete it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-delete-synonym>`_
 
         :param id: The synonyms set identifier to delete.
         """
@@ -98,7 +98,7 @@ class SynonymsClient(NamespacedClient):
           Delete a synonym rule from a synonym set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonym-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-delete-synonym-rule>`_
 
         :param set_id: The ID of the synonym set to update.
         :param rule_id: The ID of the synonym rule to delete.
@@ -151,7 +151,7 @@ class SynonymsClient(NamespacedClient):
           <p>Get a synonym set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-get-synonym>`_
 
         :param id: The synonyms set identifier to retrieve.
         :param from_: The starting offset for query rules to retrieve.
@@ -202,7 +202,7 @@ class SynonymsClient(NamespacedClient):
           Get a synonym rule from a synonym set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonym-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-get-synonym-rule>`_
 
         :param set_id: The ID of the synonym set to retrieve the synonym rule from.
         :param rule_id: The ID of the synonym rule to retrieve.
@@ -255,7 +255,7 @@ class SynonymsClient(NamespacedClient):
           Get a summary of all defined synonym sets.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-get-synonym>`_
 
         :param from_: The starting offset for synonyms sets to retrieve.
         :param size: The maximum number of synonyms sets to retrieve.
@@ -311,7 +311,7 @@ class SynonymsClient(NamespacedClient):
           This is equivalent to invoking the reload search analyzers API for all indices that use the synonyms set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-put-synonym>`_
 
         :param id: The ID of the synonyms set to be created or updated.
         :param synonyms_set: The synonym rules definitions for the synonyms set.
@@ -370,7 +370,7 @@ class SynonymsClient(NamespacedClient):
           <p>When you update a synonym rule, all analyzers using the synonyms set will be reloaded automatically to reflect the new rule.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonym-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-put-synonym-rule>`_
 
         :param set_id: The ID of the synonym set.
         :param rule_id: The ID of the synonym rule to be updated or created.

--- a/elasticsearch/_async/client/tasks.py
+++ b/elasticsearch/_async/client/tasks.py
@@ -60,7 +60,7 @@ class TasksClient(NamespacedClient):
           You can also use the node hot threads API to obtain detailed information about the work the system is doing instead of completing the cancelled task.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks>`_
 
         :param task_id: The task identifier.
         :param actions: A comma-separated list or wildcard expression of actions that
@@ -128,7 +128,7 @@ class TasksClient(NamespacedClient):
           <p>If the task identifier is not found, a 404 response code indicates that there are no resources that match the request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks>`_
 
         :param task_id: The task identifier.
         :param timeout: The period to wait for a response. If no response is received
@@ -238,7 +238,7 @@ class TasksClient(NamespacedClient):
           The <code>X-Opaque-Id</code> in the children <code>headers</code> is the child task of the task that was initiated by the REST request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks>`_
 
         :param actions: A comma-separated list or wildcard expression of actions used
             to limit the request. For example, you can use `cluser:*` to retrieve all

--- a/elasticsearch/_async/client/text_structure.py
+++ b/elasticsearch/_async/client/text_structure.py
@@ -72,7 +72,7 @@ class TextStructureClient(NamespacedClient):
           It helps determine why the returned structure was chosen.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-field-structure.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-text_structure>`_
 
         :param field: The field that should be analyzed.
         :param index: The name of the index that contains the analyzed field.
@@ -259,7 +259,7 @@ class TextStructureClient(NamespacedClient):
           It helps determine why the returned structure was chosen.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-message-structure.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-text-structure-find-message-structure>`_
 
         :param messages: The list of messages you want to analyze.
         :param column_names: If the format is `delimited`, you can specify the column
@@ -433,7 +433,7 @@ class TextStructureClient(NamespacedClient):
           However, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-structure.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-text-structure-find-structure>`_
 
         :param text_files:
         :param charset: The text's character set. It must be a character set that is
@@ -620,7 +620,7 @@ class TextStructureClient(NamespacedClient):
           The API indicates whether the lines match the pattern together with the offsets and lengths of the matched substrings.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-grok-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-text-structure-test-grok-pattern>`_
 
         :param grok_pattern: The Grok pattern to run on the text.
         :param text: The lines of text to run the Grok pattern on.

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -41,11 +41,10 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a transform.
-          Deletes a transform.</p>
+          <p>Delete a transform.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-delete-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param delete_dest_index: If this value is true, the destination index is deleted
@@ -106,10 +105,10 @@ class TransformClient(NamespacedClient):
         .. raw:: html
 
           <p>Get transforms.
-          Retrieves configuration information for transforms.</p>
+          Get configuration information for transforms.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-get-transform>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -178,11 +177,11 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get transform stats.
-          Retrieves usage information for transforms.</p>
+          <p>Get transform stats.</p>
+          <p>Get usage information for transforms.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-get-transform-stats>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -270,7 +269,7 @@ class TransformClient(NamespacedClient):
           types of the source index and the transform aggregations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-preview-transform>`_
 
         :param transform_id: Identifier for the transform to preview. If you specify
             this path parameter, you cannot provide transform configuration details in
@@ -407,7 +406,7 @@ class TransformClient(NamespacedClient):
           give users any privileges on <code>.data-frame-internal*</code> indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-put-transform>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -508,13 +507,12 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Reset a transform.
-          Resets a transform.
-          Before you can reset it, you must stop it; alternatively, use the <code>force</code> query parameter.
+          <p>Reset a transform.</p>
+          <p>Before you can reset it, you must stop it; alternatively, use the <code>force</code> query parameter.
           If the destination index was created by the transform, it is deleted.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/reset-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -566,15 +564,15 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Schedule a transform to start now.
-          Instantly runs a transform to process data.</p>
-          <p>If you _schedule_now a transform, it will process the new data instantly,
-          without waiting for the configured frequency interval. After _schedule_now API is called,
-          the transform will be processed again at now + frequency unless _schedule_now API
+          <p>Schedule a transform to start now.</p>
+          <p>Instantly run a transform to process data.
+          If you run this API, the transform will process the new data instantly,
+          without waiting for the configured frequency interval. After the API is called,
+          the transform will be processed again at <code>now + frequency</code> unless the API
           is called again in the meantime.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/schedule-now-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-schedule-now-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param timeout: Controls the time to wait for the scheduling to take place
@@ -621,8 +619,7 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Start a transform.
-          Starts a transform.</p>
+          <p>Start a transform.</p>
           <p>When you start a transform, it creates the destination index if it does not already exist. The <code>number_of_shards</code> is
           set to <code>1</code> and the <code>auto_expand_replicas</code> is set to <code>0-1</code>. If it is a pivot transform, it deduces the mapping
           definitions for the destination index from the source indices and the transform aggregations. If fields in the
@@ -638,7 +635,7 @@ class TransformClient(NamespacedClient):
           destination indices, the transform fails when it attempts unauthorized operations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-start-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param from_: Restricts the set of transformed entities to those changed after
@@ -696,7 +693,7 @@ class TransformClient(NamespacedClient):
           Stops one or more transforms.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-stop-transform>`_
 
         :param transform_id: Identifier for the transform. To stop multiple transforms,
             use a comma-separated list or a wildcard expression. To stop all transforms,
@@ -798,7 +795,7 @@ class TransformClient(NamespacedClient):
           time of update and runs with those privileges.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-update-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -879,8 +876,8 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Upgrade all transforms.
-          Transforms are compatible across minor versions and between supported major versions.
+          <p>Upgrade all transforms.</p>
+          <p>Transforms are compatible across minor versions and between supported major versions.
           However, over time, the format of transform configuration information may change.
           This API identifies transforms that have a legacy configuration format and upgrades them to the latest version.
           It also cleans up the internal data structures that store the transform state and checkpoints.
@@ -893,7 +890,7 @@ class TransformClient(NamespacedClient):
           You may want to perform a recent cluster backup prior to the upgrade.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/upgrade-transforms.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-upgrade-transforms>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -48,7 +48,7 @@ class WatcherClient(NamespacedClient):
           This happens when the condition of the watch is not met (the condition evaluates to false).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-ack-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-ack-watch>`_
 
         :param watch_id: The watch identifier.
         :param action_id: A comma-separated list of the action identifiers to acknowledge.
@@ -104,7 +104,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-activate-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-activate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -148,7 +148,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-deactivate-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-deactivate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -196,7 +196,7 @@ class WatcherClient(NamespacedClient):
           When Elasticsearch security features are enabled, make sure no write privileges are granted to anyone for the <code>.watches</code> index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-delete-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-delete-watch>`_
 
         :param id: The watch identifier.
         """
@@ -277,7 +277,7 @@ class WatcherClient(NamespacedClient):
           <p>When using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-execute-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-execute-watch>`_
 
         :param id: The watch identifier.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -365,7 +365,7 @@ class WatcherClient(NamespacedClient):
           Only a subset of settings are shown, for example <code>index.auto_expand_replicas</code> and <code>index.number_of_replicas</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-settings>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -410,7 +410,7 @@ class WatcherClient(NamespacedClient):
           <p>Get a watch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-watch>`_
 
         :param id: The watch identifier.
         """
@@ -485,7 +485,7 @@ class WatcherClient(NamespacedClient):
           If the user is able to read index <code>a</code>, but not index <code>b</code>, the same will apply when the watch runs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-put-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-put-watch>`_
 
         :param id: The identifier for the watch.
         :param actions: The list of actions that will be run if the condition matches.
@@ -579,7 +579,7 @@ class WatcherClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -598,7 +598,7 @@ class WatcherClient(NamespacedClient):
           <p>Note that only the <code>_id</code> and <code>metadata.*</code> fields are queryable or sortable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-query-watches.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-query-watches>`_
 
         :param from_: The offset from the first result to fetch. It must be non-negative.
         :param query: A query that filters the watches to be returned.
@@ -673,7 +673,7 @@ class WatcherClient(NamespacedClient):
           Start the Watcher service if it is not already running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-start>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -739,7 +739,7 @@ class WatcherClient(NamespacedClient):
           You retrieve more metrics by using the metric parameter.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stats>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -790,7 +790,7 @@ class WatcherClient(NamespacedClient):
           Stop the Watcher service if it is running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stop>`_
 
         :param master_timeout: The period to wait for the master node. If the master
             node is not available before the timeout expires, the request fails and returns
@@ -848,7 +848,7 @@ class WatcherClient(NamespacedClient):
           This includes <code>index.auto_expand_replicas</code> and <code>index.number_of_replicas</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-update-settings>`_
 
         :param index_auto_expand_replicas:
         :param index_number_of_replicas:

--- a/elasticsearch/_async/client/xpack.py
+++ b/elasticsearch/_async/client/xpack.py
@@ -54,7 +54,7 @@ class XPackClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/info-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-info>`_
 
         :param accept_enterprise: If this param is used it must be set to true
         :param categories: A comma-separated list of the information categories to include
@@ -103,7 +103,7 @@ class XPackClient(NamespacedClient):
           The API also provides some usage statistics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/usage-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-xpack>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -626,6 +626,7 @@ class Elasticsearch(BaseClient):
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
+        include_source_on_error: t.Optional[bool] = None,
         list_executed_pipelines: t.Optional[bool] = None,
         pipeline: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
@@ -728,11 +729,13 @@ class Elasticsearch(BaseClient):
           The other two shards that make up the index do not participate in the <code>_bulk</code> request at all.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk>`_
 
         :param operations:
         :param index: The name of the data stream, index, or index alias to perform bulk
             actions on.
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param list_executed_pipelines: If `true`, the response will include the ingest
             pipelines that were run for each index or create.
         :param pipeline: The pipeline identifier to use to preprocess incoming documents.
@@ -790,6 +793,8 @@ class Elasticsearch(BaseClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if list_executed_pipelines is not None:
             __query["list_executed_pipelines"] = list_executed_pipelines
         if pipeline is not None:
@@ -849,7 +854,7 @@ class Elasticsearch(BaseClient):
           Clear the search context and results for a scrolling search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-clear-scroll>`_
 
         :param scroll_id: The scroll IDs to clear. To clear all scroll IDs, use `_all`.
         """
@@ -906,7 +911,7 @@ class Elasticsearch(BaseClient):
           However, keeping points in time has a cost; close them as soon as they are no longer required for search requests.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time>`_
 
         :param id: The ID of the point-in-time.
         """
@@ -982,15 +987,15 @@ class Elasticsearch(BaseClient):
 
           <p>Count search results.
           Get the number of documents matching a query.</p>
-          <p>The query can either be provided using a simple query string as a parameter or using the Query DSL defined within the request body.
-          The latter must be nested in a <code>query</code> key, which is the same as the search API.</p>
+          <p>The query can be provided either by using a simple query string as a parameter, or by defining Query DSL within the request body.
+          The query is optional. When no query is provided, the API uses <code>match_all</code> to count all the documents.</p>
           <p>The count API supports multi-target syntax. You can run a single count API search across multiple data streams and indices.</p>
           <p>The operation is broadcast across all shards.
           For each shard ID group, a replica is chosen and the search is run against it.
           This means that replicas increase the scalability of the count.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-count>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams and indices,
@@ -1025,10 +1030,10 @@ class Elasticsearch(BaseClient):
             in the result.
         :param preference: The node or shard the operation should be performed on. By
             default, it is random.
-        :param q: The query in Lucene query string syntax.
-        :param query: Defines the search definition using the Query DSL. The query is
-            optional, and when not provided, it will use `match_all` to count all the
-            docs.
+        :param q: The query in Lucene query string syntax. This parameter cannot be used
+            with a request body.
+        :param query: Defines the search query using Query DSL. A request body query
+            cannot be used with the `q` query string parameter.
         :param routing: A custom value used to route operations to a specific shard.
         :param terminate_after: The maximum number of documents to collect for each shard.
             If a query reaches this limit, Elasticsearch terminates the query early.
@@ -1114,6 +1119,7 @@ class Elasticsearch(BaseClient):
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
+        include_source_on_error: t.Optional[bool] = None,
         pipeline: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         refresh: t.Optional[
@@ -1186,7 +1192,7 @@ class Elasticsearch(BaseClient):
           The <code>_shards</code> section of the API response reveals the number of shard copies on which replication succeeded and failed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-create>`_
 
         :param index: The name of the data stream or index to target. If the target doesn't
             exist and matches the name or wildcard (`*`) pattern of an index template
@@ -1196,6 +1202,8 @@ class Elasticsearch(BaseClient):
         :param id: A unique identifier for the document. To automatically generate a
             document ID, use the `POST /<target>/_doc/` request format.
         :param document:
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param pipeline: The ID of the pipeline to use to preprocess incoming documents.
             If the index has a default ingest pipeline specified, setting the value to
             `_none` turns off the default ingest pipeline for this request. If a final
@@ -1244,6 +1252,8 @@ class Elasticsearch(BaseClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if pipeline is not None:
             __query["pipeline"] = pipeline
         if pretty is not None:
@@ -1326,7 +1336,7 @@ class Elasticsearch(BaseClient):
           It then gets redirected into the primary shard within that ID group and replicated (if needed) to shard replicas within that ID group.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete>`_
 
         :param index: The name of the target index.
         :param id: A unique identifier for the document.
@@ -1515,7 +1525,7 @@ class Elasticsearch(BaseClient):
           The get task status API will continue to list the delete by query task until this task checks that it has been cancelled and terminates itself.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams or indices,
@@ -1712,7 +1722,7 @@ class Elasticsearch(BaseClient):
           Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html#docs-delete-by-query-rethrottle>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query-rethrottle>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per
@@ -1762,14 +1772,16 @@ class Elasticsearch(BaseClient):
           Deletes a stored script or search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-script>`_
 
-        :param id: Identifier for the stored script or search template.
-        :param master_timeout: Period to wait for a connection to the master node. If
-            no response is received before the timeout expires, the request fails and
-            returns an error.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param id: The identifier for the stored script or search template.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error. It can also be set to `-1` to indicate that the request
+            should never timeout.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error. It can
+            also be set to `-1` to indicate that the request should never timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -1844,7 +1856,7 @@ class Elasticsearch(BaseClient):
           Elasticsearch cleans up deleted documents in the background as you continue to index more data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases. It
             supports wildcards (`*`).
@@ -1967,7 +1979,7 @@ class Elasticsearch(BaseClient):
           <p>A document's source is not available if it is disabled in the mapping.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases. It
             supports wildcards (`*`).
@@ -2069,34 +2081,44 @@ class Elasticsearch(BaseClient):
         .. raw:: html
 
           <p>Explain a document match result.
-          Returns information about why a specific document matches, or doesn’t match, a query.</p>
+          Get information about why a specific document matches, or doesn't match, a query.
+          It computes a score explanation for a query and a specific document.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-explain>`_
 
-        :param index: Index names used to limit the request. Only a single index name
-            can be provided to this parameter.
-        :param id: Defines the document ID.
+        :param index: Index names that are used to limit the request. Only a single index
+            name can be provided to this parameter.
+        :param id: The document identifier.
         :param analyze_wildcard: If `true`, wildcard and prefix queries are analyzed.
-        :param analyzer: Analyzer to use for the query string. This parameter can only
-            be used when the `q` query string parameter is specified.
+            This parameter can be used only when the `q` query string parameter is specified.
+        :param analyzer: The analyzer to use for the query string. This parameter can
+            be used only when the `q` query string parameter is specified.
         :param default_operator: The default operator for query string query: `AND` or
-            `OR`.
-        :param df: Field to use as default where no field prefix is given in the query
-            string.
+            `OR`. This parameter can be used only when the `q` query string parameter
+            is specified.
+        :param df: The field to use as default where no field prefix is given in the
+            query string. This parameter can be used only when the `q` query string parameter
+            is specified.
         :param lenient: If `true`, format-based query failures (such as providing text
-            to a numeric field) in the query string will be ignored.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param q: Query in the Lucene query string syntax.
+            to a numeric field) in the query string will be ignored. This parameter can
+            be used only when the `q` query string parameter is specified.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
+        :param q: The query in the Lucene query string syntax.
         :param query: Defines the search definition using the Query DSL.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param source: True or false to return the `_source` field or not, or a list
+        :param routing: A custom value used to route operations to a specific shard.
+        :param source: `True` or `false` to return the `_source` field or not or a list
             of fields to return.
         :param source_excludes: A comma-separated list of source fields to exclude from
-            the response.
+            the response. You can also use this parameter to exclude fields from the
+            subset specified in `_source_includes` query parameter. If the `_source`
+            parameter is `false`, this parameter is ignored.
         :param source_includes: A comma-separated list of source fields to include in
-            the response.
+            the response. If this parameter is specified, only these source fields are
+            returned. You can exclude fields from this subset using the `_source_excludes`
+            query parameter. If the `_source` parameter is `false`, this parameter is
+            ignored.
         :param stored_fields: A comma-separated list of stored fields to return in the
             response.
         """
@@ -2198,9 +2220,9 @@ class Elasticsearch(BaseClient):
           For example, a runtime field with a type of keyword is returned the same as any other field that belongs to the <code>keyword</code> family.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-field-caps>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases used
+        :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (*). To target all data streams
             and indices, omit this parameter or use * or _all.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -2208,25 +2230,32 @@ class Elasticsearch(BaseClient):
             This behavior applies even if the request targets other open indices. For
             example, a request targeting `foo*,bar*` returns an error if an index starts
             with foo but no index starts with bar.
-        :param expand_wildcards: Type of index that wildcard patterns can match. If the
-            request can target data streams, this argument determines whether wildcard
-            expressions match hidden data streams. Supports comma-separated values, such
-            as `open,hidden`.
-        :param fields: List of fields to retrieve capabilities for. Wildcard (`*`) expressions
-            are supported.
-        :param filters: An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. Supports comma-separated
+            values, such as `open,hidden`.
+        :param fields: A list of fields to retrieve capabilities for. Wildcard (`*`)
+            expressions are supported.
+        :param filters: A comma-separated list of filters to apply to the response.
         :param ignore_unavailable: If `true`, missing or closed indices are not included
             in the response.
         :param include_empty_fields: If false, empty fields are not included in the response.
         :param include_unmapped: If true, unmapped fields are included in the response.
-        :param index_filter: Allows to filter indices if the provided query rewrites
-            to match_none on every shard.
-        :param runtime_mappings: Defines ad-hoc runtime fields in the request similar
+        :param index_filter: Filter indices if the provided query rewrites to `match_none`
+            on every shard. IMPORTANT: The filtering is done on a best-effort basis,
+            it uses index statistics and mappings to rewrite queries to `match_none`
+            instead of fully running the request. For instance a range query over a date
+            field can rewrite to `match_none` if all documents within a shard (including
+            deleted documents) are outside of the provided range. However, not all queries
+            can rewrite to `match_none` so this API may return an index even if the provided
+            filter matches no document.
+        :param runtime_mappings: Define ad-hoc runtime fields in the request similar
             to the way it is done in search requests. These fields exist only as part
             of the query and take precedence over fields defined with the same name in
             the index mappings.
-        :param types: Only return results for fields that have one of the types in the
-            list
+        :param types: A comma-separated list of field types to include. Any fields that
+            do not match one of these types will be excluded from the results. It defaults
+            to empty, meaning that all field types are returned.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
@@ -2352,7 +2381,7 @@ class Elasticsearch(BaseClient):
           Elasticsearch cleans up deleted documents in the background as you continue to index more data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: The name of the index that contains the document.
         :param id: A unique document identifier.
@@ -2459,10 +2488,13 @@ class Elasticsearch(BaseClient):
           Retrieves a stored script or search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get-script>`_
 
-        :param id: Identifier for the stored script or search template.
-        :param master_timeout: Specify timeout for connection to master
+        :param id: The identifier for the stored script or search template.
+        :param master_timeout: The period to wait for the master node. If the master
+            node is not available before the timeout expires, the request fails and returns
+            an error. It can also be set to `-1` to indicate that the request should
+            never timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -2505,7 +2537,7 @@ class Elasticsearch(BaseClient):
           <p>Get a list of supported script contexts and their methods.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get-script-context>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_context"
@@ -2544,7 +2576,7 @@ class Elasticsearch(BaseClient):
           <p>Get a list of available script types, languages, and contexts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get-script-languages>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_script_language"
@@ -2609,7 +2641,7 @@ class Elasticsearch(BaseClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get>`_
 
         :param index: The name of the index that contains the document.
         :param id: A unique document identifier.
@@ -2709,7 +2741,7 @@ class Elasticsearch(BaseClient):
           When setting up automated polling of the API for health status, set verbose to false to disable the more expensive analysis logic.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/health-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-health-report>`_
 
         :param feature: A feature of the cluster, as returned by the top-level health
             report API.
@@ -2764,6 +2796,7 @@ class Elasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         if_primary_term: t.Optional[int] = None,
         if_seq_no: t.Optional[int] = None,
+        include_source_on_error: t.Optional[bool] = None,
         op_type: t.Optional[t.Union[str, t.Literal["create", "index"]]] = None,
         pipeline: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
@@ -2873,7 +2906,7 @@ class Elasticsearch(BaseClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-create>`_
 
         :param index: The name of the data stream or index to target. If the target doesn't
             exist and matches the name or wildcard (`*`) pattern of an index template
@@ -2889,6 +2922,8 @@ class Elasticsearch(BaseClient):
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param op_type: Set to `create` to only index the document if it does not already
             exist (put if absent). If a document with the specified `_id` already exists,
             the indexing operation will fail. The behavior is the same as using the `<index>/_create`
@@ -2953,6 +2988,8 @@ class Elasticsearch(BaseClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if op_type is not None:
             __query["op_type"] = op_type
         if pipeline is not None:
@@ -3001,7 +3038,7 @@ class Elasticsearch(BaseClient):
           Get basic build, version, and cluster information.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rest-api-root.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-info>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/"
@@ -3067,30 +3104,37 @@ class Elasticsearch(BaseClient):
           This means the results returned are not always the true k closest neighbors.</p>
           <p>The kNN search API supports restricting the search using a filter.
           The search will return the top k documents that also match the filter query.</p>
+          <p>A kNN search response has the exact same structure as a search API response.
+          However, certain sections have a meaning specific to kNN search:</p>
+          <ul>
+          <li>The document <code>_score</code> is determined by the similarity between the query and document vector.</li>
+          <li>The <code>hits.total</code> object contains the total number of nearest neighbor candidates considered, which is <code>num_candidates * num_shards</code>. The <code>hits.total.relation</code> will always be <code>eq</code>, indicating an exact value.</li>
+          </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/knn-search-api.html>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
-            to perform the operation on all indices
-        :param knn: kNN query to execute
+            to perform the operation on all indices.
+        :param knn: The kNN query to run.
         :param docvalue_fields: The request returns doc values for field names matching
-            these patterns in the hits.fields property of the response. Accepts wildcard
-            (*) patterns.
+            these patterns in the `hits.fields` property of the response. It accepts
+            wildcard (`*`) patterns.
         :param fields: The request returns values for field names matching these patterns
-            in the hits.fields property of the response. Accepts wildcard (*) patterns.
-        :param filter: Query to filter the documents that can match. The kNN search will
-            return the top `k` documents that also match this filter. The value can be
-            a single query or a list of queries. If `filter` isn't provided, all documents
-            are allowed to match.
-        :param routing: A comma-separated list of specific routing values
+            in the `hits.fields` property of the response. It accepts wildcard (`*`)
+            patterns.
+        :param filter: A query to filter the documents that can match. The kNN search
+            will return the top `k` documents that also match this filter. The value
+            can be a single query or a list of queries. If `filter` isn't provided, all
+            documents are allowed to match.
+        :param routing: A comma-separated list of specific routing values.
         :param source: Indicates which source fields are returned for matching documents.
-            These fields are returned in the hits._source property of the search response.
-        :param stored_fields: List of stored fields to return as part of a hit. If no
-            fields are specified, no stored fields are included in the response. If this
-            field is specified, the _source parameter defaults to false. You can pass
-            _source: true to return both source fields and stored fields in the search
-            response.
+            These fields are returned in the `hits._source` property of the search response.
+        :param stored_fields: A list of stored fields to return as part of a hit. If
+            no fields are specified, no stored fields are included in the response. If
+            this field is specified, the `_source` parameter defaults to `false`. You
+            can pass `_source: true` to return both source fields and stored fields in
+            the search response.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -3174,9 +3218,17 @@ class Elasticsearch(BaseClient):
           <p>Get multiple JSON documents by ID from one or more indices.
           If you specify an index in the request URI, you only need to specify the document IDs in the request body.
           To ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.</p>
+          <p><strong>Filter source fields</strong></p>
+          <p>By default, the <code>_source</code> field is returned for every document (if stored).
+          Use the <code>_source</code> and <code>_source_include</code> or <code>source_exclude</code> attributes to filter what fields are returned for a particular document.
+          You can include the <code>_source</code>, <code>_source_includes</code>, and <code>_source_excludes</code> query parameters in the request URI to specify the defaults to use when there are no per-document instructions.</p>
+          <p><strong>Get stored fields</strong></p>
+          <p>Use the <code>stored_fields</code> attribute to specify the set of stored fields you want to retrieve.
+          Any requested fields that are not stored are ignored.
+          You can include the <code>stored_fields</code> query parameter in the request URI to specify the defaults to use when there are no per-document instructions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-mget>`_
 
         :param index: Name of the index to retrieve documents from when `ids` are specified,
             or when a document in the `docs` array does not specify an index.
@@ -3311,7 +3363,7 @@ class Elasticsearch(BaseClient):
           When sending requests to this endpoint the <code>Content-Type</code> header should be set to <code>application/x-ndjson</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-msearch>`_
 
         :param searches:
         :param index: Comma-separated list of data streams, indices, and index aliases
@@ -3444,22 +3496,32 @@ class Elasticsearch(BaseClient):
         .. raw:: html
 
           <p>Run multiple templated searches.</p>
+          <p>Run multiple templated searches with a single request.
+          If you are providing a text file or text input to <code>curl</code>, use the <code>--data-binary</code> flag instead of <code>-d</code> to preserve newlines.
+          For example:</p>
+          <pre><code>$ cat requests
+          { &quot;index&quot;: &quot;my-index&quot; }
+          { &quot;id&quot;: &quot;my-search-template&quot;, &quot;params&quot;: { &quot;query_string&quot;: &quot;hello world&quot;, &quot;from&quot;: 0, &quot;size&quot;: 10 }}
+          { &quot;index&quot;: &quot;my-other-index&quot; }
+          { &quot;id&quot;: &quot;my-other-search-template&quot;, &quot;params&quot;: { &quot;query_type&quot;: &quot;match_all&quot; }}
+
+          $ curl -H &quot;Content-Type: application/x-ndjson&quot; -XGET localhost:9200/_msearch/template --data-binary &quot;@requests&quot;; echo
+          </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-msearch-template>`_
 
         :param search_templates:
-        :param index: Comma-separated list of data streams, indices, and aliases to search.
-            Supports wildcards (`*`). To search all data streams and indices, omit this
-            parameter or use `*`.
+        :param index: A comma-separated list of data streams, indices, and aliases to
+            search. It supports wildcards (`*`). To search all data streams and indices,
+            omit this parameter or use `*`.
         :param ccs_minimize_roundtrips: If `true`, network round-trips are minimized
             for cross-cluster search requests.
-        :param max_concurrent_searches: Maximum number of concurrent searches the API
-            can run.
+        :param max_concurrent_searches: The maximum number of concurrent searches the
+            API can run.
         :param rest_total_hits_as_int: If `true`, the response returns `hits.total` as
             an integer. If `false`, it returns `hits.total` as an object.
-        :param search_type: The type of the search operation. Available options: `query_then_fetch`,
-            `dfs_query_then_fetch`.
+        :param search_type: The type of the search operation.
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
@@ -3542,34 +3604,38 @@ class Elasticsearch(BaseClient):
         .. raw:: html
 
           <p>Get multiple term vectors.</p>
-          <p>You can specify existing documents by index and ID or provide artificial documents in the body of the request.
+          <p>Get multiple term vectors with a single request.
+          You can specify existing documents by index and ID or provide artificial documents in the body of the request.
           You can specify the index in the request body or request URI.
           The response contains a <code>docs</code> array with all the fetched termvectors.
           Each element has the structure provided by the termvectors API.</p>
+          <p><strong>Artificial documents</strong></p>
+          <p>You can also use <code>mtermvectors</code> to generate term vectors for artificial documents provided in the body of the request.
+          The mapping used is determined by the specified <code>_index</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-mtermvectors>`_
 
-        :param index: Name of the index that contains the documents.
-        :param docs: Array of existing or artificial documents.
+        :param index: The name of the index that contains the documents.
+        :param docs: An array of existing or artificial documents.
         :param field_statistics: If `true`, the response includes the document count,
             sum of document frequencies, and sum of total term frequencies.
-        :param fields: Comma-separated list or wildcard expressions of fields to include
-            in the statistics. Used as the default list unless a specific field list
-            is provided in the `completion_fields` or `fielddata_fields` parameters.
-        :param ids: Simplified syntax to specify documents by their ID if they're in
+        :param fields: A comma-separated list or wildcard expressions of fields to include
+            in the statistics. It is used as the default list unless a specific field
+            list is provided in the `completion_fields` or `fielddata_fields` parameters.
+        :param ids: A simplified syntax to specify documents by their ID if they're in
             the same index.
         :param offsets: If `true`, the response includes term offsets.
         :param payloads: If `true`, the response includes term payloads.
         :param positions: If `true`, the response includes term positions.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
         :param realtime: If true, the request is real-time as opposed to near-real-time.
-        :param routing: Custom value used to route operations to a specific shard.
+        :param routing: A custom value used to route operations to a specific shard.
         :param term_statistics: If true, the response includes term frequency and document
             frequency.
         :param version: If `true`, returns the document version as part of a hit.
-        :param version_type: Specific version type.
+        :param version_type: The version type.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
@@ -3688,7 +3754,7 @@ class Elasticsearch(BaseClient):
           You can check how many point-in-times (that is, search contexts) are open with the nodes stats API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time>`_
 
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
@@ -3782,20 +3848,21 @@ class Elasticsearch(BaseClient):
           Creates or updates a stored script or search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-put-script>`_
 
-        :param id: Identifier for the stored script or search template. Must be unique
-            within the cluster.
-        :param script: Contains the script or search template, its parameters, and its
-            language.
-        :param context: Context in which the script or search template should run. To
-            prevent errors, the API immediately compiles the script or template in this
-            context.
-        :param master_timeout: Period to wait for a connection to the master node. If
-            no response is received before the timeout expires, the request fails and
-            returns an error.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param id: The identifier for the stored script or search template. It must be
+            unique within the cluster.
+        :param script: The script or search template, its parameters, and its language.
+        :param context: The context in which the script or search template should run.
+            To prevent errors, the API immediately compiles the script or template in
+            this context.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error. It can also be set to `-1` to indicate that the request
+            should never timeout.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error. It can
+            also be set to `-1` to indicate that the request should never timeout.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -3871,11 +3938,11 @@ class Elasticsearch(BaseClient):
           <p>Evaluate the quality of ranked search results over a set of typical search queries.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rank-eval>`_
 
         :param requests: A set of typical search requests, together with their provided
             ratings.
-        :param index: Comma-separated list of data streams, indices, and index aliases
+        :param index: A comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard (`*`) expressions are supported. To target
             all data streams and indices in a cluster, omit this parameter or use `_all`
             or `*`.
@@ -4103,7 +4170,7 @@ class Elasticsearch(BaseClient):
           It is not possible to configure SSL in the body of the reindex request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex>`_
 
         :param dest: The destination you are copying to.
         :param source: The source you are copying from.
@@ -4227,7 +4294,7 @@ class Elasticsearch(BaseClient):
           This behavior prevents scroll timeouts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex>`_
 
         :param task_id: The task identifier, which can be found by using the tasks API.
         :param requests_per_second: The throttle for this request in sub-requests per
@@ -4283,15 +4350,15 @@ class Elasticsearch(BaseClient):
           <p>Render a search template as a search request body.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/render-search-template-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-render-search-template>`_
 
-        :param id: ID of the search template to render. If no `source` is specified,
+        :param id: The ID of the search template to render. If no `source` is specified,
             this or the `id` request body parameter is required.
         :param file:
         :param params: Key-value pairs used to replace Mustache variables in the template.
             The key is the variable name. The value is the variable value.
-        :param source: An inline search template. Supports the same parameters as the
-            search API's request body. These parameters also support Mustache variables.
+        :param source: An inline search template. It supports the same parameters as
+            the search API's request body. These parameters also support Mustache variables.
             If no `id` or `<templated-id>` is specified, this parameter is required.
         """
         __path_parts: t.Dict[str, str]
@@ -4450,13 +4517,13 @@ class Elasticsearch(BaseClient):
           <p>IMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-scroll>`_
 
-        :param scroll_id: Scroll ID of the search.
+        :param scroll_id: The scroll ID of the search.
         :param rest_total_hits_as_int: If true, the API response’s hit.total property
             is returned as an integer. If false, the API response’s hit.total property
             is returned as an object.
-        :param scroll: Period to retain the search context for scrolling.
+        :param scroll: The period to retain the search context for scrolling.
         """
         if scroll_id is None and body is None:
             raise ValueError("Empty value passed for parameter 'scroll_id'")
@@ -4602,7 +4669,7 @@ class Elasticsearch(BaseClient):
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         search_type: t.Optional[
             t.Union[str, t.Literal["dfs_query_then_fetch", "query_then_fetch"]]
@@ -4655,7 +4722,7 @@ class Elasticsearch(BaseClient):
           This situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams and indices,
@@ -5091,53 +5158,373 @@ class Elasticsearch(BaseClient):
         .. raw:: html
 
           <p>Search a vector tile.</p>
-          <p>Search a vector tile for geospatial values.</p>
+          <p>Search a vector tile for geospatial values.
+          Before using this API, you should be familiar with the Mapbox vector tile specification.
+          The API returns results as a binary mapbox vector tile.</p>
+          <p>Internally, Elasticsearch translates a vector tile search API request into a search containing:</p>
+          <ul>
+          <li>A <code>geo_bounding_box</code> query on the <code>&lt;field&gt;</code>. The query uses the <code>&lt;zoom&gt;/&lt;x&gt;/&lt;y&gt;</code> tile as a bounding box.</li>
+          <li>A <code>geotile_grid</code> or <code>geohex_grid</code> aggregation on the <code>&lt;field&gt;</code>. The <code>grid_agg</code> parameter determines the aggregation type. The aggregation uses the <code>&lt;zoom&gt;/&lt;x&gt;/&lt;y&gt;</code> tile as a bounding box.</li>
+          <li>Optionally, a <code>geo_bounds</code> aggregation on the <code>&lt;field&gt;</code>. The search only includes this aggregation if the <code>exact_bounds</code> parameter is <code>true</code>.</li>
+          <li>If the optional parameter <code>with_labels</code> is <code>true</code>, the internal search will include a dynamic runtime field that calls the <code>getLabelPosition</code> function of the geometry doc value. This enables the generation of new point features containing suggested geometry labels, so that, for example, multi-polygons will have only one label.</li>
+          </ul>
+          <p>For example, Elasticsearch may translate a vector tile search API request with a <code>grid_agg</code> argument of <code>geotile</code> and an <code>exact_bounds</code> argument of <code>true</code> into the following search</p>
+          <pre><code>GET my-index/_search
+          {
+            &quot;size&quot;: 10000,
+            &quot;query&quot;: {
+              &quot;geo_bounding_box&quot;: {
+                &quot;my-geo-field&quot;: {
+                  &quot;top_left&quot;: {
+                    &quot;lat&quot;: -40.979898069620134,
+                    &quot;lon&quot;: -45
+                  },
+                  &quot;bottom_right&quot;: {
+                    &quot;lat&quot;: -66.51326044311186,
+                    &quot;lon&quot;: 0
+                  }
+                }
+              }
+            },
+            &quot;aggregations&quot;: {
+              &quot;grid&quot;: {
+                &quot;geotile_grid&quot;: {
+                  &quot;field&quot;: &quot;my-geo-field&quot;,
+                  &quot;precision&quot;: 11,
+                  &quot;size&quot;: 65536,
+                  &quot;bounds&quot;: {
+                    &quot;top_left&quot;: {
+                      &quot;lat&quot;: -40.979898069620134,
+                      &quot;lon&quot;: -45
+                    },
+                    &quot;bottom_right&quot;: {
+                      &quot;lat&quot;: -66.51326044311186,
+                      &quot;lon&quot;: 0
+                    }
+                  }
+                }
+              },
+              &quot;bounds&quot;: {
+                &quot;geo_bounds&quot;: {
+                  &quot;field&quot;: &quot;my-geo-field&quot;,
+                  &quot;wrap_longitude&quot;: false
+                }
+              }
+            }
+          }
+          </code></pre>
+          <p>The API returns results as a binary Mapbox vector tile.
+          Mapbox vector tiles are encoded as Google Protobufs (PBF). By default, the tile contains three layers:</p>
+          <ul>
+          <li>A <code>hits</code> layer containing a feature for each <code>&lt;field&gt;</code> value matching the <code>geo_bounding_box</code> query.</li>
+          <li>An <code>aggs</code> layer containing a feature for each cell of the <code>geotile_grid</code> or <code>geohex_grid</code>. The layer only contains features for cells with matching data.</li>
+          <li>A meta layer containing:
+          <ul>
+          <li>A feature containing a bounding box. By default, this is the bounding box of the tile.</li>
+          <li>Value ranges for any sub-aggregations on the <code>geotile_grid</code> or <code>geohex_grid</code>.</li>
+          <li>Metadata for the search.</li>
+          </ul>
+          </li>
+          </ul>
+          <p>The API only returns features that can display at its zoom level.
+          For example, if a polygon feature has no area at its zoom level, the API omits it.
+          The API returns errors as UTF-8 encoded JSON.</p>
+          <p>IMPORTANT: You can specify several options for this API as either a query parameter or request body parameter.
+          If you specify both parameters, the query parameter takes precedence.</p>
+          <p><strong>Grid precision for geotile</strong></p>
+          <p>For a <code>grid_agg</code> of <code>geotile</code>, you can use cells in the <code>aggs</code> layer as tiles for lower zoom levels.
+          <code>grid_precision</code> represents the additional zoom levels available through these cells. The final precision is computed by as follows: <code>&lt;zoom&gt; + grid_precision</code>.
+          For example, if <code>&lt;zoom&gt;</code> is 7 and <code>grid_precision</code> is 8, then the <code>geotile_grid</code> aggregation will use a precision of 15.
+          The maximum final precision is 29.
+          The <code>grid_precision</code> also determines the number of cells for the grid as follows: <code>(2^grid_precision) x (2^grid_precision)</code>.
+          For example, a value of 8 divides the tile into a grid of 256 x 256 cells.
+          The <code>aggs</code> layer only contains features for cells with matching data.</p>
+          <p><strong>Grid precision for geohex</strong></p>
+          <p>For a <code>grid_agg</code> of <code>geohex</code>, Elasticsearch uses <code>&lt;zoom&gt;</code> and <code>grid_precision</code> to calculate a final precision as follows: <code>&lt;zoom&gt; + grid_precision</code>.</p>
+          <p>This precision determines the H3 resolution of the hexagonal cells produced by the <code>geohex</code> aggregation.
+          The following table maps the H3 resolution for each precision.
+          For example, if <code>&lt;zoom&gt;</code> is 3 and <code>grid_precision</code> is 3, the precision is 6.
+          At a precision of 6, hexagonal cells have an H3 resolution of 2.
+          If <code>&lt;zoom&gt;</code> is 3 and <code>grid_precision</code> is 4, the precision is 7.
+          At a precision of 7, hexagonal cells have an H3 resolution of 3.</p>
+          <table>
+          <thead>
+          <tr>
+          <th>Precision</th>
+          <th>Unique tile bins</th>
+          <th>H3 resolution</th>
+          <th>Unique hex bins</th>
+          <th>Ratio</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>1</td>
+          <td>4</td>
+          <td>0</td>
+          <td>122</td>
+          <td>30.5</td>
+          </tr>
+          <tr>
+          <td>2</td>
+          <td>16</td>
+          <td>0</td>
+          <td>122</td>
+          <td>7.625</td>
+          </tr>
+          <tr>
+          <td>3</td>
+          <td>64</td>
+          <td>1</td>
+          <td>842</td>
+          <td>13.15625</td>
+          </tr>
+          <tr>
+          <td>4</td>
+          <td>256</td>
+          <td>1</td>
+          <td>842</td>
+          <td>3.2890625</td>
+          </tr>
+          <tr>
+          <td>5</td>
+          <td>1024</td>
+          <td>2</td>
+          <td>5882</td>
+          <td>5.744140625</td>
+          </tr>
+          <tr>
+          <td>6</td>
+          <td>4096</td>
+          <td>2</td>
+          <td>5882</td>
+          <td>1.436035156</td>
+          </tr>
+          <tr>
+          <td>7</td>
+          <td>16384</td>
+          <td>3</td>
+          <td>41162</td>
+          <td>2.512329102</td>
+          </tr>
+          <tr>
+          <td>8</td>
+          <td>65536</td>
+          <td>3</td>
+          <td>41162</td>
+          <td>0.6280822754</td>
+          </tr>
+          <tr>
+          <td>9</td>
+          <td>262144</td>
+          <td>4</td>
+          <td>288122</td>
+          <td>1.099098206</td>
+          </tr>
+          <tr>
+          <td>10</td>
+          <td>1048576</td>
+          <td>4</td>
+          <td>288122</td>
+          <td>0.2747745514</td>
+          </tr>
+          <tr>
+          <td>11</td>
+          <td>4194304</td>
+          <td>5</td>
+          <td>2016842</td>
+          <td>0.4808526039</td>
+          </tr>
+          <tr>
+          <td>12</td>
+          <td>16777216</td>
+          <td>6</td>
+          <td>14117882</td>
+          <td>0.8414913416</td>
+          </tr>
+          <tr>
+          <td>13</td>
+          <td>67108864</td>
+          <td>6</td>
+          <td>14117882</td>
+          <td>0.2103728354</td>
+          </tr>
+          <tr>
+          <td>14</td>
+          <td>268435456</td>
+          <td>7</td>
+          <td>98825162</td>
+          <td>0.3681524172</td>
+          </tr>
+          <tr>
+          <td>15</td>
+          <td>1073741824</td>
+          <td>8</td>
+          <td>691776122</td>
+          <td>0.644266719</td>
+          </tr>
+          <tr>
+          <td>16</td>
+          <td>4294967296</td>
+          <td>8</td>
+          <td>691776122</td>
+          <td>0.1610666797</td>
+          </tr>
+          <tr>
+          <td>17</td>
+          <td>17179869184</td>
+          <td>9</td>
+          <td>4842432842</td>
+          <td>0.2818666889</td>
+          </tr>
+          <tr>
+          <td>18</td>
+          <td>68719476736</td>
+          <td>10</td>
+          <td>33897029882</td>
+          <td>0.4932667053</td>
+          </tr>
+          <tr>
+          <td>19</td>
+          <td>274877906944</td>
+          <td>11</td>
+          <td>237279209162</td>
+          <td>0.8632167343</td>
+          </tr>
+          <tr>
+          <td>20</td>
+          <td>1099511627776</td>
+          <td>11</td>
+          <td>237279209162</td>
+          <td>0.2158041836</td>
+          </tr>
+          <tr>
+          <td>21</td>
+          <td>4398046511104</td>
+          <td>12</td>
+          <td>1660954464122</td>
+          <td>0.3776573213</td>
+          </tr>
+          <tr>
+          <td>22</td>
+          <td>17592186044416</td>
+          <td>13</td>
+          <td>11626681248842</td>
+          <td>0.6609003122</td>
+          </tr>
+          <tr>
+          <td>23</td>
+          <td>70368744177664</td>
+          <td>13</td>
+          <td>11626681248842</td>
+          <td>0.165225078</td>
+          </tr>
+          <tr>
+          <td>24</td>
+          <td>281474976710656</td>
+          <td>14</td>
+          <td>81386768741882</td>
+          <td>0.2891438866</td>
+          </tr>
+          <tr>
+          <td>25</td>
+          <td>1125899906842620</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.5060018015</td>
+          </tr>
+          <tr>
+          <td>26</td>
+          <td>4503599627370500</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.1265004504</td>
+          </tr>
+          <tr>
+          <td>27</td>
+          <td>18014398509482000</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.03162511259</td>
+          </tr>
+          <tr>
+          <td>28</td>
+          <td>72057594037927900</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.007906278149</td>
+          </tr>
+          <tr>
+          <td>29</td>
+          <td>288230376151712000</td>
+          <td>15</td>
+          <td>569707381193162</td>
+          <td>0.001976569537</td>
+          </tr>
+          </tbody>
+          </table>
+          <p>Hexagonal cells don't align perfectly on a vector tile.
+          Some cells may intersect more than one vector tile.
+          To compute the H3 resolution for each precision, Elasticsearch compares the average density of hexagonal bins at each resolution with the average density of tile bins at each zoom level.
+          Elasticsearch uses the H3 resolution that is closest to the corresponding geotile density.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-mvt>`_
 
         :param index: Comma-separated list of data streams, indices, or aliases to search
         :param field: Field containing geospatial data to return
         :param zoom: Zoom level for the vector tile to search
         :param x: X coordinate for the vector tile to search
         :param y: Y coordinate for the vector tile to search
-        :param aggs: Sub-aggregations for the geotile_grid. Supports the following aggregation
-            types: - avg - cardinality - max - min - sum
-        :param buffer: Size, in pixels, of a clipping buffer outside the tile. This allows
-            renderers to avoid outline artifacts from geometries that extend past the
-            extent of the tile.
-        :param exact_bounds: If false, the meta layer’s feature is the bounding box of
-            the tile. If true, the meta layer’s feature is a bounding box resulting from
-            a geo_bounds aggregation. The aggregation runs on <field> values that intersect
-            the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting bounding
-            box may be larger than the vector tile.
-        :param extent: Size, in pixels, of a side of the tile. Vector tiles are square
+        :param aggs: Sub-aggregations for the geotile_grid. It supports the following
+            aggregation types: - `avg` - `boxplot` - `cardinality` - `extended stats`
+            - `max` - `median absolute deviation` - `min` - `percentile` - `percentile-rank`
+            - `stats` - `sum` - `value count` The aggregation names can't start with
+            `_mvt_`. The `_mvt_` prefix is reserved for internal aggregations.
+        :param buffer: The size, in pixels, of a clipping buffer outside the tile. This
+            allows renderers to avoid outline artifacts from geometries that extend past
+            the extent of the tile.
+        :param exact_bounds: If `false`, the meta layer's feature is the bounding box
+            of the tile. If `true`, the meta layer's feature is a bounding box resulting
+            from a `geo_bounds` aggregation. The aggregation runs on <field> values that
+            intersect the `<zoom>/<x>/<y>` tile with `wrap_longitude` set to `false`.
+            The resulting bounding box may be larger than the vector tile.
+        :param extent: The size, in pixels, of a side of the tile. Vector tiles are square
             with equal sides.
-        :param fields: Fields to return in the `hits` layer. Supports wildcards (`*`).
-            This parameter does not support fields with array values. Fields with array
-            values may return inconsistent results.
-        :param grid_agg: Aggregation used to create a grid for the `field`.
+        :param fields: The fields to return in the `hits` layer. It supports wildcards
+            (`*`). This parameter does not support fields with array values. Fields with
+            array values may return inconsistent results.
+        :param grid_agg: The aggregation used to create a grid for the `field`.
         :param grid_precision: Additional zoom levels available through the aggs layer.
-            For example, if <zoom> is 7 and grid_precision is 8, you can zoom in up to
-            level 15. Accepts 0-8. If 0, results don’t include the aggs layer.
+            For example, if `<zoom>` is `7` and `grid_precision` is `8`, you can zoom
+            in up to level 15. Accepts 0-8. If 0, results don't include the aggs layer.
         :param grid_type: Determines the geometry type for features in the aggs layer.
-            In the aggs layer, each feature represents a geotile_grid cell. If 'grid'
-            each feature is a Polygon of the cells bounding box. If 'point' each feature
+            In the aggs layer, each feature represents a `geotile_grid` cell. If `grid,
+            each feature is a polygon of the cells bounding box. If `point`, each feature
             is a Point that is the centroid of the cell.
-        :param query: Query DSL used to filter documents for the search.
+        :param query: The query DSL used to filter documents for the search.
         :param runtime_mappings: Defines one or more runtime fields in the search request.
             These fields take precedence over mapped fields with the same name.
-        :param size: Maximum number of features to return in the hits layer. Accepts
-            0-10000. If 0, results don’t include the hits layer.
-        :param sort: Sorts features in the hits layer. By default, the API calculates
-            a bounding box for each feature. It sorts features based on this box’s diagonal
+        :param size: The maximum number of features to return in the hits layer. Accepts
+            0-10000. If 0, results don't include the hits layer.
+        :param sort: Sort the features in the hits layer. By default, the API calculates
+            a bounding box for each feature. It sorts features based on this box's diagonal
             length, from longest to shortest.
-        :param track_total_hits: Number of hits matching the query to count accurately.
+        :param track_total_hits: The number of hits matching the query to count accurately.
             If `true`, the exact number of hits is returned at the cost of some performance.
             If `false`, the response does not include the total number of hits matching
             the query.
         :param with_labels: If `true`, the hits and aggs layers will contain additional
             point features representing suggested label positions for the original features.
+            * `Point` and `MultiPoint` features will have one of the points selected.
+            * `Polygon` and `MultiPolygon` features will have a single point generated,
+            either the centroid, if it is within the polygon, or another point within
+            the polygon selected from the sorted triangle-tree. * `LineString` features
+            will likewise provide a roughly central point selected from the triangle-tree.
+            * The aggregation results will provide one central point for each aggregation
+            bucket. All attributes from the original features will also be copied to
+            the new label features. In addition, the new features will be distinguishable
+            using the tag `_mvt_label_position`.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5252,13 +5639,15 @@ class Elasticsearch(BaseClient):
           <p>Get the search shards.</p>
           <p>Get the indices and shards that a search request would be run against.
           This information can be useful for working out issues or planning optimizations with routing and shard preferences.
-          When filtered aliases are used, the filter is returned as part of the indices section.</p>
+          When filtered aliases are used, the filter is returned as part of the <code>indices</code> section.</p>
+          <p>If the Elasticsearch security features are enabled, you must have the <code>view_index_metadata</code> or <code>manage</code> index privilege for the target data stream, index, or alias.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-shards>`_
 
-        :param index: Returns the indices and shards that a search request would be executed
-            against.
+        :param index: A comma-separated list of data streams, indices, and aliases to
+            search. It supports wildcards (`*`). To search all data streams and indices,
+            omit this parameter or use `*` or `_all`.
         :param allow_no_indices: If `false`, the request returns an error if any wildcard
             expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
@@ -5272,10 +5661,13 @@ class Elasticsearch(BaseClient):
             a missing or closed index.
         :param local: If `true`, the request retrieves information from the local node
             only.
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
-        :param routing: Custom value used to route operations to a specific shard.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. IT can also be set to `-1` to indicate that the
+            request should never timeout.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
+        :param routing: A custom value used to route operations to a specific shard.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH:
@@ -5362,10 +5754,10 @@ class Elasticsearch(BaseClient):
           <p>Run a search with a search template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-template>`_
 
-        :param index: Comma-separated list of data streams, indices, and aliases to search.
-            Supports wildcards (*).
+        :param index: A comma-separated list of data streams, indices, and aliases to
+            search. It supports wildcards (`*`).
         :param allow_no_indices: If `false`, the request returns an error if any wildcard
             expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
@@ -5373,32 +5765,34 @@ class Elasticsearch(BaseClient):
             with `foo` but no index starts with `bar`.
         :param ccs_minimize_roundtrips: If `true`, network round-trips are minimized
             for cross-cluster search requests.
-        :param expand_wildcards: Type of index that wildcard patterns can match. If the
-            request can target data streams, this argument determines whether wildcard
-            expressions match hidden data streams. Supports comma-separated values, such
-            as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. Supports comma-separated
+            values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`,
+            `hidden`, `none`.
         :param explain: If `true`, returns detailed information about score calculation
-            as part of each hit.
-        :param id: ID of the search template to use. If no source is specified, this
-            parameter is required.
+            as part of each hit. If you specify both this and the `explain` query parameter,
+            the API uses only the query parameter.
+        :param id: The ID of the search template to use. If no `source` is specified,
+            this parameter is required.
         :param ignore_throttled: If `true`, specified concrete, expanded, or aliased
             indices are not included in the response when throttled.
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
         :param params: Key-value pairs used to replace Mustache variables in the template.
             The key is the variable name. The value is the variable value.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
         :param profile: If `true`, the query execution is profiled.
-        :param rest_total_hits_as_int: If true, hits.total are rendered as an integer
-            in the response.
-        :param routing: Custom value used to route operations to a specific shard.
+        :param rest_total_hits_as_int: If `true`, `hits.total` is rendered as an integer
+            in the response. If `false`, it is rendered as an object.
+        :param routing: A custom value used to route operations to a specific shard.
         :param scroll: Specifies how long a consistent view of the index should be maintained
             for scrolled search.
         :param search_type: The type of the search operation.
         :param source: An inline search template. Supports the same parameters as the
-            search API's request body. Also supports Mustache variables. If no id is
-            specified, this parameter is required.
+            search API's request body. It also supports Mustache variables. If no `id`
+            is specified, this parameter is required.
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
@@ -5496,30 +5890,35 @@ class Elasticsearch(BaseClient):
 
           <p>Get terms in an index.</p>
           <p>Discover terms that match a partial string in an index.
-          This &quot;terms enum&quot; API is designed for low-latency look-ups used in auto-complete scenarios.</p>
-          <p>If the <code>complete</code> property in the response is false, the returned terms set may be incomplete and should be treated as approximate.
-          This can occur due to a few reasons, such as a request timeout or a node error.</p>
-          <p>NOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.</p>
+          This API is designed for low-latency look-ups used in auto-complete scenarios.</p>
+          <blockquote>
+          <p>info
+          The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-terms-enum.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-terms-enum>`_
 
-        :param index: Comma-separated list of data streams, indices, and index aliases
-            to search. Wildcard (*) expressions are supported.
+        :param index: A comma-separated list of data streams, indices, and index aliases
+            to search. Wildcard (`*`) expressions are supported. To search all data streams
+            or indices, omit this parameter or use `*` or `_all`.
         :param field: The string to match at the start of indexed terms. If not provided,
             all terms in the field are considered.
-        :param case_insensitive: When true the provided search string is matched against
+        :param case_insensitive: When `true`, the provided search string is matched against
             index terms without case sensitivity.
-        :param index_filter: Allows to filter an index shard if the provided query rewrites
-            to match_none.
-        :param search_after:
-        :param size: How many matching terms to return.
-        :param string: The string after which terms in the index should be returned.
-            Allows for a form of pagination if the last result from one request is passed
-            as the search_after parameter for a subsequent request.
-        :param timeout: The maximum length of time to spend collecting results. Defaults
-            to "1s" (one second). If the timeout is exceeded the complete flag set to
-            false in the response and the results may be partial or empty.
+        :param index_filter: Filter an index shard if the provided query rewrites to
+            `match_none`.
+        :param search_after: The string after which terms in the index should be returned.
+            It allows for a form of pagination if the last result from one request is
+            passed as the `search_after` parameter for a subsequent request.
+        :param size: The number of matching terms to return.
+        :param string: The string to match at the start of indexed terms. If it is not
+            provided, all terms in the field are considered. > info > The prefix string
+            cannot be larger than the largest possible keyword value, which is Lucene's
+            term byte-length limit of 32766.
+        :param timeout: The maximum length of time to spend collecting results. If the
+            timeout is exceeded the `complete` flag set to `false` in the response and
+            the results may be partial or empty.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5602,32 +6001,73 @@ class Elasticsearch(BaseClient):
 
           <p>Get term vector information.</p>
           <p>Get information and statistics about terms in the fields of a particular document.</p>
+          <p>You can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.
+          You can specify the fields you are interested in through the <code>fields</code> parameter or by adding the fields to the request body.
+          For example:</p>
+          <pre><code>GET /my-index-000001/_termvectors/1?fields=message
+          </code></pre>
+          <p>Fields can be specified using wildcards, similar to the multi match query.</p>
+          <p>Term vectors are real-time by default, not near real-time.
+          This can be changed by setting <code>realtime</code> parameter to <code>false</code>.</p>
+          <p>You can request three types of values: <em>term information</em>, <em>term statistics</em>, and <em>field statistics</em>.
+          By default, all term information and field statistics are returned for all fields but term statistics are excluded.</p>
+          <p><strong>Term information</strong></p>
+          <ul>
+          <li>term frequency in the field (always returned)</li>
+          <li>term positions (<code>positions: true</code>)</li>
+          <li>start and end offsets (<code>offsets: true</code>)</li>
+          <li>term payloads (<code>payloads: true</code>), as base64 encoded bytes</li>
+          </ul>
+          <p>If the requested information wasn't stored in the index, it will be computed on the fly if possible.
+          Additionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.</p>
+          <blockquote>
+          <p>warn
+          Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.</p>
+          </blockquote>
+          <p><strong>Behaviour</strong></p>
+          <p>The term and field statistics are not accurate.
+          Deleted documents are not taken into account.
+          The information is only retrieved for the shard the requested document resides in.
+          The term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.
+          By default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.
+          Use <code>routing</code> only to hit a particular shard.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-termvectors>`_
 
-        :param index: Name of the index that contains the document.
-        :param id: Unique identifier of the document.
+        :param index: The name of the index that contains the document.
+        :param id: A unique identifier for the document.
         :param doc: An artificial document (a document not present in the index) for
             which you want to retrieve term vectors.
-        :param field_statistics: If `true`, the response includes the document count,
-            sum of document frequencies, and sum of total term frequencies.
-        :param fields: Comma-separated list or wildcard expressions of fields to include
-            in the statistics. Used as the default list unless a specific field list
-            is provided in the `completion_fields` or `fielddata_fields` parameters.
-        :param filter: Filter terms based on their tf-idf scores.
+        :param field_statistics: If `true`, the response includes: * The document count
+            (how many documents contain this field). * The sum of document frequencies
+            (the sum of document frequencies for all terms in this field). * The sum
+            of total term frequencies (the sum of total term frequencies of each term
+            in this field).
+        :param fields: A comma-separated list or wildcard expressions of fields to include
+            in the statistics. It is used as the default list unless a specific field
+            list is provided in the `completion_fields` or `fielddata_fields` parameters.
+        :param filter: Filter terms based on their tf-idf scores. This could be useful
+            in order find out a good characteristic vector of a document. This feature
+            works in a similar manner to the second phase of the More Like This Query.
         :param offsets: If `true`, the response includes term offsets.
         :param payloads: If `true`, the response includes term payloads.
-        :param per_field_analyzer: Overrides the default per-field analyzer.
+        :param per_field_analyzer: Override the default per-field analyzer. This is useful
+            in order to generate term vectors in any fashion, especially when using artificial
+            documents. When providing an analyzer for a field that already stores term
+            vectors, the term vectors will be regenerated.
         :param positions: If `true`, the response includes term positions.
-        :param preference: Specifies the node or shard the operation should be performed
-            on. Random by default.
+        :param preference: The node or shard the operation should be performed on. It
+            is random by default.
         :param realtime: If true, the request is real-time as opposed to near-real-time.
-        :param routing: Custom value used to route operations to a specific shard.
-        :param term_statistics: If `true`, the response includes term frequency and document
-            frequency.
+        :param routing: A custom value that is used to route operations to a specific
+            shard.
+        :param term_statistics: If `true`, the response includes: * The total term frequency
+            (how often a term occurs in all documents). * The document frequency (the
+            number of documents containing the current term). By default these values
+            are not returned since term statistics can have a serious performance impact.
         :param version: If `true`, returns the document version as part of a hit.
-        :param version_type: Specific version type.
+        :param version_type: The version type.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -5723,6 +6163,7 @@ class Elasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         if_primary_term: t.Optional[int] = None,
         if_seq_no: t.Optional[int] = None,
+        include_source_on_error: t.Optional[bool] = None,
         lang: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         refresh: t.Optional[
@@ -5763,7 +6204,7 @@ class Elasticsearch(BaseClient):
           In addition to <code>_source</code>, you can access the following variables through the <code>ctx</code> map: <code>_index</code>, <code>_type</code>, <code>_id</code>, <code>_version</code>, <code>_routing</code>, and <code>_now</code> (the current timestamp).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update>`_
 
         :param index: The name of the target index. By default, the index is created
             automatically if it doesn't exist.
@@ -5778,6 +6219,8 @@ class Elasticsearch(BaseClient):
             term.
         :param if_seq_no: Only perform the operation if the document has this sequence
             number.
+        :param include_source_on_error: True or false if to include the document source
+            in the error message in case of parsing errors.
         :param lang: The script language.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
             this operation visible to search. If 'wait_for', it waits for a refresh to
@@ -5822,6 +6265,8 @@ class Elasticsearch(BaseClient):
             __query["if_primary_term"] = if_primary_term
         if if_seq_no is not None:
             __query["if_seq_no"] = if_seq_no
+        if include_source_on_error is not None:
+            __query["include_source_on_error"] = include_source_on_error
         if lang is not None:
             __query["lang"] = lang
         if pretty is not None:
@@ -5997,7 +6442,7 @@ class Elasticsearch(BaseClient):
           This API enables you to only modify the source of matching documents; you cannot move them.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update-by-query>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             search. It supports wildcards (`*`). To search all data streams or indices,
@@ -6217,7 +6662,7 @@ class Elasticsearch(BaseClient):
           Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html#docs-update-by-query-rethrottle>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update-by-query-rethrottle>`_
 
         :param task_id: The ID for the task.
         :param requests_per_second: The throttle for this request in sub-requests per

--- a/elasticsearch/_sync/client/async_search.py
+++ b/elasticsearch/_sync/client/async_search.py
@@ -44,7 +44,7 @@ class AsyncSearchClient(NamespacedClient):
           If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the <code>cancel_task</code> cluster privilege.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param id: A unique identifier for the async search.
         """
@@ -94,11 +94,11 @@ class AsyncSearchClient(NamespacedClient):
           If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param id: A unique identifier for the async search.
-        :param keep_alive: Specifies how long the async search should be available in
-            the cluster. When not specified, the `keep_alive` set with the corresponding
+        :param keep_alive: The length of time that the async search should be available
+            in the cluster. When not specified, the `keep_alive` set with the corresponding
             submit async request will be used. Otherwise, it is possible to override
             the value and extend the validity of the request. When this period expires,
             the search, if still running, is cancelled. If the search is completed, its
@@ -157,13 +157,17 @@ class AsyncSearchClient(NamespacedClient):
 
           <p>Get the async search status.</p>
           <p>Get the status of a previously submitted async search request given its identifier, without retrieving search results.
-          If the Elasticsearch security features are enabled, use of this API is restricted to the <code>monitoring_user</code> role.</p>
+          If the Elasticsearch security features are enabled, the access to the status of a specific async search is restricted to:</p>
+          <ul>
+          <li>The user or API key that submitted the original async search request.</li>
+          <li>Users that have the <code>monitor</code> cluster privilege or greater privileges.</li>
+          </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param id: A unique identifier for the async search.
-        :param keep_alive: Specifies how long the async search needs to be available.
+        :param keep_alive: The length of time that the async search needs to be available.
             Ongoing async searches and any saved search results are deleted after this
             period.
         """
@@ -294,7 +298,7 @@ class AsyncSearchClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         search_type: t.Optional[
             t.Union[str, t.Literal["dfs_query_then_fetch", "query_then_fetch"]]
@@ -341,7 +345,7 @@ class AsyncSearchClient(NamespacedClient):
           The maximum allowed size for a stored async search response can be set by changing the <code>search.max_async_search_response_size</code> cluster level setting.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-async-search-submit>`_
 
         :param index: A comma-separated list of index names to search; use `_all` or
             empty string to perform the operation on all indices

--- a/elasticsearch/_sync/client/autoscaling.py
+++ b/elasticsearch/_sync/client/autoscaling.py
@@ -44,7 +44,7 @@ class AutoscalingClient(NamespacedClient):
           <p>NOTE: This feature is designed for indirect use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes. Direct use is not supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-delete-autoscaling-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-delete-autoscaling-policy>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -104,7 +104,7 @@ class AutoscalingClient(NamespacedClient):
           Do not use this information to make autoscaling decisions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-get-autoscaling-capacity>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -151,7 +151,7 @@ class AutoscalingClient(NamespacedClient):
           <p>NOTE: This feature is designed for indirect use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes. Direct use is not supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-get-autoscaling-capacity.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-get-autoscaling-capacity>`_
 
         :param name: the name of the autoscaling policy
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -206,7 +206,7 @@ class AutoscalingClient(NamespacedClient):
           <p>NOTE: This feature is designed for indirect use by Elasticsearch Service, Elastic Cloud Enterprise, and Elastic Cloud on Kubernetes. Direct use is not supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-put-autoscaling-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-autoscaling-put-autoscaling-policy>`_
 
         :param name: the name of the autoscaling policy
         :param policy:

--- a/elasticsearch/_sync/client/cat.py
+++ b/elasticsearch/_sync/client/cat.py
@@ -64,7 +64,7 @@ class CatClient(NamespacedClient):
           <p>IMPORTANT: CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-aliases>`_
 
         :param name: A comma-separated list of aliases to retrieve. Supports wildcards
             (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
@@ -154,7 +154,7 @@ class CatClient(NamespacedClient):
           <p>IMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-allocation>`_
 
         :param node_id: A comma-separated list of node identifiers or names used to limit
             the returned information.
@@ -243,7 +243,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use the get component template API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-component-templates>`_
 
         :param name: The name of the component template. It accepts wildcard expressions.
             If it is omitted, all component templates are returned.
@@ -327,7 +327,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use the count API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-count>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. It supports wildcards (`*`). To target all data streams
@@ -405,7 +405,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use the nodes stats API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-fielddata>`_
 
         :param fields: Comma-separated list of fields used to limit returned information.
             To retrieve all fields, omit this parameter.
@@ -491,7 +491,7 @@ class CatClient(NamespacedClient):
           You also can use the API to track the recovery of a large cluster over a longer period of time.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-health>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -549,7 +549,7 @@ class CatClient(NamespacedClient):
           <p>Get help for the CAT APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-cat>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_cat"
@@ -616,7 +616,7 @@ class CatClient(NamespacedClient):
           They are not intended for use by applications. For application consumption, use an index endpoint.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-indices>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -714,7 +714,7 @@ class CatClient(NamespacedClient):
           <p>IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-master>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -892,7 +892,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get data frame analytics jobs statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-data-frame-analytics>`_
 
         :param id: The ID of the data frame analytics to fetch
         :param allow_no_match: Whether to ignore if a wildcard expression matches no
@@ -1060,7 +1060,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get datafeed statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-datafeeds>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed.
@@ -1426,7 +1426,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get anomaly detection job statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-jobs>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param allow_no_match: Specifies what to do when the request: * Contains wildcard
@@ -1611,7 +1611,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get trained models statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-trained-models>`_
 
         :param model_id: A unique identifier for the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -1704,7 +1704,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-nodeattrs>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1787,7 +1787,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-nodes>`_
 
         :param bytes: The unit used to display byte values.
         :param format: Specifies the format to return the columnar data in, can be set
@@ -1874,7 +1874,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-pending-tasks>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -1954,7 +1954,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-plugins>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -2042,7 +2042,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-recovery>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2130,7 +2130,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-repositories>`_
 
         :param format: Specifies the format to return the columnar data in, can be set
             to `text`, `json`, `cbor`, `yaml`, or `smile`.
@@ -2211,7 +2211,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-segments>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2305,7 +2305,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-shards>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2394,7 +2394,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-snapshots>`_
 
         :param repository: A comma-separated list of snapshot repositories used to limit
             the request. Accepts wildcard expressions. `_all` returns all repositories.
@@ -2487,7 +2487,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the task management API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-tasks>`_
 
         :param actions: The task action names, which are used to limit the response.
         :param detailed: If `true`, the response includes detailed information about
@@ -2581,7 +2581,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-templates>`_
 
         :param name: The name of the template to return. Accepts wildcard expressions.
             If omitted, all templates are returned.
@@ -2669,7 +2669,7 @@ class CatClient(NamespacedClient):
           IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-thread-pool>`_
 
         :param thread_pool_patterns: A comma-separated list of thread pool names used
             to limit the request. Accepts wildcard expressions.
@@ -2926,7 +2926,7 @@ class CatClient(NamespacedClient):
           application consumption, use the get transform statistics API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-transforms>`_
 
         :param transform_id: A transform identifier or a wildcard expression. If you
             do not specify one of these options, the API returns information for all

--- a/elasticsearch/_sync/client/ccr.py
+++ b/elasticsearch/_sync/client/ccr.py
@@ -39,14 +39,17 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete auto-follow patterns.
-          Delete a collection of cross-cluster replication auto-follow patterns.</p>
+          <p>Delete auto-follow patterns.</p>
+          <p>Delete a collection of cross-cluster replication auto-follow patterns.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-delete-auto-follow-pattern>`_
 
-        :param name: The name of the auto follow pattern.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The auto-follow pattern collection to delete.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -127,7 +130,7 @@ class CcrClient(NamespacedClient):
           When the API returns, the follower index exists and cross-cluster replication starts replicating operations from the leader index to the follower index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-follow>`_
 
         :param index: The name of the follower index.
         :param leader_index: The name of the index in the leader cluster to follow.
@@ -251,16 +254,18 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get follower information.
-          Get information about all cross-cluster replication follower indices.
+          <p>Get follower information.</p>
+          <p>Get information about all cross-cluster replication follower indices.
           For example, the results include follower index names, leader index names, replication options, and whether the follower indices are active or paused.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-follow-info>`_
 
-        :param index: A comma-separated list of index patterns; use `_all` to perform
-            the operation on all indices
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param index: A comma-delimited list of follower index patterns.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -301,17 +306,16 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get follower stats.
-          Get cross-cluster replication follower stats.
+          <p>Get follower stats.</p>
+          <p>Get cross-cluster replication follower stats.
           The API returns shard-level stats about the &quot;following tasks&quot; associated with each shard for the specified indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-follow-stats>`_
 
-        :param index: A comma-separated list of index patterns; use `_all` to perform
-            the operation on all indices
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param index: A comma-delimited list of index patterns.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -376,7 +380,7 @@ class CcrClient(NamespacedClient):
           The only purpose of this API is to handle the case of failure to remove the following retention leases after the unfollow API is invoked.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-forget-follower>`_
 
         :param index: the name of the leader index for which specified follower retention
             leases should be removed
@@ -437,15 +441,18 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get auto-follow patterns.
-          Get cross-cluster replication auto-follow patterns.</p>
+          <p>Get auto-follow patterns.</p>
+          <p>Get cross-cluster replication auto-follow patterns.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-get-auto-follow-pattern-1>`_
 
-        :param name: Specifies the auto-follow pattern collection that you want to retrieve.
-            If you do not specify a name, the API returns information for all collections.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The auto-follow pattern collection that you want to retrieve. If
+            you do not specify a name, the API returns information for all collections.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         __path_parts: t.Dict[str, str]
         if name not in SKIP_IN_PATH:
@@ -489,8 +496,8 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Pause an auto-follow pattern.
-          Pause a cross-cluster replication auto-follow pattern.
+          <p>Pause an auto-follow pattern.</p>
+          <p>Pause a cross-cluster replication auto-follow pattern.
           When the API returns, the auto-follow pattern is inactive.
           New indices that are created on the remote cluster and match the auto-follow patterns are ignored.</p>
           <p>You can resume auto-following with the resume auto-follow pattern API.
@@ -498,11 +505,13 @@ class CcrClient(NamespacedClient):
           Remote indices that were created while the pattern was paused will also be followed, unless they have been deleted or closed in the interim.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-pause-auto-follow-pattern>`_
 
-        :param name: The name of the auto follow pattern that should pause discovering
-            new indices to follow.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The name of the auto-follow pattern to pause.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -543,18 +552,20 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Pause a follower.
-          Pause a cross-cluster replication follower index.
+          <p>Pause a follower.</p>
+          <p>Pause a cross-cluster replication follower index.
           The follower index will not fetch any additional operations from the leader index.
           You can resume following with the resume follower API.
           You can pause and resume a follower index to change the configuration of the following task.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-pause-follow>`_
 
-        :param index: The name of the follower index that should pause following its
-            leader index.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param index: The name of the follower index.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -637,7 +648,7 @@ class CcrClient(NamespacedClient):
           NOTE: Follower indices that were configured automatically before updating an auto-follow pattern will remain unchanged even if they do not match against the new patterns.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-put-auto-follow-pattern>`_
 
         :param name: The name of the collection of auto-follow patterns.
         :param remote_cluster: The remote cluster containing the leader indices to match
@@ -765,17 +776,19 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Resume an auto-follow pattern.
-          Resume a cross-cluster replication auto-follow pattern that was paused.
+          <p>Resume an auto-follow pattern.</p>
+          <p>Resume a cross-cluster replication auto-follow pattern that was paused.
           The auto-follow pattern will resume configuring following indices for newly created indices that match its patterns on the remote cluster.
           Remote indices created while the pattern was paused will also be followed unless they have been deleted or closed in the interim.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-resume-auto-follow-pattern>`_
 
-        :param name: The name of the auto follow pattern to resume discovering new indices
-            to follow.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param name: The name of the auto-follow pattern to resume.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -847,7 +860,7 @@ class CcrClient(NamespacedClient):
           When this API returns, the follower index will resume fetching operations from the leader index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-resume-follow>`_
 
         :param index: The name of the follow index to resume following.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -934,15 +947,18 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get cross-cluster replication stats.
-          This API returns stats about auto-following and the same shard-level stats as the get follower stats API.</p>
+          <p>Get cross-cluster replication stats.</p>
+          <p>This API returns stats about auto-following and the same shard-level stats as the get follower stats API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-stats>`_
 
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ccr/stats"
@@ -983,18 +999,23 @@ class CcrClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Unfollow an index.
-          Convert a cross-cluster replication follower index to a regular index.
+          <p>Unfollow an index.</p>
+          <p>Convert a cross-cluster replication follower index to a regular index.
           The API stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication.
           The follower index must be paused and closed before you call the unfollow API.</p>
-          <p>NOTE: Currently cross-cluster replication does not support converting an existing regular index to a follower index. Converting a follower index to a regular index is an irreversible operation.</p>
+          <blockquote>
+          <p>info
+          Currently cross-cluster replication does not support converting an existing regular index to a follower index. Converting a follower index to a regular index is an irreversible operation.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-unfollow>`_
 
-        :param index: The name of the follower index that should be turned into a regular
-            index.
-        :param master_timeout: Period to wait for a connection to the master node.
+        :param index: The name of the follower index.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If the master node is not available before the timeout expires, the request
+            fails and returns an error. It can also be set to `-1` to indicate that the
+            request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")

--- a/elasticsearch/_sync/client/cluster.py
+++ b/elasticsearch/_sync/client/cluster.py
@@ -54,7 +54,7 @@ class ClusterClient(NamespacedClient):
           This API can be very useful when attempting to diagnose why a shard is unassigned or why a shard continues to remain on its current node when you might expect otherwise.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-allocation-explain>`_
 
         :param current_node: Specifies the node ID or the name of the node to only explain
             a shard that is currently located on the specified node.
@@ -130,7 +130,7 @@ class ClusterClient(NamespacedClient):
           Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Comma-separated list or wildcard expression of component template
             names used to limit the request.
@@ -185,7 +185,7 @@ class ClusterClient(NamespacedClient):
           Remove master-eligible nodes from the voting configuration exclusion list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
@@ -239,7 +239,7 @@ class ClusterClient(NamespacedClient):
           Returns information about whether a particular component template exists.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (*) expressions are supported.
@@ -298,7 +298,7 @@ class ClusterClient(NamespacedClient):
           Get information about component templates.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Comma-separated list of component template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -365,7 +365,7 @@ class ClusterClient(NamespacedClient):
           By default, it returns only settings that have been explicitly defined.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-get-settings>`_
 
         :param flat_settings: If `true`, returns settings in flat format.
         :param include_defaults: If `true`, returns default cluster settings from the
@@ -447,8 +447,8 @@ class ClusterClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get the cluster health status.
-          You can also use the API to get the health status of only specified data streams and indices.
+          <p>Get the cluster health status.</p>
+          <p>You can also use the API to get the health status of only specified data streams and indices.
           For data streams, the API retrieves the health status of the stream’s backing indices.</p>
           <p>The cluster health status is: green, yellow or red.
           On the shard level, a red status indicates that the specific shard is not allocated in the cluster. Yellow means that the primary shard is allocated but replicas are not. Green means that all shards are allocated.
@@ -457,7 +457,7 @@ class ClusterClient(NamespacedClient):
           The cluster status is controlled by the worst index status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-health>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (`*`) are supported. To target
@@ -565,7 +565,7 @@ class ClusterClient(NamespacedClient):
           Returns basic information about the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-info>`_
 
         :param target: Limits the information returned to the specific target. Supports
             a comma-separated list, such as http,ingest.
@@ -614,7 +614,7 @@ class ClusterClient(NamespacedClient):
           However, if a user-initiated task such as a create index command causes a cluster state update, the activity of this task might be reported by both task api and pending cluster tasks API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-pending-tasks>`_
 
         :param local: If `true`, the request retrieves information from the local node
             only. If `false`, information is retrieved from the master node.
@@ -680,7 +680,7 @@ class ClusterClient(NamespacedClient):
           They are not required when removing master-ineligible nodes or when removing fewer than half of the master-eligible nodes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param node_ids: A comma-separated list of the persistent ids of the nodes to
@@ -761,7 +761,7 @@ class ClusterClient(NamespacedClient):
           To be applied, a component template must be included in an index template's <code>composed_of</code> list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template>`_
 
         :param name: Name of the component template to create. Elasticsearch includes
             the following built-in component templates: `logs-mappings`; `logs-settings`;
@@ -850,8 +850,8 @@ class ClusterClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Update the cluster settings.
-          Configure and update dynamic settings on a running cluster.
+          <p>Update the cluster settings.</p>
+          <p>Configure and update dynamic settings on a running cluster.
           You can also configure dynamic settings locally on an unstarted or shut down node in <code>elasticsearch.yml</code>.</p>
           <p>Updates made with this API can be persistent, which apply across cluster restarts, or transient, which reset after a cluster restart.
           You can also reset transient or persistent settings by assigning them a null value.</p>
@@ -866,7 +866,7 @@ class ClusterClient(NamespacedClient):
           If a cluster becomes unstable, transient settings can clear unexpectedly, resulting in a potentially undesired cluster configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-settings>`_
 
         :param flat_settings: Return settings in flat format (default: false)
         :param master_timeout: Explicit operation timeout for connection to master node
@@ -920,12 +920,19 @@ class ClusterClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get remote cluster information.
-          Get all of the configured remote cluster information.
-          This API returns connection and endpoint information keyed by the configured remote cluster alias.</p>
+          <p>Get remote cluster information.</p>
+          <p>Get information about configured remote clusters.
+          The API returns connection and endpoint information keyed by the configured remote cluster alias.</p>
+          <blockquote>
+          <p>info
+          This API returns information that reflects current state on the local cluster.
+          The <code>connected</code> field does not necessarily reflect whether a remote cluster is down or unavailable, only whether there is currently an open connection to it.
+          Elasticsearch does not spontaneously try to reconnect to a disconnected remote cluster.
+          To trigger a reconnection, attempt a cross-cluster search, ES|QL cross-cluster search, or try the <a href="https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-resolve-cluster">resolve cluster endpoint</a>.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-remote-info>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_remote/info"
@@ -982,7 +989,7 @@ class ClusterClient(NamespacedClient):
           <p>Once the problem has been corrected, allocation can be manually retried by calling the reroute API with the <code>?retry_failed</code> URI query parameter, which will attempt a single retry round for these shards.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-reroute>`_
 
         :param commands: Defines the commands to perform.
         :param dry_run: If true, then the request simulates the operation. It will calculate
@@ -1087,7 +1094,7 @@ class ClusterClient(NamespacedClient):
           Instead, obtain the information you require using other more stable cluster APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-state>`_
 
         :param metric: Limit the information returned to the specified metrics
         :param index: A comma-separated list of index names; use `_all` or empty string
@@ -1175,7 +1182,7 @@ class ClusterClient(NamespacedClient):
           Get basic index metrics (shard numbers, store size, memory usage) and information about the current nodes that form the cluster (number, roles, os, jvm versions, memory usage, cpu and installed plugins).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-stats>`_
 
         :param node_id: Comma-separated list of node filters used to limit returned information.
             Defaults to all nodes in the cluster.

--- a/elasticsearch/_sync/client/connector.py
+++ b/elasticsearch/_sync/client/connector.py
@@ -49,7 +49,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the <code>last_seen</code> field in the connector and set it to the current timestamp.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/check-in-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-check-in>`_
 
         :param connector_id: The unique identifier of the connector to be checked in
         """
@@ -99,7 +99,7 @@ class ConnectorClient(NamespacedClient):
           These need to be removed manually.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-delete>`_
 
         :param connector_id: The unique identifier of the connector to be deleted
         :param delete_sync_jobs: A flag indicating if associated sync jobs should be
@@ -152,7 +152,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get the details about a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-get>`_
 
         :param connector_id: The unique identifier of the connector
         :param include_deleted: A flag to indicate if the desired connector should be
@@ -256,7 +256,7 @@ class ConnectorClient(NamespacedClient):
           This action is used for analytics and monitoring.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-last-sync-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-last-sync>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param last_access_control_sync_error:
@@ -356,7 +356,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get information about all connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-list>`_
 
         :param connector_name: A comma-separated list of connector names to fetch connector
             documents for
@@ -441,7 +441,7 @@ class ConnectorClient(NamespacedClient):
           Self-managed connectors (Connector clients) are self-managed on your infrastructure.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-put>`_
 
         :param description:
         :param index_name:
@@ -523,7 +523,7 @@ class ConnectorClient(NamespacedClient):
           <p>Create or update a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-put>`_
 
         :param connector_id: The unique identifier of the connector to be created or
             updated. ID is auto-generated if not provided.
@@ -598,7 +598,7 @@ class ConnectorClient(NamespacedClient):
           The connector service is then responsible for setting the status of connector sync jobs to cancelled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cancel-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-cancel>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -649,7 +649,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/check-in-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-check-in>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be checked in.
@@ -709,7 +709,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/claim-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-claim>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param worker_hostname: The host name of the current system that will run the
@@ -771,7 +771,7 @@ class ConnectorClient(NamespacedClient):
           This is a destructive action that is not recoverable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-delete>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
             to be deleted
@@ -825,7 +825,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-error-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-error>`_
 
         :param connector_sync_job_id: The unique identifier for the connector sync job.
         :param error: The error for the connector sync job error field.
@@ -879,7 +879,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get a connector sync job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-get>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job
         """
@@ -952,7 +952,7 @@ class ConnectorClient(NamespacedClient):
           <p>Get information about all stored connector sync jobs listed by their creation date in ascending order.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-connector-sync-jobs-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-list>`_
 
         :param connector_id: A connector id to fetch connector sync jobs for
         :param from_: Starting offset (default: 0)
@@ -1018,7 +1018,7 @@ class ConnectorClient(NamespacedClient):
           <p>Create a connector sync job document in the internal index and initialize its counters and timestamps with default values.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-sync-job-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-post>`_
 
         :param id: The id of the associated connector
         :param job_type:
@@ -1094,7 +1094,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-stats-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-update-stats>`_
 
         :param connector_sync_job_id: The unique identifier of the connector sync job.
         :param deleted_document_count: The number of documents the sync job deleted.
@@ -1177,7 +1177,7 @@ class ConnectorClient(NamespacedClient):
           <p>Activates the valid draft filtering for a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-filtering>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         """
@@ -1230,7 +1230,7 @@ class ConnectorClient(NamespacedClient):
           Self-managed connectors (connector clients) do not use this field.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-api-key-id-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-api-key-id>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param api_key_id:
@@ -1289,7 +1289,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the configuration field in the connector document.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-configuration-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-configuration>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param configuration:
@@ -1349,7 +1349,7 @@ class ConnectorClient(NamespacedClient):
           Otherwise, if the error is reset to null, the connector status is updated to connected.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-error-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-error>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param error:
@@ -1417,7 +1417,7 @@ class ConnectorClient(NamespacedClient):
           This service runs automatically on Elastic Cloud for Elastic managed connectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-features-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-features>`_
 
         :param connector_id: The unique identifier of the connector to be updated.
         :param features:
@@ -1478,7 +1478,7 @@ class ConnectorClient(NamespacedClient):
           The filtering property is used to configure sync rules (both basic and advanced) for a connector.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-filtering-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-filtering>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param advanced_snippet:
@@ -1596,7 +1596,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the <code>index_name</code> field of a connector, specifying the index where the data ingested by the connector is stored.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-index-name-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-index-name>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param index_name:
@@ -1653,7 +1653,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector name and description.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-name-description-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-name>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param description:
@@ -1767,7 +1767,7 @@ class ConnectorClient(NamespacedClient):
           <p>When you create a new connector, the configuration of an ingest pipeline is populated with default settings.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-pipeline>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param pipeline:
@@ -1823,7 +1823,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector scheduling.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-scheduling-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-scheduling>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param scheduling:
@@ -1879,7 +1879,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector service type.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-service-type-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-service-type>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param service_type:
@@ -1942,7 +1942,7 @@ class ConnectorClient(NamespacedClient):
           <p>Update the connector status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-status>`_
 
         :param connector_id: The unique identifier of the connector to be updated
         :param status:

--- a/elasticsearch/_sync/client/dangling_indices.py
+++ b/elasticsearch/_sync/client/dangling_indices.py
@@ -46,7 +46,7 @@ class DanglingIndicesClient(NamespacedClient):
           For example, this can happen if you delete more than <code>cluster.indices.tombstones.size</code> indices while an Elasticsearch node is offline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-index-delete.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-dangling-indices-delete-dangling-index>`_
 
         :param index_uuid: The UUID of the index to delete. Use the get dangling indices
             API to find the UUID.
@@ -107,7 +107,7 @@ class DanglingIndicesClient(NamespacedClient):
           For example, this can happen if you delete more than <code>cluster.indices.tombstones.size</code> indices while an Elasticsearch node is offline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-index-import.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-dangling-indices-import-dangling-index>`_
 
         :param index_uuid: The UUID of the index to import. Use the get dangling indices
             API to locate the UUID.
@@ -168,7 +168,7 @@ class DanglingIndicesClient(NamespacedClient):
           <p>Use this API to list dangling indices, which you can then import or delete.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-indices-list.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-dangling-indices-list-dangling-indices>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_dangling"

--- a/elasticsearch/_sync/client/enrich.py
+++ b/elasticsearch/_sync/client/enrich.py
@@ -43,7 +43,7 @@ class EnrichClient(NamespacedClient):
           Deletes an existing enrich policy and its enrich index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-delete-policy>`_
 
         :param name: Enrich policy to delete.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -92,7 +92,7 @@ class EnrichClient(NamespacedClient):
           Create the enrich index for an existing enrich policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-execute-policy>`_
 
         :param name: Enrich policy to execute.
         :param master_timeout: Period to wait for a connection to the master node.
@@ -144,7 +144,7 @@ class EnrichClient(NamespacedClient):
           Returns information about an enrich policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-get-policy>`_
 
         :param name: Comma-separated list of enrich policy names used to limit the request.
             To return information for all enrich policies, omit this parameter.
@@ -202,7 +202,7 @@ class EnrichClient(NamespacedClient):
           Creates an enrich policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-enrich-policy-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-put-policy>`_
 
         :param name: Name of the enrich policy to create or update.
         :param geo_match: Matches enrich data to incoming documents based on a `geo_shape`
@@ -263,7 +263,7 @@ class EnrichClient(NamespacedClient):
           Returns enrich coordinator statistics and information about enrich policies that are currently executing.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-stats-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-stats>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_sync/client/eql.py
+++ b/elasticsearch/_sync/client/eql.py
@@ -43,7 +43,7 @@ class EqlClient(NamespacedClient):
           The API also deletes results for the search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-delete>`_
 
         :param id: Identifier for the search to delete. A search ID is provided in the
             EQL search API's response for an async search. A search ID is also provided
@@ -93,7 +93,7 @@ class EqlClient(NamespacedClient):
           Get the current status and available results for an async EQL search or a stored synchronous EQL search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-get>`_
 
         :param id: Identifier for the search.
         :param keep_alive: Period for which the search and its results are stored on
@@ -147,7 +147,7 @@ class EqlClient(NamespacedClient):
           Get the current status for an async EQL search or a stored synchronous EQL search without returning results.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-get-status>`_
 
         :param id: Identifier for the search.
         """
@@ -246,13 +246,20 @@ class EqlClient(NamespacedClient):
           EQL assumes each document in a data stream or index corresponds to an event.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-search>`_
 
         :param index: The name of the index to scope the operation
         :param query: EQL query you wish to run.
         :param allow_no_indices:
-        :param allow_partial_search_results:
-        :param allow_partial_sequence_results:
+        :param allow_partial_search_results: Allow query execution also in case of shard
+            failures. If true, the query will keep running and will return results based
+            on the available shards. For sequences, the behavior can be further refined
+            using allow_partial_sequence_results
+        :param allow_partial_sequence_results: This flag applies only to sequences and
+            has effect only if allow_partial_search_results=true. If true, the sequence
+            query will return results based on the available shards, ignoring the others.
+            If false, the sequence query will return successfully, but will always have
+            empty results.
         :param case_sensitive:
         :param event_category_field: Field containing the event classification, such
             as process, file, or network.

--- a/elasticsearch/_sync/client/esql.py
+++ b/elasticsearch/_sync/client/esql.py
@@ -30,6 +30,7 @@ class EsqlClient(NamespacedClient):
             "query",
             "columnar",
             "filter",
+            "include_ccs_metadata",
             "locale",
             "params",
             "profile",
@@ -56,12 +57,11 @@ class EsqlClient(NamespacedClient):
             ]
         ] = None,
         human: t.Optional[bool] = None,
+        include_ccs_metadata: t.Optional[bool] = None,
         keep_alive: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         keep_on_completion: t.Optional[bool] = None,
         locale: t.Optional[str] = None,
-        params: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
-        ] = None,
+        params: t.Optional[t.Sequence[t.Union[None, bool, float, int, str]]] = None,
         pretty: t.Optional[bool] = None,
         profile: t.Optional[bool] = None,
         tables: t.Optional[
@@ -80,7 +80,7 @@ class EsqlClient(NamespacedClient):
           <p>The API accepts the same parameters and request body as the synchronous query API, along with additional async related properties.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-async-query>`_
 
         :param query: The ES|QL query API accepts an ES|QL query string in the query
             parameter, runs it, and returns the results.
@@ -97,6 +97,10 @@ class EsqlClient(NamespacedClient):
         :param filter: Specify a Query DSL query in the filter parameter to filter the
             set of documents that an ES|QL query runs on.
         :param format: A short version of the Accept header, for example `json` or `yaml`.
+        :param include_ccs_metadata: When set to `true` and performing a cross-cluster
+            query, the response will include an extra `_clusters` object with information
+            about the clusters that participated in the search along with info such as
+            shards count.
         :param keep_alive: The period for which the query and its results are stored
             in the cluster. The default period is five days. When this period expires,
             the query and its results are deleted, even if the query is still ongoing.
@@ -155,6 +159,8 @@ class EsqlClient(NamespacedClient):
                 __body["columnar"] = columnar
             if filter is not None:
                 __body["filter"] = filter
+            if include_ccs_metadata is not None:
+                __body["include_ccs_metadata"] = include_ccs_metadata
             if locale is not None:
                 __body["locale"] = locale
             if params is not None:
@@ -197,7 +203,7 @@ class EsqlClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-delete-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-async-query-delete>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -250,7 +256,7 @@ class EsqlClient(NamespacedClient):
           If the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can retrieve the results using this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-get-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-async-query-get>`_
 
         :param id: The unique identifier of the query. A query ID is provided in the
             ES|QL async query API response for a query that does not complete in the
@@ -298,11 +304,67 @@ class EsqlClient(NamespacedClient):
             path_parts=__path_parts,
         )
 
+    @_rewrite_parameters()
+    def async_query_stop(
+        self,
+        *,
+        id: str,
+        drop_null_columns: t.Optional[bool] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        .. raw:: html
+
+          <p>Stop async ES|QL query.</p>
+          <p>This API interrupts the query execution and returns the results so far.
+          If the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can stop it.</p>
+
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-stop-api.html>`_
+
+        :param id: The unique identifier of the query. A query ID is provided in the
+            ES|QL async query API response for a query that does not complete in the
+            designated time. A query ID is also provided when the request was submitted
+            with the `keep_on_completion` parameter set to `true`.
+        :param drop_null_columns: Indicates whether columns that are entirely `null`
+            will be removed from the `columns` and `values` portion of the results. If
+            `true`, the response will include an extra section under the name `all_columns`
+            which has the name of all the columns.
+        """
+        if id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'id'")
+        __path_parts: t.Dict[str, str] = {"id": _quote(id)}
+        __path = f'/_query/async/{__path_parts["id"]}/stop'
+        __query: t.Dict[str, t.Any] = {}
+        if drop_null_columns is not None:
+            __query["drop_null_columns"] = drop_null_columns
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        __headers = {"accept": "application/json"}
+        return self.perform_request(  # type: ignore[return-value]
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            endpoint_id="esql.async_query_stop",
+            path_parts=__path_parts,
+        )
+
     @_rewrite_parameters(
         body_fields=(
             "query",
             "columnar",
             "filter",
+            "include_ccs_metadata",
             "locale",
             "params",
             "profile",
@@ -329,10 +391,9 @@ class EsqlClient(NamespacedClient):
             ]
         ] = None,
         human: t.Optional[bool] = None,
+        include_ccs_metadata: t.Optional[bool] = None,
         locale: t.Optional[str] = None,
-        params: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
-        ] = None,
+        params: t.Optional[t.Sequence[t.Union[None, bool, float, int, str]]] = None,
         pretty: t.Optional[bool] = None,
         profile: t.Optional[bool] = None,
         tables: t.Optional[
@@ -364,6 +425,10 @@ class EsqlClient(NamespacedClient):
         :param filter: Specify a Query DSL query in the filter parameter to filter the
             set of documents that an ES|QL query runs on.
         :param format: A short version of the Accept header, e.g. json, yaml.
+        :param include_ccs_metadata: When set to `true` and performing a cross-cluster
+            query, the response will include an extra `_clusters` object with information
+            about the clusters that participated in the search along with info such as
+            shards count.
         :param locale:
         :param params: To avoid any attempts of hacking or code injection, extract the
             values in a separate list of parameters. Use question mark placeholders (?)
@@ -402,6 +467,8 @@ class EsqlClient(NamespacedClient):
                 __body["columnar"] = columnar
             if filter is not None:
                 __body["filter"] = filter
+            if include_ccs_metadata is not None:
+                __body["include_ccs_metadata"] = include_ccs_metadata
             if locale is not None:
                 __body["locale"] = locale
             if params is not None:

--- a/elasticsearch/_sync/client/features.py
+++ b/elasticsearch/_sync/client/features.py
@@ -48,7 +48,7 @@ class FeaturesClient(NamespacedClient):
           In order for a feature state to be listed in this API and recognized as a valid feature state by the create snapshot API, the plugin that defines that feature must be installed on the master node.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-features-get-features>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -102,7 +102,7 @@ class FeaturesClient(NamespacedClient):
           <p>IMPORTANT: The features installed on the node you submit this request to are the features that will be reset. Run on the master node if you have any doubts about which plugins are installed on individual nodes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-features-reset-features>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """

--- a/elasticsearch/_sync/client/fleet.py
+++ b/elasticsearch/_sync/client/fleet.py
@@ -48,12 +48,12 @@ class FleetClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get global checkpoints.
-          Get the current global checkpoints for an index.
+          <p>Get global checkpoints.</p>
+          <p>Get the current global checkpoints for an index.
           This API is designed for internal use by the Fleet server project.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-global-checkpoints.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-fleet>`_
 
         :param index: A single index or index alias that resolves to a single index.
         :param checkpoints: A comma separated list of previous global checkpoints. When
@@ -143,6 +143,8 @@ class FleetClient(NamespacedClient):
           The API follows the same structure as the multi search API.
           However, similar to the Fleet search API, it supports the <code>wait_for_checkpoints</code> parameter.</p>
 
+
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-fleet-msearch>`_
 
         :param searches:
         :param index: A single target to search. If the target is an index alias, it
@@ -348,7 +350,7 @@ class FleetClient(NamespacedClient):
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         search_type: t.Optional[
             t.Union[str, t.Literal["dfs_query_then_fetch", "query_then_fetch"]]
@@ -390,6 +392,8 @@ class FleetClient(NamespacedClient):
           The purpose of the Fleet search API is to provide an API where the search will be run only
           after the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.</p>
 
+
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-fleet-search>`_
 
         :param index: A single target to search. If the target is an index alias, it
             must resolve to a single index.

--- a/elasticsearch/_sync/client/graph.py
+++ b/elasticsearch/_sync/client/graph.py
@@ -55,7 +55,7 @@ class GraphClient(NamespacedClient):
           You can exclude vertices that have already been returned.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-graph>`_
 
         :param index: Name of the index.
         :param connections: Specifies or more fields from which you want to extract terms

--- a/elasticsearch/_sync/client/ilm.py
+++ b/elasticsearch/_sync/client/ilm.py
@@ -44,7 +44,7 @@ class IlmClient(NamespacedClient):
           You cannot delete policies that are currently in use. If the policy is being used to manage any indices, the request fails and returns an error.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-delete-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-delete-lifecycle>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -102,7 +102,7 @@ class IlmClient(NamespacedClient):
           <p>The response indicates when the index entered each lifecycle state, provides the definition of the running phase, and information about any failures.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-explain-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-explain-lifecycle>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to target.
             Supports wildcards (`*`). To target all data streams and indices, use `*`
@@ -163,7 +163,7 @@ class IlmClient(NamespacedClient):
           <p>Get lifecycle policies.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-get-lifecycle>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -214,11 +214,11 @@ class IlmClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get the ILM status.
-          Get the current index lifecycle management status.</p>
+          <p>Get the ILM status.</p>
+          <p>Get the current index lifecycle management status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-get-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-get-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ilm/status"
@@ -252,6 +252,7 @@ class IlmClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         legacy_template_to_delete: t.Optional[str] = None,
+        master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         node_attribute: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         body: t.Optional[t.Dict[str, t.Any]] = None,
@@ -274,12 +275,16 @@ class IlmClient(NamespacedClient):
           Use the stop ILM and get ILM status APIs to wait until the reported operation mode is <code>STOPPED</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-migrate-to-data-tiers.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-migrate-to-data-tiers>`_
 
         :param dry_run: If true, simulates the migration from node attributes based allocation
             filters to data tiers, but does not perform the migration. This provides
             a way to retrieve the indices and ILM policies that need to be migrated.
         :param legacy_template_to_delete:
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error. It can also be set to `-1` to indicate that the request
+            should never timeout.
         :param node_attribute:
         """
         __path_parts: t.Dict[str, str] = {}
@@ -294,6 +299,8 @@ class IlmClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
         if not __body:
@@ -347,7 +354,7 @@ class IlmClient(NamespacedClient):
           An index cannot move to a step that is not part of its policy.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-move-to-step.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-move-to-step>`_
 
         :param index: The name of the index whose lifecycle step is to change
         :param current_step: The step that the index is expected to be in.
@@ -415,7 +422,7 @@ class IlmClient(NamespacedClient):
           <p>NOTE: Only the latest version of the policy is stored, you cannot revert to previous versions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-put-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-put-lifecycle>`_
 
         :param name: Identifier for the policy.
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -479,7 +486,7 @@ class IlmClient(NamespacedClient):
           It also stops managing the indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-remove-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-remove-policy>`_
 
         :param index: The name of the index to remove policy on
         """
@@ -525,7 +532,7 @@ class IlmClient(NamespacedClient):
           Use the explain lifecycle state API to determine whether an index is in the ERROR step.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-retry-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-retry>`_
 
         :param index: The name of the indices (comma-separated) whose failed lifecycle
             step is to be retry
@@ -573,7 +580,7 @@ class IlmClient(NamespacedClient):
           Restarting ILM is necessary only when it has been stopped using the stop ILM API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-start.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-start>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -627,7 +634,7 @@ class IlmClient(NamespacedClient):
           Use the get ILM status API to check whether ILM is running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-stop.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-stop>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and

--- a/elasticsearch/_sync/client/indices.py
+++ b/elasticsearch/_sync/client/indices.py
@@ -57,23 +57,40 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Add an index block.
-          Limits the operations allowed on an index by blocking specific operation types.</p>
+          <p>Add an index block.</p>
+          <p>Add an index block to an index.
+          Index blocks limit the operations allowed on an index by blocking specific operation types.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-add-block>`_
 
-        :param index: A comma separated list of indices to add a block to
-        :param block: The block to add (one of read, write, read_only or metadata)
-        :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
-            into no concrete indices. (This includes `_all` string or when no indices
-            have been specified)
-        :param expand_wildcards: Whether to expand wildcard expression to concrete indices
-            that are open, closed or both.
-        :param ignore_unavailable: Whether specified concrete indices should be ignored
-            when unavailable (missing or closed)
-        :param master_timeout: Specify timeout for connection to master
-        :param timeout: Explicit operation timeout
+        :param index: A comma-separated list or wildcard expression of index names used
+            to limit the request. By default, you must explicitly name the indices you
+            are adding blocks to. To allow the adding of blocks to indices with `_all`,
+            `*`, or other wildcard expressions, change the `action.destructive_requires_name`
+            setting to `false`. You can update this setting in the `elasticsearch.yml`
+            file or by using the cluster update settings API.
+        :param block: The block type to add to the index.
+        :param allow_no_indices: If `false`, the request returns an error if any wildcard
+            expression, index alias, or `_all` value targets only missing or closed indices.
+            This behavior applies even if the request targets other open indices. For
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`.
+        :param expand_wildcards: The type of index that wildcard patterns can match.
+            If the request can target data streams, this argument determines whether
+            wildcard expressions match hidden data streams. It supports comma-separated
+            values, such as `open,hidden`.
+        :param ignore_unavailable: If `false`, the request returns an error if it targets
+            a missing or closed index.
+        :param master_timeout: The period to wait for the master node. If the master
+            node is not available before the timeout expires, the request fails and returns
+            an error. It can also be set to `-1` to indicate that the request should
+            never timeout.
+        :param timeout: The period to wait for a response from all relevant nodes in
+            the cluster after updating the cluster metadata. If no response is received
+            before the timeout expires, the cluster metadata update still applies but
+            the response will indicate that it was not completely acknowledged. It can
+            also be set to `-1` to indicate that the request should never timeout.
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
@@ -156,7 +173,7 @@ class IndicesClient(NamespacedClient):
           The <code>_analyze</code> endpoint without a specified index will always use <code>10000</code> as its limit.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-analyze>`_
 
         :param index: Index used to derive the analyzer. If specified, the `analyzer`
             or field parameter overrides this value. If no index is specified or the
@@ -310,7 +327,7 @@ class IndicesClient(NamespacedClient):
           To clear the cache only of specific fields, use the <code>fields</code> parameter.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-clear-cache>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -432,7 +449,7 @@ class IndicesClient(NamespacedClient):
           <p>Because the clone operation creates a new index to clone the shards to, the wait for active shards setting on index creation applies to the clone index action as well.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-clone>`_
 
         :param index: Name of the source index to clone.
         :param target: Name of the target index to create.
@@ -536,7 +553,7 @@ class IndicesClient(NamespacedClient):
           Closing indices can be turned off with the cluster settings API by setting <code>cluster.indices.close.enable</code> to <code>false</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-close.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-close>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -637,7 +654,7 @@ class IndicesClient(NamespacedClient):
           Note that changing this setting will also affect the <code>wait_for_active_shards</code> value on all subsequent write operations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create>`_
 
         :param index: Name of the index you wish to create.
         :param aliases: Aliases for the index.
@@ -710,12 +727,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Create a data stream.
-          Creates a data stream.
-          You must have a matching index template with data stream enabled.</p>
+          <p>Create a data stream.</p>
+          <p>You must have a matching index template with data stream enabled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create-data-stream>`_
 
         :param name: Name of the data stream, which must meet the following criteria:
             Lowercase only; Cannot include `\\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`,
@@ -841,11 +857,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data stream stats.
-          Retrieves statistics for one or more data streams.</p>
+          <p>Get data stream stats.</p>
+          <p>Get statistics for one or more data streams.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-data-streams-stats-1>`_
 
         :param name: Comma-separated list of data streams used to limit the request.
             Wildcard expressions (`*`) are supported. To target all data streams in a
@@ -914,7 +930,7 @@ class IndicesClient(NamespacedClient):
           You can then use the delete index API to delete the previous write index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete>`_
 
         :param index: Comma-separated list of indices to delete. You cannot specify index
             aliases. By default, this parameter does not support wildcards (`*`) or `_all`.
@@ -988,7 +1004,7 @@ class IndicesClient(NamespacedClient):
           Removes a data stream or index from an alias.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-alias.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-alias>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`).
@@ -1056,7 +1072,7 @@ class IndicesClient(NamespacedClient):
           Removes the data stream lifecycle from a data stream, rendering it not managed by the data stream lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-data-lifecycle>`_
 
         :param name: A comma-separated list of data streams of which the data stream
             lifecycle will be deleted; use `*` to get all data streams
@@ -1120,7 +1136,7 @@ class IndicesClient(NamespacedClient):
           Deletes one or more data streams and their backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-data-stream>`_
 
         :param name: Comma-separated list of data streams to delete. Wildcard (`*`) expressions
             are supported.
@@ -1178,7 +1194,7 @@ class IndicesClient(NamespacedClient):
           existing templates.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-index-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1233,7 +1249,7 @@ class IndicesClient(NamespacedClient):
           <p>Delete a legacy index template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-template>`_
 
         :param name: The name of the legacy index template to delete. Wildcard (`*`)
             expressions are supported.
@@ -1305,7 +1321,7 @@ class IndicesClient(NamespacedClient):
           The stored size of the <code>_id</code> field is likely underestimated while the <code>_source</code> field is overestimated.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-disk-usage>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. It’s recommended to execute this API with a single
@@ -1388,7 +1404,7 @@ class IndicesClient(NamespacedClient):
           The source index must be read only (<code>index.blocks.write: true</code>).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-downsample-data-stream.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-downsample>`_
 
         :param index: Name of the time series index to downsample.
         :param target_index: Name of the index to create.
@@ -1460,7 +1476,7 @@ class IndicesClient(NamespacedClient):
           Check if one or more indices, index aliases, or data streams exist.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases. Supports
             wildcards (`*`).
@@ -1538,11 +1554,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Check aliases.
-          Checks if one or more data stream or index aliases exist.</p>
+          <p>Check aliases.</p>
+          <p>Check if one or more data stream or index aliases exist.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-alias>`_
 
         :param name: Comma-separated list of aliases to check. Supports wildcards (`*`).
         :param index: Comma-separated list of data streams or indices used to limit the
@@ -1613,11 +1629,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Check index templates.
-          Check whether index templates exist.</p>
+          <p>Check index templates.</p>
+          <p>Check whether index templates exist.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-index-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -1672,7 +1688,7 @@ class IndicesClient(NamespacedClient):
           <p>IMPORTANT: This documentation is about legacy index templates, which are deprecated and will be replaced by the composable templates introduced in Elasticsearch 7.8.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-template-exists-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-template>`_
 
         :param name: A comma-separated list of index template names used to limit the
             request. Wildcard (`*`) expressions are supported.
@@ -1730,7 +1746,7 @@ class IndicesClient(NamespacedClient):
           Get information about an index or data stream's current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-explain-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-explain-data-lifecycle>`_
 
         :param index: The name of the index to explain
         :param include_defaults: indicates if the API should return the default values
@@ -1800,7 +1816,7 @@ class IndicesClient(NamespacedClient):
           A given request will increment each count by a maximum value of 1, even if the request accesses the same field multiple times.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-field-usage-stats>`_
 
         :param index: Comma-separated list or wildcard expression of index names used
             to limit the request.
@@ -1890,7 +1906,7 @@ class IndicesClient(NamespacedClient):
           If you call the flush API after indexing some documents then a successful response indicates that Elasticsearch has flushed all the documents that were indexed before the flush API was called.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-flush>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases to flush.
             Supports wildcards (`*`). To flush all data streams and indices, omit this
@@ -2015,7 +2031,7 @@ class IndicesClient(NamespacedClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-forcemerge>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices
@@ -2113,7 +2129,7 @@ class IndicesClient(NamespacedClient):
           stream’s backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get>`_
 
         :param index: Comma-separated list of data streams, indices, and index aliases
             used to limit the request. Wildcard expressions (*) are supported.
@@ -2206,7 +2222,7 @@ class IndicesClient(NamespacedClient):
           Retrieves information for one or more data stream or index aliases.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-alias.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-alias>`_
 
         :param index: Comma-separated list of data streams or indices used to limit the
             request. Supports wildcards (`*`). To target all data streams and indices,
@@ -2289,11 +2305,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data stream lifecycles.
-          Retrieves the data stream lifecycle configuration of one or more data streams.</p>
+          <p>Get data stream lifecycles.</p>
+          <p>Get the data stream lifecycle configuration of one or more data streams.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-lifecycle>`_
 
         :param name: Comma-separated list of data streams to limit the request. Supports
             wildcards (`*`). To target all data streams, omit this parameter or use `*`
@@ -2351,7 +2367,7 @@ class IndicesClient(NamespacedClient):
           Get statistics about the data streams that are managed by a data stream lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-lifecycle-stats>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_lifecycle/stats"
@@ -2398,11 +2414,11 @@ class IndicesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data streams.
-          Retrieves information about one or more data streams.</p>
+          <p>Get data streams.</p>
+          <p>Get information about one or more data streams.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-stream>`_
 
         :param name: Comma-separated list of data stream names used to limit the request.
             Wildcard (`*`) expressions are supported. If omitted, all data streams are
@@ -2471,7 +2487,6 @@ class IndicesClient(NamespacedClient):
         human: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
         include_defaults: t.Optional[bool] = None,
-        local: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -2483,7 +2498,7 @@ class IndicesClient(NamespacedClient):
           <p>This API is useful if you don't need a complete mapping or if an index mapping contains a large number of fields.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-mapping>`_
 
         :param fields: Comma-separated list or wildcard expression of fields used to
             limit returned information. Supports wildcards (`*`).
@@ -2500,8 +2515,6 @@ class IndicesClient(NamespacedClient):
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
         :param include_defaults: If `true`, return all default settings in the response.
-        :param local: If `true`, the request retrieves information from the local node
-            only.
         """
         if fields in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'fields'")
@@ -2529,8 +2542,6 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if include_defaults is not None:
             __query["include_defaults"] = include_defaults
-        if local is not None:
-            __query["local"] = local
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -2564,7 +2575,7 @@ class IndicesClient(NamespacedClient):
           Get information about one or more index templates.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-index-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (*) expressions are supported.
@@ -2641,7 +2652,7 @@ class IndicesClient(NamespacedClient):
           For data streams, the API retrieves mappings for the stream’s backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-mapping>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2775,7 +2786,7 @@ class IndicesClient(NamespacedClient):
           For data streams, it returns setting information for the stream's backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-settings>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -2867,7 +2878,7 @@ class IndicesClient(NamespacedClient):
           <p>IMPORTANT: This documentation is about legacy index templates, which are deprecated and will be replaced by the composable templates introduced in Elasticsearch 7.8.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-template>`_
 
         :param name: Comma-separated list of index template names used to limit the request.
             Wildcard (`*`) expressions are supported. To return all index templates,
@@ -3130,7 +3141,7 @@ class IndicesClient(NamespacedClient):
           <p>Because opening or closing an index allocates its shards, the <code>wait_for_active_shards</code> setting on index creation applies to the <code>_open</code> and <code>_close</code> index actions as well.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-open>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). By default, you must explicitly
@@ -3357,14 +3368,15 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_name="lifecycle",
+        body_fields=("data_retention", "downsampling", "enabled"),
     )
     def put_data_lifecycle(
         self,
         *,
         name: t.Union[str, t.Sequence[str]],
-        lifecycle: t.Optional[t.Mapping[str, t.Any]] = None,
-        body: t.Optional[t.Mapping[str, t.Any]] = None,
+        data_retention: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        downsampling: t.Optional[t.Mapping[str, t.Any]] = None,
+        enabled: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
             t.Union[
@@ -3379,6 +3391,7 @@ class IndicesClient(NamespacedClient):
         master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         .. raw:: html
@@ -3391,7 +3404,15 @@ class IndicesClient(NamespacedClient):
 
         :param name: Comma-separated list of data streams used to limit the request.
             Supports wildcards (`*`). To target all data streams use `*` or `_all`.
-        :param lifecycle:
+        :param data_retention: If defined, every document added to this data stream will
+            be stored at least for this time frame. Any time after this duration the
+            document could be deleted. When empty, every document in this data stream
+            will be stored indefinitely.
+        :param downsampling: The downsampling configuration to execute for the managed
+            backing index after rollover.
+        :param enabled: If defined, it turns data stream lifecycle on/off (`true`/`false`)
+            for this data stream. A data stream lifecycle that's disabled (enabled: `false`)
+            will have no effect on the data stream.
         :param expand_wildcards: Type of data stream that wildcard patterns can match.
             Supports comma-separated values, such as `open,hidden`. Valid values are:
             `all`, `hidden`, `open`, `closed`, `none`.
@@ -3403,15 +3424,10 @@ class IndicesClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if lifecycle is None and body is None:
-            raise ValueError(
-                "Empty value passed for parameters 'lifecycle' and 'body', one of them should be set."
-            )
-        elif lifecycle is not None and body is not None:
-            raise ValueError("Cannot set both 'lifecycle' and 'body'")
         __path_parts: t.Dict[str, str] = {"name": _quote(name)}
         __path = f'/_data_stream/{__path_parts["name"]}/_lifecycle'
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
@@ -3426,8 +3442,18 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        __body = lifecycle if lifecycle is not None else body
-        __headers = {"accept": "application/json", "content-type": "application/json"}
+        if not __body:
+            if data_retention is not None:
+                __body["data_retention"] = data_retention
+            if downsampling is not None:
+                __body["downsampling"] = downsampling
+            if enabled is not None:
+                __body["enabled"] = enabled
+        if not __body:
+            __body = None  # type: ignore[assignment]
+        __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
             "PUT",
             __path,
@@ -3633,10 +3659,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         dynamic_date_formats: t.Optional[t.Sequence[str]] = None,
         dynamic_templates: t.Optional[
-            t.Union[
-                t.Mapping[str, t.Mapping[str, t.Any]],
-                t.Sequence[t.Mapping[str, t.Mapping[str, t.Any]]],
-            ]
+            t.Sequence[t.Mapping[str, t.Mapping[str, t.Any]]]
         ] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
@@ -3688,7 +3711,7 @@ class IndicesClient(NamespacedClient):
           Instead, add an alias field to create an alternate field name.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping>`_
 
         :param index: A comma-separated list of index names the mapping should be added
             to (supports wildcards); use `_all` or omit to add the mapping on all indices.
@@ -3833,7 +3856,7 @@ class IndicesClient(NamespacedClient):
           To change the analyzer for existing backing indices, you must create a new data stream and reindex your data into it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-settings>`_
 
         :param settings:
         :param index: Comma-separated list of data streams, indices, and aliases used
@@ -3954,7 +3977,7 @@ class IndicesClient(NamespacedClient):
           NOTE: Multiple matching templates with the same order value will result in a non-deterministic merging order.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-template>`_
 
         :param name: The name of the template
         :param aliases: Aliases for the index.
@@ -4056,7 +4079,7 @@ class IndicesClient(NamespacedClient):
           This means that if a shard copy completes a recovery and then Elasticsearch relocates it onto a different node then the information about the original recovery will not be shown in the recovery API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-recovery>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4130,7 +4153,7 @@ class IndicesClient(NamespacedClient):
           This option ensures the indexing operation waits for a periodic refresh before running the search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-refresh>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4213,7 +4236,7 @@ class IndicesClient(NamespacedClient):
           This ensures the synonym file is updated everywhere in the cluster in case shards are relocated in the future.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-reload-search-analyzers>`_
 
         :param index: A comma-separated list of index names to reload analyzers for
         :param allow_no_indices: Whether to ignore if a wildcard indices expression resolves
@@ -4257,7 +4280,7 @@ class IndicesClient(NamespacedClient):
     def resolve_cluster(
         self,
         *,
-        name: t.Union[str, t.Sequence[str]],
+        name: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
@@ -4273,19 +4296,20 @@ class IndicesClient(NamespacedClient):
         ignore_throttled: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         .. raw:: html
 
-          <p>Resolve the cluster.
-          Resolve the specified index expressions to return information about each cluster, including the local cluster, if included.
-          Multiple patterns and remote clusters are supported.</p>
+          <p>Resolve the cluster.</p>
+          <p>Resolve the specified index expressions to return information about each cluster, including the local &quot;querying&quot; cluster, if included.
+          If no index expression is provided, the API will return information about all the remote clusters that are configured on the querying cluster.</p>
           <p>This endpoint is useful before doing a cross-cluster search in order to determine which remote clusters should be included in a search.</p>
           <p>You use the same index expression with this endpoint as you would for cross-cluster search.
           Index and cluster exclusions are also supported with this endpoint.</p>
           <p>For each cluster in the index expression, information is returned about:</p>
           <ul>
-          <li>Whether the querying (&quot;local&quot;) cluster is currently connected to each remote cluster in the index expression scope.</li>
+          <li>Whether the querying (&quot;local&quot;) cluster is currently connected to each remote cluster specified in the index expression. Note that this endpoint actively attempts to contact the remote clusters, unlike the <code>remote/info</code> endpoint.</li>
           <li>Whether each remote cluster is configured with <code>skip_unavailable</code> as <code>true</code> or <code>false</code>.</li>
           <li>Whether there are any indices, aliases, or data streams on that cluster that match the index expression.</li>
           <li>Whether the search is likely to have errors returned when you do the cross-cluster search (including any authorization errors if you do not have permission to query the index).</li>
@@ -4293,7 +4317,13 @@ class IndicesClient(NamespacedClient):
           </ul>
           <p>For example, <code>GET /_resolve/cluster/my-index-*,cluster*:my-index-*</code> returns information about the local cluster and all remotely configured clusters that start with the alias <code>cluster*</code>.
           Each cluster returns information about whether it has any indices, aliases or data streams that match <code>my-index-*</code>.</p>
-          <p><strong>Advantages of using this endpoint before a cross-cluster search</strong></p>
+          <h2>Note on backwards compatibility</h2>
+          <p>The ability to query without an index expression was added in version 8.18, so when
+          querying remote clusters older than that, the local cluster will send the index
+          expression <code>dummy*</code> to those remote clusters. Thus, if an errors occur, you may see a reference
+          to that index expression even though you didn't request it. If it causes a problem, you can
+          instead include an index expression like <code>*:*</code> to bypass the issue.</p>
+          <h2>Advantages of using this endpoint before a cross-cluster search</h2>
           <p>You may want to exclude a cluster or index from a search when:</p>
           <ul>
           <li>A remote cluster is not currently connected and is configured with <code>skip_unavailable=false</code>. Running a cross-cluster search under those conditions will cause the entire search to fail.</li>
@@ -4301,31 +4331,60 @@ class IndicesClient(NamespacedClient):
           <li>The index expression (combined with any query parameters you specify) will likely cause an exception to be thrown when you do the search. In these cases, the &quot;error&quot; field in the <code>_resolve/cluster</code> response will be present. (This is also where security/permission errors will be shown.)</li>
           <li>A remote cluster is an older version that does not support the feature you want to use in your search.</li>
           </ul>
+          <h2>Test availability of remote clusters</h2>
+          <p>The <code>remote/info</code> endpoint is commonly used to test whether the &quot;local&quot; cluster (the cluster being queried) is connected to its remote clusters, but it does not necessarily reflect whether the remote cluster is available or not.
+          The remote cluster may be available, while the local cluster is not currently connected to it.</p>
+          <p>You can use the <code>_resolve/cluster</code> API to attempt to reconnect to remote clusters.
+          For example with <code>GET _resolve/cluster</code> or <code>GET _resolve/cluster/*:*</code>.
+          The <code>connected</code> field in the response will indicate whether it was successful.
+          If a connection was (re-)established, this will also cause the <code>remote/info</code> endpoint to now indicate a connected status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-cluster-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-resolve-cluster>`_
 
-        :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
-            and data streams to resolve. Resources on remote clusters can be specified
-            using the `<cluster>`:`<name>` syntax.
+        :param name: A comma-separated list of names or index patterns for the indices,
+            aliases, and data streams to resolve. Resources on remote clusters can be
+            specified using the `<cluster>`:`<name>` syntax. Index and cluster exclusions
+            (e.g., `-cluster1:*`) are also supported. If no index expression is specified,
+            information about all remote clusters configured on the local cluster is
+            returned without doing any index matching
         :param allow_no_indices: If false, the request returns an error if any wildcard
-            expression, index alias, or _all value targets only missing or closed indices.
+            expression, index alias, or `_all` value targets only missing or closed indices.
             This behavior applies even if the request targets other open indices. For
-            example, a request targeting foo*,bar* returns an error if an index starts
-            with foo but no index starts with bar.
+            example, a request targeting `foo*,bar*` returns an error if an index starts
+            with `foo` but no index starts with `bar`. NOTE: This option is only supported
+            when specifying an index expression. You will get an error if you specify
+            index options to the `_resolve/cluster` API endpoint that takes no index
+            expression.
         :param expand_wildcards: Type of index that wildcard patterns can match. If the
             request can target data streams, this argument determines whether wildcard
             expressions match hidden data streams. Supports comma-separated values, such
             as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-        :param ignore_throttled: If true, concrete, expanded or aliased indices are ignored
-            when frozen. Defaults to false.
+            NOTE: This option is only supported when specifying an index expression.
+            You will get an error if you specify index options to the `_resolve/cluster`
+            API endpoint that takes no index expression.
+        :param ignore_throttled: If true, concrete, expanded, or aliased indices are
+            ignored when frozen. NOTE: This option is only supported when specifying
+            an index expression. You will get an error if you specify index options to
+            the `_resolve/cluster` API endpoint that takes no index expression.
         :param ignore_unavailable: If false, the request returns an error if it targets
-            a missing or closed index. Defaults to false.
+            a missing or closed index. NOTE: This option is only supported when specifying
+            an index expression. You will get an error if you specify index options to
+            the `_resolve/cluster` API endpoint that takes no index expression.
+        :param timeout: The maximum time to wait for remote clusters to respond. If a
+            remote cluster does not respond within this timeout period, the API response
+            will show the cluster as not connected and include an error message that
+            the request timed out. The default timeout is unset and the query can take
+            as long as the networking layer is configured to wait for remote clusters
+            that are not responding (typically 30 seconds).
         """
-        if name in SKIP_IN_PATH:
-            raise ValueError("Empty value passed for parameter 'name'")
-        __path_parts: t.Dict[str, str] = {"name": _quote(name)}
-        __path = f'/_resolve/cluster/{__path_parts["name"]}'
+        __path_parts: t.Dict[str, str]
+        if name not in SKIP_IN_PATH:
+            __path_parts = {"name": _quote(name)}
+            __path = f'/_resolve/cluster/{__path_parts["name"]}'
+        else:
+            __path_parts = {}
+            __path = "/_resolve/cluster"
         __query: t.Dict[str, t.Any] = {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
@@ -4343,6 +4402,8 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if pretty is not None:
             __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
         __headers = {"accept": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "GET",
@@ -4381,7 +4442,7 @@ class IndicesClient(NamespacedClient):
           Multiple patterns and remote clusters are supported.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-resolve-index>`_
 
         :param name: Comma-separated name(s) or index pattern(s) of the indices, aliases,
             and data streams to resolve. Resources on remote clusters can be specified
@@ -4482,7 +4543,7 @@ class IndicesClient(NamespacedClient):
           If you roll over the alias on May 7, 2099, the new index's name is <code>my-index-2099.05.07-000002</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-rollover>`_
 
         :param alias: Name of the data stream or index alias to roll over.
         :param new_index: Name of the index to create. Supports date math. Data streams
@@ -4591,7 +4652,7 @@ class IndicesClient(NamespacedClient):
           For data streams, the API returns information about the stream's backing indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-segments>`_
 
         :param index: Comma-separated list of data streams, indices, and aliases used
             to limit the request. Supports wildcards (`*`). To target all data streams
@@ -4680,7 +4741,7 @@ class IndicesClient(NamespacedClient):
           <p>By default, the API returns store information only for primary shards that are unassigned or have one or more unassigned replica shards.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-shard-stores>`_
 
         :param index: List of data streams, indices, and aliases used to limit the request.
         :param allow_no_indices: If false, the request returns an error if any wildcard
@@ -4782,7 +4843,7 @@ class IndicesClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-shrink>`_
 
         :param index: Name of the source index to shrink.
         :param target: Name of the target index to create.
@@ -4861,7 +4922,7 @@ class IndicesClient(NamespacedClient):
           Get the index configuration that would be applied to the specified index from an existing index template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-simulate-index-template>`_
 
         :param name: Name of the index to simulate
         :param include_defaults: If true, returns all relevant default configurations
@@ -4942,7 +5003,7 @@ class IndicesClient(NamespacedClient):
           Get the index configuration that would be applied by a particular index template.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-simulate-template>`_
 
         :param name: Name of the index template to simulate. To test a template configuration
             before you add it to the cluster, omit this parameter and specify the template
@@ -5110,7 +5171,7 @@ class IndicesClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-split>`_
 
         :param index: Name of the source index to split.
         :param target: Name of the target index to create.
@@ -5212,7 +5273,7 @@ class IndicesClient(NamespacedClient):
           Although the shard is no longer part of the node, that node retains any node-level statistics to which the shard contributed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-stats>`_
 
         :param index: A comma-separated list of index names; use `_all` or empty string
             to perform the operation on all indices

--- a/elasticsearch/_sync/client/inference.py
+++ b/elasticsearch/_sync/client/inference.py
@@ -49,14 +49,14 @@ class InferenceClient(NamespacedClient):
           <p>Delete an inference endpoint</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-delete>`_
 
-        :param inference_id: The inference Id
+        :param inference_id: The inference identifier.
         :param task_type: The task type
-        :param dry_run: When true, the endpoint is not deleted, and a list of ingest
-            processors which reference this endpoint is returned
+        :param dry_run: When true, the endpoint is not deleted and a list of ingest processors
+            which reference this endpoint is returned.
         :param force: When true, the inference endpoint is forcefully deleted even if
-            it is still being used by ingest processors or semantic text fields
+            it is still being used by ingest processors or semantic text fields.
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
@@ -117,7 +117,7 @@ class InferenceClient(NamespacedClient):
           <p>Get an inference endpoint</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-get>`_
 
         :param task_type: The task type
         :param inference_id: The inference Id
@@ -180,18 +180,29 @@ class InferenceClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Perform inference on the service</p>
+          <p>Perform inference on the service.</p>
+          <p>This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.
+          It returns a response with the results of the tasks.
+          The inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.</p>
+          <blockquote>
+          <p>info
+          The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-inference>`_
 
-        :param inference_id: The inference Id
-        :param input: Inference input. Either a string or an array of strings.
-        :param task_type: The task type
-        :param query: Query input, required for rerank task. Not required for other tasks.
-        :param task_settings: Optional task settings
-        :param timeout: Specifies the amount of time to wait for the inference request
-            to complete.
+        :param inference_id: The unique identifier for the inference endpoint.
+        :param input: The text on which you want to perform the inference task. It can
+            be a single string or an array. > info > Inference endpoints for the `completion`
+            task type currently only support a single string as input.
+        :param task_type: The type of inference task that the model performs.
+        :param query: The query input, which is required only for the `rerank` task.
+            It is not required for other tasks.
+        :param task_settings: Task settings for the individual inference request. These
+            settings are specific to the task type you specified and override the task
+            settings specified when initializing the service.
+        :param timeout: The amount of time to wait for the inference request to complete.
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
@@ -277,7 +288,7 @@ class InferenceClient(NamespacedClient):
           However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put>`_
 
         :param inference_id: The inference Id
         :param inference_config:
@@ -354,7 +365,7 @@ class InferenceClient(NamespacedClient):
           However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-inference-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-update>`_
 
         :param inference_id: The unique identifier of the inference endpoint.
         :param inference_config:

--- a/elasticsearch/_sync/client/ingest.py
+++ b/elasticsearch/_sync/client/ingest.py
@@ -40,18 +40,18 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete GeoIP database configurations.
-          Delete one or more IP geolocation database configurations.</p>
+          <p>Delete GeoIP database configurations.</p>
+          <p>Delete one or more IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-geoip-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-delete-geoip-database>`_
 
         :param id: A comma-separated list of geoip database configurations to delete
-        :param master_timeout: Period to wait for a connection to the master node. If
-            no response is received before the timeout expires, the request fails and
-            returns an error.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+            If no response is received before the timeout expires, the request fails
+            and returns an error.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -98,7 +98,7 @@ class IngestClient(NamespacedClient):
           <p>Delete IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-ip-location-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-delete-ip-location-database>`_
 
         :param id: A comma-separated list of IP location database configurations.
         :param master_timeout: The period to wait for a connection to the master node.
@@ -155,7 +155,7 @@ class IngestClient(NamespacedClient):
           Delete one or more ingest pipelines.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-delete-pipeline>`_
 
         :param id: Pipeline ID or wildcard expression of pipeline IDs used to limit the
             request. To delete all ingest pipelines in a cluster, use a value of `*`.
@@ -244,15 +244,15 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get GeoIP database configurations.
-          Get information about one or more IP geolocation database configurations.</p>
+          <p>Get GeoIP database configurations.</p>
+          <p>Get information about one or more IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-geoip-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-get-geoip-database>`_
 
-        :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
-            (`*`) expressions are supported. To get all database configurations, omit
-            this parameter or use `*`.
+        :param id: A comma-separated list of database configuration IDs to retrieve.
+            Wildcard (`*`) expressions are supported. To get all database configurations,
+            omit this parameter or use `*`.
         """
         __path_parts: t.Dict[str, str]
         if id not in SKIP_IN_PATH:
@@ -297,7 +297,7 @@ class IngestClient(NamespacedClient):
           <p>Get IP geolocation database configurations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ip-location-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-get-ip-location-database>`_
 
         :param id: Comma-separated list of database configuration IDs to retrieve. Wildcard
             (`*`) expressions are supported. To get all database configurations, omit
@@ -350,12 +350,12 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get pipelines.
-          Get information about one or more ingest pipelines.
+          <p>Get pipelines.</p>
+          <p>Get information about one or more ingest pipelines.
           This API returns a local reference of the pipeline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-get-pipeline>`_
 
         :param id: Comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions
             are supported. To get all ingest pipelines, omit this parameter or use `*`.
@@ -455,11 +455,11 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Create or update a GeoIP database configuration.
-          Refer to the create or update IP geolocation database configuration API.</p>
+          <p>Create or update a GeoIP database configuration.</p>
+          <p>Refer to the create or update IP geolocation database configuration API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-geoip-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-put-geoip-database>`_
 
         :param id: ID of the database configuration to create or update.
         :param maxmind: The configuration necessary to identify which IP geolocation
@@ -534,7 +534,7 @@ class IngestClient(NamespacedClient):
           <p>Create or update an IP geolocation database configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-ip-location-database-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-put-ip-location-database>`_
 
         :param id: The database configuration identifier.
         :param configuration:
@@ -712,17 +712,17 @@ class IngestClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Simulate a pipeline.
-          Run an ingest pipeline against a set of provided documents.
+          <p>Simulate a pipeline.</p>
+          <p>Run an ingest pipeline against a set of provided documents.
           You can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-simulate>`_
 
         :param docs: Sample documents to test in the pipeline.
-        :param id: Pipeline to test. If you don’t specify a `pipeline` in the request
+        :param id: The pipeline to test. If you don't specify a `pipeline` in the request
             body, this parameter is required.
-        :param pipeline: Pipeline to test. If you don’t specify the `pipeline` request
+        :param pipeline: The pipeline to test. If you don't specify the `pipeline` request
             path parameter, this parameter is required. If you specify both this and
             the request path parameter, the API only uses the request path parameter.
         :param verbose: If `true`, the response includes output data for each processor

--- a/elasticsearch/_sync/client/license.py
+++ b/elasticsearch/_sync/client/license.py
@@ -39,16 +39,16 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete the license.
-          When the license expires, your subscription level reverts to Basic.</p>
+          <p>Delete the license.</p>
+          <p>When the license expires, your subscription level reverts to Basic.</p>
           <p>If the operator privileges feature is enabled, only operator users can use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-delete>`_
 
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license"
@@ -89,13 +89,16 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get license information.
-          Get information about your Elastic license including its type, its status, when it was issued, and when it expires.</p>
-          <p>NOTE: If the master node is generating a new cluster state, the get license API may return a <code>404 Not Found</code> response.
+          <p>Get license information.</p>
+          <p>Get information about your Elastic license including its type, its status, when it was issued, and when it expires.</p>
+          <blockquote>
+          <p>info
+          If the master node is generating a new cluster state, the get license API may return a <code>404 Not Found</code> response.
           If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.</p>
+          </blockquote>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-get>`_
 
         :param accept_enterprise: If `true`, this parameter returns enterprise for Enterprise
             license types. If `false`, this parameter returns platinum for both platinum
@@ -144,7 +147,7 @@ class LicenseClient(NamespacedClient):
           <p>Get the basic license status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-get-basic-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/basic_status"
@@ -182,7 +185,7 @@ class LicenseClient(NamespacedClient):
           <p>Get the trial status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-get-trial-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license/trial_status"
@@ -225,8 +228,8 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Update the license.
-          You can update your license at runtime without shutting down your nodes.
+          <p>Update the license.</p>
+          <p>You can update your license at runtime without shutting down your nodes.
           License updates take effect immediately.
           If the license you are installing does not support all of the features that were available with your previous license, however, you are notified in the response.
           You must then re-submit the API request with the acknowledge parameter set to true.</p>
@@ -234,15 +237,15 @@ class LicenseClient(NamespacedClient):
           If the operator privileges feature is enabled, only operator users can use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:
         :param licenses: A sequence of one or more JSON documents containing the license
             information.
-        :param master_timeout: Period to wait for a connection to the master node.
-        :param timeout: Period to wait for a response. If no response is received before
-            the timeout expires, the request fails and returns an error.
+        :param master_timeout: The period to wait for a connection to the master node.
+        :param timeout: The period to wait for a response. If no response is received
+            before the timeout expires, the request fails and returns an error.
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_license"
@@ -297,15 +300,15 @@ class LicenseClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Start a basic license.
-          Start an indefinite basic license, which gives access to all the basic features.</p>
+          <p>Start a basic license.</p>
+          <p>Start an indefinite basic license, which gives access to all the basic features.</p>
           <p>NOTE: In order to start a basic license, you must not currently have a basic license.</p>
           <p>If the basic license does not support all of the features that are available with your current license, however, you are notified in the response.
           You must then re-submit the API request with the <code>acknowledge</code> parameter set to <code>true</code>.</p>
           <p>To check the status of your basic license, use the get basic license API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post-start-basic>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)
@@ -362,7 +365,7 @@ class LicenseClient(NamespacedClient):
           <p>To check the status of your trial, use the get trial status API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post-start-trial>`_
 
         :param acknowledge: whether the user has acknowledged acknowledge messages (default:
             false)

--- a/elasticsearch/_sync/client/logstash.py
+++ b/elasticsearch/_sync/client/logstash.py
@@ -43,7 +43,7 @@ class LogstashClient(NamespacedClient):
           If the request succeeds, you receive an empty response with an appropriate status code.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-delete-pipeline.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-logstash-delete-pipeline>`_
 
         :param id: An identifier for the pipeline.
         """
@@ -87,7 +87,7 @@ class LogstashClient(NamespacedClient):
           Get pipelines that are used for Logstash Central Management.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-get-pipeline.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-logstash-get-pipeline>`_
 
         :param id: A comma-separated list of pipeline identifiers.
         """
@@ -139,7 +139,7 @@ class LogstashClient(NamespacedClient):
           If the specified pipeline exists, it is replaced.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/logstash-api-put-pipeline.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-logstash-put-pipeline>`_
 
         :param id: An identifier for the pipeline.
         :param pipeline:

--- a/elasticsearch/_sync/client/migration.py
+++ b/elasticsearch/_sync/client/migration.py
@@ -44,7 +44,7 @@ class MigrationClient(NamespacedClient):
           You are strongly recommended to use the Upgrade Assistant.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-deprecations>`_
 
         :param index: Comma-separate list of data streams or indices to check. Wildcard
             (*) expressions are supported.
@@ -94,7 +94,7 @@ class MigrationClient(NamespacedClient):
           You are strongly recommended to use the Upgrade Assistant.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/feature-migration-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-get-feature-upgrade-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"
@@ -136,7 +136,7 @@ class MigrationClient(NamespacedClient):
           <p>TIP: The API is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/feature-migration-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-get-feature-upgrade-status>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_migration/system_features"

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -38,14 +38,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Clear trained model deployment cache.
-          Cache will be cleared on all nodes where the trained model is assigned.
+          <p>Clear trained model deployment cache.</p>
+          <p>Cache will be cleared on all nodes where the trained model is assigned.
           A trained model deployment may have an inference cache enabled.
           As requests are handled by each allocated node, their responses may be cached on that individual node.
           Calling this API clears the caches without restarting the deployment.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-trained-model-deployment-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-clear-trained-model-deployment-cache>`_
 
         :param model_id: The unique identifier of the trained model.
         """
@@ -93,14 +93,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Close anomaly detection jobs.
-          A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.
+          <p>Close anomaly detection jobs.</p>
+          <p>A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.
           When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data.
           If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.
           When a datafeed that has a specified end date stops, it automatically closes its associated job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-close-job>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. You can close multiple anomaly detection
@@ -161,11 +161,11 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a calendar.
-          Removes all scheduled events from a calendar, then deletes it.</p>
+          <p>Delete a calendar.</p>
+          <p>Remove all scheduled events from a calendar, then delete it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-calendar>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         """
@@ -209,7 +209,7 @@ class MlClient(NamespacedClient):
           <p>Delete events from a calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-calendar-event>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param event_id: Identifier for the scheduled event. You can obtain this identifier
@@ -260,7 +260,7 @@ class MlClient(NamespacedClient):
           <p>Delete anomaly jobs from a calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-calendar-job>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -312,7 +312,7 @@ class MlClient(NamespacedClient):
           <p>Delete a data frame analytics job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job.
         :param force: If `true`, it deletes a job that is not stopped; this method is
@@ -363,7 +363,7 @@ class MlClient(NamespacedClient):
           <p>Delete a datafeed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -415,18 +415,18 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete expired ML data.
-          Deletes all job results, model snapshots and forecast data that have exceeded
+          <p>Delete expired ML data.</p>
+          <p>Delete all job results, model snapshots and forecast data that have exceeded
           their retention days period. Machine learning state documents that are not
           associated with any job are also deleted.
           You can limit the request to a single or set of anomaly detection jobs by
           using a job identifier, a group name, a comma-separated list of jobs, or a
           wildcard expression. You can delete expired data for all anomaly detection
-          jobs by using _all, by specifying * as the &lt;job_id&gt;, or by omitting the
-          &lt;job_id&gt;.</p>
+          jobs by using <code>_all</code>, by specifying <code>*</code> as the <code>&lt;job_id&gt;</code>, or by omitting the
+          <code>&lt;job_id&gt;</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-expired-data.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-expired-data>`_
 
         :param job_id: Identifier for an anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression.
@@ -485,12 +485,12 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a filter.
-          If an anomaly detection job references the filter, you cannot delete the
+          <p>Delete a filter.</p>
+          <p>If an anomaly detection job references the filter, you cannot delete the
           filter. You must update or delete the job before you can delete the filter.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-filter>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         """
@@ -533,14 +533,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete forecasts from a job.
-          By default, forecasts are retained for 14 days. You can specify a
+          <p>Delete forecasts from a job.</p>
+          <p>By default, forecasts are retained for 14 days. You can specify a
           different retention period with the <code>expires_in</code> parameter in the forecast
           jobs API. The delete forecast API enables you to delete one or more
           forecasts before they expire.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-forecast.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-forecast>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param forecast_id: A comma-separated list of forecast identifiers. If you do
@@ -607,8 +607,8 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete an anomaly detection job.
-          All job configuration, model state and results are deleted.
+          <p>Delete an anomaly detection job.</p>
+          <p>All job configuration, model state and results are deleted.
           It is not currently possible to delete multiple jobs using wildcards or a
           comma separated list. If you delete a job that has a datafeed, the request
           first tries to delete the datafeed. This behavior is equivalent to calling
@@ -616,7 +616,7 @@ class MlClient(NamespacedClient):
           delete job request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-job>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -670,13 +670,13 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a model snapshot.
-          You cannot delete the active model snapshot. To delete that snapshot, first
+          <p>Delete a model snapshot.</p>
+          <p>You cannot delete the active model snapshot. To delete that snapshot, first
           revert to a different one. To identify the active model snapshot, refer to
           the <code>model_snapshot_id</code> in the results from the get jobs API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-model-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -724,11 +724,11 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete an unreferenced trained model.
-          The request deletes a trained inference model that is not referenced by an ingest pipeline.</p>
+          <p>Delete an unreferenced trained model.</p>
+          <p>The request deletes a trained inference model that is not referenced by an ingest pipeline.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-trained-model>`_
 
         :param model_id: The unique identifier of the trained model.
         :param force: Forcefully deletes a trained model that is referenced by ingest
@@ -777,13 +777,13 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a trained model alias.
-          This API deletes an existing model alias that refers to a trained model. If
+          <p>Delete a trained model alias.</p>
+          <p>This API deletes an existing model alias that refers to a trained model. If
           the model alias is missing or refers to a model other than the one identified
           by the <code>model_id</code>, this API returns an error.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-trained-models-aliases.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-trained-model-alias>`_
 
         :param model_id: The trained model ID to which the model alias refers.
         :param model_alias: The model alias to delete.
@@ -838,13 +838,13 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Estimate job model memory usage.
-          Makes an estimation of the memory usage for an anomaly detection job model.
-          It is based on analysis configuration details for the job and cardinality
+          <p>Estimate job model memory usage.</p>
+          <p>Make an estimation of the memory usage for an anomaly detection job model.
+          The estimate is based on analysis configuration details for the job and cardinality
           estimates for the fields it references.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-apis.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-estimate-model-memory>`_
 
         :param analysis_config: For a list of the properties that you can specify in
             the `analysis_config` component of the body of this API.
@@ -909,14 +909,14 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Evaluate data frame analytics.
-          The API packages together commonly used evaluation metrics for various types
+          <p>Evaluate data frame analytics.</p>
+          <p>The API packages together commonly used evaluation metrics for various types
           of machine learning features. This has been designed for use on indexes
           created by data frame analytics. Evaluation requires both a ground truth
           field and an analytics result field to be present.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-evaluate-data-frame>`_
 
         :param evaluation: Defines the type of evaluation you want to perform.
         :param index: Defines the `index` in which the evaluation will be performed.
@@ -990,8 +990,8 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Explain data frame analytics config.
-          This API provides explanations for a data frame analytics config that either
+          <p>Explain data frame analytics config.</p>
+          <p>This API provides explanations for a data frame analytics config that either
           exists already or one that has not been created yet. The following
           explanations are provided:</p>
           <ul>
@@ -1001,7 +1001,7 @@ class MlClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-explain-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -1112,7 +1112,7 @@ class MlClient(NamespacedClient):
           analyzing further data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-flush-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-flush-job>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param advance_time: Refer to the description for the `advance_time` query parameter.
@@ -1187,7 +1187,7 @@ class MlClient(NamespacedClient):
           based on historical data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-forecast.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-forecast>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must be open
             when you create a forecast; otherwise, an error occurs.
@@ -1273,7 +1273,7 @@ class MlClient(NamespacedClient):
           The API presents a chronological view of the records, grouped by bucket.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-bucket.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-buckets>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timestamp: The timestamp of a single bucket result. If you do not specify
@@ -1371,7 +1371,7 @@ class MlClient(NamespacedClient):
           <p>Get info about events in calendars.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-calendar-events>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1440,7 +1440,7 @@ class MlClient(NamespacedClient):
           <p>Get calendar configuration info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-calendars>`_
 
         :param calendar_id: A string that uniquely identifies a calendar. You can get
             information for multiple calendars by using a comma-separated list of ids
@@ -1516,7 +1516,7 @@ class MlClient(NamespacedClient):
           <p>Get anomaly detection job results for categories.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-category.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-categories>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param category_id: Identifier for the category, which is unique in the job.
@@ -1604,7 +1604,7 @@ class MlClient(NamespacedClient):
           wildcard expression.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1679,7 +1679,7 @@ class MlClient(NamespacedClient):
           <p>Get data frame analytics jobs usage info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-data-frame-analytics-stats>`_
 
         :param id: Identifier for the data frame analytics job. If you do not specify
             this option, the API returns information for the first hundred data frame
@@ -1753,7 +1753,7 @@ class MlClient(NamespacedClient):
           This API returns a maximum of 10,000 datafeeds.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-datafeed-stats>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1817,7 +1817,7 @@ class MlClient(NamespacedClient):
           This API returns a maximum of 10,000 datafeeds.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-datafeeds>`_
 
         :param datafeed_id: Identifier for the datafeed. It can be a datafeed identifier
             or a wildcard expression. If you do not specify one of these options, the
@@ -1884,7 +1884,7 @@ class MlClient(NamespacedClient):
           You can get a single filter or all filters.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-filters>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param from_: Skips the specified number of filters.
@@ -1952,7 +1952,7 @@ class MlClient(NamespacedClient):
           <code>influencer_field_name</code> is specified in the job configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-influencer.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-influencers>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: If true, the results are sorted in descending order.
@@ -2036,7 +2036,7 @@ class MlClient(NamespacedClient):
           <p>Get anomaly detection jobs usage info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-job-stats>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs, or a wildcard expression. If
@@ -2100,7 +2100,7 @@ class MlClient(NamespacedClient):
           <code>_all</code>, by specifying <code>*</code> as the <code>&lt;job_id&gt;</code>, or by omitting the <code>&lt;job_id&gt;</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-jobs>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, or a wildcard expression. If you do not specify one of these
@@ -2166,7 +2166,7 @@ class MlClient(NamespacedClient):
           on each node, both within the JVM heap, and natively, outside of the JVM.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-memory.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-memory-stats>`_
 
         :param node_id: The names of particular nodes in the cluster to target. For example,
             `nodeId1,nodeId2` or `ml:true`
@@ -2224,7 +2224,7 @@ class MlClient(NamespacedClient):
           <p>Get anomaly detection job model snapshot upgrade usage info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-model-snapshot-upgrade-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-model-snapshot-upgrade-stats>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2298,7 +2298,7 @@ class MlClient(NamespacedClient):
           <p>Get model snapshots info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-model-snapshots>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -2418,7 +2418,7 @@ class MlClient(NamespacedClient):
           jobs' largest bucket span.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-overall-buckets.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-overall-buckets>`_
 
         :param job_id: Identifier for the anomaly detection job. It can be a job identifier,
             a group name, a comma-separated list of jobs or groups, or a wildcard expression.
@@ -2528,7 +2528,7 @@ class MlClient(NamespacedClient):
           number of detectors.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-record.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-records>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param desc: Refer to the description for the `desc` query parameter.
@@ -2627,7 +2627,7 @@ class MlClient(NamespacedClient):
           <p>Get trained model configuration info.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-trained-models>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             You can get information for multiple trained models in a single API request
@@ -2718,7 +2718,7 @@ class MlClient(NamespacedClient):
           models in a single API request by using a comma-separated list of model IDs or a wildcard expression.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-get-trained-models-stats>`_
 
         :param model_id: The unique identifier of the trained model or a model alias.
             It can be a comma-separated list or a wildcard expression.
@@ -2784,7 +2784,7 @@ class MlClient(NamespacedClient):
           <p>Evaluate a trained model.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-infer-trained-model>`_
 
         :param model_id: The unique identifier of the trained model.
         :param docs: An array of objects to pass to the model for inference. The objects
@@ -2851,7 +2851,7 @@ class MlClient(NamespacedClient):
           cluster configuration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ml-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-info>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ml/info"
@@ -2891,8 +2891,8 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Open anomaly detection jobs.
-          An anomaly detection job must be opened to be ready to receive and analyze
+          <p>Open anomaly detection jobs.</p>
+          <p>An anomaly detection job must be opened to be ready to receive and analyze
           data. It can be opened and closed multiple times throughout its lifecycle.
           When you open a new job, it starts with an empty model.
           When you open an existing job, the most recent model state is automatically
@@ -2900,7 +2900,7 @@ class MlClient(NamespacedClient):
           new data is received.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-open-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-open-job>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param timeout: Refer to the description for the `timeout` query parameter.
@@ -2957,7 +2957,7 @@ class MlClient(NamespacedClient):
           <p>Add scheduled events to the calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-calendar-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-post-calendar-events>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param events: A list of one of more scheduled events. The event’s start and
@@ -3018,7 +3018,7 @@ class MlClient(NamespacedClient):
           It is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-data.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-post-data>`_
 
         :param job_id: Identifier for the anomaly detection job. The job must have a
             state of open to receive and process the data.
@@ -3082,10 +3082,10 @@ class MlClient(NamespacedClient):
         .. raw:: html
 
           <p>Preview features used by data frame analytics.
-          Previews the extracted features used by a data frame analytics config.</p>
+          Preview the extracted features used by a data frame analytics config.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-preview-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job.
         :param config: A data frame analytics config as described in create data frame
@@ -3158,7 +3158,7 @@ class MlClient(NamespacedClient):
           You can also use secondary authorization headers to supply the credentials.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-preview-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-preview-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3237,7 +3237,7 @@ class MlClient(NamespacedClient):
           <p>Create a calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-calendar>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param description: A description of the calendar.
@@ -3294,7 +3294,7 @@ class MlClient(NamespacedClient):
           <p>Add anomaly detection job to calendar.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-calendar-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-calendar-job>`_
 
         :param calendar_id: A string that uniquely identifies a calendar.
         :param job_id: An identifier for the anomaly detection jobs. It can be a job
@@ -3377,7 +3377,7 @@ class MlClient(NamespacedClient):
           <p>If you supply only a subset of the regression or classification parameters, hyperparameter optimization occurs. It determines a value for each of the undefined parameters.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -3562,7 +3562,7 @@ class MlClient(NamespacedClient):
           directly to the <code>.ml-config</code> index. Do not give users <code>write</code> privileges on the <code>.ml-config</code> index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -3724,7 +3724,7 @@ class MlClient(NamespacedClient):
           Specifically, filters are referenced in the <code>custom_rules</code> property of detector configuration objects.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-filter>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param description: A description of the filter.
@@ -3821,12 +3821,12 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Create an anomaly detection job.
-          If you include a <code>datafeed_config</code>, you must have read index privileges on the source index.
+          <p>Create an anomaly detection job.</p>
+          <p>If you include a <code>datafeed_config</code>, you must have read index privileges on the source index.
           If you include a <code>datafeed_config</code> but do not provide a query, the datafeed uses <code>{&quot;match_all&quot;: {&quot;boost&quot;: 1}}</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-job>`_
 
         :param job_id: The identifier for the anomaly detection job. This identifier
             can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and
@@ -4034,7 +4034,7 @@ class MlClient(NamespacedClient):
           Enable you to supply a trained model that is not created by data frame analytics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model>`_
 
         :param model_id: The unique identifier of the trained model.
         :param compressed_definition: The compressed (GZipped and Base64 encoded) inference
@@ -4155,7 +4155,7 @@ class MlClient(NamespacedClient):
           returns a warning.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-models-aliases.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model-alias>`_
 
         :param model_id: The identifier for the trained model that the alias refers to.
         :param model_alias: The alias to create or update. This value cannot end in numbers.
@@ -4216,7 +4216,7 @@ class MlClient(NamespacedClient):
           <p>Create part of a trained model definition.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-definition-part.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model-definition-part>`_
 
         :param model_id: The unique identifier of the trained model.
         :param part: The definition part number. When the definition is loaded for inference
@@ -4298,7 +4298,7 @@ class MlClient(NamespacedClient):
           The vocabulary is stored in the index as described in <code>inference_config.*.vocabulary</code> of the trained model definition.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-vocabulary.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model-vocabulary>`_
 
         :param model_id: The unique identifier of the trained model.
         :param vocabulary: The model vocabulary, which must not be empty.
@@ -4361,7 +4361,7 @@ class MlClient(NamespacedClient):
           comma separated list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-reset-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-reset-job>`_
 
         :param job_id: The ID of the job to reset.
         :param delete_user_annotations: Specifies whether annotations that have been
@@ -4425,7 +4425,7 @@ class MlClient(NamespacedClient):
           snapshot after Black Friday or a critical system failure.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-revert-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-revert-model-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: You can specify `empty` as the <snapshot_id>. Reverting to
@@ -4500,7 +4500,7 @@ class MlClient(NamespacedClient):
           machine learning info API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-set-upgrade-mode.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-set-upgrade-mode>`_
 
         :param enabled: When `true`, it enables `upgrade_mode` which temporarily halts
             all job and datafeed tasks and prohibits new job and datafeed tasks from
@@ -4560,7 +4560,7 @@ class MlClient(NamespacedClient):
           the destination index in advance with custom settings and mappings.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-start-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4623,7 +4623,7 @@ class MlClient(NamespacedClient):
           authorization headers when you created or updated the datafeed, those credentials are used instead.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-start-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -4669,11 +4669,14 @@ class MlClient(NamespacedClient):
             path_parts=__path_parts,
         )
 
-    @_rewrite_parameters()
+    @_rewrite_parameters(
+        body_fields=("adaptive_allocations",),
+    )
     def start_trained_model_deployment(
         self,
         *,
         model_id: str,
+        adaptive_allocations: t.Optional[t.Mapping[str, t.Any]] = None,
         cache_size: t.Optional[t.Union[int, str]] = None,
         deployment_id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -4688,6 +4691,7 @@ class MlClient(NamespacedClient):
         wait_for: t.Optional[
             t.Union[str, t.Literal["fully_allocated", "started", "starting"]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         .. raw:: html
@@ -4696,10 +4700,13 @@ class MlClient(NamespacedClient):
           It allocates the model to every machine learning node.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-start-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
+        :param adaptive_allocations: Adaptive allocations configuration. When enabled,
+            the number of allocations is set based on the current load. If adaptive_allocations
+            is enabled, do not set the number of allocations manually.
         :param cache_size: The inference cache size (in memory outside the JVM heap)
             per node for the model. The default value is the same size as the `model_size_bytes`.
             To disable the cache, `0b` can be provided.
@@ -4709,7 +4716,8 @@ class MlClient(NamespacedClient):
             model in memory but use a separate set of threads to evaluate the model.
             Increasing this value generally increases the throughput. If this setting
             is greater than the number of hardware threads it will automatically be changed
-            to a value less than the number of hardware threads.
+            to a value less than the number of hardware threads. If adaptive_allocations
+            is enabled, do not set this value, because it’s automatically set.
         :param priority: The deployment priority.
         :param queue_capacity: Specifies the number of inference requests that are allowed
             in the queue. After the number of requests exceeds this value, new requests
@@ -4729,6 +4737,7 @@ class MlClient(NamespacedClient):
         __path_parts: t.Dict[str, str] = {"model_id": _quote(model_id)}
         __path = f'/_ml/trained_models/{__path_parts["model_id"]}/deployment/_start'
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if cache_size is not None:
             __query["cache_size"] = cache_size
         if deployment_id is not None:
@@ -4753,12 +4762,20 @@ class MlClient(NamespacedClient):
             __query["timeout"] = timeout
         if wait_for is not None:
             __query["wait_for"] = wait_for
+        if not __body:
+            if adaptive_allocations is not None:
+                __body["adaptive_allocations"] = adaptive_allocations
+        if not __body:
+            __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
         return self.perform_request(  # type: ignore[return-value]
             "POST",
             __path,
             params=__query,
             headers=__headers,
+            body=__body,
             endpoint_id="ml.start_trained_model_deployment",
             path_parts=__path_parts,
         )
@@ -4784,7 +4801,7 @@ class MlClient(NamespacedClient):
           throughout its lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-stop-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -4854,7 +4871,7 @@ class MlClient(NamespacedClient):
           multiple times throughout its lifecycle.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-stop-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-stop-datafeed>`_
 
         :param datafeed_id: Identifier for the datafeed. You can stop multiple datafeeds
             in a single API request by using a comma-separated list of datafeeds or a
@@ -4919,7 +4936,7 @@ class MlClient(NamespacedClient):
           <p>Stop a trained model deployment.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-stop-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model.
         :param allow_no_match: Specifies what to do when the request: contains wildcard
@@ -4987,7 +5004,7 @@ class MlClient(NamespacedClient):
           <p>Update a data frame analytics job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -5102,7 +5119,7 @@ class MlClient(NamespacedClient):
           those credentials are used instead.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-datafeed>`_
 
         :param datafeed_id: A numerical character string that uniquely identifies the
             datafeed. This identifier can contain lowercase alphanumeric characters (a-z
@@ -5269,7 +5286,7 @@ class MlClient(NamespacedClient):
           Updates the description of a filter, adds items, or removes items from the list.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-filter.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-filter>`_
 
         :param filter_id: A string that uniquely identifies a filter.
         :param add_items: The items to add to the filter.
@@ -5363,7 +5380,7 @@ class MlClient(NamespacedClient):
           Updates certain properties of an anomaly detection job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-job>`_
 
         :param job_id: Identifier for the job.
         :param allow_lazy_open: Advanced configuration option. Specifies whether this
@@ -5495,7 +5512,7 @@ class MlClient(NamespacedClient):
           Updates certain properties of a snapshot.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-model-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: Identifier for the model snapshot.
@@ -5540,12 +5557,13 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=("number_of_allocations",),
+        body_fields=("adaptive_allocations", "number_of_allocations"),
     )
     def update_trained_model_deployment(
         self,
         *,
         model_id: str,
+        adaptive_allocations: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -5559,16 +5577,20 @@ class MlClient(NamespacedClient):
           <p>Update a trained model deployment.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-trained-model-deployment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.
+        :param adaptive_allocations: Adaptive allocations configuration. When enabled,
+            the number of allocations is set based on the current load. If adaptive_allocations
+            is enabled, do not set the number of allocations manually.
         :param number_of_allocations: The number of model allocations on each node where
             the model is deployed. All allocations on a node share the same copy of the
             model in memory but use a separate set of threads to evaluate the model.
             Increasing this value generally increases the throughput. If this setting
             is greater than the number of hardware threads it will automatically be changed
-            to a value less than the number of hardware threads.
+            to a value less than the number of hardware threads. If adaptive_allocations
+            is enabled, do not set this value, because it’s automatically set.
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
@@ -5585,6 +5607,8 @@ class MlClient(NamespacedClient):
         if pretty is not None:
             __query["pretty"] = pretty
         if not __body:
+            if adaptive_allocations is not None:
+                __body["adaptive_allocations"] = adaptive_allocations
             if number_of_allocations is not None:
                 __body["number_of_allocations"] = number_of_allocations
         if not __body:
@@ -5619,7 +5643,7 @@ class MlClient(NamespacedClient):
         .. raw:: html
 
           <p>Upgrade a snapshot.
-          Upgrades an anomaly detection model snapshot to the latest major version.
+          Upgrade an anomaly detection model snapshot to the latest major version.
           Over time, older snapshot formats are deprecated and removed. Anomaly
           detection jobs support only snapshots that are from the current or previous
           major version.
@@ -5630,7 +5654,7 @@ class MlClient(NamespacedClient):
           job.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-upgrade-job-snapshot>`_
 
         :param job_id: Identifier for the anomaly detection job.
         :param snapshot_id: A numerical character string that uniquely identifies the
@@ -5782,7 +5806,7 @@ class MlClient(NamespacedClient):
           <p>Validate an anomaly detection job.</p>
 
 
-        `<https://www.elastic.co/guide/en/machine-learning/master/ml-jobs.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch>`_
 
         :param detector:
         """

--- a/elasticsearch/_sync/client/monitoring.py
+++ b/elasticsearch/_sync/client/monitoring.py
@@ -48,7 +48,7 @@ class MonitoringClient(NamespacedClient):
           This API is used by the monitoring features to send monitoring data.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch>`_
 
         :param interval: Collection interval (e.g., '10s' or '10000ms') of the payload
         :param operations:

--- a/elasticsearch/_sync/client/nodes.py
+++ b/elasticsearch/_sync/client/nodes.py
@@ -50,7 +50,7 @@ class NodesClient(NamespacedClient):
           Clear the archived repositories metering information in the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-repositories-metering-archive-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-clear-repositories-metering-archive>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -105,7 +105,7 @@ class NodesClient(NamespacedClient):
           Additionally, the information exposed by this API is volatile, meaning that it will not be present after node restarts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-repositories-metering-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-get-repositories-metering-info>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information. All the nodes selective options are explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes).
@@ -162,7 +162,7 @@ class NodesClient(NamespacedClient):
           The output is plain text with a breakdown of the top hot threads for each node.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-hot-threads>`_
 
         :param node_id: List of node IDs or names used to limit returned information.
         :param ignore_idle_threads: If true, known idle threads (e.g. waiting in a socket
@@ -231,11 +231,11 @@ class NodesClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get node information.
-          By default, the API returns all attributes and core settings for cluster nodes.</p>
+          <p>Get node information.</p>
+          <p>By default, the API returns all attributes and core settings for cluster nodes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-info>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -308,7 +308,7 @@ class NodesClient(NamespacedClient):
           Alternatively, you can reload the secure settings on each node by locally accessing the API and passing the node-specific Elasticsearch keystore password.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-reload-secure-settings>`_
 
         :param node_id: The names of particular nodes in the cluster to target.
         :param secure_settings_password: The password for the Elasticsearch keystore.
@@ -383,7 +383,7 @@ class NodesClient(NamespacedClient):
           By default, all stats are returned. You can limit the returned information by using metrics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats>`_
 
         :param node_id: Comma-separated list of node IDs or names used to limit returned
             information.
@@ -498,7 +498,7 @@ class NodesClient(NamespacedClient):
           <p>Get feature usage information.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-usage>`_
 
         :param node_id: A comma-separated list of node IDs or names to limit the returned
             information; use `_local` to return information from the node you're connecting

--- a/elasticsearch/_sync/client/query_rules.py
+++ b/elasticsearch/_sync/client/query_rules.py
@@ -44,7 +44,7 @@ class QueryRulesClient(NamespacedClient):
           This is a destructive action that is only recoverable by re-adding the same rule with the create or update query rule API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-delete-rule>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to delete
@@ -97,7 +97,7 @@ class QueryRulesClient(NamespacedClient):
           This is a destructive action that is not recoverable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-delete-ruleset>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to delete
         """
@@ -142,7 +142,7 @@ class QueryRulesClient(NamespacedClient):
           Get details about a query rule within a query ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-get-rule>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to retrieve
@@ -194,7 +194,7 @@ class QueryRulesClient(NamespacedClient):
           Get details about a query ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-get-ruleset>`_
 
         :param ruleset_id: The unique identifier of the query ruleset
         """
@@ -241,7 +241,7 @@ class QueryRulesClient(NamespacedClient):
           Get summarized information about the query rulesets.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-list-rulesets>`_
 
         :param from_: The offset from the first result to fetch.
         :param size: The maximum number of results to retrieve.
@@ -302,7 +302,7 @@ class QueryRulesClient(NamespacedClient):
           If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-put-rule>`_
 
         :param ruleset_id: The unique identifier of the query ruleset containing the
             rule to be created or updated.
@@ -389,7 +389,7 @@ class QueryRulesClient(NamespacedClient):
           If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-put-ruleset>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated.
@@ -446,7 +446,7 @@ class QueryRulesClient(NamespacedClient):
           Evaluate match criteria against a query ruleset to identify the rules that would match that criteria.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-query-ruleset.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-test>`_
 
         :param ruleset_id: The unique identifier of the query ruleset to be created or
             updated

--- a/elasticsearch/_sync/client/rollup.py
+++ b/elasticsearch/_sync/client/rollup.py
@@ -67,7 +67,7 @@ class RollupClient(NamespacedClient):
           </code></pre>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-delete-job>`_
 
         :param id: Identifier for the job.
         """
@@ -115,7 +115,7 @@ class RollupClient(NamespacedClient):
           For details about a historical rollup job, the rollup capabilities API may be more useful.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-jobs>`_
 
         :param id: Identifier for the rollup job. If it is `_all` or omitted, the API
             returns all rollup jobs.
@@ -171,7 +171,7 @@ class RollupClient(NamespacedClient):
           </ol>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-rollup-caps>`_
 
         :param id: Index, indices or index-pattern to return rollup capabilities for.
             `_all` may be used to fetch rollup capabilities from all jobs.
@@ -225,7 +225,7 @@ class RollupClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-rollup-index-caps>`_
 
         :param index: Data stream or index to check for rollup capabilities. Wildcard
             (`*`) expressions are supported.
@@ -295,7 +295,7 @@ class RollupClient(NamespacedClient):
           <p>Jobs are created in a <code>STOPPED</code> state. You can start them with the start rollup jobs API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-put-job>`_
 
         :param id: Identifier for the rollup job. This can be any alphanumeric string
             and uniquely identifies the data that is associated with the rollup job.
@@ -443,7 +443,7 @@ class RollupClient(NamespacedClient):
           During the merging process, if there is any overlap in buckets between the two responses, the buckets from the non-rollup index are used.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-rollup-search>`_
 
         :param index: A comma-separated list of data streams and indices used to limit
             the request. This parameter has the following rules: * At least one data
@@ -521,7 +521,7 @@ class RollupClient(NamespacedClient):
           If you try to start a job that is already started, nothing happens.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-start-job>`_
 
         :param id: Identifier for the rollup job.
         """
@@ -575,7 +575,7 @@ class RollupClient(NamespacedClient):
           If the specified time elapses without the job moving to STOPPED, a timeout exception occurs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-stop-job>`_
 
         :param id: Identifier for the rollup job.
         :param timeout: If `wait_for_completion` is `true`, the API blocks for (at maximum)

--- a/elasticsearch/_sync/client/search_application.py
+++ b/elasticsearch/_sync/client/search_application.py
@@ -45,13 +45,13 @@ class SearchApplicationClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a search application.
-          Remove a search application and its associated alias. Indices attached to the search application are not removed.</p>
+          <p>Delete a search application.</p>
+          <p>Remove a search application and its associated alias. Indices attached to the search application are not removed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-search-application.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-delete>`_
 
-        :param name: The name of the search application to delete
+        :param name: The name of the search application to delete.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -94,7 +94,7 @@ class SearchApplicationClient(NamespacedClient):
           The associated data stream is also deleted.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-delete-behavioral-analytics>`_
 
         :param name: The name of the analytics collection to be deleted
         """
@@ -138,7 +138,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Get search application details.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get>`_
 
         :param name: The name of the search application
         """
@@ -182,7 +182,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Get behavioral analytics collections.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get-behavioral-analytics>`_
 
         :param name: A list of analytics collections to limit the returned information
         """
@@ -234,7 +234,7 @@ class SearchApplicationClient(NamespacedClient):
           Get information about search applications.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-search-applications.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get-behavioral-analytics>`_
 
         :param from_: Starting offset.
         :param q: Query in the Lucene query string syntax.
@@ -290,7 +290,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Create a behavioral analytics collection event.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/post-analytics-collection-event.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-post-behavioral-analytics-event>`_
 
         :param collection_name: The name of the behavioral analytics collection.
         :param event_type: The analytics event type.
@@ -357,7 +357,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Create or update a search application.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-put>`_
 
         :param name: The name of the search application to be created or updated.
         :param search_application:
@@ -414,7 +414,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>Create a behavioral analytics collection.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-put-behavioral-analytics>`_
 
         :param name: The name of the analytics collection to be created or updated.
         """
@@ -467,7 +467,7 @@ class SearchApplicationClient(NamespacedClient):
           <p>You must have <code>read</code> privileges on the backing alias of the search application.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-render-query.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-render-query>`_
 
         :param name: The name of the search application to render teh query for.
         :param params:
@@ -531,7 +531,7 @@ class SearchApplicationClient(NamespacedClient):
           Unspecified template parameters are assigned their default values if applicable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-search>`_
 
         :param name: The name of the search application to be searched.
         :param params: Query parameters specific to this request, which will override

--- a/elasticsearch/_sync/client/searchable_snapshots.py
+++ b/elasticsearch/_sync/client/searchable_snapshots.py
@@ -50,7 +50,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           Get statistics about the shared cache for partially mounted indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-cache-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-cache-stats>`_
 
         :param node_id: The names of the nodes in the cluster to target.
         :param master_timeout:
@@ -111,7 +111,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           Clear indices and data streams from the shared cache for partially mounted indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-clear-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-clear-cache>`_
 
         :param index: A comma-separated list of data streams, indices, and aliases to
             clear from the cache. It supports wildcards (`*`).
@@ -190,7 +190,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           Manually mounting ILM-managed snapshots can interfere with ILM processes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-mount>`_
 
         :param repository: The name of the repository containing the snapshot of the
             index to mount.
@@ -278,7 +278,7 @@ class SearchableSnapshotsClient(NamespacedClient):
           <p>Get searchable snapshot statistics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-stats>`_
 
         :param index: A comma-separated list of data streams and indices to retrieve
             statistics for.

--- a/elasticsearch/_sync/client/security.py
+++ b/elasticsearch/_sync/client/security.py
@@ -58,7 +58,7 @@ class SecurityClient(NamespacedClient):
           Any updates do not change existing content for either the <code>labels</code> or <code>data</code> fields.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-activate-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-activate-user-profile>`_
 
         :param grant_type: The type of grant.
         :param access_token: The user's Elasticsearch access token or JWT. Both `access`
@@ -124,7 +124,7 @@ class SecurityClient(NamespacedClient):
           If the user cannot be authenticated, this API returns a 401 status code.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-authenticate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-authenticate>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/_authenticate"
@@ -171,7 +171,7 @@ class SecurityClient(NamespacedClient):
           The bulk delete roles API cannot delete roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-bulk-delete-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-bulk-delete-role>`_
 
         :param names: An array of role names to delete
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -232,7 +232,7 @@ class SecurityClient(NamespacedClient):
           The bulk create or update roles API cannot update roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-bulk-put-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-bulk-put-role>`_
 
         :param roles: A dictionary of role name to RoleDescriptor objects to add or update
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -300,7 +300,7 @@ class SecurityClient(NamespacedClient):
           <p>A successful request returns a JSON structure that contains the IDs of all updated API keys, the IDs of API keys that already had the requested changes and did not require an update, and error details for any failed update.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-bulk-update-api-keys.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-bulk-update-api-keys>`_
 
         :param ids: The API key identifiers.
         :param expiration: Expiration time for the API keys. By default, API keys never
@@ -378,7 +378,7 @@ class SecurityClient(NamespacedClient):
           <p>Change the passwords of users in the native realm and built-in users.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-change-password.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-change-password>`_
 
         :param username: The user whose password you want to change. If you do not specify
             this parameter, the password is changed for the current user.
@@ -445,7 +445,7 @@ class SecurityClient(NamespacedClient):
           The cache is also automatically cleared on state changes of the security index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-api-key-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-api-key-cache>`_
 
         :param ids: Comma-separated list of API key IDs to evict from the API key cache.
             To evict all API keys, use `*`. Does not support other wildcard patterns.
@@ -491,7 +491,7 @@ class SecurityClient(NamespacedClient):
           The cache is also automatically cleared for applications that have their privileges updated.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-privilege-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-privileges>`_
 
         :param application: A comma-separated list of applications. To clear all applications,
             use an asterism (`*`). It does not support other wildcard patterns.
@@ -541,7 +541,7 @@ class SecurityClient(NamespacedClient):
           For more information, refer to the documentation about controlling the user cache.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-realms>`_
 
         :param realms: A comma-separated list of realms. To clear all realms, use an
             asterisk (`*`). It does not support other wildcard patterns.
@@ -591,7 +591,7 @@ class SecurityClient(NamespacedClient):
           <p>Evict roles from the native role cache.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-role-cache.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-roles>`_
 
         :param name: A comma-separated list of roles to evict from the role cache. To
             evict all roles, use an asterisk (`*`). It does not support other wildcard
@@ -643,7 +643,7 @@ class SecurityClient(NamespacedClient):
           The cache for tokens backed by the <code>service_tokens</code> file is cleared automatically on file changes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-clear-service-token-caches.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clear-cached-service-tokens>`_
 
         :param namespace: The namespace, which is a top-level grouping of service accounts.
         :param service: The name of the service, which must be unique within its namespace.
@@ -715,7 +715,7 @@ class SecurityClient(NamespacedClient):
           To configure or turn off the API key service, refer to API key service setting documentation.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key>`_
 
         :param expiration: The expiration time for the API key. By default, API keys
             never expire.
@@ -805,7 +805,7 @@ class SecurityClient(NamespacedClient):
           Attempting to update them with the update REST API key API or the bulk update REST API keys API will result in an error.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-cross-cluster-api-key>`_
 
         :param access: The access to be granted to this API key. The access is composed
             of permissions for cross-cluster search and cross-cluster replication. At
@@ -880,7 +880,7 @@ class SecurityClient(NamespacedClient):
           You must actively delete them if they are no longer needed.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-service-token>`_
 
         :param namespace: The name of the namespace, which is a top-level grouping of
             service accounts.
@@ -966,7 +966,7 @@ class SecurityClient(NamespacedClient):
           The proxy is trusted to have performed the TLS authentication and this API translates that authentication into an Elasticsearch access token.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delegate-pki-authentication.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delegate-pki>`_
 
         :param x509_certificate_chain: The X509Certificate chain, which is represented
             as an ordered string array. Each string in the array is a base64-encoded
@@ -1030,7 +1030,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-privilege.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-privileges>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application.
@@ -1093,7 +1093,7 @@ class SecurityClient(NamespacedClient):
           The delete roles API cannot remove roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-role>`_
 
         :param name: The name of the role.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1147,7 +1147,7 @@ class SecurityClient(NamespacedClient):
           The delete role mappings API cannot remove role mappings that are defined in role mapping files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-role-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-role-mapping>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1203,7 +1203,7 @@ class SecurityClient(NamespacedClient):
           <p>Delete service account tokens for a service in a specified namespace.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-service-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-service-token>`_
 
         :param namespace: The namespace, which is a top-level grouping of service accounts.
         :param service: The service name.
@@ -1265,7 +1265,7 @@ class SecurityClient(NamespacedClient):
           <p>Delete users from the native realm.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delete-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-user>`_
 
         :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1319,7 +1319,7 @@ class SecurityClient(NamespacedClient):
           You can use this API to revoke a user's access to Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-disable-user>`_
 
         :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1376,7 +1376,7 @@ class SecurityClient(NamespacedClient):
           To re-enable a disabled user profile, use the enable user profile API .</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-disable-user-profile>`_
 
         :param uid: Unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1429,7 +1429,7 @@ class SecurityClient(NamespacedClient):
           By default, when you create users, they are enabled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enable-user>`_
 
         :param username: An identifier for the user.
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -1486,7 +1486,7 @@ class SecurityClient(NamespacedClient):
           If you later disable the user profile, you can use the enable user profile API to make the profile visible in these searches again.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enable-user-profile>`_
 
         :param uid: A unique identifier for the user profile.
         :param refresh: If 'true', Elasticsearch refreshes the affected shards to make
@@ -1536,7 +1536,7 @@ class SecurityClient(NamespacedClient):
           Kibana uses this API internally to configure itself for communications with an Elasticsearch cluster that already has security features enabled.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enroll-kibana>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/kibana"
@@ -1577,7 +1577,7 @@ class SecurityClient(NamespacedClient):
           The response contains key and certificate material that allows the caller to generate valid signed certificates for the HTTP layer of all nodes in the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-enroll-node>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/enroll/node"
@@ -1626,7 +1626,7 @@ class SecurityClient(NamespacedClient):
           If you have <code>read_security</code>, <code>manage_api_key</code> or greater privileges (including <code>manage_security</code>), this API returns all API keys regardless of ownership.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-api-key>`_
 
         :param active_only: A boolean flag that can be used to query API keys that are
             currently active. An API key is considered active if it is neither invalidated,
@@ -1704,7 +1704,7 @@ class SecurityClient(NamespacedClient):
           <p>Get the list of cluster privileges and index privileges that are available in this version of Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-builtin-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-builtin-privileges>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_security/privilege/_builtin"
@@ -1749,7 +1749,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-privileges>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -1805,7 +1805,7 @@ class SecurityClient(NamespacedClient):
           The get roles API cannot retrieve roles that are defined in roles files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-role>`_
 
         :param name: The name of the role. You can specify multiple roles as a comma-separated
             list. If you do not specify this parameter, the API returns information about
@@ -1856,7 +1856,7 @@ class SecurityClient(NamespacedClient):
           The get role mappings API cannot retrieve role mappings that are defined in role mapping files.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-role-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-role-mapping>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -1909,7 +1909,7 @@ class SecurityClient(NamespacedClient):
           <p>NOTE: Currently, only the <code>elastic/fleet-server</code> service account is available.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-accounts.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-service-accounts>`_
 
         :param namespace: The name of the namespace. Omit this parameter to retrieve
             information about all service accounts. If you omit this parameter, you must
@@ -1967,7 +1967,7 @@ class SecurityClient(NamespacedClient):
           Tokens with the same name from different nodes are assumed to be the same token and are only counted once towards the total number of service tokens.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-service-credentials.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-service-credentials>`_
 
         :param namespace: The name of the namespace.
         :param service: The service name.
@@ -2023,7 +2023,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-settings>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -2099,7 +2099,7 @@ class SecurityClient(NamespacedClient):
           If you want to invalidate a token immediately, you can do so by using the invalidate token API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-token>`_
 
         :param grant_type: The type of grant. Supported grant types are: `password`,
             `_kerberos`, `client_credentials`, and `refresh_token`.
@@ -2173,7 +2173,7 @@ class SecurityClient(NamespacedClient):
           <p>Get information about users in the native realm and built-in users.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-user>`_
 
         :param username: An identifier for the user. You can specify multiple usernames
             as a comma-separated list. If you omit this parameter, the API retrieves
@@ -2231,7 +2231,7 @@ class SecurityClient(NamespacedClient):
           To check whether a user has a specific list of privileges, use the has privileges API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-user-privileges>`_
 
         :param application: The name of the application. Application privileges are always
             associated with exactly one application. If you do not specify this parameter,
@@ -2288,7 +2288,7 @@ class SecurityClient(NamespacedClient):
           Elastic reserves the right to change or remove this feature in future releases without prior notice.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-user-profile>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: A comma-separated list of filters for the `data` field of the profile
@@ -2372,7 +2372,7 @@ class SecurityClient(NamespacedClient):
           <p>By default, API keys never expire. You can specify expiration information when you create the API keys.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-grant-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-grant-api-key>`_
 
         :param api_key: The API key.
         :param grant_type: The type of grant. Supported grant types are: `access_token`,
@@ -2519,7 +2519,7 @@ class SecurityClient(NamespacedClient):
           To check the privileges of other users, you must use the run as feature.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-has-privileges>`_
 
         :param user: Username
         :param application:
@@ -2584,7 +2584,7 @@ class SecurityClient(NamespacedClient):
           Elastic reserves the right to change or remove this feature in future releases without prior notice.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-has-privileges-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-has-privileges-user-profile>`_
 
         :param privileges: An object containing all the privileges to be checked.
         :param uids: A list of profile IDs. The privileges are checked for associated
@@ -2658,7 +2658,7 @@ class SecurityClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-invalidate-api-key>`_
 
         :param id:
         :param ids: A list of API key ids. This parameter cannot be used with any of
@@ -2742,7 +2742,7 @@ class SecurityClient(NamespacedClient):
           If none of these two are specified, then <code>realm_name</code> and/or <code>username</code> need to be specified.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-invalidate-token.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-invalidate-token>`_
 
         :param realm_name: The name of an authentication realm. This parameter cannot
             be used with either `refresh_token` or `token`.
@@ -2810,7 +2810,7 @@ class SecurityClient(NamespacedClient):
           These APIs are used internally by Kibana in order to provide OpenID Connect based authentication, but can also be used by other, custom web applications or other clients.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-oidc-authenticate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-oidc-authenticate>`_
 
         :param nonce: Associate a client session with an ID token and mitigate replay
             attacks. This value needs to be the same as the one that was provided to
@@ -2890,7 +2890,7 @@ class SecurityClient(NamespacedClient):
           These APIs are used internally by Kibana in order to provide OpenID Connect based authentication, but can also be used by other, custom web applications or other clients.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-oidc-logout.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-oidc-logout>`_
 
         :param access_token: The access token to be invalidated.
         :param refresh_token: The refresh token to be invalidated.
@@ -2952,7 +2952,7 @@ class SecurityClient(NamespacedClient):
           These APIs are used internally by Kibana in order to provide OpenID Connect based authentication, but can also be used by other, custom web applications or other clients.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-oidc-prepare-authentication.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-oidc-prepare-authentication>`_
 
         :param iss: In the case of a third party initiated single sign on, this is the
             issuer identifier for the OP that the RP is to send the authentication request
@@ -3048,7 +3048,7 @@ class SecurityClient(NamespacedClient):
           <p>Action names can contain any number of printable ASCII characters and must contain at least one of the following characters: <code>/</code>, <code>*</code>, <code>:</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-privileges.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-privileges>`_
 
         :param privileges:
         :param refresh: If `true` (the default) then refresh the affected shards to make
@@ -3200,7 +3200,7 @@ class SecurityClient(NamespacedClient):
           File-based role management is not available in Elastic Serverless.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role>`_
 
         :param name: The name of the role that is being created or updated. On Elasticsearch
             Serverless, the role name must begin with a letter or digit and can only
@@ -3335,7 +3335,7 @@ class SecurityClient(NamespacedClient):
           If the format of the template is set to &quot;json&quot; then the template is expected to produce a JSON string or an array of JSON strings for the role names.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-role-mapping.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role-mapping>`_
 
         :param name: The distinct name that identifies the role mapping. The name is
             used solely as an identifier to facilitate interaction via the API; it does
@@ -3437,7 +3437,7 @@ class SecurityClient(NamespacedClient):
           To change a user's password without updating any other fields, use the change password API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-user>`_
 
         :param username: An identifier for the user. NOTE: Usernames must be at least
             1 and no more than 507 characters. They can contain alphanumeric characters
@@ -3531,7 +3531,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -3556,7 +3556,7 @@ class SecurityClient(NamespacedClient):
           If you have the <code>read_security</code>, <code>manage_api_key</code>, or greater privileges (including <code>manage_security</code>), this API returns all API keys regardless of ownership.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-query-api-keys>`_
 
         :param aggregations: Any aggregations to run over the corpus of returned API
             keys. Aggregations and queries work together. Aggregations are computed only
@@ -3677,7 +3677,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -3699,7 +3699,7 @@ class SecurityClient(NamespacedClient):
           Also, the results can be paginated and sorted.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-role.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-query-role>`_
 
         :param from_: The starting document offset. It must not be negative. By default,
             you cannot page through more than 10,000 hits using the `from` and `size`
@@ -3770,7 +3770,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -3792,7 +3792,7 @@ class SecurityClient(NamespacedClient):
           This API is only for native users.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-user.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-query-user>`_
 
         :param from_: The starting document offset. It must not be negative. By default,
             you cannot page through more than 10,000 hits using the `from` and `size`
@@ -3885,7 +3885,7 @@ class SecurityClient(NamespacedClient):
           This API endpoint essentially exchanges SAML responses that indicate successful authentication in the IdP for Elasticsearch access and refresh tokens, which can be used for authentication against Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-authenticate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-authenticate>`_
 
         :param content: The SAML response as it was sent by the user's browser, usually
             a Base64 encoded XML document.
@@ -3958,7 +3958,7 @@ class SecurityClient(NamespacedClient):
           The caller of this API must prepare the request accordingly so that this API can handle either of them.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-complete-logout.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-complete-logout>`_
 
         :param ids: A JSON array with all the valid SAML Request Ids that the caller
             of the API has for the current user.
@@ -4034,7 +4034,7 @@ class SecurityClient(NamespacedClient):
           Thus the user can be redirected back to their IdP.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-invalidate.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-invalidate>`_
 
         :param query_string: The query part of the URL that the user was redirected to
             by the SAML IdP to initiate the Single Logout. This query should include
@@ -4109,7 +4109,7 @@ class SecurityClient(NamespacedClient):
           If the SAML realm in Elasticsearch is configured accordingly and the SAML IdP supports this, the Elasticsearch response contains a URL to redirect the user to the IdP that contains a SAML logout request (starting an SP-initiated SAML Single Logout).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-logout.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-logout>`_
 
         :param token: The access token that was returned as a response to calling the
             SAML authenticate API. Alternatively, the most recent token that was received
@@ -4179,7 +4179,7 @@ class SecurityClient(NamespacedClient):
           The caller of this API needs to store this identifier as it needs to be used in a following step of the authentication process.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-prepare-authentication.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-prepare-authentication>`_
 
         :param acs: The Assertion Consumer Service URL that matches the one of the SAML
             realms in Elasticsearch. The realm is used to generate the authentication
@@ -4240,7 +4240,7 @@ class SecurityClient(NamespacedClient):
           This API generates Service Provider metadata based on the configuration of a SAML realm in Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-saml-sp-metadata.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-saml-service-provider-metadata>`_
 
         :param realm_name: The name of the SAML realm in Elasticsearch.
         """
@@ -4293,7 +4293,7 @@ class SecurityClient(NamespacedClient):
           Elastic reserves the right to change or remove this feature in future releases without prior notice.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-suggest-user-profile.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-suggest-user-profiles>`_
 
         :param data: A comma-separated list of filters for the `data` field of the profile
             document. To return all content use `data=*`. To return a subset of content,
@@ -4380,7 +4380,7 @@ class SecurityClient(NamespacedClient):
           This change can occur if the owner user's permissions have changed since the API key was created or last modified.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-api-key>`_
 
         :param id: The ID of the API key to update.
         :param expiration: The expiration time for the API key. By default, API keys
@@ -4468,7 +4468,7 @@ class SecurityClient(NamespacedClient):
           <p>NOTE: This API cannot update REST API keys, which should be updated by either the update API key or bulk update API keys API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-cross-cluster-api-key.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-cross-cluster-api-key>`_
 
         :param id: The ID of the cross-cluster API key to update.
         :param access: The access to be granted to this API key. The access is composed
@@ -4547,7 +4547,7 @@ class SecurityClient(NamespacedClient):
           This API does not yet support configuring the settings for indices before they are in use.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-settings>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -4632,7 +4632,7 @@ class SecurityClient(NamespacedClient):
           The <code>update_profile_data</code> global privilege grants privileges for updating only the allowed namespaces.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-user-profile-data.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-update-user-profile-data>`_
 
         :param uid: A unique identifier for the user profile.
         :param data: Non-searchable data that you want to associate with the user profile.

--- a/elasticsearch/_sync/client/shutdown.py
+++ b/elasticsearch/_sync/client/shutdown.py
@@ -53,7 +53,7 @@ class ShutdownClient(NamespacedClient):
           <p>If the operator privileges feature is enabled, you must be an operator to use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-shutdown.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-shutdown-delete-node>`_
 
         :param node_id: The node id of node to be removed from the shutdown state
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -112,7 +112,7 @@ class ShutdownClient(NamespacedClient):
           <p>If the operator privileges feature is enabled, you must be an operator to use this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-shutdown.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-shutdown-get-node>`_
 
         :param node_id: Which node for which to retrieve the shutdown status
         :param master_timeout: Period to wait for a connection to the master node. If
@@ -187,7 +187,7 @@ class ShutdownClient(NamespacedClient):
           Monitor the node shutdown status to determine when it is safe to stop Elasticsearch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-shutdown.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-shutdown-put-node>`_
 
         :param node_id: The node identifier. This parameter is not validated against
             the cluster's active nodes. This enables you to register a node for shut

--- a/elasticsearch/_sync/client/simulate.py
+++ b/elasticsearch/_sync/client/simulate.py
@@ -81,7 +81,7 @@ class SimulateClient(NamespacedClient):
           These will be used in place of the pipeline definitions that are already in the system. This can be used to replace existing pipeline definitions or to create new ones. The pipeline substitutions are used only within this request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-ingest-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-simulate-ingest>`_
 
         :param docs: Sample documents to test in the pipeline.
         :param index: The index to simulate ingesting into. This value can be overridden

--- a/elasticsearch/_sync/client/slm.py
+++ b/elasticsearch/_sync/client/slm.py
@@ -45,7 +45,7 @@ class SlmClient(NamespacedClient):
           This operation prevents any future snapshots from being taken but does not cancel in-progress snapshots or remove previously-taken snapshots.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-delete-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-delete-lifecycle>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to remove
         :param master_timeout: The period to wait for a connection to the master node.
@@ -101,7 +101,7 @@ class SlmClient(NamespacedClient):
           The snapshot policy is normally applied according to its schedule, but you might want to manually run a policy before performing an upgrade or other maintenance.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-lifecycle.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-execute-lifecycle>`_
 
         :param policy_id: The id of the snapshot lifecycle policy to be executed
         :param master_timeout: The period to wait for a connection to the master node.
@@ -156,7 +156,7 @@ class SlmClient(NamespacedClient):
           The retention policy is normally applied according to its schedule.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-execute-retention.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-execute-retention>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -208,7 +208,7 @@ class SlmClient(NamespacedClient):
           Get snapshot lifecycle policy definitions and information about the latest snapshot attempts.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-get-lifecycle>`_
 
         :param policy_id: Comma-separated list of snapshot lifecycle policies to retrieve
         :param master_timeout: The period to wait for a connection to the master node.
@@ -265,7 +265,7 @@ class SlmClient(NamespacedClient):
           Get global and policy-level statistics about actions taken by snapshot lifecycle management.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-get-stats>`_
 
         :param master_timeout: Period to wait for a connection to the master node. If
             no response is received before the timeout expires, the request fails and
@@ -315,7 +315,7 @@ class SlmClient(NamespacedClient):
           <p>Get the snapshot lifecycle management status.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-status.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-get-status>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -379,7 +379,7 @@ class SlmClient(NamespacedClient):
           Only the latest version of a policy is stored.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-put-policy.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-put-lifecycle>`_
 
         :param policy_id: The identifier for the snapshot lifecycle policy you want to
             create or update.
@@ -465,7 +465,7 @@ class SlmClient(NamespacedClient):
           Manually starting SLM is necessary only if it has been stopped using the stop SLM API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-start.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-start>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -523,7 +523,7 @@ class SlmClient(NamespacedClient):
           Use the get snapshot lifecycle management status API to see if SLM is running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-stop.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-slm-stop>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/_sync/client/snapshot.py
+++ b/elasticsearch/_sync/client/snapshot.py
@@ -50,7 +50,7 @@ class SnapshotClient(NamespacedClient):
           Trigger the review of the contents of a snapshot repository and delete any stale data not referenced by existing snapshots.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-cleanup-repository>`_
 
         :param name: The name of the snapshot repository to clean up.
         :param master_timeout: The period to wait for a connection to the master node.
@@ -115,7 +115,7 @@ class SnapshotClient(NamespacedClient):
           Clone part of all of a snapshot into another snapshot in the same repository.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clone-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-clone>`_
 
         :param repository: The name of the snapshot repository that both source and target
             snapshot belong to.
@@ -216,7 +216,7 @@ class SnapshotClient(NamespacedClient):
           Take a snapshot of a cluster or of data streams and indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/create-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-create>`_
 
         :param repository: The name of the repository for the snapshot.
         :param snapshot: The name of the snapshot. It supportes date math. It must be
@@ -343,7 +343,7 @@ class SnapshotClient(NamespacedClient):
           If both parameters are specified, only the query parameter is used.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-create-repository>`_
 
         :param name: The name of the snapshot repository to register or update.
         :param repository:
@@ -415,7 +415,7 @@ class SnapshotClient(NamespacedClient):
           <p>Delete snapshots.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-delete>`_
 
         :param repository: The name of the repository to delete a snapshot from.
         :param snapshot: A comma-separated list of snapshot names to delete. It also
@@ -474,7 +474,7 @@ class SnapshotClient(NamespacedClient):
           The snapshots themselves are left untouched and in place.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-delete-repository>`_
 
         :param name: The ame of the snapshot repositories to unregister. Wildcard (`*`)
             patterns are supported.
@@ -560,7 +560,7 @@ class SnapshotClient(NamespacedClient):
           Snapshots concurrently created may be seen during an iteration.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-get>`_
 
         :param repository: A comma-separated list of snapshot repository names used to
             limit the request. Wildcard (`*`) expressions are supported.
@@ -686,7 +686,7 @@ class SnapshotClient(NamespacedClient):
           <p>Get snapshot repository information.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-get-repository>`_
 
         :param name: A comma-separated list of snapshot repository names used to limit
             the request. Wildcard (`*`) expressions are supported including combining
@@ -830,7 +830,7 @@ class SnapshotClient(NamespacedClient):
           Some operations also verify the behavior on small blobs with sizes other than 8 bytes.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/repo-analysis-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-repository-analyze>`_
 
         :param name: The name of the repository.
         :param blob_count: The total number of blobs to write to the repository during
@@ -963,7 +963,7 @@ class SnapshotClient(NamespacedClient):
           The response body format is therefore not considered stable and may be different in newer versions.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/verify-repo-integrity-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-repository-verify-integrity>`_
 
         :param name: The name of the snapshot repository.
         :param blob_thread_pool_concurrency: If `verify_blob_contents` is `true`, this
@@ -1085,7 +1085,7 @@ class SnapshotClient(NamespacedClient):
           <p>If your snapshot contains data from App Search or Workplace Search, you must restore the Enterprise Search encryption key before you restore the snapshot.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/restore-snapshot-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-restore>`_
 
         :param repository: The name of the repository to restore a snapshot from.
         :param snapshot: The name of the snapshot to restore.
@@ -1235,7 +1235,7 @@ class SnapshotClient(NamespacedClient):
           These requests can also tax machine resources and, when using cloud storage, incur high processing costs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-snapshot-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-status>`_
 
         :param repository: The snapshot repository name used to limit the request. It
             supports wildcards (`*`) if `<snapshot>` isn't specified.
@@ -1303,7 +1303,7 @@ class SnapshotClient(NamespacedClient):
           Check for common misconfigurations in a snapshot repository.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/verify-snapshot-repo-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-verify-repository>`_
 
         :param name: The name of the snapshot repository to verify.
         :param master_timeout: The period to wait for the master node. If the master

--- a/elasticsearch/_sync/client/sql.py
+++ b/elasticsearch/_sync/client/sql.py
@@ -44,7 +44,7 @@ class SqlClient(NamespacedClient):
           <p>Clear an SQL search cursor.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-sql-cursor-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-clear-cursor>`_
 
         :param cursor: Cursor to clear.
         """
@@ -99,7 +99,7 @@ class SqlClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-async-sql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-delete-async>`_
 
         :param id: The identifier for the search.
         """
@@ -150,7 +150,7 @@ class SqlClient(NamespacedClient):
           <p>If the Elasticsearch security features are enabled, only the user who first submitted the SQL search can retrieve the search using this API.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-get-async>`_
 
         :param id: The identifier for the search.
         :param delimiter: The separator for CSV results. The API supports this parameter
@@ -212,7 +212,7 @@ class SqlClient(NamespacedClient):
           Get the current status of an async SQL search or a stored synchronous SQL search.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-status-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-get-async-status>`_
 
         :param id: The identifier for the search.
         """
@@ -301,7 +301,7 @@ class SqlClient(NamespacedClient):
           Run an SQL request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-search-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-query>`_
 
         :param allow_partial_search_results: If `true`, the response has partial results
             when there are shard request timeouts or shard failures. If `false`, the
@@ -427,7 +427,7 @@ class SqlClient(NamespacedClient):
           It accepts the same request body parameters as the SQL search API, excluding <code>cursor</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-translate>`_
 
         :param query: The SQL query to run.
         :param fetch_size: The maximum number of rows (or entries) to return in one response.

--- a/elasticsearch/_sync/client/ssl.py
+++ b/elasticsearch/_sync/client/ssl.py
@@ -52,7 +52,7 @@ class SslClient(NamespacedClient):
           <p>If Elasticsearch is configured to use a keystore or truststore, the API output includes all certificates in that store, even though some of the certificates might not be in active use within the cluster.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ssl-certificates>`_
         """
         __path_parts: t.Dict[str, str] = {}
         __path = "/_ssl/certificates"

--- a/elasticsearch/_sync/client/synonyms.py
+++ b/elasticsearch/_sync/client/synonyms.py
@@ -53,7 +53,7 @@ class SynonymsClient(NamespacedClient):
           When the synonyms set is not used in analyzers, you will be able to delete it.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-delete-synonym>`_
 
         :param id: The synonyms set identifier to delete.
         """
@@ -98,7 +98,7 @@ class SynonymsClient(NamespacedClient):
           Delete a synonym rule from a synonym set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonym-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-delete-synonym-rule>`_
 
         :param set_id: The ID of the synonym set to update.
         :param rule_id: The ID of the synonym rule to delete.
@@ -151,7 +151,7 @@ class SynonymsClient(NamespacedClient):
           <p>Get a synonym set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-get-synonym>`_
 
         :param id: The synonyms set identifier to retrieve.
         :param from_: The starting offset for query rules to retrieve.
@@ -202,7 +202,7 @@ class SynonymsClient(NamespacedClient):
           Get a synonym rule from a synonym set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonym-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-get-synonym-rule>`_
 
         :param set_id: The ID of the synonym set to retrieve the synonym rule from.
         :param rule_id: The ID of the synonym rule to retrieve.
@@ -255,7 +255,7 @@ class SynonymsClient(NamespacedClient):
           Get a summary of all defined synonym sets.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-get-synonym>`_
 
         :param from_: The starting offset for synonyms sets to retrieve.
         :param size: The maximum number of synonyms sets to retrieve.
@@ -311,7 +311,7 @@ class SynonymsClient(NamespacedClient):
           This is equivalent to invoking the reload search analyzers API for all indices that use the synonyms set.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonyms-set.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-put-synonym>`_
 
         :param id: The ID of the synonyms set to be created or updated.
         :param synonyms_set: The synonym rules definitions for the synonyms set.
@@ -370,7 +370,7 @@ class SynonymsClient(NamespacedClient):
           <p>When you update a synonym rule, all analyzers using the synonyms set will be reloaded automatically to reflect the new rule.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonym-rule.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-put-synonym-rule>`_
 
         :param set_id: The ID of the synonym set.
         :param rule_id: The ID of the synonym rule to be updated or created.

--- a/elasticsearch/_sync/client/tasks.py
+++ b/elasticsearch/_sync/client/tasks.py
@@ -60,7 +60,7 @@ class TasksClient(NamespacedClient):
           You can also use the node hot threads API to obtain detailed information about the work the system is doing instead of completing the cancelled task.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks>`_
 
         :param task_id: The task identifier.
         :param actions: A comma-separated list or wildcard expression of actions that
@@ -128,7 +128,7 @@ class TasksClient(NamespacedClient):
           <p>If the task identifier is not found, a 404 response code indicates that there are no resources that match the request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks>`_
 
         :param task_id: The task identifier.
         :param timeout: The period to wait for a response. If no response is received
@@ -238,7 +238,7 @@ class TasksClient(NamespacedClient):
           The <code>X-Opaque-Id</code> in the children <code>headers</code> is the child task of the task that was initiated by the REST request.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks>`_
 
         :param actions: A comma-separated list or wildcard expression of actions used
             to limit the request. For example, you can use `cluser:*` to retrieve all

--- a/elasticsearch/_sync/client/text_structure.py
+++ b/elasticsearch/_sync/client/text_structure.py
@@ -72,7 +72,7 @@ class TextStructureClient(NamespacedClient):
           It helps determine why the returned structure was chosen.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-field-structure.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-text_structure>`_
 
         :param field: The field that should be analyzed.
         :param index: The name of the index that contains the analyzed field.
@@ -259,7 +259,7 @@ class TextStructureClient(NamespacedClient):
           It helps determine why the returned structure was chosen.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-message-structure.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-text-structure-find-message-structure>`_
 
         :param messages: The list of messages you want to analyze.
         :param column_names: If the format is `delimited`, you can specify the column
@@ -433,7 +433,7 @@ class TextStructureClient(NamespacedClient):
           However, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/find-structure.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-text-structure-find-structure>`_
 
         :param text_files:
         :param charset: The text's character set. It must be a character set that is
@@ -620,7 +620,7 @@ class TextStructureClient(NamespacedClient):
           The API indicates whether the lines match the pattern together with the offsets and lengths of the matched substrings.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-grok-pattern.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-text-structure-test-grok-pattern>`_
 
         :param grok_pattern: The Grok pattern to run on the text.
         :param text: The lines of text to run the Grok pattern on.

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -41,11 +41,10 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Delete a transform.
-          Deletes a transform.</p>
+          <p>Delete a transform.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-delete-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param delete_dest_index: If this value is true, the destination index is deleted
@@ -106,10 +105,10 @@ class TransformClient(NamespacedClient):
         .. raw:: html
 
           <p>Get transforms.
-          Retrieves configuration information for transforms.</p>
+          Get configuration information for transforms.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-get-transform>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -178,11 +177,11 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get transform stats.
-          Retrieves usage information for transforms.</p>
+          <p>Get transform stats.</p>
+          <p>Get usage information for transforms.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-get-transform-stats>`_
 
         :param transform_id: Identifier for the transform. It can be a transform identifier
             or a wildcard expression. You can get information for all transforms by using
@@ -270,7 +269,7 @@ class TransformClient(NamespacedClient):
           types of the source index and the transform aggregations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/preview-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-preview-transform>`_
 
         :param transform_id: Identifier for the transform to preview. If you specify
             this path parameter, you cannot provide transform configuration details in
@@ -407,7 +406,7 @@ class TransformClient(NamespacedClient):
           give users any privileges on <code>.data-frame-internal*</code> indices.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-put-transform>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -508,13 +507,12 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Reset a transform.
-          Resets a transform.
-          Before you can reset it, you must stop it; alternatively, use the <code>force</code> query parameter.
+          <p>Reset a transform.</p>
+          <p>Before you can reset it, you must stop it; alternatively, use the <code>force</code> query parameter.
           If the destination index was created by the transform, it is deleted.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/reset-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform>`_
 
         :param transform_id: Identifier for the transform. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -566,15 +564,15 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Schedule a transform to start now.
-          Instantly runs a transform to process data.</p>
-          <p>If you _schedule_now a transform, it will process the new data instantly,
-          without waiting for the configured frequency interval. After _schedule_now API is called,
-          the transform will be processed again at now + frequency unless _schedule_now API
+          <p>Schedule a transform to start now.</p>
+          <p>Instantly run a transform to process data.
+          If you run this API, the transform will process the new data instantly,
+          without waiting for the configured frequency interval. After the API is called,
+          the transform will be processed again at <code>now + frequency</code> unless the API
           is called again in the meantime.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/schedule-now-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-schedule-now-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param timeout: Controls the time to wait for the scheduling to take place
@@ -621,8 +619,7 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Start a transform.
-          Starts a transform.</p>
+          <p>Start a transform.</p>
           <p>When you start a transform, it creates the destination index if it does not already exist. The <code>number_of_shards</code> is
           set to <code>1</code> and the <code>auto_expand_replicas</code> is set to <code>0-1</code>. If it is a pivot transform, it deduces the mapping
           definitions for the destination index from the source indices and the transform aggregations. If fields in the
@@ -638,7 +635,7 @@ class TransformClient(NamespacedClient):
           destination indices, the transform fails when it attempts unauthorized operations.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-start-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param from_: Restricts the set of transformed entities to those changed after
@@ -696,7 +693,7 @@ class TransformClient(NamespacedClient):
           Stops one or more transforms.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-stop-transform>`_
 
         :param transform_id: Identifier for the transform. To stop multiple transforms,
             use a comma-separated list or a wildcard expression. To stop all transforms,
@@ -798,7 +795,7 @@ class TransformClient(NamespacedClient):
           time of update and runs with those privileges.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-update-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -879,8 +876,8 @@ class TransformClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Upgrade all transforms.
-          Transforms are compatible across minor versions and between supported major versions.
+          <p>Upgrade all transforms.</p>
+          <p>Transforms are compatible across minor versions and between supported major versions.
           However, over time, the format of transform configuration information may change.
           This API identifies transforms that have a legacy configuration format and upgrades them to the latest version.
           It also cleans up the internal data structures that store the transform state and checkpoints.
@@ -893,7 +890,7 @@ class TransformClient(NamespacedClient):
           You may want to perform a recent cluster backup prior to the upgrade.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/upgrade-transforms.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-upgrade-transforms>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_sync/client/watcher.py
+++ b/elasticsearch/_sync/client/watcher.py
@@ -48,7 +48,7 @@ class WatcherClient(NamespacedClient):
           This happens when the condition of the watch is not met (the condition evaluates to false).</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-ack-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-ack-watch>`_
 
         :param watch_id: The watch identifier.
         :param action_id: A comma-separated list of the action identifiers to acknowledge.
@@ -104,7 +104,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-activate-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-activate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -148,7 +148,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-deactivate-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-deactivate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -196,7 +196,7 @@ class WatcherClient(NamespacedClient):
           When Elasticsearch security features are enabled, make sure no write privileges are granted to anyone for the <code>.watches</code> index.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-delete-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-delete-watch>`_
 
         :param id: The watch identifier.
         """
@@ -277,7 +277,7 @@ class WatcherClient(NamespacedClient):
           <p>When using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-execute-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-execute-watch>`_
 
         :param id: The watch identifier.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -365,7 +365,7 @@ class WatcherClient(NamespacedClient):
           Only a subset of settings are shown, for example <code>index.auto_expand_replicas</code> and <code>index.number_of_replicas</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-settings>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -410,7 +410,7 @@ class WatcherClient(NamespacedClient):
           <p>Get a watch.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-get-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-watch>`_
 
         :param id: The watch identifier.
         """
@@ -485,7 +485,7 @@ class WatcherClient(NamespacedClient):
           If the user is able to read index <code>a</code>, but not index <code>b</code>, the same will apply when the watch runs.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-put-watch.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-put-watch>`_
 
         :param id: The identifier for the watch.
         :param actions: The list of actions that will be run if the condition matches.
@@ -579,7 +579,7 @@ class WatcherClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         search_after: t.Optional[
-            t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
+            t.Sequence[t.Union[None, bool, float, int, str]]
         ] = None,
         size: t.Optional[int] = None,
         sort: t.Optional[
@@ -598,7 +598,7 @@ class WatcherClient(NamespacedClient):
           <p>Note that only the <code>_id</code> and <code>metadata.*</code> fields are queryable or sortable.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-query-watches.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-query-watches>`_
 
         :param from_: The offset from the first result to fetch. It must be non-negative.
         :param query: A query that filters the watches to be returned.
@@ -673,7 +673,7 @@ class WatcherClient(NamespacedClient):
           Start the Watcher service if it is not already running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-start.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-start>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -739,7 +739,7 @@ class WatcherClient(NamespacedClient):
           You retrieve more metrics by using the metric parameter.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stats.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stats>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -790,7 +790,7 @@ class WatcherClient(NamespacedClient):
           Stop the Watcher service if it is running.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-stop.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stop>`_
 
         :param master_timeout: The period to wait for the master node. If the master
             node is not available before the timeout expires, the request fails and returns
@@ -848,7 +848,7 @@ class WatcherClient(NamespacedClient):
           This includes <code>index.auto_expand_replicas</code> and <code>index.number_of_replicas</code>.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/watcher-api-update-settings.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-update-settings>`_
 
         :param index_auto_expand_replicas:
         :param index_number_of_replicas:

--- a/elasticsearch/_sync/client/xpack.py
+++ b/elasticsearch/_sync/client/xpack.py
@@ -54,7 +54,7 @@ class XPackClient(NamespacedClient):
           </ul>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/info-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-info>`_
 
         :param accept_enterprise: If this param is used it must be set to true
         :param categories: A comma-separated list of the information categories to include
@@ -103,7 +103,7 @@ class XPackClient(NamespacedClient):
           The API also provides some usage statistics.</p>
 
 
-        `<https://www.elastic.co/guide/en/elasticsearch/reference/master/usage-api.html>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-xpack>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails


### PR DESCRIPTION
* Update all URLs to use the new Elasticsearch API docs
* Add `include_source_on_error` to Create, Index, Update and Bulk APIs
* Add `include_ccs_metadata` to ES|QL query and async query APIs
* Add Stop async ES|QL query
* Add `master_timeout` to Migrate to data tiers routing APIs
* Remove `local` from Get mapping definitions API
* Add `data_retention`, `downsampling` and `enabled` to Update data stream lifecycles API
* Add `timeout` to Resolve the cluster API
* Add `adaptive_allocations` body field to Start and Update a trained model deployment API