### PR TITLE
Clarify Elasticsearch 9.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ of the getting started documentation.
 
 ## Compatibility
 
-Language clients are forward compatible; meaning that the clients support communicating with greater or equal minor versions of {{es}} without breaking. It does not mean that the clients automatically support new features of newer {{es}} versions; it is only possible after a release of a new client version. For example, a 8.12 client version won’t automatically support the new features of the 8.13 version of {{es}}, the 8.13 client version is required for that. {{es}} language clients are only backwards compatible across minor versions with default distributions and without guarantees made. To upgrade to a new major version, you first need to upgrade Elasticsearch, then the Python Elasticsearch client.
+Language clients are _forward compatible:_ each client version works with equivalent and later minor versions of Elasticsearch without breaking.
+
+Compatibility does not imply full feature parity. New Elasticsearch features are supported only in equivalent client versions. For example, an 8.12 client fully supports Elasticsearch 8.12 features and works with 8.13 without breaking; however, it does not support new Elasticsearch 8.13 features. An 8.13 client fully supports Elasticsearch 8.13 features.
 
 | Elasticsearch version | elasticsearch-py branch |
 | --- | --- |
@@ -72,8 +74,12 @@ Language clients are forward compatible; meaning that the clients support commun
 | 9.x | 8.x |
 | 8.x | 8.x |
 
-If you have a need to have multiple versions installed at the same time older
-versions are also released as ``elasticsearch7`` and ``elasticsearch8``.
+Elasticsearch language clients are also _backward compatible_ across minor versions &mdash; with default distributions and without guarantees.
+
+> [!NOTE]
+> To upgrade to a new major version, first upgrade Elasticsearch, then upgrade the Python Elasticsearch client.
+
+If you need to work with multiple client versions, note that older versions are also released as `elasticsearch7` and `elasticsearch8`.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -63,21 +63,14 @@ of the getting started documentation.
 
 ## Compatibility
 
-Language clients are forward compatible; meaning that the clients support
-communicating with greater or equal minor versions of Elasticsearch without
-breaking. It does not mean that the clients automatically support new features
-of newer Elasticsearch versions; it is only possible after a release of a new
-client version. For example, a 8.12 client version won't automatically support
-the new features of the 8.13 version of Elasticsearch, the 8.13 client version
-is required for that. Elasticsearch language clients are only backwards
-compatible with default distributions and without guarantees made.
+Language clients are forward compatible; meaning that the clients support communicating with greater or equal minor versions of {{es}} without breaking. It does not mean that the clients automatically support new features of newer {{es}} versions; it is only possible after a release of a new client version. For example, a 8.12 client version won’t automatically support the new features of the 8.13 version of {{es}}, the 8.13 client version is required for that. {{es}} language clients are only backwards compatible across minor versions with default distributions and without guarantees made. To upgrade to a new major version, you first need to upgrade Elasticsearch, then the Python Elasticsearch client.
 
-| Elasticsearch Version | Elasticsearch-Python Branch | Supported |
-| --------------------- | ------------------------ | --------- |
-| main                  | main                     |           |
-| 8.x                   | 8.x                      | 8.x       |
-| 7.x                   | 7.x                      | 7.17      |
-
+| Elasticsearch version | elasticsearch-py branch |
+| --- | --- |
+| main | main |
+| 9.x | 9.x |
+| 9.x | 8.x |
+| 8.x | 8.x |
 
 If you have a need to have multiple versions installed at the same time older
 versions are also released as ``elasticsearch7`` and ``elasticsearch8``.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Compatibility does not imply full feature parity. New Elasticsearch features are
 
 Elasticsearch language clients are also _backward compatible_ across minor versions &mdash; with default distributions and without guarantees.
 
-> [!NOTE]
+> [!TIP]
 > To upgrade to a new major version, first upgrade Elasticsearch, then upgrade the Python Elasticsearch client.
 
 If you need to work with multiple client versions, note that older versions are also released as `elasticsearch7` and `elasticsearch8`.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -56,13 +56,13 @@ For a higher level access with more limited scope, have a look at the DSL module
 
 ## Compatibility [_compatibility]
 
