### PR TITLE
Use relative imports to fix elasticsearch9 package imports

### DIFF
--- a/elasticsearch/_async/client/esql.py
+++ b/elasticsearch/_async/client/esql.py
@@ -29,7 +29,7 @@ from .utils import (
 )
 
 if t.TYPE_CHECKING:
-    from elasticsearch.esql import ESQLBase
+    from ...esql import ESQLBase
 
 
 class EsqlClient(NamespacedClient):

--- a/elasticsearch/_sync/client/esql.py
+++ b/elasticsearch/_sync/client/esql.py
@@ -29,7 +29,7 @@ from .utils import (
 )
 
 if t.TYPE_CHECKING:
-    from elasticsearch.esql import ESQLBase
+    from ...esql import ESQLBase
 
 
 class EsqlClient(NamespacedClient):

--- a/elasticsearch/dsl/_async/document.py
+++ b/elasticsearch/dsl/_async/document.py
@@ -31,9 +31,8 @@ from typing import (
 
 from typing_extensions import Self, dataclass_transform
 
-from elasticsearch.exceptions import NotFoundError, RequestError
-from elasticsearch.helpers import async_bulk
-
+from ...exceptions import NotFoundError, RequestError
+from ...helpers import async_bulk
 from .._async.index import AsyncIndex
 from ..async_connections import get_connection
 from ..document_base import DocumentBase, DocumentMeta, mapped_field
@@ -42,8 +41,8 @@ from ..utils import DOC_META_FIELDS, META_FIELDS, AsyncUsingType, merge
 from .search import AsyncSearch
 
 if TYPE_CHECKING:
-    from elasticsearch import AsyncElasticsearch
-    from elasticsearch.esql.esql import ESQLBase
+    from ... import AsyncElasticsearch
+    from ...esql.esql import ESQLBase
 
 
 class AsyncIndexMeta(DocumentMeta):

--- a/elasticsearch/dsl/_async/index.py
+++ b/elasticsearch/dsl/_async/index.py
@@ -30,7 +30,7 @@ from .update_by_query import AsyncUpdateByQuery
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
 
-    from elasticsearch import AsyncElasticsearch
+    from ... import AsyncElasticsearch
 
 
 class AsyncIndexTemplate:

--- a/elasticsearch/dsl/_async/search.py
+++ b/elasticsearch/dsl/_async/search.py
@@ -29,9 +29,8 @@ from typing import (
 
 from typing_extensions import Self
 
-from elasticsearch.exceptions import ApiError
-from elasticsearch.helpers import async_scan
-
+from ...exceptions import ApiError
+from ...helpers import async_scan
 from ..async_connections import get_connection
 from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase

--- a/elasticsearch/dsl/_sync/document.py
+++ b/elasticsearch/dsl/_sync/document.py
@@ -31,9 +31,8 @@ from typing import (
 
 from typing_extensions import Self, dataclass_transform
 
-from elasticsearch.exceptions import NotFoundError, RequestError
-from elasticsearch.helpers import bulk
-
+from ...exceptions import NotFoundError, RequestError
+from ...helpers import bulk
 from .._sync.index import Index
 from ..connections import get_connection
 from ..document_base import DocumentBase, DocumentMeta, mapped_field
@@ -42,8 +41,8 @@ from ..utils import DOC_META_FIELDS, META_FIELDS, UsingType, merge
 from .search import Search
 
 if TYPE_CHECKING:
-    from elasticsearch import Elasticsearch
-    from elasticsearch.esql.esql import ESQLBase
+    from ... import Elasticsearch
+    from ...esql.esql import ESQLBase
 
 
 class IndexMeta(DocumentMeta):

--- a/elasticsearch/dsl/_sync/index.py
+++ b/elasticsearch/dsl/_sync/index.py
@@ -30,7 +30,7 @@ from .update_by_query import UpdateByQuery
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
 
-    from elasticsearch import Elasticsearch
+    from ... import Elasticsearch
 
 
 class IndexTemplate:

--- a/elasticsearch/dsl/_sync/search.py
+++ b/elasticsearch/dsl/_sync/search.py
@@ -28,9 +28,8 @@ from typing import (
 
 from typing_extensions import Self
 
-from elasticsearch.exceptions import ApiError
-from elasticsearch.helpers import scan
-
+from ...exceptions import ApiError
+from ...helpers import scan
 from ..connections import get_connection
 from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase

--- a/elasticsearch/dsl/async_connections.py
+++ b/elasticsearch/dsl/async_connections.py
@@ -17,8 +17,7 @@
 
 from typing import Type
 
-from elasticsearch import AsyncElasticsearch
-
+from .. import AsyncElasticsearch
 from .connections import Connections
 
 

--- a/elasticsearch/dsl/connections.py
+++ b/elasticsearch/dsl/connections.py
@@ -17,8 +17,7 @@
 
 from typing import Any, Dict, Generic, Type, TypeVar, Union
 
-from elasticsearch import Elasticsearch, __versionstr__
-
+from .. import Elasticsearch, __versionstr__
 from .serializer import serializer
 
 _T = TypeVar("_T")

--- a/elasticsearch/dsl/pydantic.py
+++ b/elasticsearch/dsl/pydantic.py
@@ -20,7 +20,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import Annotated, Self, dataclass_transform
 
-from elasticsearch import dsl
+from .. import dsl
 
 
 class ESMeta(BaseModel):

--- a/elasticsearch/dsl/serializer.py
+++ b/elasticsearch/dsl/serializer.py
@@ -17,8 +17,7 @@
 
 from typing import Any
 
-from elasticsearch.serializer import JSONSerializer
-
+from ..serializer import JSONSerializer
 from .utils import AttrList
 
 

--- a/elasticsearch/dsl/utils.py
+++ b/elasticsearch/dsl/utils.py
@@ -44,8 +44,7 @@ from .exceptions import UnknownDslObject, ValidationException
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
 
-    from elasticsearch import AsyncElasticsearch, Elasticsearch
-
+    from .. import AsyncElasticsearch, Elasticsearch
     from .document_base import DocumentOptions
     from .field import Field
     from .index_base import IndexBase

--- a/elasticsearch/esql/functions.py
+++ b/elasticsearch/esql/functions.py
@@ -18,8 +18,8 @@
 import json
 from typing import Any
 
-from elasticsearch.dsl.document_base import InstrumentedExpression
-from elasticsearch.esql.esql import ESQLBase, ExpressionType
+from ..dsl.document_base import InstrumentedExpression
+from ..esql.esql import ESQLBase, ExpressionType
 
 
 def _render(v: Any) -> str:

--- a/elasticsearch/helpers/vectorstore/__init__.py
+++ b/elasticsearch/helpers/vectorstore/__init__.py
@@ -15,31 +15,31 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from elasticsearch.helpers.vectorstore._async.embedding_service import (
+from ...helpers.vectorstore._async.embedding_service import (
     AsyncElasticsearchEmbeddings,
     AsyncEmbeddingService,
 )
-from elasticsearch.helpers.vectorstore._async.strategies import (
+from ...helpers.vectorstore._async.strategies import (
     AsyncBM25Strategy,
     AsyncDenseVectorScriptScoreStrategy,
     AsyncDenseVectorStrategy,
     AsyncRetrievalStrategy,
     AsyncSparseVectorStrategy,
 )
-from elasticsearch.helpers.vectorstore._async.vectorstore import AsyncVectorStore
-from elasticsearch.helpers.vectorstore._sync.embedding_service import (
+from ...helpers.vectorstore._async.vectorstore import AsyncVectorStore
+from ...helpers.vectorstore._sync.embedding_service import (
     ElasticsearchEmbeddings,
     EmbeddingService,
 )
-from elasticsearch.helpers.vectorstore._sync.strategies import (
+from ...helpers.vectorstore._sync.strategies import (
     BM25Strategy,
     DenseVectorScriptScoreStrategy,
     DenseVectorStrategy,
     RetrievalStrategy,
     SparseVectorStrategy,
 )
-from elasticsearch.helpers.vectorstore._sync.vectorstore import VectorStore
-from elasticsearch.helpers.vectorstore._utils import DistanceMetric
+from ...helpers.vectorstore._sync.vectorstore import VectorStore
+from ...helpers.vectorstore._utils import DistanceMetric
 
 __all__ = [
     "AsyncBM25Strategy",

--- a/elasticsearch/helpers/vectorstore/_async/_utils.py
+++ b/elasticsearch/helpers/vectorstore/_async/_utils.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from elasticsearch import AsyncElasticsearch, BadRequestError, NotFoundError
+from .... import AsyncElasticsearch, BadRequestError, NotFoundError
 
 
 async def model_must_be_deployed(client: AsyncElasticsearch, model_id: str) -> None:

--- a/elasticsearch/helpers/vectorstore/_async/embedding_service.py
+++ b/elasticsearch/helpers/vectorstore/_async/embedding_service.py
@@ -18,8 +18,8 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from elasticsearch import AsyncElasticsearch
-from elasticsearch._version import __versionstr__ as lib_version
+from .... import AsyncElasticsearch
+from ...._version import __versionstr__ as lib_version
 
 
 class AsyncEmbeddingService(ABC):

--- a/elasticsearch/helpers/vectorstore/_async/strategies.py
+++ b/elasticsearch/helpers/vectorstore/_async/strategies.py
@@ -18,9 +18,9 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
-from elasticsearch import AsyncElasticsearch
-from elasticsearch.helpers.vectorstore._async._utils import model_must_be_deployed
-from elasticsearch.helpers.vectorstore._utils import DistanceMetric
+from .... import AsyncElasticsearch
+from ....helpers.vectorstore._async._utils import model_must_be_deployed
+from ....helpers.vectorstore._utils import DistanceMetric
 
 
 class AsyncRetrievalStrategy(ABC):

--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -19,14 +19,14 @@ import logging
 import uuid
 from typing import Any, Callable, Dict, List, Optional
 
-from elasticsearch import AsyncElasticsearch
-from elasticsearch._version import __versionstr__ as lib_version
-from elasticsearch.helpers import BulkIndexError, async_bulk
-from elasticsearch.helpers.vectorstore import (
+from .... import AsyncElasticsearch
+from ...._version import __versionstr__ as lib_version
+from ....helpers import BulkIndexError, async_bulk
+from ....helpers.vectorstore import (
     AsyncEmbeddingService,
     AsyncRetrievalStrategy,
 )
-from elasticsearch.helpers.vectorstore._utils import maximal_marginal_relevance
+from ....helpers.vectorstore._utils import maximal_marginal_relevance
 
 logger = logging.getLogger(__name__)
 

--- a/elasticsearch/helpers/vectorstore/_sync/_utils.py
+++ b/elasticsearch/helpers/vectorstore/_sync/_utils.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from elasticsearch import BadRequestError, Elasticsearch, NotFoundError
+from .... import BadRequestError, Elasticsearch, NotFoundError
 
 
 def model_must_be_deployed(client: Elasticsearch, model_id: str) -> None:

--- a/elasticsearch/helpers/vectorstore/_sync/embedding_service.py
+++ b/elasticsearch/helpers/vectorstore/_sync/embedding_service.py
@@ -18,8 +18,8 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from elasticsearch import Elasticsearch
-from elasticsearch._version import __versionstr__ as lib_version
+from .... import Elasticsearch
+from ...._version import __versionstr__ as lib_version
 
 
 class EmbeddingService(ABC):

--- a/elasticsearch/helpers/vectorstore/_sync/strategies.py
+++ b/elasticsearch/helpers/vectorstore/_sync/strategies.py
@@ -18,9 +18,9 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
-from elasticsearch import Elasticsearch
-from elasticsearch.helpers.vectorstore._sync._utils import model_must_be_deployed
-from elasticsearch.helpers.vectorstore._utils import DistanceMetric
+from .... import Elasticsearch
+from ....helpers.vectorstore._sync._utils import model_must_be_deployed
+from ....helpers.vectorstore._utils import DistanceMetric
 
 
 class RetrievalStrategy(ABC):

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -19,14 +19,14 @@ import logging
 import uuid
 from typing import Any, Callable, Dict, List, Optional
 
-from elasticsearch import Elasticsearch
-from elasticsearch._version import __versionstr__ as lib_version
-from elasticsearch.helpers import BulkIndexError, bulk
-from elasticsearch.helpers.vectorstore import (
+from .... import Elasticsearch
+from ...._version import __versionstr__ as lib_version
+from ....helpers import BulkIndexError, bulk
+from ....helpers.vectorstore import (
     EmbeddingService,
     RetrievalStrategy,
 )
-from elasticsearch.helpers.vectorstore._utils import maximal_marginal_relevance
+from ....helpers.vectorstore._utils import maximal_marginal_relevance
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #3224

There were many absolute imports, which break when using the `elasticsearch8` or `elasticsearch9` packages. This PR switches all the absolute imports I found to relative.