### PR TITLE
[8.17] Simplify lint and format nox sessions (#2790)

### DIFF
--- a/elasticsearch/__init__.py
+++ b/elasticsearch/__init__.py
@@ -27,7 +27,7 @@ from ._utils import fixup_module_metadata
 from ._version import __versionstr__
 
 # Ensure that a compatible version of elastic-transport is installed.
-_version_groups = tuple(int(x) for x in re.search(r"^(\d+)\.(\d+)\.(\d+)", _elastic_transport_version).groups())  # type: ignore
+_version_groups = tuple(int(x) for x in re.search(r"^(\d+)\.(\d+)\.(\d+)", _elastic_transport_version).groups())  # type: ignore[union-attr]
 if _version_groups < (8, 0, 0) or _version_groups > (9, 0, 0):
     raise ImportError(
         "An incompatible version of elastic-transport is installed. Must be between "
@@ -35,7 +35,7 @@ if _version_groups < (8, 0, 0) or _version_groups > (9, 0, 0):
         "$ python -m pip install 'elastic-transport>=8, <9'"
     )
 
-_version_groups = re.search(r"^(\d+)\.(\d+)\.(\d+)", __versionstr__).groups()  # type: ignore
+_version_groups = re.search(r"^(\d+)\.(\d+)\.(\d+)", __versionstr__).groups()  # type: ignore[assignment, union-attr]
 _major, _minor, _patch = (int(x) for x in _version_groups)
 VERSION = __version__ = (_major, _minor, _patch)
 

--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -257,7 +257,7 @@ async def async_streaming_bulk(
                 ]
                 ok: bool
                 info: Dict[str, Any]
-                async for data, (ok, info) in azip(  # type: ignore
+                async for data, (ok, info) in azip(  # type: ignore[assignment, misc]
                     bulk_data,
                     _process_bulk_chunk(
                         client,

--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -232,7 +232,7 @@ def host_mapping_to_node_config(host: Mapping[str, Union[str, int]]) -> NodeConf
         )
         options["path_prefix"] = options.pop("url_prefix")
 
-    return NodeConfig(**options)  # type: ignore
+    return NodeConfig(**options)  # type: ignore[arg-type]
 
 
 def cloud_id_to_node_configs(cloud_id: str) -> List[NodeConfig]:

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -593,7 +593,7 @@ def parallel_bulk(
 
     class BlockingPool(ThreadPool):
         def _setup_queues(self) -> None:
-            super()._setup_queues()  # type: ignore
+            super()._setup_queues()  # type: ignore[misc]
             # The queue must be at least the size of the number of threads to
             # prevent hanging when inserting sentinel values during teardown.
             self._inqueue: Queue[


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Simplify lint and format nox sessions (#2790)](https://github.com/elastic/elasticsearch-py/pull/2790)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)