### PR TITLE
[DOCS] Edit recent updates for clarity and Elastic style

### DIFF
--- a/docs/reference/dsl_tutorials.md
+++ b/docs/reference/dsl_tutorials.md
@@ -228,7 +228,7 @@ for a in Article.esql_execute(query):
     print(a.title)
 ```
 
-Review the [ES|QL Query Builder section](esql-query-builder.md) to learn more about building ES|QL queries in Python.
+Review the [ES|QL query builder section](esql-query-builder.md) to learn more about building ES|QL queries in Python.
 
 ## Migration from the standard client [_migration_from_the_standard_client]
 

--- a/docs/reference/esql-query-builder.md
+++ b/docs/reference/esql-query-builder.md
@@ -1,10 +1,10 @@
-# ES|QL Query Builder
+# ES|QL query builder
 
 ::::{warning}
 This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 ::::
 
-The ES|QL Query Builder allows you to construct ES|QL queries using Python syntax. Consider the following example:
+The ES|QL query builder allows you to construct ES|QL queries using Python syntax. Consider the following example:
 
 ```python
 >>> from elasticsearch.esql import ESQL

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,9 +7,11 @@ mapped_pages:
 
 # {{es}} Python client [overview]
 
-This documentation covers the [official Python client for {{es}}](https://github.com/elastic/elasticsearch-py). The goal of the Python client is to provide common ground for all {{es}}-related code in Python. The client is designed to be unopinionated and extendable. 
+This documentation covers the [official Python client for {{es}}](https://github.com/elastic/elasticsearch-py). The Python client provides a comprehensive foundation for working with {{es}} in Python. The client is designed to be unopinionated and extensible. 
 
 ## Example [_example]
+
+Here's an example of basic Python client usage:
 
 ::::{tab-set}
 
@@ -67,19 +69,19 @@ async def main():
 
 ## Overview [_overview]
 
-This package is composed of several modules:
+The {{es}} Python client package consists of several modules: the core client, a set of bulk helper functions, an ES|QL query builder, and a DSL module.
 
-### The actual client
+### The core client
 
-This module, sometimes also called the "low-level" client, implements the support for sending requests to {{es}} servers. The client provides access to the entire surface of the {{es}} API.
+This module, also known as the low-level client, enables sending requests to {{es}} servers. The client provides access to the entire surface of the {{es}} API.
 
-* [Getting Started guide](getting-started.md)
-* [Ingest data with Python walkthrough](docs-content://manage-data/ingest/ingesting-data-from-applications/ingest-data-with-python-on-elasticsearch-service.md)
+* [](getting-started.md)
+* [Walkthrough: Ingest data with Python](docs-content://manage-data/ingest/ingesting-data-from-applications/ingest-data-with-python-on-elasticsearch-service.md)
 * [Reference documentation](https://elasticsearch-py.readthedocs.io/en/stable/es_api.html)
 
 #### Features [_features]
 
-The client's features include:
+The core client's features include:
 
 * Translating basic Python data types to and from JSON
 * Configurable automatic discovery of cluster nodes
@@ -91,23 +93,23 @@ The client's features include:
 
 ### Bulk helpers
 
-The bulk helpers are a set of functions that simplify the ingest of large amounts of data through a high-level interface based on Python iterables.
+The bulk helpers simplify ingesting large amounts of data, by providing a high-level interface based on Python iterables.
 
-* [User guide](client-helpers.md#bulk-helpers)
+* [](client-helpers.md#bulk-helpers)
 * [Reference documentation](https://elasticsearch-py.readthedocs.io/en/stable/api_helpers.html)
 
 ### ES|QL query builder
 
-This module offers an idiomatic interface to construct ES|QL queries using Python expressions.
+The ES|QL query builder offers an idiomatic interface for constructing ES|QL queries using Python expressions.
 
-* [User guide](esql-query-builder.md)
+* [](esql-query-builder.md)
 * [Reference documentation](https://elasticsearch-py.readthedocs.io/en/stable/esql.html)
 
 ### DSL module
 
-The DSL module could be thought of as a "high-level" client for {{es}}. It allows applications to manipulate documents and queries using Python classes and objects instead of primitive types such as dictionaries and lists.
+The DSL module can be thought of as a high-level client for {{es}}. It allows applications to manipulate documents and queries using Python classes and objects, instead of primitive types such as dictionaries and lists.
 
-* [User guide](elasticsearch-dsl.md)
+* [](elasticsearch-dsl.md)
 * [Reference documentation](https://elasticsearch-py.readthedocs.io/en/stable/dsl.html)
 
 ## Compatibility [_compatibility]


### PR DESCRIPTION
I was on PTO when #3158 flew by, so offering some suggestions in this PR.

# Preview
[docs/reference/index.md](https://docs-v3-preview.elastic.dev/elastic/elasticsearch-py/pull/3194/reference)

# Summary of changes
- Changed values of `from_` and `size` to integers rather than strings
- Various editorial improvements for clarity, readability, and consistency with Elastic style

(Does not include any changes to the Compatibility section because I have an in-progress PR for that section)