### PR TITLE
Auto-generated code for 8.x

### DIFF
--- a/elasticsearch/_async/client/cluster.py
+++ b/elasticsearch/_async/client/cluster.py
@@ -185,7 +185,7 @@ class ClusterClient(NamespacedClient):
           Remove master-eligible nodes from the voting configuration exclusion list.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
@@ -680,7 +680,7 @@ class ClusterClient(NamespacedClient):
           They are not required when removing master-ineligible nodes or when removing fewer than half of the master-eligible nodes.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param node_ids: A comma-separated list of the persistent ids of the nodes to

--- a/elasticsearch/_async/client/inference.py
+++ b/elasticsearch/_async/client/inference.py
@@ -235,6 +235,113 @@ class InferenceClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
+        body_fields=("input", "query", "task_settings"),
+    )
+    async def inference(
+        self,
+        *,
+        inference_id: str,
+        input: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        task_type: t.Optional[
+            t.Union[
+                str,
+                t.Literal[
+                    "chat_completion",
+                    "completion",
+                    "rerank",
+                    "sparse_embedding",
+                    "text_embedding",
+                ],
+            ]
+        ] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        query: t.Optional[str] = None,
+        task_settings: t.Optional[t.Any] = None,
+        timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        .. raw:: html
+
+          <p>Perform inference on the service.</p>
+          <p>This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.
+          It returns a response with the results of the tasks.
+          The inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.</p>
+          <p>For details about using this API with a service, such as Amazon Bedrock, Anthropic, or HuggingFace, refer to the service-specific documentation.</p>
+          <blockquote>
+          <p>info
+          The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
+          </blockquote>
+
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/post-inference-api.html>`_
+
+        :param inference_id: The unique identifier for the inference endpoint.
+        :param input: The text on which you want to perform the inference task. It can
+            be a single string or an array. > info > Inference endpoints for the `completion`
+            task type currently only support a single string as input.
+        :param task_type: The type of inference task that the model performs.
+        :param query: The query input, which is required only for the `rerank` task.
+            It is not required for other tasks.
+        :param task_settings: Task settings for the individual inference request. These
+            settings are specific to the task type you specified and override the task
+            settings specified when initializing the service.
+        :param timeout: The amount of time to wait for the inference request to complete.
+        """
+        if inference_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'inference_id'")
+        if input is None and body is None:
+            raise ValueError("Empty value passed for parameter 'input'")
+        __path_parts: t.Dict[str, str]
+        if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
+        elif inference_id not in SKIP_IN_PATH:
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
+        else:
+            raise ValueError("Couldn't find a path for the given parameters")
+        __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
+        if not __body:
+            if input is not None:
+                __body["input"] = input
+            if query is not None:
+                __body["query"] = query
+            if task_settings is not None:
+                __body["task_settings"] = task_settings
+        if not __body:
+            __body = None  # type: ignore[assignment]
+        __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
+        return await self.perform_request(  # type: ignore[return-value]
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.inference",
+            path_parts=__path_parts,
+        )
+
+    @_rewrite_parameters(
         body_name="inference_config",
     )
     async def put(

--- a/elasticsearch/_async/client/license.py
+++ b/elasticsearch/_async/client/license.py
@@ -237,7 +237,7 @@ class LicenseClient(NamespacedClient):
           If the operator privileges feature is enabled, only operator users can use this API.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-license-post>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:

--- a/elasticsearch/_async/client/ml.py
+++ b/elasticsearch/_async/client/ml.py
@@ -1676,7 +1676,7 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data frame analytics jobs usage info.</p>
+          <p>Get data frame analytics job stats.</p>
 
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-dfanalytics-stats.html>`_
@@ -1744,7 +1744,7 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get datafeeds usage info.
+          <p>Get datafeed stats.
           You can get statistics for multiple datafeeds in a single API request by
           using a comma-separated list of datafeeds or a wildcard expression. You can
           get statistics for all datafeeds by using <code>_all</code>, by specifying <code>*</code> as the
@@ -2033,7 +2033,7 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get anomaly detection jobs usage info.</p>
+          <p>Get anomaly detection job stats.</p>
 
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job-stats.html>`_
@@ -5004,7 +5004,7 @@ class MlClient(NamespacedClient):
           <p>Update a data frame analytics job.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-data-frame-analytics>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-ml-update-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -5577,7 +5577,7 @@ class MlClient(NamespacedClient):
           <p>Update a trained model deployment.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-trained-model-deployment>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-ml-update-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.

--- a/elasticsearch/_async/client/transform.py
+++ b/elasticsearch/_async/client/transform.py
@@ -795,7 +795,7 @@ class TransformClient(NamespacedClient):
           time of update and runs with those privileges.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-update-transform>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-transform-update-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -890,7 +890,7 @@ class TransformClient(NamespacedClient):
           You may want to perform a recent cluster backup prior to the upgrade.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-upgrade-transforms>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-transform-upgrade-transforms>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_async/client/watcher.py
+++ b/elasticsearch/_async/client/watcher.py
@@ -48,7 +48,7 @@ class WatcherClient(NamespacedClient):
           This happens when the condition of the watch is not met (the condition evaluates to false).</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-ack-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-ack-watch>`_
 
         :param watch_id: The watch identifier.
         :param action_id: A comma-separated list of the action identifiers to acknowledge.
@@ -104,7 +104,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-activate-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-activate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -148,7 +148,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-deactivate-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-deactivate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -196,7 +196,7 @@ class WatcherClient(NamespacedClient):
           When Elasticsearch security features are enabled, make sure no write privileges are granted to anyone for the <code>.watches</code> index.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-delete-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-delete-watch>`_
 
         :param id: The watch identifier.
         """
@@ -277,7 +277,7 @@ class WatcherClient(NamespacedClient):
           <p>When using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-execute-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-execute-watch>`_
 
         :param id: The watch identifier.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -365,7 +365,7 @@ class WatcherClient(NamespacedClient):
           Only a subset of settings are shown, for example <code>index.auto_expand_replicas</code> and <code>index.number_of_replicas</code>.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-settings>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-get-settings>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -410,7 +410,7 @@ class WatcherClient(NamespacedClient):
           <p>Get a watch.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-get-watch>`_
 
         :param id: The watch identifier.
         """
@@ -485,7 +485,7 @@ class WatcherClient(NamespacedClient):
           If the user is able to read index <code>a</code>, but not index <code>b</code>, the same will apply when the watch runs.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-put-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-put-watch>`_
 
         :param id: The identifier for the watch.
         :param actions: The list of actions that will be run if the condition matches.
@@ -598,7 +598,7 @@ class WatcherClient(NamespacedClient):
           <p>Note that only the <code>_id</code> and <code>metadata.*</code> fields are queryable or sortable.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-query-watches>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-query-watches>`_
 
         :param from_: The offset from the first result to fetch. It must be non-negative.
         :param query: A query that filters the watches to be returned.
@@ -673,7 +673,7 @@ class WatcherClient(NamespacedClient):
           Start the Watcher service if it is not already running.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-start>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-start>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -739,7 +739,7 @@ class WatcherClient(NamespacedClient):
           You retrieve more metrics by using the metric parameter.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stats>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-stats>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -790,7 +790,7 @@ class WatcherClient(NamespacedClient):
           Stop the Watcher service if it is running.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stop>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-stop>`_
 
         :param master_timeout: The period to wait for the master node. If the master
             node is not available before the timeout expires, the request fails and returns
@@ -851,7 +851,7 @@ class WatcherClient(NamespacedClient):
           Watcher shards must always be in the <code>data_content</code> tier.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-update-settings>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-update-settings>`_
 
         :param index_auto_expand_replicas:
         :param index_number_of_replicas:

--- a/elasticsearch/_async/client/xpack.py
+++ b/elasticsearch/_async/client/xpack.py
@@ -103,7 +103,7 @@ class XPackClient(NamespacedClient):
           The API also provides some usage statistics.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-xpack>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/group/endpoint-xpack>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/_sync/client/cluster.py
+++ b/elasticsearch/_sync/client/cluster.py
@@ -185,7 +185,7 @@ class ClusterClient(NamespacedClient):
           Remove master-eligible nodes from the voting configuration exclusion list.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param wait_for_removal: Specifies whether to wait for all excluded nodes to
@@ -680,7 +680,7 @@ class ClusterClient(NamespacedClient):
           They are not required when removing master-ineligible nodes or when removing fewer than half of the master-eligible nodes.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-post-voting-config-exclusions>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-cluster-post-voting-config-exclusions>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         :param node_ids: A comma-separated list of the persistent ids of the nodes to

--- a/elasticsearch/_sync/client/inference.py
+++ b/elasticsearch/_sync/client/inference.py
@@ -235,6 +235,113 @@ class InferenceClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
+        body_fields=("input", "query", "task_settings"),
+    )
+    def inference(
+        self,
+        *,
+        inference_id: str,
+        input: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        task_type: t.Optional[
+            t.Union[
+                str,
+                t.Literal[
+                    "chat_completion",
+                    "completion",
+                    "rerank",
+                    "sparse_embedding",
+                    "text_embedding",
+                ],
+            ]
+        ] = None,
+        error_trace: t.Optional[bool] = None,
+        filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        human: t.Optional[bool] = None,
+        pretty: t.Optional[bool] = None,
+        query: t.Optional[str] = None,
+        task_settings: t.Optional[t.Any] = None,
+        timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
+    ) -> ObjectApiResponse[t.Any]:
+        """
+        .. raw:: html
+
+          <p>Perform inference on the service.</p>
+          <p>This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.
+          It returns a response with the results of the tasks.
+          The inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.</p>
+          <p>For details about using this API with a service, such as Amazon Bedrock, Anthropic, or HuggingFace, refer to the service-specific documentation.</p>
+          <blockquote>
+          <p>info
+          The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.</p>
+          </blockquote>
+
+
+        `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/post-inference-api.html>`_
+
+        :param inference_id: The unique identifier for the inference endpoint.
+        :param input: The text on which you want to perform the inference task. It can
+            be a single string or an array. > info > Inference endpoints for the `completion`
+            task type currently only support a single string as input.
+        :param task_type: The type of inference task that the model performs.
+        :param query: The query input, which is required only for the `rerank` task.
+            It is not required for other tasks.
+        :param task_settings: Task settings for the individual inference request. These
+            settings are specific to the task type you specified and override the task
+            settings specified when initializing the service.
+        :param timeout: The amount of time to wait for the inference request to complete.
+        """
+        if inference_id in SKIP_IN_PATH:
+            raise ValueError("Empty value passed for parameter 'inference_id'")
+        if input is None and body is None:
+            raise ValueError("Empty value passed for parameter 'input'")
+        __path_parts: t.Dict[str, str]
+        if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
+            __path_parts = {
+                "task_type": _quote(task_type),
+                "inference_id": _quote(inference_id),
+            }
+            __path = f'/_inference/{__path_parts["task_type"]}/{__path_parts["inference_id"]}'
+        elif inference_id not in SKIP_IN_PATH:
+            __path_parts = {"inference_id": _quote(inference_id)}
+            __path = f'/_inference/{__path_parts["inference_id"]}'
+        else:
+            raise ValueError("Couldn't find a path for the given parameters")
+        __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
+        if error_trace is not None:
+            __query["error_trace"] = error_trace
+        if filter_path is not None:
+            __query["filter_path"] = filter_path
+        if human is not None:
+            __query["human"] = human
+        if pretty is not None:
+            __query["pretty"] = pretty
+        if timeout is not None:
+            __query["timeout"] = timeout
+        if not __body:
+            if input is not None:
+                __body["input"] = input
+            if query is not None:
+                __body["query"] = query
+            if task_settings is not None:
+                __body["task_settings"] = task_settings
+        if not __body:
+            __body = None  # type: ignore[assignment]
+        __headers = {"accept": "application/json"}
+        if __body is not None:
+            __headers["content-type"] = "application/json"
+        return self.perform_request(  # type: ignore[return-value]
+            "POST",
+            __path,
+            params=__query,
+            headers=__headers,
+            body=__body,
+            endpoint_id="inference.inference",
+            path_parts=__path_parts,
+        )
+
+    @_rewrite_parameters(
         body_name="inference_config",
     )
     def put(

--- a/elasticsearch/_sync/client/license.py
+++ b/elasticsearch/_sync/client/license.py
@@ -237,7 +237,7 @@ class LicenseClient(NamespacedClient):
           If the operator privileges feature is enabled, only operator users can use this API.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-post>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-license-post>`_
 
         :param acknowledge: Specifies whether you acknowledge the license changes.
         :param license:

--- a/elasticsearch/_sync/client/ml.py
+++ b/elasticsearch/_sync/client/ml.py
@@ -1676,7 +1676,7 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get data frame analytics jobs usage info.</p>
+          <p>Get data frame analytics job stats.</p>
 
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/get-dfanalytics-stats.html>`_
@@ -1744,7 +1744,7 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get datafeeds usage info.
+          <p>Get datafeed stats.
           You can get statistics for multiple datafeeds in a single API request by
           using a comma-separated list of datafeeds or a wildcard expression. You can
           get statistics for all datafeeds by using <code>_all</code>, by specifying <code>*</code> as the
@@ -2033,7 +2033,7 @@ class MlClient(NamespacedClient):
         """
         .. raw:: html
 
-          <p>Get anomaly detection jobs usage info.</p>
+          <p>Get anomaly detection job stats.</p>
 
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/8.17/ml-get-job-stats.html>`_
@@ -5004,7 +5004,7 @@ class MlClient(NamespacedClient):
           <p>Update a data frame analytics job.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-data-frame-analytics>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-ml-update-data-frame-analytics>`_
 
         :param id: Identifier for the data frame analytics job. This identifier can contain
             lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
@@ -5577,7 +5577,7 @@ class MlClient(NamespacedClient):
           <p>Update a trained model deployment.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-update-trained-model-deployment>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-ml-update-trained-model-deployment>`_
 
         :param model_id: The unique identifier of the trained model. Currently, only
             PyTorch models are supported.

--- a/elasticsearch/_sync/client/transform.py
+++ b/elasticsearch/_sync/client/transform.py
@@ -795,7 +795,7 @@ class TransformClient(NamespacedClient):
           time of update and runs with those privileges.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-update-transform>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-transform-update-transform>`_
 
         :param transform_id: Identifier for the transform.
         :param defer_validation: When true, deferrable validations are not run. This
@@ -890,7 +890,7 @@ class TransformClient(NamespacedClient):
           You may want to perform a recent cluster backup prior to the upgrade.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-upgrade-transforms>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-transform-upgrade-transforms>`_
 
         :param dry_run: When true, the request checks for updates but does not run them.
         :param timeout: Period to wait for a response. If no response is received before

--- a/elasticsearch/_sync/client/watcher.py
+++ b/elasticsearch/_sync/client/watcher.py
@@ -48,7 +48,7 @@ class WatcherClient(NamespacedClient):
           This happens when the condition of the watch is not met (the condition evaluates to false).</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-ack-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-ack-watch>`_
 
         :param watch_id: The watch identifier.
         :param action_id: A comma-separated list of the action identifiers to acknowledge.
@@ -104,7 +104,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-activate-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-activate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -148,7 +148,7 @@ class WatcherClient(NamespacedClient):
           A watch can be either active or inactive.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-deactivate-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-deactivate-watch>`_
 
         :param watch_id: The watch identifier.
         """
@@ -196,7 +196,7 @@ class WatcherClient(NamespacedClient):
           When Elasticsearch security features are enabled, make sure no write privileges are granted to anyone for the <code>.watches</code> index.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-delete-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-delete-watch>`_
 
         :param id: The watch identifier.
         """
@@ -277,7 +277,7 @@ class WatcherClient(NamespacedClient):
           <p>When using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-execute-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-execute-watch>`_
 
         :param id: The watch identifier.
         :param action_modes: Determines how to handle the watch actions as part of the
@@ -365,7 +365,7 @@ class WatcherClient(NamespacedClient):
           Only a subset of settings are shown, for example <code>index.auto_expand_replicas</code> and <code>index.number_of_replicas</code>.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-settings>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-get-settings>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails
@@ -410,7 +410,7 @@ class WatcherClient(NamespacedClient):
           <p>Get a watch.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-get-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-get-watch>`_
 
         :param id: The watch identifier.
         """
@@ -485,7 +485,7 @@ class WatcherClient(NamespacedClient):
           If the user is able to read index <code>a</code>, but not index <code>b</code>, the same will apply when the watch runs.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-put-watch>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-put-watch>`_
 
         :param id: The identifier for the watch.
         :param actions: The list of actions that will be run if the condition matches.
@@ -598,7 +598,7 @@ class WatcherClient(NamespacedClient):
           <p>Note that only the <code>_id</code> and <code>metadata.*</code> fields are queryable or sortable.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-query-watches>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-query-watches>`_
 
         :param from_: The offset from the first result to fetch. It must be non-negative.
         :param query: A query that filters the watches to be returned.
@@ -673,7 +673,7 @@ class WatcherClient(NamespacedClient):
           Start the Watcher service if it is not already running.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-start>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-start>`_
 
         :param master_timeout: Period to wait for a connection to the master node.
         """
@@ -739,7 +739,7 @@ class WatcherClient(NamespacedClient):
           You retrieve more metrics by using the metric parameter.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stats>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-stats>`_
 
         :param metric: Defines which additional metrics are included in the response.
         :param emit_stacktraces: Defines whether stack traces are generated for each
@@ -790,7 +790,7 @@ class WatcherClient(NamespacedClient):
           Stop the Watcher service if it is running.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-stop>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-stop>`_
 
         :param master_timeout: The period to wait for the master node. If the master
             node is not available before the timeout expires, the request fails and returns
@@ -851,7 +851,7 @@ class WatcherClient(NamespacedClient):
           Watcher shards must always be in the <code>data_content</code> tier.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-watcher-update-settings>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-watcher-update-settings>`_
 
         :param index_auto_expand_replicas:
         :param index_number_of_replicas:

--- a/elasticsearch/_sync/client/xpack.py
+++ b/elasticsearch/_sync/client/xpack.py
@@ -103,7 +103,7 @@ class XPackClient(NamespacedClient):
           The API also provides some usage statistics.</p>
 
 
-        `<https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-xpack>`_
+        `<https://www.elastic.co/docs/api/doc/elasticsearch/v8/group/endpoint-xpack>`_
 
         :param master_timeout: The period to wait for a connection to the master node.
             If no response is received before the timeout expires, the request fails

--- a/elasticsearch/dsl/field.py
+++ b/elasticsearch/dsl/field.py
@@ -437,7 +437,9 @@ class Object(Field):
         doc_class: Union[Type["InnerDoc"], "DefaultType"] = DEFAULT,
         *args: Any,
         enabled: Union[bool, "DefaultType"] = DEFAULT,
-        subobjects: Union[bool, "DefaultType"] = DEFAULT,
+        subobjects: Union[
+            Literal["true", "false", "auto"], bool, "DefaultType"
+        ] = DEFAULT,
         copy_to: Union[
             Union[str, "InstrumentedField"],
             Sequence[Union[str, "InstrumentedField"]],
@@ -1109,6 +1111,56 @@ class ConstantKeyword(Field):
         super().__init__(*args, **kwargs)
 
 
+class CountedKeyword(Field):
+    """
+    :arg index:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "counted_keyword"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        index: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if index is not DEFAULT:
+            kwargs["index"] = index
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
+        super().__init__(*args, **kwargs)
+
+
 class Date(Field):
     """
     :arg default_timezone: timezone that will be automatically used for tz-naive values
@@ -1118,6 +1170,8 @@ class Date(Field):
     :arg format:
     :arg ignore_malformed:
     :arg index:
+    :arg script:
+    :arg on_script_error:
     :arg null_value:
     :arg precision_step:
     :arg locale:
@@ -1150,6 +1204,8 @@ class Date(Field):
         format: Union[str, "DefaultType"] = DEFAULT,
         ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
         index: Union[bool, "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
         null_value: Any = DEFAULT,
         precision_step: Union[int, "DefaultType"] = DEFAULT,
         locale: Union[str, "DefaultType"] = DEFAULT,
@@ -1182,6 +1238,10 @@ class Date(Field):
             kwargs["ignore_malformed"] = ignore_malformed
         if index is not DEFAULT:
             kwargs["index"] = index
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
         if null_value is not DEFAULT:
             kwargs["null_value"] = null_value
         if precision_step is not DEFAULT:
@@ -1246,6 +1306,8 @@ class DateNanos(Field):
     :arg format:
     :arg ignore_malformed:
     :arg index:
+    :arg script:
+    :arg on_script_error:
     :arg null_value:
     :arg precision_step:
     :arg doc_values:
@@ -1272,6 +1334,8 @@ class DateNanos(Field):
         format: Union[str, "DefaultType"] = DEFAULT,
         ignore_malformed: Union[bool, "DefaultType"] = DEFAULT,
         index: Union[bool, "DefaultType"] = DEFAULT,
+        script: Union["types.Script", Dict[str, Any], "DefaultType"] = DEFAULT,
+        on_script_error: Union[Literal["fail", "continue"], "DefaultType"] = DEFAULT,
         null_value: Any = DEFAULT,
         precision_step: Union[int, "DefaultType"] = DEFAULT,
         doc_values: Union[bool, "DefaultType"] = DEFAULT,
@@ -1301,6 +1365,10 @@ class DateNanos(Field):
             kwargs["ignore_malformed"] = ignore_malformed
         if index is not DEFAULT:
             kwargs["index"] = index
+        if script is not DEFAULT:
+            kwargs["script"] = script
+        if on_script_error is not DEFAULT:
+            kwargs["on_script_error"] = on_script_error
         if null_value is not DEFAULT:
             kwargs["null_value"] = null_value
         if precision_step is not DEFAULT:
@@ -3082,6 +3150,76 @@ class Nested(Object):
         if synthetic_source_keep is not DEFAULT:
             kwargs["synthetic_source_keep"] = synthetic_source_keep
         kwargs.setdefault("multi", True)
+        super().__init__(*args, **kwargs)
+
+
+class Passthrough(Field):
+    """
+    :arg enabled:
+    :arg priority:
+    :arg time_series_dimension:
+    :arg copy_to:
+    :arg store:
+    :arg meta: Metadata about the field.
+    :arg properties:
+    :arg ignore_above:
+    :arg dynamic:
+    :arg fields:
+    :arg synthetic_source_keep:
+    """
+
+    name = "passthrough"
+    _param_defs = {
+        "properties": {"type": "field", "hash": True},
+        "fields": {"type": "field", "hash": True},
+    }
+
+    def __init__(
+        self,
+        *args: Any,
+        enabled: Union[bool, "DefaultType"] = DEFAULT,
+        priority: Union[int, "DefaultType"] = DEFAULT,
+        time_series_dimension: Union[bool, "DefaultType"] = DEFAULT,
+        copy_to: Union[
+            Union[str, "InstrumentedField"],
+            Sequence[Union[str, "InstrumentedField"]],
+            "DefaultType",
+        ] = DEFAULT,
+        store: Union[bool, "DefaultType"] = DEFAULT,
+        meta: Union[Mapping[str, str], "DefaultType"] = DEFAULT,
+        properties: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        ignore_above: Union[int, "DefaultType"] = DEFAULT,
+        dynamic: Union[
+            Literal["strict", "runtime", "true", "false"], bool, "DefaultType"
+        ] = DEFAULT,
+        fields: Union[Mapping[str, Field], "DefaultType"] = DEFAULT,
+        synthetic_source_keep: Union[
+            Literal["none", "arrays", "all"], "DefaultType"
+        ] = DEFAULT,
+        **kwargs: Any,
+    ):
+        if enabled is not DEFAULT:
+            kwargs["enabled"] = enabled
+        if priority is not DEFAULT:
+            kwargs["priority"] = priority
+        if time_series_dimension is not DEFAULT:
+            kwargs["time_series_dimension"] = time_series_dimension
+        if copy_to is not DEFAULT:
+            kwargs["copy_to"] = str(copy_to)
+        if store is not DEFAULT:
+            kwargs["store"] = store
+        if meta is not DEFAULT:
+            kwargs["meta"] = meta
+        if properties is not DEFAULT:
+            kwargs["properties"] = properties
+        if ignore_above is not DEFAULT:
+            kwargs["ignore_above"] = ignore_above
+        if dynamic is not DEFAULT:
+            kwargs["dynamic"] = dynamic
+        if fields is not DEFAULT:
+            kwargs["fields"] = fields
+        if synthetic_source_keep is not DEFAULT:
+            kwargs["synthetic_source_keep"] = synthetic_source_keep
         super().__init__(*args, **kwargs)
 
 

--- a/elasticsearch/dsl/query.py
+++ b/elasticsearch/dsl/query.py
@@ -1083,6 +1083,8 @@ class Knn(Query):
     :arg filter: Filters for the kNN search query
     :arg similarity: The minimum similarity for a vector to be considered
         a match
+    :arg rescore_vector: Apply oversampling and rescoring to quantized
+        vectors *
     :arg boost: Floating point number used to decrease or increase the
         relevance scores of the query. Boost values are relative to the
         default value of 1.0. A boost value between 0 and 1.0 decreases
@@ -1108,6 +1110,9 @@ class Knn(Query):
         k: Union[int, "DefaultType"] = DEFAULT,
         filter: Union[Query, Sequence[Query], "DefaultType"] = DEFAULT,
         similarity: Union[float, "DefaultType"] = DEFAULT,
+        rescore_vector: Union[
+            "types.RescoreVector", Dict[str, Any], "DefaultType"
+        ] = DEFAULT,
         boost: Union[float, "DefaultType"] = DEFAULT,
         _name: Union[str, "DefaultType"] = DEFAULT,
         **kwargs: Any,
@@ -1120,6 +1125,7 @@ class Knn(Query):
             k=k,
             filter=filter,
             similarity=similarity,
+            rescore_vector=rescore_vector,
             boost=boost,
             _name=_name,
             **kwargs,

--- a/elasticsearch/dsl/types.py
+++ b/elasticsearch/dsl/types.py
@@ -380,15 +380,24 @@ class DenseVectorIndexOptions(AttrDict[Any]):
         `int4_flat` index types.
     :arg ef_construction: The number of candidates to track while
         assembling the list of nearest neighbors for each new node.  Only
-        applicable to `hnsw`, `int8_hnsw`, and `int4_hnsw` index types.
-        Defaults to `100` if omitted.
+        applicable to `hnsw`, `int8_hnsw`, `bbq_hnsw`, and `int4_hnsw`
+        index types. Defaults to `100` if omitted.
     :arg m: The number of neighbors each node will be connected to in the
-        HNSW graph.  Only applicable to `hnsw`, `int8_hnsw`, and
-        `int4_hnsw` index types. Defaults to `16` if omitted.
+        HNSW graph.  Only applicable to `hnsw`, `int8_hnsw`, `bbq_hnsw`,
+        and `int4_hnsw` index types. Defaults to `16` if omitted.
     """
 
     type: Union[
-        Literal["flat", "hnsw", "int4_flat", "int4_hnsw", "int8_flat", "int8_hnsw"],
+        Literal[
+            "bbq_flat",
+            "bbq_hnsw",
+            "flat",
+            "hnsw",
+            "int4_flat",
+            "int4_hnsw",
+            "int8_flat",
+            "int8_hnsw",
+        ],
         DefaultType,
     ]
     confidence_interval: Union[float, DefaultType]
@@ -399,7 +408,16 @@ class DenseVectorIndexOptions(AttrDict[Any]):
         self,
         *,
         type: Union[
-            Literal["flat", "hnsw", "int4_flat", "int4_hnsw", "int8_flat", "int8_hnsw"],
+            Literal[
+                "bbq_flat",
+                "bbq_hnsw",
+                "flat",
+                "hnsw",
+                "int4_flat",
+                "int4_hnsw",
+                "int8_flat",
+                "int8_hnsw",
+            ],
             DefaultType,
         ] = DEFAULT,
         confidence_interval: Union[float, DefaultType] = DEFAULT,
@@ -591,6 +609,7 @@ class FieldSort(AttrDict[Any]):
             "completion",
             "nested",
             "object",
+            "passthrough",
             "version",
             "murmur3",
             "token_count",
@@ -617,6 +636,7 @@ class FieldSort(AttrDict[Any]):
             "shape",
             "histogram",
             "constant_keyword",
+            "counted_keyword",
             "aggregate_metric_double",
             "dense_vector",
             "semantic_text",
@@ -654,6 +674,7 @@ class FieldSort(AttrDict[Any]):
                 "completion",
                 "nested",
                 "object",
+                "passthrough",
                 "version",
                 "murmur3",
                 "token_count",
@@ -680,6 +701,7 @@ class FieldSort(AttrDict[Any]):
                 "shape",
                 "histogram",
                 "constant_keyword",
+                "counted_keyword",
                 "aggregate_metric_double",
                 "dense_vector",
                 "semantic_text",
@@ -2847,6 +2869,22 @@ class RegressionInferenceOptions(AttrDict[Any]):
             kwargs["num_top_feature_importance_values"] = (
                 num_top_feature_importance_values
             )
+        super().__init__(kwargs)
+
+
+class RescoreVector(AttrDict[Any]):
+    """
+    :arg oversample: (required) Applies the specified oversample factor to
+        k on the approximate kNN search
+    """
+
+    oversample: Union[float, DefaultType]
+
+    def __init__(
+        self, *, oversample: Union[float, DefaultType] = DEFAULT, **kwargs: Any
+    ):
+        if oversample is not DEFAULT:
+            kwargs["oversample"] = oversample
         super().__init__(kwargs)
 
 


### PR DESCRIPTION
* Add back `inference.inference` APIs that were removed by mistake

DSL

* Add `CountedKeyword` and `Passthrough` fields
* Add `rescore_vector` to Knn query
* Add `bbq_flat` and `bbq_hnsw` vector index types
* Add `script` and `on_script_error` to `Date` and `DateNanos` fields