### PR TITLE
[8.19] Fix pytest 9 error (#3152)

### DIFF
--- a/test_elasticsearch/test_async/test_server/conftest.py
+++ b/test_elasticsearch/test_async/test_server/conftest.py
@@ -15,6 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
 import pytest_asyncio
 
 import elasticsearch


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix pytest 9 error (#3152)](https://github.com/elastic/elasticsearch-py/pull/3152)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)