### PR TITLE
Explain how to use sub clients in API docs

### DIFF
--- a/docs/sphinx/api/elasticsearch.rst
+++ b/docs/sphinx/api/elasticsearch.rst
@@ -3,7 +3,7 @@
 Elasticsearch
 -------------
 
-.. py:module:: elasticsearch.client
+.. py:module:: elasticsearch
 
 .. autoclass:: Elasticsearch
    :members:

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -21,9 +21,39 @@ import elasticsearch
 
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.doctest", "sphinx.ext.intersphinx"]
 
-autoclass_content = "both"
+autoclass_content = "class"
+autodoc_class_signature = "separated"
 
 autodoc_typehints = "description"
+
+
+def client_name(full_name):
+    # Get the class name, e.g. ['elasticsearch', 'client', 'TextStructureClient'] -> 'TextStructure'
+    class_name = full_name.split(".")[-1].removesuffix("Client")
+    # Convert to snake case, e.g. 'TextStructure' -> '_text_structure'
+    snake_case = "".join(["_" + c.lower() if c.isupper() else c for c in class_name])
+    # Remove the leading underscore
+    return snake_case.lstrip("_")
+
+
+def add_client_usage_example(app, what, name, obj, options, lines):
+    if what == "class" and "Client" in name:
+        sub_client_name = client_name(name)
+        lines.append(
+            f"To use this client, access ``client.{sub_client_name}`` from an "
+            " :class:`~elasticsearch.Elasticsearch` client. For example::"
+        )
+        lines.append("")
+        lines.append("    # Create the client instance")
+        lines.append("    client = Elasticsearch(...)")
+        lines.append(f"    # Use the {sub_client_name} client")
+        lines.append(f"    client.{sub_client_name}.<method>(...)")
+        lines.append("")
+
+
+def setup(app):
+    app.connect("autodoc-process-docstring", add_client_usage_example)
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -44,6 +44,8 @@ def add_client_usage_example(app, what, name, obj, options, lines):
             " :class:`~elasticsearch.Elasticsearch` client. For example::"
         )
         lines.append("")
+        lines.append("    from elasticsearch import Elasticsearch")
+        lines.append("")
         lines.append("    # Create the client instance")
         lines.append("    client = Elasticsearch(...)")
         lines.append(f"    # Use the {sub_client_name} client")

--- a/elasticsearch/client.py
+++ b/elasticsearch/client.py
@@ -73,6 +73,8 @@ from ._sync.client.xpack import XPackClient as XPackClient  # noqa: F401
 from ._utils import fixup_module_metadata
 
 # This file exists for backwards compatibility.
+# We can't remove it as we use it for the Sphinx docs which show the full page, and we'd
+# rather show `elasticsearch.client.FooClient` than `elasticsearch._sync.client.FooClient`.
 warnings.warn(
     "Importing from the 'elasticsearch.client' module is deprecated. "
     "Instead use 'elasticsearch' module for importing the client.",


### PR DESCRIPTION
I have not found a way to not display the name of the class. But I removed the parameters and added an explanation text.


# Before
<img width="729" alt="Screenshot 2025-02-14 at 18 17 23" src="https://github.com/user-attachments/assets/0811f192-2b6b-4324-9173-2b34c5b65700" />

# After
<img width="729" alt="Screenshot 2025-02-14 at 18 17 03" src="https://github.com/user-attachments/assets/558834c6-6df3-4315-bdf1-c782d0e714da" />
