### PR TITLE
Send Elastic-Api-Version header when talking to serverless (#3329)

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -144,6 +144,7 @@ class AsyncElasticsearch(BaseClient):
         basic_auth: t.Optional[t.Union[str, t.Tuple[str, str]]] = None,
         bearer_auth: t.Optional[str] = None,
         opaque_id: t.Optional[str] = None,
+        server_mode: str = "stack",
         # Node
         headers: t.Union[DefaultType, t.Mapping[str, str]] = DEFAULT,
         connections_per_node: t.Union[DefaultType, int] = DEFAULT,
@@ -188,6 +189,11 @@ class AsyncElasticsearch(BaseClient):
         if hosts is None and cloud_id is None and _transport is None:
             raise ValueError("Either 'hosts' or 'cloud_id' must be specified")
 
+        if server_mode not in ("stack", "serverless"):
+            raise ValueError(
+                "'server_mode' must be 'stack' or 'serverless', " f"not {server_mode!r}"
+            )
+
         if serializer is not None:
             if serializers is not DEFAULT:
                 raise ValueError(
@@ -214,6 +220,13 @@ class AsyncElasticsearch(BaseClient):
         ):
             raise ValueError(
                 "Sniffing should not be enabled when connecting to Elastic Cloud"
+            )
+
+        if server_mode == "serverless" and any(
+            x is not DEFAULT and x is not None for x in sniffing_options
+        ):
+            raise ValueError(
+                "Sniffing should not be enabled when 'server_mode' is 'serverless'"
             )
 
         sniff_callback = None
@@ -328,6 +341,8 @@ class AsyncElasticsearch(BaseClient):
 
         else:
             super().__init__(_transport)
+
+        self._is_serverless = server_mode == "serverless"
 
         if headers is not DEFAULT and headers is not None:
             self._headers.update(headers)
@@ -474,6 +489,8 @@ class AsyncElasticsearch(BaseClient):
             client._retry_on_timeout = retry_on_timeout
         else:
             client._retry_on_timeout = self._retry_on_timeout
+
+        client._is_serverless = self._is_serverless
 
         return client
 

--- a/elasticsearch/_async/client/_base.py
+++ b/elasticsearch/_async/client/_base.py
@@ -46,7 +46,7 @@ from elastic_transport import (
 from elastic_transport.client_utils import DEFAULT, DefaultType
 
 from ..._otel import OpenTelemetry
-from ..._version import __versionstr__
+from ..._version import _SERVERLESS_API_VERSION, __versionstr__
 from ...compat import warn_stacklevel
 from ...exceptions import (
     HTTP_EXCEPTIONS,
@@ -245,6 +245,7 @@ class BaseClient:
         self._max_retries: Union[DefaultType, int] = DEFAULT
         self._retry_on_timeout: Union[DefaultType, bool] = DEFAULT
         self._retry_on_status: Union[DefaultType, Collection[int]] = DEFAULT
+        self._is_serverless = False
         self._verified_elasticsearch = False
         self._otel = OpenTelemetry()
 
@@ -295,17 +296,21 @@ class BaseClient:
         else:
             request_headers = self._headers
 
-        def mimetype_header_to_compat(header: str) -> None:
-            # Converts all parts of a Accept/Content-Type headers
-            # from application/X -> application/vnd.elasticsearch+X
-            mimetype = request_headers.get(header, None)
-            if mimetype:
-                request_headers[header] = _COMPAT_MIMETYPE_RE.sub(
-                    _COMPAT_MIMETYPE_SUB, mimetype
-                )
+        if self._is_serverless:
+            request_headers["elastic-api-version"] = _SERVERLESS_API_VERSION
+        else:
 
-        mimetype_header_to_compat("Accept")
-        mimetype_header_to_compat("Content-Type")
+            def mimetype_header_to_compat(header: str) -> None:
+                # Converts all parts of a Accept/Content-Type headers
+                # from application/X -> application/vnd.elasticsearch+X
+                mimetype = request_headers.get(header, None)
+                if mimetype:
+                    request_headers[header] = _COMPAT_MIMETYPE_RE.sub(
+                        _COMPAT_MIMETYPE_SUB, mimetype
+                    )
+
+            mimetype_header_to_compat("Accept")
+            mimetype_header_to_compat("Content-Type")
 
         if params:
             target = f"{path}?{_quote_query(params)}"
@@ -405,6 +410,7 @@ class NamespacedClient(BaseClient):
     def __init__(self, client: "BaseClient") -> None:
         self._client = client
         super().__init__(self._client.transport)
+        self._is_serverless = self._client._is_serverless
 
     async def perform_request(
         self,

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -144,6 +144,7 @@ class Elasticsearch(BaseClient):
         basic_auth: t.Optional[t.Union[str, t.Tuple[str, str]]] = None,
         bearer_auth: t.Optional[str] = None,
         opaque_id: t.Optional[str] = None,
+        server_mode: str = "stack",
         # Node
         headers: t.Union[DefaultType, t.Mapping[str, str]] = DEFAULT,
         connections_per_node: t.Union[DefaultType, int] = DEFAULT,
@@ -188,6 +189,11 @@ class Elasticsearch(BaseClient):
         if hosts is None and cloud_id is None and _transport is None:
             raise ValueError("Either 'hosts' or 'cloud_id' must be specified")
 
+        if server_mode not in ("stack", "serverless"):
+            raise ValueError(
+                "'server_mode' must be 'stack' or 'serverless', " f"not {server_mode!r}"
+            )
+
         if serializer is not None:
             if serializers is not DEFAULT:
                 raise ValueError(
@@ -214,6 +220,13 @@ class Elasticsearch(BaseClient):
         ):
             raise ValueError(
                 "Sniffing should not be enabled when connecting to Elastic Cloud"
+            )
+
+        if server_mode == "serverless" and any(
+            x is not DEFAULT and x is not None for x in sniffing_options
+        ):
+            raise ValueError(
+                "Sniffing should not be enabled when 'server_mode' is 'serverless'"
             )
 
         sniff_callback = None
@@ -328,6 +341,8 @@ class Elasticsearch(BaseClient):
 
         else:
             super().__init__(_transport)
+
+        self._is_serverless = server_mode == "serverless"
 
         if headers is not DEFAULT and headers is not None:
             self._headers.update(headers)
@@ -474,6 +489,8 @@ class Elasticsearch(BaseClient):
             client._retry_on_timeout = retry_on_timeout
         else:
             client._retry_on_timeout = self._retry_on_timeout
+
+        client._is_serverless = self._is_serverless
 
         return client
 

--- a/elasticsearch/_version.py
+++ b/elasticsearch/_version.py
@@ -17,3 +17,4 @@
 
 __versionstr__ = "9.3.0"
 __es_specification_commit__ = "e7c19dcd3aa9fd34b15509f0453af0e4756ea080"
+_SERVERLESS_API_VERSION = "2023-10-31"

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -32,6 +32,7 @@ from elastic_transport._node import NodeApiResponse
 from elastic_transport.client_utils import DEFAULT
 
 from elasticsearch import Elasticsearch, __versionstr__
+from elasticsearch._version import _SERVERLESS_API_VERSION
 from elasticsearch.exceptions import (
     ApiError,
     ConnectionError,
@@ -681,3 +682,99 @@ def test_warning_header(headers):
         str(w[0].message)
         == "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
     )
+
+
+class TestServerMode:
+    def test_default_stack_mode_sends_compat_headers(self):
+        client = Elasticsearch(
+            "http://localhost:9200", meta_header=False, node_class=DummyNode
+        )
+        client.info()
+
+        calls = client.transport.node_pool.get().calls
+        assert 1 == len(calls)
+        headers = calls[0][1]["headers"]
+        compat_version = __versionstr__.partition(".")[0]
+        assert headers["accept"] == (
+            f"application/vnd.elasticsearch+json; compatible-with={compat_version}"
+        )
+        assert "elastic-api-version" not in headers
+
+    def test_serverless_mode_sends_api_version_header_on_get(self):
+        client = Elasticsearch(
+            "http://localhost:9200",
+            meta_header=False,
+            node_class=DummyNode,
+            server_mode="serverless",
+        )
+        client.info()
+
+        calls = client.transport.node_pool.get().calls
+        assert 1 == len(calls)
+        headers = calls[0][1]["headers"]
+        assert headers["elastic-api-version"] == _SERVERLESS_API_VERSION
+        assert headers["accept"] == "application/json"
+
+    def test_serverless_mode_sends_plain_headers_on_post(self):
+        client = Elasticsearch(
+            "http://localhost:9200",
+            meta_header=False,
+            node_class=DummyNode,
+            server_mode="serverless",
+        )
+        client.search(query={"match_all": {}})
+
+        calls = client.transport.node_pool.get().calls
+        assert 1 == len(calls)
+        headers = calls[0][1]["headers"]
+        assert headers["elastic-api-version"] == _SERVERLESS_API_VERSION
+        assert headers["accept"] == "application/json"
+        assert headers["content-type"] == "application/json"
+        assert "compatible-with" not in headers.get("accept", "")
+        assert "compatible-with" not in headers.get("content-type", "")
+
+    def test_invalid_server_mode_raises_error(self):
+        with pytest.raises(ValueError, match="'server_mode' must be"):
+            Elasticsearch(
+                "http://localhost:9200",
+                node_class=DummyNode,
+                server_mode="invalid",
+            )
+
+    def test_serverless_mode_with_sniffing_raises_error(self):
+        with pytest.raises(
+            ValueError,
+            match="Sniffing should not be enabled when 'server_mode' is 'serverless'",
+        ):
+            Elasticsearch(
+                "http://localhost:9200",
+                node_class=DummyNode,
+                server_mode="serverless",
+                sniff_on_start=True,
+            )
+
+    def test_serverless_mode_preserved_in_options(self):
+        client = Elasticsearch(
+            "http://localhost:9200",
+            meta_header=False,
+            node_class=DummyNode,
+            server_mode="serverless",
+        )
+        client2 = client.options(request_timeout=30)
+        client2.info()
+
+        calls = client2.transport.node_pool.get().calls
+        assert 1 == len(calls)
+        headers = calls[0][1]["headers"]
+        assert headers["elastic-api-version"] == _SERVERLESS_API_VERSION
+        assert "compatible-with" not in headers.get("accept", "")
+
+    def test_serverless_mode_inherited_by_namespaces(self):
+        client = Elasticsearch(
+            "http://localhost:9200",
+            meta_header=False,
+            node_class=DummyNode,
+            server_mode="serverless",
+        )
+        assert client._is_serverless is True
+        assert client.indices._is_serverless is True


### PR DESCRIPTION
* serverless header

* lint

* lint

* merge conflict

* lint

(cherry picked from commit aaa012dac9e6fb7d4e3a3e206a25f7bbe6dc7269)