### PR TITLE
[8.18] Stop using event_loop fixture (#2969)

### DIFF
--- a/docs/guide/async.asciidoc
+++ b/docs/guide/async.asciidoc
@@ -37,8 +37,7 @@ async def main():
     )
     print(resp)
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+asyncio.run(main())
 ----
 
 All APIs that are available under the sync client are also available

--- a/test_elasticsearch/test_async/test_transport.py
+++ b/test_elasticsearch/test_async/test_transport.py
@@ -527,7 +527,8 @@ class TestTransport:
         assert request_failed_in_error
         assert len(client.transport.node_pool) == 3
 
-    async def test_sniff_after_n_seconds(self, event_loop):
+    async def test_sniff_after_n_seconds(self):
+        event_loop = asyncio.get_running_loop()
         client = AsyncElasticsearch(  # noqa: F821
             [NodeConfig("http", "localhost", 9200, _extras={"data": CLUSTER_NODES})],
             node_class=DummyNode,
@@ -581,7 +582,8 @@ class TestTransport:
             == "Sniffing should not be enabled when connecting to Elastic Cloud"
         )
 
-    async def test_sniff_on_start_close_unlocks_async_calls(self, event_loop):
+    async def test_sniff_on_start_close_unlocks_async_calls(self):
+        event_loop = asyncio.get_running_loop()
         client = AsyncElasticsearch(  # noqa: F821
             [
                 NodeConfig(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Stop using event_loop fixture (#2969)](https://github.com/elastic/elasticsearch-py/pull/2969)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)