### PR TITLE
Fix ES|QL multi_match() signature

### DIFF
--- a/elasticsearch/esql/functions.py
+++ b/elasticsearch/esql/functions.py
@@ -649,7 +649,7 @@ def min_over_time(field: ExpressionType) -> InstrumentedExpression:
 
 
 def multi_match(
-    query: ExpressionType, fields: ExpressionType, options: ExpressionType = None
+    query: ExpressionType, *fields: ExpressionType, options: ExpressionType = None
 ) -> InstrumentedExpression:
     """Use `MULTI_MATCH` to perform a multi-match query on the specified field.
     The multi_match query builds on the match query to allow multi-field queries.


### PR DESCRIPTION
The signature of the `elasticsearch.esql.functions.multi_match()` function was incorrect. We'll release note that this is a breaking change. The ES|QL query builder was released as a technical preview, exactly to cover for this type of situation.