### PR TITLE
Fix main docs location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <br/>
   <a href="https://github.com/elastic/elasticsearch-py/actions/workflows/ci.yml?query=workflow%3ACI"><img alt="Build Status on GitHub" src="https://github.com/elastic/elasticsearch-py/workflows/CI/badge.svg" /></a>
   <a href="https://buildkite.com/elastic/elasticsearch-py-integration-tests"><img alt="Buildkite Status on Buildkite" src="https://badge.buildkite.com/68e22afcb2ea8f6dcc20834e3a5b5ab4431beee33d3bd751f3.svg?branch=main" /></a>
-  <a href="https://elasticsearch-py.readthedocs.io"><img alt="Documentation Status" src="https://readthedocs.org/projects/elasticsearch-py/badge/?version=latest" /></a><br>
+  <a href="https://www.elastic.co/docs/reference/elasticsearch/clients/python"><img alt="Documentation Status" src="https://readthedocs.org/projects/elasticsearch-py/badge/?version=latest" /></a><br>
 </p>
 
 *The official Python client for Elasticsearch.*


### PR DESCRIPTION
Using the ReadTheDocs badge isn't appropriate, but I wanted to share that finding the new DSL docs isn't easy today:

 * Searching "Elasticsearch DSL" pointed me to https://elasticsearch-dsl.readthedocs.io/en/latest/ (other searches get me to the elastic.co docs, but that's not the one I did)
 * This links to https://github.com/elastic/elasticsearch-py first (I was too lazy to read everything and notice the correct links)
 * This contains "docs" badge pointing to https://elasticsearch-py.readthedocs.io/en/v9.1.3/
 * The DSL docs at https://elasticsearch-py.readthedocs.io/en/v9.1.3/dsl.html don't link to the narrative docs.

Suggestions:

 * GitHub doc link should not link to API docs
 * DSL API docs should link to elastic.co docs
 * DSL API should be named "Elasticsearch DSL API", as was done to "Elasticsearch API". This will clarify the scope at the Google search level.