### PR TITLE
Revert default dense vector options

### DIFF
--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -54,7 +54,7 @@ try:
 
     __all__.append("PyArrowSerializer")
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class JsonSerializer(_JsonSerializer):

--- a/test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py
@@ -1065,14 +1065,9 @@ class TestAsyncVectorStore:
             "dims": 10,
             "index": True,
             "index_options": {
-                "bits": 4,
-                "cluster_size": 384,
-                "default_visit_percentage": 0.0,
-                "flat_index_threshold": -1,
-                "rescore_vector": {
-                    "oversample": 3.0,
-                },
-                "type": "bbq_disk",
+                "ef_construction": 100,
+                "m": 16,
+                "type": "int8_hnsw",
             },
             "similarity": "cosine",
         }

--- a/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
@@ -1045,14 +1045,9 @@ class TestVectorStore:
             "dims": 10,
             "index": True,
             "index_options": {
-                "bits": 4,
-                "cluster_size": 384,
-                "default_visit_percentage": 0.0,
-                "flat_index_threshold": -1,
-                "rescore_vector": {
-                    "oversample": 3.0,
-                },
-                "type": "bbq_disk",
+                "ef_construction": 100,
+                "m": 16,
+                "type": "int8_hnsw",
             },
             "similarity": "cosine",
         }


### PR DESCRIPTION
As with #3378, more changes have been made upstream, requiring the default options for dense vectors to be updated in the test suite.