### PR TITLE
[8.18] Fix logo URL (#2825)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://github.com/elastic/elasticsearch-py/raw/main/docs/logo-elastic-glyph-color.svg" width="20%" alt="Elastic logo" />
+    <img src="https://github.com/elastic/elasticsearch-py/raw/main/docs/images/logo-elastic-glyph-color.svg" width="20%" alt="Elastic logo" />
 </p>
 
 # Elasticsearch Python Client


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix logo URL (#2825)](https://github.com/elastic/elasticsearch-py/pull/2825)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)