### PR TITLE
Surface caused_by in ApiError

### DIFF
--- a/elasticsearch/exceptions.py
+++ b/elasticsearch/exceptions.py
@@ -61,7 +61,7 @@ class ApiError(_ApiError):
             if self.body and isinstance(self.body, dict) and "error" in self.body:
                 if isinstance(self.body["error"], dict):
                     root_cause = self.body["error"]["root_cause"][0]
-                    caused_by = self.body["error"].get("caused_by")
+                    caused_by = self.body["error"].get("caused_by", {})
                     cause = ", ".join(
                         filter(
                             None,

--- a/elasticsearch/exceptions.py
+++ b/elasticsearch/exceptions.py
@@ -61,6 +61,7 @@ class ApiError(_ApiError):
             if self.body and isinstance(self.body, dict) and "error" in self.body:
                 if isinstance(self.body["error"], dict):
                     root_cause = self.body["error"]["root_cause"][0]
+                    caused_by = self.body["error"].get("caused_by")
                     cause = ", ".join(
                         filter(
                             None,
@@ -68,6 +69,7 @@ class ApiError(_ApiError):
                                 repr(root_cause["reason"]),
                                 root_cause.get("resource.id"),
                                 root_cause.get("resource.type"),
+                                caused_by.get("reason"),
                             ],
                         )
                     )

--- a/test_elasticsearch/test_exceptions.py
+++ b/test_elasticsearch/test_exceptions.py
@@ -46,3 +46,33 @@ class TestTransformError:
         assert (
             str(e) == "ApiError(500, 'InternalServerError', 'something error message')"
         )
+
+    def test_transform_invalid_media_type_error(self):
+        e = ApiError(
+            message="InvalidMediaType",
+            meta=error_meta,
+            body={
+                "error": {
+                    "root_cause": [
+                        {
+                            "type": "media_type_header_exception",
+                            "reason": "Invalid media-type value on headers [Accept, Content-Type]",
+                        }
+                    ],
+                    "type": "media_type_header_exception",
+                    "reason": "Invalid media-type value on headers [Accept, Content-Type]",
+                    "caused_by": {
+                        "type": "status_exception",
+                        "reason": "Accept version must be either version 8 or 7, but found 9. Accept=application/vnd.elasticsearch+json; compatible-with=9",
+                    },
+                },
+                "status": 400,
+            },
+        )
+
+        assert str(e) == (
+            "ApiError(500, 'InvalidMediaType', "
+            "'Invalid media-type value on headers [Accept, Content-Type]', "
+            "Accept version must be either version 8 or 7, but found 9. "
+            "Accept=application/vnd.elasticsearch+json; compatible-with=9)"
+        )


### PR DESCRIPTION
In particular, this will give a clear error when using elasticsearch-py 9.0.0 on an 8.x clusters. Which helps with issues likes #2927 and #2923.

Before:

> elasticsearch.BadRequestError: BadRequestError(400, 'media_type_header_exception', 'Invalid media-type value on headers [Accept, Content-Type]')

After:

> elasticsearch.BadRequestError: BadRequestError(400, 'media_type_header_exception', 'Invalid media-type value on headers [Accept, Content-Type]', Accept version must be either version 8 or 7, but found 9. Accept=application/vnd.elasticsearch+json; compatible-with=9)