### PR TITLE
[8.17] Switch to Black 2025 and isort 6 (#2779)

### DIFF
--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -22,7 +22,10 @@ from typing import Any, Callable, Dict, List, Optional
 from elasticsearch import Elasticsearch
 from elasticsearch._version import __versionstr__ as lib_version
 from elasticsearch.helpers import BulkIndexError, bulk
-from elasticsearch.helpers.vectorstore import EmbeddingService, RetrievalStrategy
+from elasticsearch.helpers.vectorstore import (
+    EmbeddingService,
+    RetrievalStrategy,
+)
 from elasticsearch.helpers.vectorstore._utils import maximal_marginal_relevance
 
 logger = logging.getLogger(__name__)

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,7 @@ def test_otel(session):
 
 @nox.session()
 def format(session):
-    session.install("black~=24.0", "isort", "flynt", "unasync>=0.6.0")
+    session.install("black~=25.0", "isort~=6.0", "flynt", "unasync>=0.6.0", "jinja2")
 
     session.run("python", "utils/run-unasync.py")
     session.run("isort", "--profile=black", *SOURCE_FILES)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Switch to Black 2025 and isort 6 (#2779)](https://github.com/elastic/elasticsearch-py/pull/2779)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)