### PR TITLE
Address integration test failures in Python 3.8

### DIFF
--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -78,6 +78,7 @@ FAILING_TESTS = {
     "cluster/voting_config_exclusions",
     "entsearch/10_basic",
     "indices/clone",
+    "indices/data_stream_mappings[0]",
     "indices/resolve_cluster",
     "indices/settings",
     "indices/split",
@@ -501,7 +502,13 @@ try:
     )
 
     # Download the zip and start reading YAML from the files in memory
-    package_zip = zipfile.ZipFile(io.BytesIO(http.request("GET", yaml_tests_url).data))
+    package_zip = zipfile.ZipFile(
+        io.BytesIO(
+            http.request(
+                "GET", yaml_tests_url, retries=urllib3.Retry(3, redirect=10)
+            ).data
+        )
+    )
 
     for yaml_file in package_zip.namelist():
         if not re.match(r"^.*\/tests\/.*\.ya?ml$", yaml_file):

--- a/test_elasticsearch/utils.py
+++ b/test_elasticsearch/utils.py
@@ -179,7 +179,7 @@ def wipe_data_streams(client):
 def wipe_indices(client):
     indices = client.cat.indices().strip().splitlines()
     if len(indices) > 0:
-        index_names = [i.split(" ")[2] for i in indices]
+        index_names = [i.split()[2] for i in indices]
         client.options(ignore_status=404).indices.delete(
             index=",".join(index_names),
             expand_wildcards="all",


### PR DESCRIPTION
Three changes that address some of the recent failures we've been seeing in integration test runs.

1. The `wipe_indices()` function that we use to reset the Elasticsearch database between tests had a small parsing bug that caused it to fail, and leave some indices in the database. This in turn could cause the next test to fail, either due to being unable to create an index, or more likely to fail in obscure ways when the test results were different because the index existed from before with data from another test.
2. While debugging the first issue, I noticed that some test runs fail to download the YAML tests, so these were being skipped. The error was "too many redirect" from urllib3. I've added more redirects to make sure that these tests are not skipped.
3. There was one of the YAML tests that failed (main and 9.1 branches only). I have added this test to the list of known failures.  