### PR TITLE
[8.17] Stop using event_loop fixture (#2969)

### DIFF
--- a/docs/sphinx/async.rst
+++ b/docs/sphinx/async.rst
@@ -37,8 +37,7 @@ and are used in the same way as other APIs, just with an extra ``await``:
         )
         print(resp)
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())
 
 All APIs that are available under the sync client are also available under the async client.
 
@@ -153,8 +152,7 @@ Bulk and Streaming Bulk
     async def main():
         await async_bulk(client, gendata())
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())
 
  .. autofunction:: async_streaming_bulk
 
@@ -180,8 +178,7 @@ Bulk and Streaming Bulk
             if not ok:
                 print("failed to %s document %s" % ())
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())
 
 Scan
 ~~~~
@@ -204,8 +201,7 @@ Scan
         ):
             print(doc)
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())
 
 Reindex
 ~~~~~~~

--- a/test_elasticsearch/test_async/test_transport.py
+++ b/test_elasticsearch/test_async/test_transport.py
@@ -527,7 +527,8 @@ class TestTransport:
         assert request_failed_in_error
         assert len(client.transport.node_pool) == 3
 
-    async def test_sniff_after_n_seconds(self, event_loop):
+    async def test_sniff_after_n_seconds(self):
+        event_loop = asyncio.get_running_loop()
         client = AsyncElasticsearch(  # noqa: F821
             [NodeConfig("http", "localhost", 9200, _extras={"data": CLUSTER_NODES})],
             node_class=DummyNode,
@@ -581,7 +582,8 @@ class TestTransport:
             == "Sniffing should not be enabled when connecting to Elastic Cloud"
         )
 
-    async def test_sniff_on_start_close_unlocks_async_calls(self, event_loop):
+    async def test_sniff_on_start_close_unlocks_async_calls(self):
+        event_loop = asyncio.get_running_loop()
         client = AsyncElasticsearch(  # noqa: F821
             [
                 NodeConfig(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Stop using event_loop fixture (#2969)](https://github.com/elastic/elasticsearch-py/pull/2969)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)