### PR TITLE
Update link in dsl_how_to_guides.md

### DIFF
--- a/docs/reference/dsl_how_to_guides.md
+++ b/docs/reference/dsl_how_to_guides.md
@@ -927,7 +927,7 @@ first = Post.get(id=42)
 first.update(published=True, published_by='me')
 ```
 
-In case you wish to use a `painless` script to perform the update you can pass in the script string as `script` or the `id` of a [stored script](docs-content://explore-analyze/scripting/modules-scripting-using.md#script-stored-scripts) via `script_id`. All additional keyword arguments to the `update` method will then be passed in as parameters of the script. The document will not be updated in place.
+In case you wish to use a `painless` script to perform the update you can pass in the script string as `script` or the `id` of a [stored script](docs-content://explore-analyze/scripting/modules-scripting-using.md) via `script_id`. All additional keyword arguments to the `update` method will then be passed in as parameters of the script. The document will not be updated in place.
 
 ```python
 # retrieve the document


### PR DESCRIPTION
Hi! In the Python client docs I'd like to temporarily divert the anchor link that points to [Store and retrieve scripts](https://www.elastic.co/docs/explore-analyze/scripting/modules-scripting-using#script-stored-scripts) to instead point to the top of that page. 

As part of this [Painless docs overhaul PR](https://github.com/elastic/docs-content/pull/3580), "Store a retrieve scripts" will be broken out as a separate page. Once the overhaul PR is merged, I will open a new PR to fix this link to target the new page.