### PR TITLE
[Docs] Fix broken link to RTD helpers page

### DIFF
--- a/docs/reference/client-helpers.md
+++ b/docs/reference/client-helpers.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Client helpers [client-helpers]
 
-You can find here a collection of simple helper functions that abstract some specifics of the raw API. For detailed examples, refer to [this page](https://elasticsearch-py.readthedocs.io/en/stable/helpers.html).
+You can find here a collection of simple helper functions that abstract some specifics of the raw API.
 
 
 ## Bulk helpers [bulk-helpers]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -46,7 +46,7 @@ The client’s features include:
 * Thread safety
 * Pluggable architecture
 
-The client also contains a convenient set of [helpers](https://elasticsearch-py.readthedocs.org/en/master/helpers.md) for some of the more engaging tasks like bulk indexing and reindexing.
+The client also contains a convenient set of [helpers](https://elasticsearch-py.readthedocs.io/en/stable/api_helpers.html) for some of the more engaging tasks like bulk indexing and reindexing.
 
 
 ## Elasticsearch Python DSL [_elasticsearch_python_dsl]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -46,7 +46,7 @@ The client’s features include:
 * Thread safety
 * Pluggable architecture
 
-The client also contains a convenient set of [helpers](https://elasticsearch-py.readthedocs.io/en/stable/api_helpers.html) for some of the more engaging tasks like bulk indexing and reindexing.
+The client also contains a convenient set of [helpers](client-helpers.md) for some of the more engaging tasks like bulk indexing and reindexing.
 
 
 ## Elasticsearch Python DSL [_elasticsearch_python_dsl]


### PR DESCRIPTION
The Python client docs index page had a stale link to the Helpers page on Read the Docs.

[Preview](https://docs-v3-preview.elastic.dev/elastic/elasticsearch-py/pull/2958/reference/#_features)
The last sentence under Features has the link to "helpers."

(via Slack)