### PR TITLE
[DOCS]:Update links to ESQL reference docs

### DIFF
--- a/docs/reference/esql-pandas.md
+++ b/docs/reference/esql-pandas.md
@@ -355,7 +355,7 @@ You can now analyze the data with Pandas or you can also continue transforming t
 
 ## Analyze the data with Pandas [analyze-data]
 
-In the next example, the [STATS …​ BY](elasticsearch://reference/query-languages/esql/esql-commands.md#esql-stats-by) command is utilized to count how many employees are speaking a given language. The results are sorted with the `languages` column using [SORT](elasticsearch://reference/query-languages/esql/esql-commands.md#esql-sort):
+In the next example, the [STATS …​ BY](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-stats-by) command is utilized to count how many employees are speaking a given language. The results are sorted with the `languages` column using [SORT](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-sort):
 
 ```python
 response = client.esql.query(


### PR DESCRIPTION
Update links to ESQL reference docs following up on https://github.com/elastic/elasticsearch/pull/126279 that splits the Functions and Operators page into separate pages, one for each group of similar functions and one for the operators.
Based on https://github.com/elastic/docs-content/issues/1072