### PR TITLE
Address typing error for new mypy release

### DIFF
--- a/elasticsearch/dsl/response/aggs.py
+++ b/elasticsearch/dsl/response/aggs.py
@@ -63,7 +63,7 @@ class BucketData(AggResponse[_R]):
         )
 
     def __iter__(self) -> Iterator["Agg"]:  # type: ignore[override]
-        return iter(self.buckets)  # type: ignore[arg-type]
+        return iter(self.buckets)
 
     def __len__(self) -> int:
         return len(self.buckets)


### PR DESCRIPTION
The new release of mypy considers one of the typing exceptions in the DSL module to be unnecessary.