### PR TITLE
Fix recursive errors generated in transport test

### DIFF
--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -43,7 +43,7 @@ from elasticsearch.exceptions import (
 class DummyNode(BaseNode):
     def __init__(self, config: NodeConfig):
         self.resp_status = config._extras.pop("status", 200)
-        self.resp_error = config._extras.pop("exception", None)
+        self.resp_error = config._extras.pop("exception_factory", None)
         self.resp_data = config._extras.pop("data", b"{}")
         self.resp_headers = config._extras.pop(
             "headers", {"X-elastic-product": "Elasticsearch"}
@@ -55,7 +55,7 @@ class DummyNode(BaseNode):
     def perform_request(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         if self.resp_error:
-            raise self.resp_error
+            raise self.resp_error()
         return NodeApiResponse(
             ApiResponseMeta(
                 status=self.resp_status,
@@ -310,7 +310,9 @@ class TestTransport:
                     "http",
                     "localhost",
                     9200,
-                    _extras={"exception": ConnectionError("abandon ship!")},
+                    _extras={
+                        "exception_factory": lambda: ConnectionError("abandon ship!")
+                    },
                 )
             ],
             node_class=DummyNode,
@@ -335,13 +337,17 @@ class TestTransport:
                     "http",
                     "localhost",
                     9200,
-                    _extras={"exception": ConnectionError("abandon ship!")},
+                    _extras={
+                        "exception_factory": lambda: ConnectionError("abandon ship!")
+                    },
                 ),
                 NodeConfig(
                     "http",
                     "localhost",
                     9201,
-                    _extras={"exception": ConnectionError("abandon ship!")},
+                    _extras={
+                        "exception_factory": lambda: ConnectionError("abandon ship!")
+                    },
                 ),
             ],
             node_class=DummyNode,


### PR DESCRIPTION
We have a few tests that use a dummy node instance that raises errors on purpose. Unfortunately this caused errors to have recursive references to themselves when the node is asked to retry an operation. This change replaces the static exception installed in the dummy node with an exception factory.