### PR TITLE
Bulk helpers: immediatly emit a chunk when it is ready

### DIFF
--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -97,8 +97,7 @@ async def _chunk_actions(
     data: _TYPE_BULK_ACTION_BODY
     if not flush_after_seconds:
         async for action, data in actions:
-            ret = chunker.feed(action, data)
-            if ret:
+            for ret in chunker.feed(action, data):
                 yield ret
     else:
         sender, receiver = create_memory_object_stream[
@@ -128,8 +127,7 @@ async def _chunk_actions(
 
                 if action is BulkMeta.done:
                     break
-                ret = chunker.feed(action, data)
-                if ret:
+                for ret in chunker.feed(action, data):
                     yield ret
 
     ret = chunker.flush()


### PR DESCRIPTION
Chunker was withholding the last batch until a next action would arrive, even if the batch was ready. 
This behavior would cause problem in a streaming environment (such as when using `helpers.streaming_bulk`) were it cannot be predicted when there will be a "next action" available.

Closes #3206 