### PR TITLE
Add back inference.inference API

### DIFF
--- a/elasticsearch/_async/client/inference.py
+++ b/elasticsearch/_async/client/inference.py
@@ -20,7 +20,13 @@ import typing as t
 from elastic_transport import ObjectApiResponse
 
 from ._base import NamespacedClient
-from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
+from .utils import (
+    SKIP_IN_PATH,
+    Stability,
+    _quote,
+    _rewrite_parameters,
+    _stability_warning,
+)
 
 
 class InferenceClient(NamespacedClient):
@@ -231,6 +237,117 @@ class InferenceClient(NamespacedClient):
             params=__query,
             headers=__headers,
             endpoint_id="inference.get",
+            path_parts=__path_parts,
+        )
+
+    @_rewrite_parameters(
+        body_fields=("input", "query", "task_settings"),
+    )
+    @_stability_warning(
+        Stability.DEPRECATED,
+        version="8.18.0",
+        message="inference.inference() is deprecated in favor of provider-specific APIs such as inference.put_elasticsearch() or inference.put_hugging_face()",
+    )
+    async def inference(
+        self,
+        *,
+        inference_id: str,
+        input: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        task_type: t.Optional[
+            t.Union[
+                str,
+                t.Literal[
+                    "chat_completion",
+                    "completion",
+                    "rerank",
+                    "sparse_embedding",
+                    "text_embedding",
+                ],
+            ]
+        ] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        query: t.Optional[str] = None,
+        task_settings: t.Optional[t.Any] = None,
+        timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        .. raw:: html
+
+          <p>Perform inference on the service.</p>
+          <p>This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.
+          It returns a response with the results of the tasks.
+          The inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.</p>
+          <blockquote>
+          <p>info
+          The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
+          </blockquote>
+
+
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-inference>`_
+
+        :param inference_id: The unique identifier for the inference endpoint.
+        :param input: The text on which you want to perform the inference task. It can
+            be a single string or an array. > info > Inference endpoints for the `completion`
+            task type currently only support a single string as input.
+        :param task_type: The type of inference task that the model performs.
+        :param query: The query input, which is required only for the `rerank` task.
+            It is not required for other tasks.
+        :param task_settings: Task settings for the individual inference request. These
+            settings are specific to the task type you specified and override the task
+            settings specified when initializing the service.
+        :param timeout: The amount of time to wait for the inference request to complete.
+        """
+        if inference_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'inference_id'")
+        if input is None and body is None:
+            raise ValueError("Empty value passed for parameter 'input'")
+        __path_parts: t.Dict[str, str]
+        if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
+        elif inference_id not in SKIP_IN_PATH:
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
+        else:
+            raise ValueError("Couldn't find a path for the given parameters")
+        __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
+        if not __body:
+            if input is not None:
+                __body["input"] = input
+            if query is not None:
+                __body["query"] = query
+            if task_settings is not None:
+                __body["task_settings"] = task_settings
+        if not __body:
+            __body = None  # type: ignore[assignment]
+        __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
+        return await self.perform_request(  # type: ignore[return-value]
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.inference",
             path_parts=__path_parts,
         )
 

--- a/elasticsearch/_sync/client/inference.py
+++ b/elasticsearch/_sync/client/inference.py
@@ -20,7 +20,13 @@ import typing as t
 from elastic_transport import ObjectApiResponse
 
 from ._base import NamespacedClient
-from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
+from .utils import (
+    SKIP_IN_PATH,
+    Stability,
+    _quote,
+    _rewrite_parameters,
+    _stability_warning,
+)
 
 
 class InferenceClient(NamespacedClient):
@@ -231,6 +237,117 @@ class InferenceClient(NamespacedClient):
             params=__query,
             headers=__headers,
             endpoint_id="inference.get",
+            path_parts=__path_parts,
+        )
+
+    @_rewrite_parameters(
+        body_fields=("input", "query", "task_settings"),
+    )
+    @_stability_warning(
+        Stability.DEPRECATED,
+        version="8.18.0",
+        message="inference.inference() is deprecated in favor of provider-specific APIs such as inference.put_elasticsearch() or inference.put_hugging_face()",
+    )
+    def inference(
+        self,
+        *,
+        inference_id: str,
+        input: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        task_type: t.Optional[
+            t.Union[
+                str,
+                t.Literal[
+                    "chat_completion",
+                    "completion",
+                    "rerank",
+                    "sparse_embedding",
+                    "text_embedding",
+                ],
+            ]
+        ] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        query: t.Optional[str] = None,
+        task_settings: t.Optional[t.Any] = None,
+        timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        .. raw:: html
+
+          <p>Perform inference on the service.</p>
+          <p>This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.
+          It returns a response with the results of the tasks.
+          The inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.</p>
+          <blockquote>
+          <p>info
+          The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
+          </blockquote>
+
+
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-inference>`_
+
+        :param inference_id: The unique identifier for the inference endpoint.
+        :param input: The text on which you want to perform the inference task. It can
+            be a single string or an array. > info > Inference endpoints for the `completion`
+            task type currently only support a single string as input.
+        :param task_type: The type of inference task that the model performs.
+        :param query: The query input, which is required only for the `rerank` task.
+            It is not required for other tasks.
+        :param task_settings: Task settings for the individual inference request. These
+            settings are specific to the task type you specified and override the task
+            settings specified when initializing the service.
+        :param timeout: The amount of time to wait for the inference request to complete.
+        """
+        if inference_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'inference_id'")
+        if input is None and body is None:
+            raise ValueError("Empty value passed for parameter 'input'")
+        __path_parts: t.Dict[str, str]
+        if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
+        elif inference_id not in SKIP_IN_PATH:
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
+        else:
+            raise ValueError("Couldn't find a path for the given parameters")
+        __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
+        if not __body:
+            if input is not None:
+                __body["input"] = input
+            if query is not None:
+                __body["query"] = query
+            if task_settings is not None:
+                __body["task_settings"] = task_settings
+        if not __body:
+            __body = None  # type: ignore[assignment]
+        __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
+        return self.perform_request(  # type: ignore[return-value]
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.inference",
             path_parts=__path_parts,
         )
 

--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -75,6 +75,7 @@ class Stability(Enum):
     STABLE = auto()
     BETA = auto()
     EXPERIMENTAL = auto()
+    DEPRECATED = auto()
 
 
 _TYPE_HOSTS = Union[
@@ -431,6 +432,10 @@ def _stability_warning(
                     "Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.",
                     category=GeneralAvailabilityWarning,
                     stacklevel=warn_stacklevel(),
+                )
+            elif stability == Stability.DEPRECATED:
+                warnings.warn(
+                    message, category=DeprecationWarning, stacklevel=warn_stacklevel()
                 )
 
             return api(*args, **kwargs)

--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -433,9 +433,11 @@ def _stability_warning(
                     category=GeneralAvailabilityWarning,
                     stacklevel=warn_stacklevel(),
                 )
-            elif stability == Stability.DEPRECATED:
+            elif stability == Stability.DEPRECATED and message and version:
                 warnings.warn(
-                    message, category=DeprecationWarning, stacklevel=warn_stacklevel()
+                    f"In elasticsearch-py {version}, {message}.",
+                    category=DeprecationWarning,
+                    stacklevel=warn_stacklevel(),
                 )
 
             return api(*args, **kwargs)


### PR DESCRIPTION
This function was removed from the specification in favor of one API per provider and task type, but the existing function was stable and widely used in Python. Still, we mark it as deprecated to encourage users to migrate to the new APIs. Usage:

```python
❯ python
Python 3.13.2 (main, Feb  4 2025, 14:51:09) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from elasticsearch import Elasticsearch
>>> client = Elasticsearch("http://localhost:9200", basic_auth=("elastic", "..."))
>>> resp = client.inference.inference(
...     task_type="sparse_embedding",
...     inference_id="my-elser-model",
...     input="The sky above the port was the color of television tuned to a dead channel.",
... )
... print(resp)
... 
<python-input-2>:1: DeprecationWarning: In elasticsearch-py 8.18.0, inference.inference() is deprecated in favor of provider-specific APIs such as inference.put_elasticsearch() or inference.put_hugging_face().
  resp = client.inference.inference(
{'sparse_embedding': [{'is_truncated': False, 'embedding': {'port': 2.2090192, 'sky': 2.0603642, 'dead': 1.7242892, 'color': 1.5448499, 'above': 1.499859, 'television': 1.4837542, 'channel': 1.4109092, 'tv': 1.305537, 'scene': 1.1813625, 'tune': 0.9547886, 'symbol': 0.91213614, 'picture': 0.9103771, 'ports': 0.90121895, 'was': 0.8100137, 'below': 0.79527164, 'submarine': 0.77112997, 'tower': 0.7330783, 'ship': 0.7280335, 'atmosphere': 0.70177543, 'ufo': 0.6849597, 'alien': 0.6790674, 'tuned': 0.6633533, 'blue': 0.64610964, 'transmission': 0.6227346, 'russian': 0.5944273, 'bridge': 0.59391767, 'flood': 0.5818034, 'illusion': 0.5817699, 'radio': 0.5588502, 'broadcast': 0.5511641, 'airport': 0.54556763, 'prison': 0.5353672, 'signal': 0.5314421, 'station': 0.52959406, 'cloud': 0.52808267, 'island': 0.5245473, 'image': 0.5218425, 'sea': 0.5203932, 'uss': 0.51837164, 'aurora': 0.5099126, 'titanic': 0.50224626, 'pearl': 0.50044096, 'died': 0.49722457, 'naval': 0.49488223, 'broken': 0.49210304, 'sonar': 0.48001108, 'the': 0.46300593, 'song': 0.46270418, 'error': 0.46174952, 'remote': 0.4598964, 'network': 0.4586804, 'radar': 0.45608574, 'earthquake': 0.45489678, 'metaphor': 0.45072076, 'story': 0.4491404, 'lamp': 0.43336144, 'night': 0.41938552, 'became': 0.41637257, 'satellite': 0.41268998, 'underground': 0.40874982, 'death': 0.4079397, 'effect': 0.40663618, 'location': 0.40259305, 'vision': 0.40226272, 'symbolism': 0.4005573, 'episode': 0.39282712, 'poem': 0.39172614, 'status': 0.3882544, 'museum': 0.38189277, 'china': 0.37348503, 'red': 0.36933205, 'emergency': 0.3670889, 'tunnel': 0.3613389, 'incident': 0.350411, 'israel': 0.34983605, 'protocol': 0.34854302, 'film': 0.34562296, 'london': 0.336757, 'boat': 0.33477768, 'lore': 0.32566208, 'nuclear': 0.32439935, 'smell': 0.32404825, 'dream': 0.31649122, 'problem': 0.31217098, 'playback': 0.30998576, 'constellation': 0.30270416, 'purple': 0.29363653, 'cipher': 0.2912225, 'colors': 0.28874406, 'black': 0.28550884, 'were': 0.2842106, 'old': 0.28287837, 'fire': 0.28244266, 'imagery': 0.2810566, 'clue': 0.2715889, 'russia': 0.26432338, 'flag': 0.26225692, 'japanese': 0.26003373, 'cabin': 0.2597665, 'atlantic': 0.25722393, 'animation': 0.25713176, 'forest': 0.2567781, 'kennedy': 0.25460494, 'strange': 0.25116727, 'filming': 0.25008273, 'orange': 0.2482836, 'vietnam': 0.24598219, 'nearby': 0.24553679, 'iran': 0.24273792, 'aerial': 0.24193129, 'river': 0.2396681, 'green': 0.23921812, 'babylon': 0.23905087, 'strait': 0.23882979, 'sequence': 0.23608813, 'camouflage': 0.23444194, 'disney': 0.2331045, 'berlin': 0.23056225, 'camera': 0.22905798, 'fog': 0.2251829, 'legend': 0.22036001, 'zone': 0.21286118, 'virus': 0.21158794, 'point': 0.20780057, 'novel': 0.20623815, 'bird': 0.20264089, 'cathedral': 0.20263526, 'map': 0.20047511, 'egypt': 0.19883329, 'service': 0.19767128, 'flight': 0.18951172, 'painting': 0.1863695, 'fake': 0.18316564, 'airfield': 0.18034673, 'outbreak': 0.17866752, 'terminal': 0.17247757, 'conspiracy': 0.17055894, 'hospital': 0.17018627, 'anime': 0.16893299, 'moon': 0.1684777, 'lost': 0.16821538, 'factory': 0.16648911, 'window': 0.16367425, 'temple': 0.16190767, 'ocean': 0.15841754, 'bomb': 0.15705353, 'frontier': 0.15160067, 'video': 0.15018733, 'movie': 0.14806989, 'plot': 0.14697476, 'operation': 0.14466576, 'underwater': 0.13930322, 'pollution': 0.13882253, 'soviet': 0.12976635, 'york': 0.12287338, 'plane': 0.11332273, 'had': 0.11293873, 'miracle': 0.10984619, 'broadcasting': 0.10845212, 'roosevelt': 0.10508619, 'finch': 0.104957506, 'artificial': 0.10206794, 'white': 0.10005419, 'of': 0.09966204, 'street': 0.09834608, 'horror': 0.097284846, 'atlantis': 0.08996741, 'weapon': 0.08809974, 'pilot': 0.08798632, '/': 0.08737807, 'dye': 0.08705118, 'virginia': 0.086224094, 'brooklyn': 0.08584159, 'aura': 0.078928195, 'turkish': 0.07839939, 'bell': 0.07477341, 'theme': 0.071492776, 'streaming': 0.06840253, 'origin': 0.067463376, 'gulf': 0.06598424, 'photograph': 0.06392058, 'pirate': 0.062070806, 'hiroshima': 0.06158804, 'live': 0.05573571, 'she': 0.053732224, 'probe': 0.048098806, 'mine': 0.046599265, 'nasa': 0.042406052, 'haunted': 0.041438032, 'siren': 0.040074036, 'channels': 0.037849978, 'legacy': 0.034275383, 'telegraph': 0.032172866, 'elevation': 0.02726977, 'venetian': 0.027095169, 'storm': 0.021212257, 'bot': 0.021103363, 'normandy': 0.016386928, 'indicator': 0.014706303, 'dish': 0.010365698, 'pacific': 0.008873081, 'dark': 0.0043345788, 'flickering': 0.0028316185, 'show': 0.0026052603}}]}
>>> 
```