### PR TITLE
Validate ES|QL source index names

### DIFF
--- a/elasticsearch/esql/esql.py
+++ b/elasticsearch/esql/esql.py
@@ -135,7 +135,10 @@ class ESQLBase(ABC):
 
     @staticmethod
     def _format_index(index: IndexType) -> str:
-        return index._index._name if hasattr(index, "_index") else str(index)
+        s = index._index._name if hasattr(index, "_index") else str(index)
+        if re.search(r"[\s,|;`]", s):
+            raise ValueError("ES|QL index names cannot contain query delimiters")
+        return s
 
     @staticmethod
     def _format_id(id: FieldType, allow_patterns: bool = False) -> str:

--- a/test_elasticsearch/test_esql.py
+++ b/test_elasticsearch/test_esql.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch.dsl import E
 from elasticsearch.esql import ESQL, and_, functions, not_, or_
 
@@ -37,6 +39,23 @@ def test_from():
 
     query = ESQL.from_("employees").metadata("_id")
     assert query.render() == "FROM employees METADATA _id"
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        'tenant-a | EVAL tenant_id = "victim"',
+        "tenant-a, other-tenant",
+        "tenant-a;\nROW secret = true",
+        "tenant-a `escaped`",
+    ],
+)
+def test_from_rejects_query_delimiters_in_index_names(index):
+    with pytest.raises(ValueError, match="query delimiters"):
+        ESQL.from_(index).where('tenant_id == "victim"').render()
+
+    with pytest.raises(ValueError, match="query delimiters"):
+        ESQL.ts(index).render()
 
 
 def test_row():
@@ -598,6 +617,9 @@ def test_lookup_join():
 | WHERE emp_no >= 10091 AND emp_no < 10094
 | LOOKUP JOIN languages_lookup ON language_code"""
     )
+
+    with pytest.raises(ValueError, match="query delimiters"):
+        ESQL.from_("events").lookup_join("tenant-lookup | LIMIT 1").on("id").render()
 
 
 def test_metrics_info():


### PR DESCRIPTION
Summary
reject ES|QL query delimiters in source index names before rendering
cover FROM, TS, and LOOKUP JOIN source index arguments
add regression tests for pipeline, comma, semicolon/newline, and backtick inputs
Test
python -m pytest test_elasticsearch\test_esql.py -q
Result: 43 passed.