### PR TITLE
Stop using pytz

### DIFF
--- a/test_elasticsearch/test_dsl/test_integration/_async/test_document.py
+++ b/test_elasticsearch/test_dsl/test_integration/_async/test_document.py
@@ -437,8 +437,7 @@ async def test_get_with_tz_date(async_data_client: AsyncElasticsearch) -> None:
 
     tzinfo = ZoneInfo("Europe/Prague")
     assert (
-        tzinfo.localize(datetime(2014, 5, 2, 13, 47, 19, 123000))
-        == first_commit.authored_date
+        datetime(2014, 5, 2, 13, 47, 19, 123000, tzinfo) == first_commit.authored_date
     )
 
 
@@ -450,9 +449,7 @@ async def test_save_with_tz_date(async_data_client: AsyncElasticsearch) -> None:
     )
     assert first_commit is not None
 
-    first_commit.committed_date = tzinfo.localize(
-        datetime(2014, 5, 2, 13, 47, 19, 123456)
-    )
+    first_commit.committed_date = datetime(2014, 5, 2, 13, 47, 19, 123456, tzinfo)
     await first_commit.save()
 
     first_commit = await Commit.get(
@@ -461,8 +458,7 @@ async def test_save_with_tz_date(async_data_client: AsyncElasticsearch) -> None:
     assert first_commit is not None
 
     assert (
-        tzinfo.localize(datetime(2014, 5, 2, 13, 47, 19, 123456))
-        == first_commit.committed_date
+        datetime(2014, 5, 2, 13, 47, 19, 123456, tzinfo) == first_commit.committed_date
     )
 
 

--- a/test_elasticsearch/test_dsl/test_integration/_sync/test_document.py
+++ b/test_elasticsearch/test_dsl/test_integration/_sync/test_document.py
@@ -433,8 +433,7 @@ def test_get_with_tz_date(data_client: Elasticsearch) -> None:
 
     tzinfo = ZoneInfo("Europe/Prague")
     assert (
-        tzinfo.localize(datetime(2014, 5, 2, 13, 47, 19, 123000))
-        == first_commit.authored_date
+        datetime(2014, 5, 2, 13, 47, 19, 123000, tzinfo) == first_commit.authored_date
     )
 
 
@@ -446,9 +445,7 @@ def test_save_with_tz_date(data_client: Elasticsearch) -> None:
     )
     assert first_commit is not None
 
-    first_commit.committed_date = tzinfo.localize(
-        datetime(2014, 5, 2, 13, 47, 19, 123456)
-    )
+    first_commit.committed_date = datetime(2014, 5, 2, 13, 47, 19, 123456, tzinfo)
     first_commit.save()
 
     first_commit = Commit.get(
@@ -457,8 +454,7 @@ def test_save_with_tz_date(data_client: Elasticsearch) -> None:
     assert first_commit is not None
 
     assert (
-        tzinfo.localize(datetime(2014, 5, 2, 13, 47, 19, 123456))
-        == first_commit.committed_date
+        datetime(2014, 5, 2, 13, 47, 19, 123456, tzinfo) == first_commit.committed_date
     )
 
 


### PR DESCRIPTION
It never was a test dependency, and the same information can be obtained from the Python standard library.

Looks like one of our dependency recently stopped using it, which is breaking integration tests: https://buildkite.com/elastic/elasticsearch-py-integration-tests/builds/6491#019be526-55e1-4d20-9f34-7eff3638e4b5.