### PR TITLE
[9.0] [docs] fix external links (#2826)

### DIFF
--- a/docs/reference/client-helpers.md
+++ b/docs/reference/client-helpers.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Client helpers [client-helpers]
 
-You can find here a collection of simple helper functions that abstract some specifics of the raw API. For detailed examples, refer to [this page](https://elasticsearch-py.readthedocs.io/en/stable/helpers.md).
+You can find here a collection of simple helper functions that abstract some specifics of the raw API. For detailed examples, refer to [this page](https://elasticsearch-py.readthedocs.io/en/stable/helpers.html).
 
 
 ## Bulk helpers [bulk-helpers]

--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -352,6 +352,6 @@ def main(request: func.HttpRequest) -> func.HttpResponse:
 Resources used to assess these recommendations:
 
 * [GCP Cloud Functions: Tips & Tricks](https://cloud.google.com/functions/docs/bestpractices/tips#use_global_variables_to_reuse_objects_in_future_invocations)
-* [Best practices for working with AWS Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.md)
+* [Best practices for working with AWS Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html)
 * [Azure Functions Python developer guide](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python?tabs=azurecli-linux%2Capplication-level#global-variables)
-* [AWS Lambda: Comparing the effect of global scope](https://docs.aws.amazon.com/lambda/latest/operatorguide/global-scope.md)
+* [AWS Lambda: Comparing the effect of global scope](https://docs.aws.amazon.com/lambda/latest/operatorguide/global-scope.html)

--- a/docs/reference/opentelemetry.md
+++ b/docs/reference/opentelemetry.md
@@ -41,7 +41,7 @@ When using the [manual Python OpenTelemetry instrumentation](https://opentelemet
 
 ## Comparison with community instrumentation [_comparison_with_community_instrumentation]
 
-The [commmunity OpenTelemetry Elasticsearch instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/elasticsearch/elasticsearch.md) also instruments the client and sends OpenTelemetry traces, but was developed before the OpenTelemetry Semantic Conventions for {{es}}, so the traces attributes are inconsistent with other OpenTelemetry Elasticsearch client instrumentations. To avoid tracing the same requests twice, make sure to use only one instrumentation, either by uninstalling the opentelemetry-instrumentation-elasticsearch Python package or by [disabling the native instrumentation](#opentelemetry-config-enable).
+The [commmunity OpenTelemetry Elasticsearch instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/elasticsearch/elasticsearch.html) also instruments the client and sends OpenTelemetry traces, but was developed before the OpenTelemetry Semantic Conventions for {{es}}, so the traces attributes are inconsistent with other OpenTelemetry Elasticsearch client instrumentations. To avoid tracing the same requests twice, make sure to use only one instrumentation, either by uninstalling the opentelemetry-instrumentation-elasticsearch Python package or by [disabling the native instrumentation](#opentelemetry-config-enable).
 
 
 ### Configuring the OpenTelemetry instrumentation [_configuring_the_opentelemetry_instrumentation]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [fix external links (#2826)](https://github.com/elastic/elasticsearch-py/pull/2826)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)