### PR TITLE
Remove unneded nonlocal and global declarations

### DIFF
--- a/elasticsearch/_async/client/_base.py
+++ b/elasticsearch/_async/client/_base.py
@@ -272,7 +272,6 @@ class BaseClient:
         def mimetype_header_to_compat(header: str) -> None:
             # Converts all parts of a Accept/Content-Type headers
             # from application/X -> application/vnd.elasticsearch+X
-            nonlocal request_headers
             mimetype = request_headers.get(header, None)
             if mimetype:
                 request_headers[header] = _COMPAT_MIMETYPE_RE.sub(

--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -136,7 +136,6 @@ def aiter(x: Union[Iterable[T], AsyncIterable[T]]) -> AsyncIterator[T]:
         return x.__aiter__()
 
     async def f() -> AsyncIterable[T]:
-        nonlocal x
         ix: Iterable[T] = x
         for item in ix:
             yield item

--- a/elasticsearch/_sync/client/_base.py
+++ b/elasticsearch/_sync/client/_base.py
@@ -272,7 +272,6 @@ class BaseClient:
         def mimetype_header_to_compat(header: str) -> None:
             # Converts all parts of a Accept/Content-Type headers
             # from application/X -> application/vnd.elasticsearch+X
-            nonlocal request_headers
             mimetype = request_headers.get(header, None)
             if mimetype:
                 request_headers[header] = _COMPAT_MIMETYPE_RE.sub(

--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -124,7 +124,6 @@ def client_node_configs(
 
     def apply_node_options(node_config: NodeConfig) -> NodeConfig:
         """Needs special handling of headers since .replace() wipes out existing headers"""
-        nonlocal node_options
         headers = node_config.headers.copy()  # type: ignore[attr-defined]
 
         headers_to_add = node_options.pop("headers", ())
@@ -296,8 +295,6 @@ def _rewrite_parameters(
     def wrapper(api: F) -> F:
         @wraps(api)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
-            nonlocal api, body_name, body_fields
-
             # Let's give a nicer error message when users pass positional arguments.
             if len(args) >= 2:
                 raise TypeError(

--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -280,8 +280,6 @@ class YamlRunner:
         self.last_response = exception.body
 
     def run_skip(self, skip):
-        global IMPLEMENTED_FEATURES
-
         if "features" in skip:
             features = skip["features"]
             if not isinstance(features, (tuple, list)):
@@ -437,7 +435,7 @@ class YamlRunner:
         return value
 
     def _feature_enabled(self, name):
-        global XPACK_FEATURES, IMPLEMENTED_FEATURES
+        global XPACK_FEATURES
         if XPACK_FEATURES is None:
             try:
                 xinfo = self.client.xpack.info()

--- a/utils/build-dists.py
+++ b/utils/build-dists.py
@@ -42,7 +42,6 @@ def set_tmp_dir():
 
 
 def run(*argv, expect_exit_code=0):
-    global tmp_dir
     try:
         prev_dir = os.getcwd()
         if tmp_dir is None:


### PR DESCRIPTION
A new release of flake8 reports a few unnecessary `nonlocal` and `global` declarations.