### PR TITLE
Update link in dsl_how_to_guides.md (pt.2)

### DIFF
--- a/docs/reference/dsl_how_to_guides.md
+++ b/docs/reference/dsl_how_to_guides.md
@@ -927,7 +927,7 @@ first = Post.get(id=42)
 first.update(published=True, published_by='me')
 ```
 
-In case you wish to use a `painless` script to perform the update you can pass in the script string as `script` or the `id` of a [stored script](docs-content://explore-analyze/scripting/modules-scripting-using.md) via `script_id`. All additional keyword arguments to the `update` method will then be passed in as parameters of the script. The document will not be updated in place.
+In case you wish to use a `painless` script to perform the update you can pass in the script string as `script` or the `id` of a [stored script](docs-content://explore-analyze/scripting/modules-scripting-store-and-retrieve.md) via `script_id`. All additional keyword arguments to the `update` method will then be passed in as parameters of the script. The document will not be updated in place.
 
 ```python
 # retrieve the document


### PR DESCRIPTION
This is a follow-up to https://github.com/elastic/elasticsearch-py/pull/3122

I've finished reworking the Painless docs in the "Explore and Analyze" section of the docs, so this fixes the link in the DSL how-to guide to point to the [Store and retrieve scripts](https://www.elastic.co/docs/explore-analyze/scripting/modules-scripting-store-and-retrieve) page in its new location.