### PR TITLE
Allow running .buildkite scripts on macOS

### DIFF
--- a/.buildkite/functions/imports.sh
+++ b/.buildkite/functions/imports.sh
@@ -43,7 +43,7 @@ if [[ -z $es_node_name ]]; then
 
 fi
 
-  export script_path=$(dirname $(realpath -s $0))
+  export script_path=$(dirname $(realpath $0))
   source $script_path/functions/cleanup.sh
   source $script_path/functions/wait-for-container.sh
   trap "cleanup_trap ${network_name}" EXIT

--- a/.buildkite/run-elasticsearch.sh
+++ b/.buildkite/run-elasticsearch.sh
@@ -21,7 +21,7 @@
 # - Moved ELASTIC_PASSWORD and xpack.security.enabled to the base arguments for "Security On by default"
 # - Use https only when TEST_SUITE is "platinum", when "free" use http
 
-script_path=$(dirname $(realpath -s $0))
+script_path=$(dirname $(realpath $0))
 source $script_path/functions/imports.sh
 set -euo pipefail
 

--- a/.buildkite/run-tests
+++ b/.buildkite/run-tests
@@ -10,7 +10,7 @@ export TEST_SUITE="${TEST_SUITE:=platinum}"
 export PYTHON_VERSION="${PYTHON_VERSION:=3.13}"
 export PYTHON_CONNECTION_CLASS="${PYTHON_CONNECTION_CLASS:=urllib3}"
 
-script_path=$(dirname $(realpath -s $0))
+script_path=$(dirname $(realpath $0))
 source $script_path/functions/imports.sh
 set -euo pipefail
 


### PR DESCRIPTION
realpath -s is a GNU extension, but we don't need to care about symlinks here.