-Language clients are forward compatible; meaning that the clients support communicating with greater or equal minor versions of {{es}} without breaking. It does not mean that the clients automatically support new features of newer {{es}} versions; it is only possible after a release of a new client version. For example, a 8.12 client version won’t automatically support the new features of the 8.13 version of {{es}}, the 8.13 client version is required for that. {{es}} language clients are only backwards compatible with default distributions and without guarantees made.
+Language clients are forward compatible; meaning that the clients support communicating with greater or equal minor versions of {{es}} without breaking. It does not mean that the clients automatically support new features of newer {{es}} versions; it is only possible after a release of a new client version. For example, a 8.12 client version won’t automatically support the new features of the 8.13 version of {{es}}, the 8.13 client version is required for that. {{es}} language clients are only backwards compatible across minor versions with default distributions and without guarantees made. To upgrade to a new major version, you first need to upgrade Elasticsearch, then the Python Elasticsearch client.
 
-| Elasticsearch version | elasticsearch-py branch | Supported |
-| --- | --- | --- |
-| main | main |  |
-| 9.x | 9.x | 9.x |
-| 8.x | 8.x | 8.x |
-| 7.x | 7.x | 7.17 |
+| Elasticsearch version | elasticsearch-py branch |
+| --- | --- |
+| main | main |
+| 9.x | 9.x |
+| 9.x | 8.x |
+| 8.x | 8.x |
 
 If you have a need to have multiple versions installed at the same time older versions are also released as `elasticsearch7` and `elasticsearch8`.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -56,7 +56,9 @@ For a higher level access with more limited scope, have a look at the DSL module
 
 ## Compatibility [_compatibility]
 
-Language clients are forward compatible; meaning that the clients support communicating with greater or equal minor versions of {{es}} without breaking. It does not mean that the clients automatically support new features of newer {{es}} versions; it is only possible after a release of a new client version. For example, a 8.12 client version won’t automatically support the new features of the 8.13 version of {{es}}, the 8.13 client version is required for that. {{es}} language clients are only backwards compatible across minor versions with default distributions and without guarantees made. To upgrade to a new major version, you first need to upgrade Elasticsearch, then the Python Elasticsearch client.
+Language clients are _forward compatible:_ each client version works with equivalent and later minor versions of {{es}} without breaking. 
+
+Compatibility does not imply full feature parity. New {{es}} features are supported only in equivalent client versions. For example, an 8.12 client fully supports {{es}} 8.12 features and works with 8.13 without breaking; however, it does not support new {{es}} 8.13 features. An 8.13 client fully supports {{es}} 8.13 features.
 
 | Elasticsearch version | elasticsearch-py branch |
 | --- | --- |
@@ -65,4 +67,10 @@ Language clients are forward compatible; meaning that the clients support commun
 | 9.x | 8.x |
 | 8.x | 8.x |
 
-If you have a need to have multiple versions installed at the same time older versions are also released as `elasticsearch7` and `elasticsearch8`.
+{{es}} language clients are also _backward compatible_ across minor versions &mdash; with default distributions and without guarantees. 
+
+:::{tip}
+To upgrade to a new major version, first upgrade {{es}}, then upgrade the Python {{es}} client.
+:::
+
+If you need to work with multiple client versions, note that older versions are also released as `elasticsearch7` and `elasticsearch8`.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -61,6 +61,7 @@ Language clients are forward compatible; meaning that the clients support commun
 | Elasticsearch version | elasticsearch-py branch | Supported |
 | --- | --- | --- |
 | main | main |  |
+| 9.x | 9.x | 9.x |
 | 8.x | 8.x | 8.x |
 | 7.x | 7.x | 7.17 |
 


### PR DESCRIPTION
Appended the client compatibility matrix to call out the 9.x client compatibility for 9.x release.

Based off @miguelgrinberg  post here https://github.com/elastic/elasticsearch-py/issues/2927#issuecomment-2809689706 and past historical precedent, updated the matrix to show that 9.x clients work with 9.x clients and not 8.x or 7.x as they will run into `Invalid media-type value on headers` errors. You might need someone from the python api team to review prior to approval on this one in case that has changed.

Screenshot showing elasticsearch9 is a valid upgrade/install path
![ElasticSupport 2025-04-16 at 11 01 23](https://github.com/user-attachments/assets/f1ae5063-0cca-4450-a15d-63c8d1a723e5)
