### PR TITLE
Upgrade `urllib3` on 7.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ packages = [
 ]
 
 install_requires = [
-    "urllib3>=1.21.1, <2",
+    "urllib3>=2.5.0, <3",
     "certifi",
 ]
 tests_require = [


### PR DESCRIPTION
I'd like to keep using elasticsearch 7 for a bit longer, however there are some security issues with `urllib3` < 2.5.0.
This PR aims to upgrade `urllib3` to at least version 2.5.0