### PR TITLE
autogenerate field classes from schema

### DIFF
--- a/elasticsearch/dsl/field.py
+++ b/elasticsearch/dsl/field.py
@@ -251,7 +251,7 @@ class Float(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -358,7 +358,7 @@ class Integer(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -448,7 +448,7 @@ class Object(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -601,7 +601,7 @@ class AggregateMetricDouble(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -655,7 +655,7 @@ class Alias(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -714,7 +714,7 @@ class Binary(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -800,7 +800,7 @@ class Boolean(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -905,7 +905,7 @@ class Byte(Integer):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1001,7 +1001,7 @@ class Completion(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1067,7 +1067,7 @@ class ConstantKeyword(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1147,7 +1147,7 @@ class Date(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1268,7 +1268,7 @@ class DateNanos(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1351,7 +1351,7 @@ class DateRange(RangeField):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1424,7 +1424,7 @@ class DenseVector(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1523,7 +1523,7 @@ class Double(Float):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1610,7 +1610,7 @@ class DoubleRange(RangeField):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1688,7 +1688,7 @@ class Flattened(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1769,7 +1769,7 @@ class FloatRange(RangeField):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1856,7 +1856,7 @@ class GeoPoint(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -1943,7 +1943,7 @@ class GeoShape(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2038,7 +2038,7 @@ class HalfFloat(Float):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2110,7 +2110,7 @@ class Histogram(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2207,7 +2207,7 @@ class IcuCollationKeyword(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2308,7 +2308,7 @@ class IntegerRange(RangeField):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2392,7 +2392,7 @@ class Ip(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2484,7 +2484,7 @@ class IpRange(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2548,7 +2548,7 @@ class Join(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2636,7 +2636,7 @@ class Keyword(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2745,7 +2745,7 @@ class Long(Integer):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2832,7 +2832,7 @@ class LongRange(RangeField):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -2943,7 +2943,7 @@ class Murmur3(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3009,7 +3009,7 @@ class Nested(Object):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3067,7 +3067,7 @@ class Percolator(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3137,7 +3137,7 @@ class Point(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3197,7 +3197,7 @@ class RankFeature(Float):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3247,7 +3247,7 @@ class RankFeatures(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3330,7 +3330,7 @@ class ScaledFloat(Float):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3450,7 +3450,7 @@ class SearchAsYouType(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3561,7 +3561,7 @@ class Shape(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3654,7 +3654,7 @@ class Short(Integer):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3724,7 +3724,7 @@ class SparseVector(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3828,7 +3828,7 @@ class Text(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -3929,7 +3929,7 @@ class TokenCount(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -4024,7 +4024,7 @@ class UnsignedLong(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -4104,7 +4104,7 @@ class Version(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[
@@ -4168,7 +4168,7 @@ class Wildcard(Field):
         properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         ignore_above: Union[int, "DefaultType"] = DEFAULT,
         dynamic: Union[
-            Literal["strict", "runtime", "true", "false"], "DefaultType"
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
         ] = DEFAULT,
         fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
         synthetic_source_keep: Union[

--- a/elasticsearch/dsl/field.py
+++ b/elasticsearch/dsl/field.py
@@ -26,7 +26,10 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    Literal,
+    Mapping,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,
@@ -34,6 +37,7 @@ from typing import (
 )
 
 from dateutil import parser, tz
+from elastic_transport.client_utils import DEFAULT, DefaultType
 
 from .exceptions import ValidationException
 from .query import Q
@@ -46,7 +50,9 @@ if TYPE_CHECKING:
 
     from _operator import _SupportsComparison
 
+    from . import types
     from .document import InnerDoc
+    from .document_base import InstrumentedField
     from .mapping_base import MappingBase
     from .query import Query
 
@@ -170,34 +176,314 @@ class CustomField(Field):
         return d
 
 
-class Object(Field):
-    name = "object"
+class RangeField(Field):
     _coerce = True
+    _core_field: Optional[Field] = None
+
+    def _deserialize(self, data: Any) -> Range["_SupportsComparison"]:
+        if isinstance(data, Range):
+            return data
+        data = {k: self._core_field.deserialize(v) for k, v in data.items()}  # type: ignore[union-attr]
+        return Range(data)
+
+    def _serialize(self, data: Any) -> Optional[Dict[str, Any]]:
+        if data is None:
+            return None
+        if not isinstance(data, collections.abc.Mapping):
+            data = data.to_dict()
+        return {k: self._core_field.serialize(v) for k, v in data.items()}  # type: ignore[union-attr]
+
+
+class Float(Field):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "float"
+    _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
 
     def __init__(
         self,
-        doc_class: Optional[Type["InnerDoc"]] = None,
-        dynamic: Optional[Union[bool, str]] = None,
-        properties: Optional[Dict[str, Any]] = None,
+        *args: Any,
+        null_value: Union[float, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
         **kwargs: Any,
     ):
-        """
-        :arg document.InnerDoc doc_class: base doc class that handles mapping.
-            If no `doc_class` is provided, new instance of `InnerDoc` will be created,
-            populated with `properties` and used. Can not be provided together with `properties`
-        :arg dynamic: whether new properties may be created dynamically.
-            Valid values are `True`, `False`, `'strict'`.
-            Can not be provided together with `doc_class`.
-            See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html
-            for more details
-        :arg dict properties: used to construct underlying mapping if no `doc_class` is provided.
-            Can not be provided together with `doc_class`
-        """
-        if doc_class and (properties or dynamic is not None):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> float:
+        return float(data)
+
+
+class Integer(Field):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "integer"
+    _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[int, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> int:
+        return int(data)
+
+
+class Object(Field):
+    """
+    :arg doc_class: base doc class that handles mapping.
+       If no `doc_class` is provided, new instance of `InnerDoc` will be created,
+       populated with `properties` and used. Can not be provided together with `properties`
+    :arg enabled:
+    :arg subobjects:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "object"
+    _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        doc_class: Union[Type["InnerDoc"], "DefaultType"] = DEFAULT,
+        *args: Any,
+        enabled: Union[bool, "DefaultType"] = DEFAULT,
+        subobjects: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if enabled is not DEFAULT:
+            kwargs["enabled"] = enabled
+        if subobjects is not DEFAULT:
+            kwargs["subobjects"] = subobjects
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+
+        if doc_class is not DEFAULT and (
+            properties is not DEFAULT or dynamic is not DEFAULT
+        ):
             raise ValidationException(
                 "doc_class and properties/dynamic should not be provided together"
             )
-        if doc_class:
+        if doc_class is not DEFAULT:
             self._doc_class: Type["InnerDoc"] = doc_class
         else:
             # FIXME import
@@ -205,9 +491,13 @@ class Object(Field):
 
             # no InnerDoc subclass, creating one instead...
             self._doc_class = type("InnerDoc", (InnerDoc,), {})
-            for name, field in (properties or {}).items():
+            for name, field in (
+                properties if properties is not DEFAULT else {}
+            ).items():
                 self._doc_class._doc_type.mapping.field(name, field)
-            if dynamic is not None:
+            if "properties" in kwargs:
+                del kwargs["properties"]
+            if dynamic is not DEFAULT:
                 self._doc_class._doc_type.mapping.meta("dynamic", dynamic)
 
         self._mapping: "MappingBase" = deepcopy(self._doc_class._doc_type.mapping)
@@ -279,29 +569,630 @@ class Object(Field):
         self._mapping.update(other._mapping, update_only)
 
 
-class Nested(Object):
-    name = "nested"
+class AggregateMetricDouble(Field):
+    """
+    :arg default_metric: (required)
+    :arg metrics: (required)
+    :arg time_series_metric:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        kwargs.setdefault("multi", True)
+    name = "aggregate_metric_double"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        default_metric: Union[str, "DefaultType"] = DEFAULT,
+        metrics: Union[Sequence[str], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if default_metric is not DEFAULT:
+            kwargs["default_metric"] = default_metric
+        if metrics is not DEFAULT:
+            kwargs["metrics"] = metrics
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Alias(Field):
+    """
+    :arg path:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "alias"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        path: Union[str, "InstrumentedField", "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if path is not DEFAULT:
+            kwargs["path"] = str(path)
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Binary(Field):
+    """
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "binary"
+    _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data: str) -> str:
+        # Binary fields are opaque, so there's not much cleaning
+        # that can be done.
+        return data
+
+    def _deserialize(self, data: Any) -> bytes:
+        return base64.b64decode(data)
+
+    def _serialize(self, data: Any) -> Optional[str]:
+        if data is None:
+            return None
+        return base64.b64encode(data).decode()
+
+
+class Boolean(Field):
+    """
+    :arg boost:
+    :arg fielddata:
+    :arg index:
+    :arg null_value:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "boolean"
+    _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        fielddata: Union[
+            "types.NumericFielddata", Dict[str, Any], "DefaultType"
+        ] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if fielddata is not DEFAULT:
+            kwargs["fielddata"] = fielddata
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> bool:
+        if data == "false":
+            return False
+        return bool(data)
+
+    def clean(self, data: Any) -> Optional[bool]:
+        if data is not None:
+            data = self.deserialize(data)
+        if data is None and self._required:
+            raise ValidationException("Value required for this field.")
+        return data  # type: ignore[no-any-return]
+
+
+class Byte(Integer):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "byte"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[float, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Completion(Field):
+    """
+    :arg analyzer:
+    :arg contexts:
+    :arg max_input_length:
+    :arg preserve_position_increments:
+    :arg preserve_separators:
+    :arg search_analyzer:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "completion"
+    _param_defs = {
+        "analyzer": {"type": "analyzer"},
+        "search_analyzer": {"type": "analyzer"},
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        contexts: Union[
+            Sequence["types.SuggestContext"], Sequence[Dict[str, Any]], "DefaultType"
+        ] = DEFAULT,
+        max_input_length: Union[int, "DefaultType"] = DEFAULT,
+        preserve_position_increments: Union[bool, "DefaultType"] = DEFAULT,
+        preserve_separators: Union[bool, "DefaultType"] = DEFAULT,
+        search_analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if analyzer is not DEFAULT:
+            kwargs["analyzer"] = analyzer
+        if contexts is not DEFAULT:
+            kwargs["contexts"] = contexts
+        if max_input_length is not DEFAULT:
+            kwargs["max_input_length"] = max_input_length
+        if preserve_position_increments is not DEFAULT:
+            kwargs["preserve_position_increments"] = preserve_position_increments
+        if preserve_separators is not DEFAULT:
+            kwargs["preserve_separators"] = preserve_separators
+        if search_analyzer is not DEFAULT:
+            kwargs["search_analyzer"] = search_analyzer
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class ConstantKeyword(Field):
+    """
+    :arg value:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "constant_keyword"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        value: Any = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if value is not DEFAULT:
+            kwargs["value"] = value
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
         super().__init__(*args, **kwargs)
 
 
 class Date(Field):
+    """
+    :arg default_timezone: timezone that will be automatically used for tz-naive values
+       May be instance of `datetime.tzinfo` or string containing TZ offset
+    :arg boost:
+    :arg fielddata:
+    :arg format:
+    :arg ignore_malformed:
+    :arg index:
+    :arg null_value:
+    :arg precision_step:
+    :arg locale:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
     name = "date"
     _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
 
     def __init__(
         self,
-        default_timezone: Optional[Union[str, "tzinfo"]] = None,
+        default_timezone: Union[str, "tzinfo", "DefaultType"] = DEFAULT,
         *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        fielddata: Union[
+            "types.NumericFielddata", Dict[str, Any], "DefaultType"
+        ] = DEFAULT,
+        format: Union[str, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Any = DEFAULT,
+        precision_step: Union[int, "DefaultType"] = DEFAULT,
+        locale: Union[str, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
         **kwargs: Any,
     ):
-        """
-        :arg default_timezone: timezone that will be automatically used for tz-naive values
-            May be instance of `datetime.tzinfo` or string containing TZ offset
-        """
-        if isinstance(default_timezone, str):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if fielddata is not DEFAULT:
+            kwargs["fielddata"] = fielddata
+        if format is not DEFAULT:
+            kwargs["format"] = format
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if precision_step is not DEFAULT:
+            kwargs["precision_step"] = precision_step
+        if locale is not DEFAULT:
+            kwargs["locale"] = locale
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+
+        if default_timezone is DEFAULT:
+            self._default_timezone = None
+        elif isinstance(default_timezone, str):
             self._default_timezone = tz.gettz(default_timezone)
         else:
             self._default_timezone = default_timezone
@@ -332,72 +1223,241 @@ class Date(Field):
         raise ValidationException(f"Could not parse date from the value ({data!r})")
 
 
-class Text(Field):
+class DateNanos(Field):
+    """
+    :arg boost:
+    :arg format:
+    :arg ignore_malformed:
+    :arg index:
+    :arg null_value:
+    :arg precision_step:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "date_nanos"
     _param_defs = {
+        "properties": {"type": "field", "hash": True},
         "fields": {"type": "field", "hash": True},
-        "analyzer": {"type": "analyzer"},
-        "search_analyzer": {"type": "analyzer"},
-        "search_quote_analyzer": {"type": "analyzer"},
     }
-    name = "text"
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        format: Union[str, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Any = DEFAULT,
+        precision_step: Union[int, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if format is not DEFAULT:
+            kwargs["format"] = format
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if precision_step is not DEFAULT:
+            kwargs["precision_step"] = precision_step
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
-class SearchAsYouType(Field):
+class DateRange(RangeField):
+    """
+    :arg format:
+    :arg boost:
+    :arg coerce:
+    :arg index:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "date_range"
+    _core_field = Date()
     _param_defs = {
-        "analyzer": {"type": "analyzer"},
-        "search_analyzer": {"type": "analyzer"},
-        "search_quote_analyzer": {"type": "analyzer"},
-    }
-    name = "search_as_you_type"
-
-
-class Keyword(Field):
-    _param_defs = {
+        "properties": {"type": "field", "hash": True},
         "fields": {"type": "field", "hash": True},
-        "search_analyzer": {"type": "analyzer"},
-        "normalizer": {"type": "normalizer"},
     }
-    name = "keyword"
 
-
-class ConstantKeyword(Keyword):
-    name = "constant_keyword"
-
-
-class Boolean(Field):
-    name = "boolean"
-    _coerce = True
-
-    def _deserialize(self, data: Any) -> bool:
-        if data == "false":
-            return False
-        return bool(data)
-
-    def clean(self, data: Any) -> Optional[bool]:
-        if data is not None:
-            data = self.deserialize(data)
-        if data is None and self._required:
-            raise ValidationException("Value required for this field.")
-        return data  # type: ignore[no-any-return]
-
-
-class Float(Field):
-    name = "float"
-    _coerce = True
-
-    def _deserialize(self, data: Any) -> float:
-        return float(data)
+    def __init__(
+        self,
+        *args: Any,
+        format: Union[str, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if format is not DEFAULT:
+            kwargs["format"] = format
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
 class DenseVector(Field):
+    """
+    :arg element_type:
+    :arg dims:
+    :arg similarity:
+    :arg index:
+    :arg index_options:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
     name = "dense_vector"
     _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
 
-    def __init__(self, **kwargs: Any):
+    def __init__(
+        self,
+        *args: Any,
+        element_type: Union[str, "DefaultType"] = DEFAULT,
+        dims: Union[int, "DefaultType"] = DEFAULT,
+        similarity: Union[str, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        index_options: Union[
+            "types.DenseVectorIndexOptions", Dict[str, Any], "DefaultType"
+        ] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if element_type is not DEFAULT:
+            kwargs["element_type"] = element_type
+        if dims is not DEFAULT:
+            kwargs["dims"] = dims
+        if similarity is not DEFAULT:
+            kwargs["similarity"] = similarity
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if index_options is not DEFAULT:
+            kwargs["index_options"] = index_options
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
         self._element_type = kwargs.get("element_type", "float")
         if self._element_type in ["float", "byte"]:
             kwargs["multi"] = True
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
 
     def _deserialize(self, data: Any) -> Any:
         if self._element_type == "float":
@@ -407,56 +1467,972 @@ class DenseVector(Field):
         return data
 
 
-class SparseVector(Field):
-    name = "sparse_vector"
+class Double(Float):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "double"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[float, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class DoubleRange(RangeField):
+    """
+    :arg boost:
+    :arg coerce:
+    :arg index:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "double_range"
+    _core_field = Double()
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Flattened(Field):
+    """
+    :arg boost:
+    :arg depth_limit:
+    :arg doc_values:
+    :arg eager_global_ordinals:
+    :arg index:
+    :arg index_options:
+    :arg null_value:
+    :arg similarity:
+    :arg split_queries_on_whitespace:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "flattened"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        depth_limit: Union[int, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        eager_global_ordinals: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        index_options: Union[
+            Literal["docs", "freqs", "positions", "offsets"], "DefaultType"
+        ] = DEFAULT,
+        null_value: Union[str, "DefaultType"] = DEFAULT,
+        similarity: Union[str, "DefaultType"] = DEFAULT,
+        split_queries_on_whitespace: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if depth_limit is not DEFAULT:
+            kwargs["depth_limit"] = depth_limit
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if eager_global_ordinals is not DEFAULT:
+            kwargs["eager_global_ordinals"] = eager_global_ordinals
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if index_options is not DEFAULT:
+            kwargs["index_options"] = index_options
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if similarity is not DEFAULT:
+            kwargs["similarity"] = similarity
+        if split_queries_on_whitespace is not DEFAULT:
+            kwargs["split_queries_on_whitespace"] = split_queries_on_whitespace
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class FloatRange(RangeField):
+    """
+    :arg boost:
+    :arg coerce:
+    :arg index:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "float_range"
+    _core_field = Float()
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class GeoPoint(Field):
+    """
+    :arg ignore_malformed:
+    :arg ignore_z_value:
+    :arg null_value:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "geo_point"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_z_value: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Union[
+            "types.LatLonGeoLocation",
+            "types.GeoHashLocation",
+            Sequence[float],
+            str,
+            Dict[str, Any],
+            "DefaultType",
+        ] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if ignore_z_value is not DEFAULT:
+            kwargs["ignore_z_value"] = ignore_z_value
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class GeoShape(Field):
+    """
+    The `geo_shape` data type facilitates the indexing of and searching
+    with arbitrary geo shapes such as rectangles and polygons.
+
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg ignore_z_value:
+    :arg orientation:
+    :arg strategy:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "geo_shape"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_z_value: Union[bool, "DefaultType"] = DEFAULT,
+        orientation: Union[Literal["right", "left"], "DefaultType"] = DEFAULT,
+        strategy: Union[Literal["recursive", "term"], "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if ignore_z_value is not DEFAULT:
+            kwargs["ignore_z_value"] = ignore_z_value
+        if orientation is not DEFAULT:
+            kwargs["orientation"] = orientation
+        if strategy is not DEFAULT:
+            kwargs["strategy"] = strategy
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
 class HalfFloat(Float):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
     name = "half_float"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[float, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
-class ScaledFloat(Float):
-    name = "scaled_float"
+class Histogram(Field):
+    """
+    :arg ignore_malformed:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
 
-    def __init__(self, scaling_factor: int, *args: Any, **kwargs: Any):
-        super().__init__(scaling_factor=scaling_factor, *args, **kwargs)
+    name = "histogram"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
-class Double(Float):
-    name = "double"
+class IcuCollationKeyword(Field):
+    """
+    :arg norms:
+    :arg index_options:
+    :arg index: Should the field be searchable?
+    :arg null_value: Accepts a string value which is substituted for any
+        explicit null values. Defaults to null, which means the field is
+        treated as missing.
+    :arg rules:
+    :arg language:
+    :arg country:
+    :arg variant:
+    :arg strength:
+    :arg decomposition:
+    :arg alternate:
+    :arg case_level:
+    :arg case_first:
+    :arg numeric:
+    :arg variable_top:
+    :arg hiragana_quaternary_mode:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "icu_collation_keyword"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        norms: Union[bool, "DefaultType"] = DEFAULT,
+        index_options: Union[
+            Literal["docs", "freqs", "positions", "offsets"], "DefaultType"
+        ] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Union[str, "DefaultType"] = DEFAULT,
+        rules: Union[str, "DefaultType"] = DEFAULT,
+        language: Union[str, "DefaultType"] = DEFAULT,
+        country: Union[str, "DefaultType"] = DEFAULT,
+        variant: Union[str, "DefaultType"] = DEFAULT,
+        strength: Union[
+            Literal["primary", "secondary", "tertiary", "quaternary", "identical"],
+            "DefaultType",
+        ] = DEFAULT,
+        decomposition: Union[Literal["no", "identical"], "DefaultType"] = DEFAULT,
+        alternate: Union[Literal["shifted", "non-ignorable"], "DefaultType"] = DEFAULT,
+        case_level: Union[bool, "DefaultType"] = DEFAULT,
+        case_first: Union[Literal["lower", "upper"], "DefaultType"] = DEFAULT,
+        numeric: Union[bool, "DefaultType"] = DEFAULT,
+        variable_top: Union[str, "DefaultType"] = DEFAULT,
+        hiragana_quaternary_mode: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if norms is not DEFAULT:
+            kwargs["norms"] = norms
+        if index_options is not DEFAULT:
+            kwargs["index_options"] = index_options
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if rules is not DEFAULT:
+            kwargs["rules"] = rules
+        if language is not DEFAULT:
+            kwargs["language"] = language
+        if country is not DEFAULT:
+            kwargs["country"] = country
+        if variant is not DEFAULT:
+            kwargs["variant"] = variant
+        if strength is not DEFAULT:
+            kwargs["strength"] = strength
+        if decomposition is not DEFAULT:
+            kwargs["decomposition"] = decomposition
+        if alternate is not DEFAULT:
+            kwargs["alternate"] = alternate
+        if case_level is not DEFAULT:
+            kwargs["case_level"] = case_level
+        if case_first is not DEFAULT:
+            kwargs["case_first"] = case_first
+        if numeric is not DEFAULT:
+            kwargs["numeric"] = numeric
+        if variable_top is not DEFAULT:
+            kwargs["variable_top"] = variable_top
+        if hiragana_quaternary_mode is not DEFAULT:
+            kwargs["hiragana_quaternary_mode"] = hiragana_quaternary_mode
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
-class RankFeature(Float):
-    name = "rank_feature"
+class IntegerRange(RangeField):
+    """
+    :arg boost:
+    :arg coerce:
+    :arg index:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
 
+    name = "integer_range"
+    _core_field = Integer()
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
 
-class RankFeatures(Field):
-    name = "rank_features"
-
-
-class Integer(Field):
-    name = "integer"
-    _coerce = True
-
-    def _deserialize(self, data: Any) -> int:
-        return int(data)
-
-
-class Byte(Integer):
-    name = "byte"
-
-
-class Short(Integer):
-    name = "short"
-
-
-class Long(Integer):
-    name = "long"
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
 class Ip(Field):
+    """
+    :arg boost:
+    :arg index:
+    :arg ignore_malformed:
+    :arg null_value:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
     name = "ip"
     _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Union[str, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
     def _deserialize(self, data: Any) -> Union["IPv4Address", "IPv6Address"]:
         # the ipaddress library for pypy only accepts unicode.
@@ -468,51 +2444,650 @@ class Ip(Field):
         return str(data)
 
 
-class Binary(Field):
-    name = "binary"
-    _coerce = True
+class IpRange(Field):
+    """
+    :arg boost:
+    :arg coerce:
+    :arg index:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
 
-    def clean(self, data: str) -> str:
-        # Binary fields are opaque, so there's not much cleaning
-        # that can be done.
-        return data
-
-    def _deserialize(self, data: Any) -> bytes:
-        return base64.b64decode(data)
-
-    def _serialize(self, data: Any) -> Optional[str]:
-        if data is None:
-            return None
-        return base64.b64encode(data).decode()
-
-
-class Point(Field):
-    name = "point"
-
-
-class Shape(Field):
-    name = "shape"
-
-
-class GeoPoint(Field):
-    name = "geo_point"
-
-
-class GeoShape(Field):
-    name = "geo_shape"
-
-
-class Completion(Field):
+    name = "ip_range"
+    _core_field = Ip()
     _param_defs = {
-        "analyzer": {"type": "analyzer"},
-        "search_analyzer": {"type": "analyzer"},
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
     }
-    name = "completion"
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Join(Field):
+    """
+    :arg relations:
+    :arg eager_global_ordinals:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "join"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        relations: Union[
+            Mapping[str, Union[str, Sequence[str]]], "DefaultType"
+        ] = DEFAULT,
+        eager_global_ordinals: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if relations is not DEFAULT:
+            kwargs["relations"] = relations
+        if eager_global_ordinals is not DEFAULT:
+            kwargs["eager_global_ordinals"] = eager_global_ordinals
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Keyword(Field):
+    """
+    :arg boost:
+    :arg eager_global_ordinals:
+    :arg index:
+    :arg index_options:
+    :arg script:
+    :arg on_script_error:
+    :arg normalizer:
+    :arg norms:
+    :arg null_value:
+    :arg similarity:
+    :arg split_queries_on_whitespace:
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "keyword"
+    _param_defs = {
+        "normalizer": {"type": "normalizer"},
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        eager_global_ordinals: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        index_options: Union[
+            Literal["docs", "freqs", "positions", "offsets"], "DefaultType"
+        ] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        normalizer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        norms: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Union[str, "DefaultType"] = DEFAULT,
+        similarity: Union[str, None, "DefaultType"] = DEFAULT,
+        split_queries_on_whitespace: Union[bool, "DefaultType"] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if eager_global_ordinals is not DEFAULT:
+            kwargs["eager_global_ordinals"] = eager_global_ordinals
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if index_options is not DEFAULT:
+            kwargs["index_options"] = index_options
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if normalizer is not DEFAULT:
+            kwargs["normalizer"] = normalizer
+        if norms is not DEFAULT:
+            kwargs["norms"] = norms
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if similarity is not DEFAULT:
+            kwargs["similarity"] = similarity
+        if split_queries_on_whitespace is not DEFAULT:
+            kwargs["split_queries_on_whitespace"] = split_queries_on_whitespace
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Long(Integer):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "long"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[int, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class LongRange(RangeField):
+    """
+    :arg boost:
+    :arg coerce:
+    :arg index:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "long_range"
+    _core_field = Long()
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class MatchOnlyText(Field):
+    """
+    A variant of text that trades scoring and efficiency of positional
+    queries for space efficiency. This field effectively stores data the
+    same way as a text field that only indexes documents (index_options:
+    docs) and disables norms (norms: false). Term queries perform as fast
+    if not faster as on text fields, however queries that need positions
+    such as the match_phrase query perform slower as they need to look at
+    the _source document to verify whether a phrase matches. All queries
+    return constant scores that are equal to 1.0.
+
+    :arg fields:
+    :arg meta: Metadata about the field.
+    :arg copy_to: Allows you to copy the values of multiple fields into a
+        group field, which can then be queried as a single field.
+    """
+
+    name = "match_only_text"
+    _param_defs = {
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        super().__init__(*args, **kwargs)
+
+
+class Murmur3(Field):
+    """
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "murmur3"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Nested(Object):
+    """
+    :arg enabled:
+    :arg include_in_parent:
+    :arg include_in_root:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "nested"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        enabled: Union[bool, "DefaultType"] = DEFAULT,
+        include_in_parent: Union[bool, "DefaultType"] = DEFAULT,
+        include_in_root: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if enabled is not DEFAULT:
+            kwargs["enabled"] = enabled
+        if include_in_parent is not DEFAULT:
+            kwargs["include_in_parent"] = include_in_parent
+        if include_in_root is not DEFAULT:
+            kwargs["include_in_root"] = include_in_root
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        kwargs.setdefault("multi", True)
+        super().__init__(*args, **kwargs)
 
 
 class Percolator(Field):
+    """
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
     name = "percolator"
     _coerce = True
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
     def _deserialize(self, data: Any) -> "Query":
         return Q(data)  # type: ignore[no-any-return]
@@ -523,65 +3098,1102 @@ class Percolator(Field):
         return data.to_dict()  # type: ignore[no-any-return]
 
 
-class RangeField(Field):
-    _coerce = True
-    _core_field: Optional[Field] = None
+class Point(Field):
+    """
+    :arg ignore_malformed:
+    :arg ignore_z_value:
+    :arg null_value:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
 
-    def _deserialize(self, data: Any) -> Range["_SupportsComparison"]:
-        if isinstance(data, Range):
-            return data
-        data = {k: self._core_field.deserialize(v) for k, v in data.items()}  # type: ignore[union-attr]
-        return Range(data)
+    name = "point"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
 
-    def _serialize(self, data: Any) -> Optional[Dict[str, Any]]:
-        if data is None:
-            return None
-        if not isinstance(data, collections.abc.Mapping):
-            data = data.to_dict()
-        return {k: self._core_field.serialize(v) for k, v in data.items()}  # type: ignore[union-attr]
+    def __init__(
+        self,
+        *args: Any,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_z_value: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Union[str, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if ignore_z_value is not DEFAULT:
+            kwargs["ignore_z_value"] = ignore_z_value
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
-class IntegerRange(RangeField):
-    name = "integer_range"
-    _core_field = Integer()
+class RankFeature(Float):
+    """
+    :arg positive_score_impact:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "rank_feature"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        positive_score_impact: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if positive_score_impact is not DEFAULT:
+            kwargs["positive_score_impact"] = positive_score_impact
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
-class FloatRange(RangeField):
-    name = "float_range"
-    _core_field = Float()
+class RankFeatures(Field):
+    """
+    :arg positive_score_impact:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "rank_features"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        positive_score_impact: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if positive_score_impact is not DEFAULT:
+            kwargs["positive_score_impact"] = positive_score_impact
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
-class LongRange(RangeField):
-    name = "long_range"
-    _core_field = Long()
+class ScaledFloat(Float):
+    """
+    :arg null_value:
+    :arg scaling_factor:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "scaled_float"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[float, "DefaultType"] = DEFAULT,
+        scaling_factor: Union[float, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if scaling_factor is not DEFAULT:
+            kwargs["scaling_factor"] = scaling_factor
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        if "scaling_factor" not in kwargs:
+            if len(args) > 0:
+                kwargs["scaling_factor"] = args[0]
+                args = args[1:]
+            else:
+                raise TypeError("missing required argument: 'scaling_factor'")
+        super().__init__(*args, **kwargs)
 
 
-class DoubleRange(RangeField):
-    name = "double_range"
-    _core_field = Double()
+class SearchAsYouType(Field):
+    """
+    :arg analyzer:
+    :arg index:
+    :arg index_options:
+    :arg max_shingle_size:
+    :arg norms:
+    :arg search_analyzer:
+    :arg search_quote_analyzer:
+    :arg similarity:
+    :arg term_vector:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
 
+    name = "search_as_you_type"
+    _param_defs = {
+        "analyzer": {"type": "analyzer"},
+        "search_analyzer": {"type": "analyzer"},
+        "search_quote_analyzer": {"type": "analyzer"},
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
 
-class DateRange(RangeField):
-    name = "date_range"
-    _core_field = Date()
-
-
-class IpRange(Field):
-    # not a RangeField since ip_range supports CIDR ranges
-    name = "ip_range"
-
-
-class Join(Field):
-    name = "join"
-
-
-class TokenCount(Field):
-    name = "token_count"
-
-
-class Murmur3(Field):
-    name = "murmur3"
+    def __init__(
+        self,
+        *args: Any,
+        analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        index_options: Union[
+            Literal["docs", "freqs", "positions", "offsets"], "DefaultType"
+        ] = DEFAULT,
+        max_shingle_size: Union[int, "DefaultType"] = DEFAULT,
+        norms: Union[bool, "DefaultType"] = DEFAULT,
+        search_analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        search_quote_analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        similarity: Union[str, None, "DefaultType"] = DEFAULT,
+        term_vector: Union[
+            Literal[
+                "no",
+                "yes",
+                "with_offsets",
+                "with_positions",
+                "with_positions_offsets",
+                "with_positions_offsets_payloads",
+                "with_positions_payloads",
+            ],
+            "DefaultType",
+        ] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if analyzer is not DEFAULT:
+            kwargs["analyzer"] = analyzer
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if index_options is not DEFAULT:
+            kwargs["index_options"] = index_options
+        if max_shingle_size is not DEFAULT:
+            kwargs["max_shingle_size"] = max_shingle_size
+        if norms is not DEFAULT:
+            kwargs["norms"] = norms
+        if search_analyzer is not DEFAULT:
+            kwargs["search_analyzer"] = search_analyzer
+        if search_quote_analyzer is not DEFAULT:
+            kwargs["search_quote_analyzer"] = search_quote_analyzer
+        if similarity is not DEFAULT:
+            kwargs["similarity"] = similarity
+        if term_vector is not DEFAULT:
+            kwargs["term_vector"] = term_vector
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
 
 
 class SemanticText(Field):
+    """
+    :arg inference_id: (required)
+    :arg meta:
+    """
+
     name = "semantic_text"
+
+    def __init__(
+        self,
+        *args: Any,
+        inference_id: Union[str, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if inference_id is not DEFAULT:
+            kwargs["inference_id"] = inference_id
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        super().__init__(*args, **kwargs)
+
+
+class Shape(Field):
+    """
+    The `shape` data type facilitates the indexing of and searching with
+    arbitrary `x, y` cartesian shapes such as rectangles and polygons.
+
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg ignore_z_value:
+    :arg orientation:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "shape"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_z_value: Union[bool, "DefaultType"] = DEFAULT,
+        orientation: Union[Literal["right", "left"], "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if ignore_z_value is not DEFAULT:
+            kwargs["ignore_z_value"] = ignore_z_value
+        if orientation is not DEFAULT:
+            kwargs["orientation"] = orientation
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Short(Integer):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "short"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[float, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class SparseVector(Field):
+    """
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "sparse_vector"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Text(Field):
+    """
+    :arg analyzer:
+    :arg boost:
+    :arg eager_global_ordinals:
+    :arg fielddata:
+    :arg fielddata_frequency_filter:
+    :arg index:
+    :arg index_options:
+    :arg index_phrases:
+    :arg index_prefixes:
+    :arg norms:
+    :arg position_increment_gap:
+    :arg search_analyzer:
+    :arg search_quote_analyzer:
+    :arg similarity:
+    :arg term_vector:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "text"
+    _param_defs = {
+        "analyzer": {"type": "analyzer"},
+        "search_analyzer": {"type": "analyzer"},
+        "search_quote_analyzer": {"type": "analyzer"},
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        eager_global_ordinals: Union[bool, "DefaultType"] = DEFAULT,
+        fielddata: Union[bool, "DefaultType"] = DEFAULT,
+        fielddata_frequency_filter: Union[
+            "types.FielddataFrequencyFilter", Dict[str, Any], "DefaultType"
+        ] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        index_options: Union[
+            Literal["docs", "freqs", "positions", "offsets"], "DefaultType"
+        ] = DEFAULT,
+        index_phrases: Union[bool, "DefaultType"] = DEFAULT,
+        index_prefixes: Union[
+            "types.TextIndexPrefixes", None, Dict[str, Any], "DefaultType"
+        ] = DEFAULT,
+        norms: Union[bool, "DefaultType"] = DEFAULT,
+        position_increment_gap: Union[int, "DefaultType"] = DEFAULT,
+        search_analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        search_quote_analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        similarity: Union[str, None, "DefaultType"] = DEFAULT,
+        term_vector: Union[
+            Literal[
+                "no",
+                "yes",
+                "with_offsets",
+                "with_positions",
+                "with_positions_offsets",
+                "with_positions_offsets_payloads",
+                "with_positions_payloads",
+            ],
+            "DefaultType",
+        ] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if analyzer is not DEFAULT:
+            kwargs["analyzer"] = analyzer
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if eager_global_ordinals is not DEFAULT:
+            kwargs["eager_global_ordinals"] = eager_global_ordinals
+        if fielddata is not DEFAULT:
+            kwargs["fielddata"] = fielddata
+        if fielddata_frequency_filter is not DEFAULT:
+            kwargs["fielddata_frequency_filter"] = fielddata_frequency_filter
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if index_options is not DEFAULT:
+            kwargs["index_options"] = index_options
+        if index_phrases is not DEFAULT:
+            kwargs["index_phrases"] = index_phrases
+        if index_prefixes is not DEFAULT:
+            kwargs["index_prefixes"] = index_prefixes
+        if norms is not DEFAULT:
+            kwargs["norms"] = norms
+        if position_increment_gap is not DEFAULT:
+            kwargs["position_increment_gap"] = position_increment_gap
+        if search_analyzer is not DEFAULT:
+            kwargs["search_analyzer"] = search_analyzer
+        if search_quote_analyzer is not DEFAULT:
+            kwargs["search_quote_analyzer"] = search_quote_analyzer
+        if similarity is not DEFAULT:
+            kwargs["similarity"] = similarity
+        if term_vector is not DEFAULT:
+            kwargs["term_vector"] = term_vector
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class TokenCount(Field):
+    """
+    :arg analyzer:
+    :arg boost:
+    :arg index:
+    :arg null_value:
+    :arg enable_position_increments:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "token_count"
+    _param_defs = {
+        "analyzer": {"type": "analyzer"},
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        analyzer: Union[str, DslBase, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        null_value: Union[float, "DefaultType"] = DEFAULT,
+        enable_position_increments: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if analyzer is not DEFAULT:
+            kwargs["analyzer"] = analyzer
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if enable_position_increments is not DEFAULT:
+            kwargs["enable_position_increments"] = enable_position_increments
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class UnsignedLong(Field):
+    """
+    :arg null_value:
+    :arg boost:
+    :arg coerce:
+    :arg ignore_malformed:
+    :arg index:
+    :arg on_script_error:
+    :arg script:
+    :arg time_series_metric: For internal use by Elastic only. Marks the
+        field as a time series dimension. Defaults to false.
+    :arg time_series_dimension: For internal use by Elastic only. Marks
+        the field as a time series dimension. Defaults to false.
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "unsigned_long"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[int, "DefaultType"] = DEFAULT,
+        boost: Union[float, "DefaultType"] = DEFAULT,
+        coerce: Union[bool, "DefaultType"] = DEFAULT,
+        ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        time_series_metric: Union[
+            Literal["gauge", "counter", "summary", "histogram", "position"],
+            "DefaultType",
+        ] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if boost is not DEFAULT:
+            kwargs["boost"] = boost
+        if coerce is not DEFAULT:
+            kwargs["coerce"] = coerce
+        if ignore_malformed is not DEFAULT:
+            kwargs["ignore_malformed"] = ignore_malformed
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if time_series_metric is not DEFAULT:
+            kwargs["time_series_metric"] = time_series_metric
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Version(Field):
+    """
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "version"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
+class Wildcard(Field):
+    """
+    :arg null_value:
+    :arg doc_values:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "wildcard"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        null_value: Union[str, "DefaultType"] = DEFAULT,
+        doc_values: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if null_value is not DEFAULT:
+            kwargs["null_value"] = null_value
+        if doc_values is not DEFAULT:
+            kwargs["doc_values"] = doc_values
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)

--- a/elasticsearch/dsl/types.py
+++ b/elasticsearch/dsl/types.py
@@ -362,6 +362,39 @@ class DateRangeExpression(AttrDict[Any]):
         super().__init__(kwargs)
 
 
+class DenseVectorIndexOptions(AttrDict[Any]):
+    """
+    :arg type: (required)
+    :arg m:
+    :arg ef_construction:
+    :arg confidence_interval:
+    """
+
+    type: Union[str, DefaultType]
+    m: Union[int, DefaultType]
+    ef_construction: Union[int, DefaultType]
+    confidence_interval: Union[float, DefaultType]
+
+    def __init__(
+        self,
+        *,
+        type: Union[str, DefaultType] = DEFAULT,
+        m: Union[int, DefaultType] = DEFAULT,
+        ef_construction: Union[int, DefaultType] = DEFAULT,
+        confidence_interval: Union[float, DefaultType] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if type is not DEFAULT:
+            kwargs["type"] = type
+        if m is not DEFAULT:
+            kwargs["m"] = m
+        if ef_construction is not DEFAULT:
+            kwargs["ef_construction"] = ef_construction
+        if confidence_interval is not DEFAULT:
+            kwargs["confidence_interval"] = confidence_interval
+        super().__init__(kwargs)
+
+
 class EmptyObject(AttrDict[Any]):
     """
     For empty Class assignments
@@ -653,6 +686,34 @@ class FieldSort(AttrDict[Any]):
             kwargs["numeric_type"] = numeric_type
         if format is not DEFAULT:
             kwargs["format"] = format
+        super().__init__(kwargs)
+
+
+class FielddataFrequencyFilter(AttrDict[Any]):
+    """
+    :arg max: (required)
+    :arg min: (required)
+    :arg min_segment_size: (required)
+    """
+
+    max: Union[float, DefaultType]
+    min: Union[float, DefaultType]
+    min_segment_size: Union[int, DefaultType]
+
+    def __init__(
+        self,
+        *,
+        max: Union[float, DefaultType] = DEFAULT,
+        min: Union[float, DefaultType] = DEFAULT,
+        min_segment_size: Union[int, DefaultType] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if max is not DEFAULT:
+            kwargs["max"] = max
+        if min is not DEFAULT:
+            kwargs["min"] = min
+        if min_segment_size is not DEFAULT:
+            kwargs["min_segment_size"] = min_segment_size
         super().__init__(kwargs)
 
 
@@ -2474,6 +2535,24 @@ class NestedSortValue(AttrDict[Any]):
         super().__init__(kwargs)
 
 
+class NumericFielddata(AttrDict[Any]):
+    """
+    :arg format: (required)
+    """
+
+    format: Union[Literal["array", "disabled"], DefaultType]
+
+    def __init__(
+        self,
+        *,
+        format: Union[Literal["array", "disabled"], DefaultType] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if format is not DEFAULT:
+            kwargs["format"] = format
+        super().__init__(kwargs)
+
+
 class PercentageScoreHeuristic(AttrDict[Any]):
     pass
 
@@ -3404,6 +3483,39 @@ class SpanWithinQuery(AttrDict[Any]):
         super().__init__(kwargs)
 
 
+class SuggestContext(AttrDict[Any]):
+    """
+    :arg name: (required)
+    :arg type: (required)
+    :arg path:
+    :arg precision:
+    """
+
+    name: Union[str, DefaultType]
+    type: Union[str, DefaultType]
+    path: Union[str, InstrumentedField, DefaultType]
+    precision: Union[int, str, DefaultType]
+
+    def __init__(
+        self,
+        *,
+        name: Union[str, DefaultType] = DEFAULT,
+        type: Union[str, DefaultType] = DEFAULT,
+        path: Union[str, InstrumentedField, DefaultType] = DEFAULT,
+        precision: Union[int, str, DefaultType] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if name is not DEFAULT:
+            kwargs["name"] = name
+        if type is not DEFAULT:
+            kwargs["type"] = type
+        if path is not DEFAULT:
+            kwargs["path"] = str(path)
+        if precision is not DEFAULT:
+            kwargs["precision"] = precision
+        super().__init__(kwargs)
+
+
 class TDigest(AttrDict[Any]):
     """
     :arg compression: Limits the maximum number of nodes used by the
@@ -3665,6 +3777,29 @@ class TextExpansionQuery(AttrDict[Any]):
             kwargs["boost"] = boost
         if _name is not DEFAULT:
             kwargs["_name"] = _name
+        super().__init__(kwargs)
+
+
+class TextIndexPrefixes(AttrDict[Any]):
+    """
+    :arg max_chars: (required)
+    :arg min_chars: (required)
+    """
+
+    max_chars: Union[int, DefaultType]
+    min_chars: Union[int, DefaultType]
+
+    def __init__(
+        self,
+        *,
+        max_chars: Union[int, DefaultType] = DEFAULT,
+        min_chars: Union[int, DefaultType] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if max_chars is not DEFAULT:
+            kwargs["max_chars"] = max_chars
+        if min_chars is not DEFAULT:
+            kwargs["min_chars"] = min_chars
         super().__init__(kwargs)
 
 

--- a/test_elasticsearch/test_dsl/test_field.py
+++ b/test_elasticsearch/test_dsl/test_field.py
@@ -153,8 +153,7 @@ def test_multifield_supports_multiple_analyzers() -> None:
 
 def test_scaled_float() -> None:
     with pytest.raises(TypeError):
-        f = field.ScaledFloat()  # type: ignore
-        print(f.to_dict())
+        field.ScaledFloat()  # type: ignore
     f = field.ScaledFloat(123)
     assert f.to_dict() == {"scaling_factor": 123, "type": "scaled_float"}
 

--- a/test_elasticsearch/test_dsl/test_field.py
+++ b/test_elasticsearch/test_dsl/test_field.py
@@ -153,7 +153,8 @@ def test_multifield_supports_multiple_analyzers() -> None:
 
 def test_scaled_float() -> None:
     with pytest.raises(TypeError):
-        field.ScaledFloat()  # type: ignore
+        f = field.ScaledFloat()  # type: ignore
+        print(f.to_dict())
     f = field.ScaledFloat(123)
     assert f.to_dict() == {"scaling_factor": 123, "type": "scaled_float"}
 

--- a/utils/dsl-generator.py
+++ b/utils/dsl-generator.py
@@ -304,14 +304,20 @@ class ElasticsearchSchema:
 
         elif schema_type["kind"] == "enum":
             # enums are mapped to Literal[member, ...]
-            return (
+            t = (
                 "Literal["
                 + ", ".join(
                     [f"\"{member['name']}\"" for member in schema_type["members"]]
                 )
-                + "]",
-                None,
+                + "]"
             )
+            if {"name": "true"} in schema_type["members"] and {
+                "name": "false"
+            } in schema_type["members"]:
+                # this is a boolean that was later upgraded to an enum, so we
+                # should also allow bools
+                t = f"Union[{t}, bool]"
+            return t, None
 
         elif schema_type["kind"] == "interface":
             if schema_type["name"]["namespace"] == "_types.query_dsl":

--- a/utils/dsl-generator.py
+++ b/utils/dsl-generator.py
@@ -31,6 +31,7 @@ jinja_env = Environment(
     trim_blocks=True,
     lstrip_blocks=True,
 )
+field_py = jinja_env.get_template("field.py.tpl")
 query_py = jinja_env.get_template("query.py.tpl")
 aggs_py = jinja_env.get_template("aggs.py.tpl")
 response_init_py = jinja_env.get_template("response.__init__.py.tpl")
@@ -738,6 +739,35 @@ class ElasticsearchSchema:
                         }
                     )
                     k["buckets_as_dict"] = generic_type
+                elif namespace == '_types.mapping':
+                    if arg['name'] in ['fields', 'properties']:
+                        # Python DSL provides a high level representation for the
+                        # "fields" and 'properties' properties that many types support
+                        k['args'].append({
+                            'name': arg['name'],
+                            "type": 'Union[Mapping[str, Field], "DefaultType"]',
+                            "doc": [f":arg {arg['name']}:"],
+                            "required": False,
+                        })
+                        if 'params' not in k:
+                            k['params'] = []
+                        k['params'].append({'name': arg['name'], 'param': {'type': 'field', 'hash': True}})
+    
+                    else:
+                        # also the Python DSL provides implementations of analyzers
+                        # and normalizers, so here we make sure these are noted as
+                        # params.
+                        self.add_attribute(
+                            k, arg, for_types_py=for_types_py, for_response=for_response
+                        )
+                        if arg['name'].endswith('analyzer'):
+                            if 'params' not in k:
+                                k['params'] = []
+                            k['params'].append({'name': arg['name'], 'param': {'type': 'analyzer'}})
+                        elif arg['name'].endswith('normalizer'):
+                            if 'params' not in k:
+                                k['params'] = []
+                            k['params'].append({'name': arg['name'], 'param': {'type': 'normalizer'}})
                 else:
                     if interface == "Hit" and arg["name"].startswith("_"):
                         # Python DSL removes the undersore prefix from all the
@@ -764,6 +794,77 @@ class ElasticsearchSchema:
                 type_["inherits"]["type"]["namespace"],
             )
         return k
+
+
+def generate_field_py(schema, filename):
+    """Generate field.py with all the Elasticsearch fields as Python classes.
+    """
+    float_fields = ['half_float', 'scaled_float', 'double', 'rank_feature']
+    integer_fields = ['byte', 'short', 'long']
+    range_fields = ['integer_range', 'float_range', 'long_range', 'double_range', 'date_range']
+    object_fields = ['nested']
+    coerced_fields = ['boolean', 'date', 'float', 'object', 'dense_vector', 'integer', 'ip', 'binary', 'percolator']
+
+    classes = []
+    property = schema.find_type("Property", "_types.mapping")
+    for type_ in property["type"]["items"]:
+        if type_["type"]["name"] == "DynamicProperty":
+            # no support for dynamic properties
+            continue
+        field = schema.find_type(type_["type"]["name"], type_["type"]["namespace"])
+        name = class_name = ''
+        for prop in field["properties"]:
+            if prop["name"] == "type":
+                if prop["type"]["kind"] != "literal_value":        
+                    raise RuntimeError(f"Unexpected property type {prop}")
+                name = prop["type"]["value"]
+                class_name = "".join([n.title() for n in name.split("_")])
+        k = schema.interface_to_python_class(
+            type_["type"]["name"], type_["type"]["namespace"], for_types_py=False, for_response=False
+        )
+        k['name'] = class_name
+        k['field'] = name
+        k['coerced'] = name in coerced_fields
+        if name in float_fields:
+            k['parent'] = 'Float'
+        elif name in integer_fields:
+            k['parent'] = 'Integer'
+        elif name in range_fields:
+            k['parent'] = 'RangeField'
+        elif name in object_fields:
+            k['parent'] = 'Object'
+        else:
+            k['parent'] = 'Field'
+        k['args'] = [prop for prop in k['args'] if prop['name'] != 'type']
+        if name == 'object':
+            # the DSL's object field has a doc_class argument
+            k['args'] = [
+                {
+                    "name": "doc_class",
+                    "type": "Union[Type[\"InnerDoc\"], \"DefaultType\"]",
+                    "doc": [":arg doc_class: base doc class that handles mapping.",
+                            "   If no `doc_class` is provided, new instance of `InnerDoc` will be created,",
+                            "   populated with `properties` and used. Can not be provided together with `properties`"],
+                    "required": False,
+               }
+            ] + k['args']
+        elif name == "date":
+            k['args'] = [
+                {
+                    "name": "default_timezone",
+                    "type": "Union[str, \"tzinfo\", \"DefaultType\"]",
+                    "doc": [":arg default_timezone: timezone that will be automatically used for tz-naive values",
+                            "   May be instance of `datetime.tzinfo` or string containing TZ offset"],
+                    "required": False,
+               }
+            ] + k['args']
+        classes.append(k)
+    # make sure parent classes appear first
+    classes = sorted(classes, key=lambda k: f'AA{k["name"]}' if k['name'] in ['Float', 'Integer', 'Object'] else k['name'])
+
+    with open(filename, "wt") as f:
+        f.write(field_py.render(classes=classes))
+    print(f"Generated {filename}.")
 
 
 def generate_query_py(schema, filename):
@@ -849,6 +950,7 @@ def generate_types_py(schema, filename):
 
 if __name__ == "__main__":
     schema = ElasticsearchSchema()
+    generate_field_py(schema, "elasticsearch/dsl/field.py")
     generate_query_py(schema, "elasticsearch/dsl/query.py")
     generate_aggs_py(schema, "elasticsearch/dsl/aggs.py")
     generate_response_init_py(schema, "elasticsearch/dsl/response/__init__.py")

--- a/utils/templates/field.py.tpl
+++ b/utils/templates/field.py.tpl
@@ -1,0 +1,455 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import base64
+import collections.abc
+import ipaddress
+from copy import deepcopy
+from datetime import date, datetime
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from dateutil import parser, tz
+from elastic_transport.client_utils import DEFAULT, DefaultType
+
+from .exceptions import ValidationException
+from .query import Q
+from .utils import AttrDict, AttrList, DslBase
+from .wrappers import Range
+
+if TYPE_CHECKING:
+    from datetime import tzinfo
+    from ipaddress import IPv4Address, IPv6Address
+
+    from _operator import _SupportsComparison
+
+    from .document import InnerDoc
+    from .document_base import InstrumentedField
+    from .mapping_base import MappingBase
+    from .query import Query
+    from . import types
+
+unicode = str
+
+
+def construct_field(
+    name_or_field: Union[
+        str,
+        "Field",
+        Dict[str, Any],
+    ],
+    **params: Any,
+) -> "Field":
+    # {"type": "text", "analyzer": "snowball"}
+    if isinstance(name_or_field, collections.abc.Mapping):
+        if params:
+            raise ValueError(
+                "construct_field() cannot accept parameters when passing in a dict."
+            )
+        params = deepcopy(name_or_field)
+        if "type" not in params:
+            # inner object can be implicitly defined
+            if "properties" in params:
+                name = "object"
+            else:
+                raise ValueError('construct_field() needs to have a "type" key.')
+        else:
+            name = params.pop("type")
+        return Field.get_dsl_class(name)(**params)
+
+    # Text()
+    if isinstance(name_or_field, Field):
+        if params:
+            raise ValueError(
+                "construct_field() cannot accept parameters "
+                "when passing in a construct_field object."
+            )
+        return name_or_field
+
+    # "text", analyzer="snowball"
+    return Field.get_dsl_class(name_or_field)(**params)
+
+
+class Field(DslBase):
+    _type_name = "field"
+    _type_shortcut = staticmethod(construct_field)
+    # all fields can be multifields
+    _param_defs = {"fields": {"type": "field", "hash": True}}
+    name = ""
+    _coerce = False
+
+    def __init__(
+        self, multi: bool = False, required: bool = False, *args: Any, **kwargs: Any
+    ):
+        """
+        :arg bool multi: specifies whether field can contain array of values
+        :arg bool required: specifies whether field is required
+        """
+        self._multi = multi
+        self._required = required
+        super().__init__(*args, **kwargs)
+
+    def __getitem__(self, subfield: str) -> "Field":
+        return cast(Field, self._params.get("fields", {})[subfield])
+
+    def _serialize(self, data: Any) -> Any:
+        return data
+
+    def _deserialize(self, data: Any) -> Any:
+        return data
+
+    def _empty(self) -> Optional[Any]:
+        return None
+
+    def empty(self) -> Optional[Any]:
+        if self._multi:
+            return AttrList([])
+        return self._empty()
+
+    def serialize(self, data: Any) -> Any:
+        if isinstance(data, (list, AttrList, tuple)):
+            return list(map(self._serialize, cast(Iterable[Any], data)))
+        return self._serialize(data)
+
+    def deserialize(self, data: Any) -> Any:
+        if isinstance(data, (list, AttrList, tuple)):
+            data = [
+                None if d is None else self._deserialize(d)
+                for d in cast(Iterable[Any], data)
+            ]
+            return data
+        if data is None:
+            return None
+        return self._deserialize(data)
+
+    def clean(self, data: Any) -> Any:
+        if data is not None:
+            data = self.deserialize(data)
+        if data in (None, [], {}) and self._required:
+            raise ValidationException("Value required for this field.")
+        return data
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = super().to_dict()
+        name, value = cast(Tuple[str, Dict[str, Any]], d.popitem())
+        value["type"] = name
+        return value
+
+
+class CustomField(Field):
+    name = "custom"
+    _coerce = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        if isinstance(self.builtin_type, Field):
+            return self.builtin_type.to_dict()
+
+        d = super().to_dict()
+        d["type"] = self.builtin_type
+        return d
+
+
+class RangeField(Field):
+    _coerce = True
+    _core_field: Optional[Field] = None
+
+    def _deserialize(self, data: Any) -> Range["_SupportsComparison"]:
+        if isinstance(data, Range):
+            return data
+        data = {k: self._core_field.deserialize(v) for k, v in data.items()}  # type: ignore[union-attr]
+        return Range(data)
+
+    def _serialize(self, data: Any) -> Optional[Dict[str, Any]]:
+        if data is None:
+            return None
+        if not isinstance(data, collections.abc.Mapping):
+            data = data.to_dict()
+        return {k: self._core_field.serialize(v) for k, v in data.items()}  # type: ignore[union-attr]
+
+
+{% for k in classes %}
+class {{ k.name }}({{ k.parent }}):
+    """
+    {% for line in k.docstring %}
+    {{ line }}
+    {% endfor %}
+    {% if k.args %}
+        {% if k.docstring %}
+
+        {% endif %}
+        {% for kwarg in k.args %}
+            {% for line in kwarg.doc %}
+    {{ line }}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+    """
+    name = "{{ k.field }}"
+    {% if k.coerced %}
+    _coerce = True
+    {% endif %}
+    {% if k.name.endswith('Range') %}
+    _core_field = {{ k.name[:-5] }}()
+    {% endif %}
+    {% if k.params %}
+    _param_defs = {
+    {% for param in k.params %}
+        "{{ param.name }}": {{ param.param }},
+    {% endfor %}
+    }
+    {% endif %}
+
+    def __init__(
+        self,
+        {% for arg in k.args %}
+            {% if arg.positional %}
+        {{ arg.name }}: {{ arg.type }} = DEFAULT,
+            {% endif %}
+        {% endfor %}
+        *args,
+        {% for arg in k.args %}
+            {% if not arg.positional %}
+        {{ arg.name }}: {{ arg.type }} = DEFAULT,
+            {% endif %}
+        {% endfor %}
+        **kwargs: Any
+    ):
+        {% for arg in k.args %}
+            {% if not arg.positional %}
+        if {{ arg.name }} is not DEFAULT:
+                {% if "InstrumentedField" in arg.type %}
+            kwargs["{{ arg.name }}"] = str({{ arg.name }})
+                {% else %}
+            kwargs["{{ arg.name }}"] = {{ arg.name }}
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+        {% if k.field == 'object' %}
+
+        if doc_class is not DEFAULT and (properties or dynamic is not None):
+            raise ValidationException(
+                "doc_class and properties/dynamic should not be provided together"
+            )
+        if doc_class is not DEFAULT:
+            self._doc_class: Type["InnerDoc"] = doc_class  # type: ignore
+        else:
+            # FIXME import
+            from .document import InnerDoc
+
+            # no InnerDoc subclass, creating one instead...
+            self._doc_class = type("InnerDoc", (InnerDoc,), {})
+            for name, field in (properties or {}).items():  # type: ignore
+                self._doc_class._doc_type.mapping.field(name, field)
+            if dynamic is not None:
+                self._doc_class._doc_type.mapping.meta("dynamic", dynamic)
+
+        self._mapping: "MappingBase" = deepcopy(self._doc_class._doc_type.mapping)
+        super().__init__(**kwargs)
+
+    def __getitem__(self, name: str) -> Field:
+        return self._mapping[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._mapping
+
+    def _empty(self) -> "InnerDoc":
+        return self._wrap({})
+
+    def _wrap(self, data: Dict[str, Any]) -> "InnerDoc":
+        return self._doc_class.from_es(data, data_only=True)
+
+    def empty(self) -> Union["InnerDoc", AttrList[Any]]:
+        if self._multi:
+            return AttrList[Any]([], self._wrap)
+        return self._empty()
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = self._mapping.to_dict()
+        d.update(super().to_dict())
+        return d
+
+    def _collect_fields(self) -> Iterator[Field]:
+        return self._mapping.properties._collect_fields()
+
+    def _deserialize(self, data: Any) -> "InnerDoc":
+        # don't wrap already wrapped data
+        if isinstance(data, self._doc_class):
+            return data
+
+        if isinstance(data, AttrDict):
+            data = data._d_
+
+        return self._wrap(data)
+
+    def _serialize(
+        self, data: Optional[Union[Dict[str, Any], "InnerDoc"]]
+    ) -> Optional[Dict[str, Any]]:
+        if data is None:
+            return None
+
+        # somebody assigned raw dict to the field, we should tolerate that
+        if isinstance(data, collections.abc.Mapping):
+            return data
+
+        return data.to_dict()
+
+    def clean(self, data: Any) -> Any:
+        data = super().clean(data)
+        if data is None:
+            return None
+        if isinstance(data, (list, AttrList)):
+            for d in cast(Iterator["InnerDoc"], data):
+                d.full_clean()
+        else:
+            data.full_clean()
+        return data
+
+    def update(self, other: Any, update_only: bool = False) -> None:
+        if not isinstance(other, Object):
+            # not an inner/nested object, no merge possible
+            return
+
+        self._mapping.update(other._mapping, update_only)
+        {% elif k.field == "nested" %}
+        kwargs.setdefault("multi", True)
+        super().__init__(*args, **kwargs)
+        {% elif k.field == "date" %}
+
+        if default_timezone is DEFAULT:
+            self._default_timezone = None
+        elif isinstance(default_timezone, str):
+            self._default_timezone = tz.gettz(default_timezone)
+        else:
+            self._default_timezone = default_timezone  # type: ignore
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> Union[datetime, date]:
+        if isinstance(data, str):
+            try:
+                data = parser.parse(data)
+            except Exception as e:
+                raise ValidationException(
+                    f"Could not parse date from the value ({data!r})", e
+                )
+            # we treat the yyyy-MM-dd format as a special case
+            if hasattr(self, "format") and self.format == "yyyy-MM-dd":
+                data = data.date()
+
+        if isinstance(data, datetime):
+            if self._default_timezone and data.tzinfo is None:
+                data = data.replace(tzinfo=self._default_timezone)
+            return data
+        if isinstance(data, date):
+            return data
+        if isinstance(data, int):
+            # Divide by a float to preserve milliseconds on the datetime.
+            return datetime.utcfromtimestamp(data / 1000.0)
+
+        raise ValidationException(f"Could not parse date from the value ({data!r})")        
+        {% elif k.field == "boolean" %}
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> bool:
+        if data == "false":
+            return False
+        return bool(data)
+
+    def clean(self, data: Any) -> Optional[bool]:
+        if data is not None:
+            data = self.deserialize(data)
+        if data is None and self._required:
+            raise ValidationException("Value required for this field.")
+        return data  # type: ignore[no-any-return]        
+        {% elif k.field == "float" %}
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> float:
+        return float(data)
+        {% elif k.field == "dense_vector" %}
+        self._element_type = kwargs.get("element_type", "float")
+        if self._element_type in ["float", "byte"]:
+            kwargs["multi"] = True
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> Any:
+        if self._element_type == "float":
+            return float(data)
+        elif self._element_type == "byte":
+            return int(data)
+        return data
+        {% elif k.field == "scaled_float" %}
+        super().__init__(scaling_factor=scaling_factor, *args, **kwargs)        
+        {% elif k.field == "integer" %}
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> int:
+        return int(data)        
+        {% elif k.field == "ip" %}
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> Union["IPv4Address", "IPv6Address"]:
+        # the ipaddress library for pypy only accepts unicode.
+        return ipaddress.ip_address(unicode(data))
+
+    def _serialize(self, data: Any) -> Optional[str]:
+        if data is None:
+            return None
+        return str(data)        
+        {% elif k.field == "binary" %}
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data: str) -> str:
+        # Binary fields are opaque, so there's not much cleaning
+        # that can be done.
+        return data
+
+    def _deserialize(self, data: Any) -> bytes:
+        return base64.b64decode(data)
+
+    def _serialize(self, data: Any) -> Optional[str]:
+        if data is None:
+            return None
+        return base64.b64encode(data).decode()        
+        {% elif k.field == "percolator" %}
+        super().__init__(*args, **kwargs)
+
+    def _deserialize(self, data: Any) -> "Query":
+        return Q(data)  # type: ignore[no-any-return]
+
+    def _serialize(self, data: Any) -> Optional[Dict[str, Any]]:
+        if data is None:
+            return None
+        return data.to_dict()  # type: ignore[no-any-return]
+        {% else %}
+        super().__init__(*args, **kwargs)
+        {% endif %}
+
+
+{% endfor %}


### PR DESCRIPTION
This change adds autogeneration of field classes in the DSL module from the Elasticsearch specification, so that the class constructors have explicit arguments and docstrings.