### PR TITLE
Validate request_timeout type in client constructor and options() (Fixes #3423)

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -333,6 +333,12 @@ class AsyncElasticsearch(BaseClient):
             super().__init__(_transport)
 
             # These are set per-request so are stored separately.
+            if request_timeout is not DEFAULT and not isinstance(
+                request_timeout, (int, float, type(None))
+            ):
+                raise TypeError(
+                    "'request_timeout' must be of type 'int', 'float', or 'None'"
+                )
             self._request_timeout = request_timeout
             self._max_retries = max_retries
             self._retry_on_timeout = retry_on_timeout
@@ -460,6 +466,10 @@ class AsyncElasticsearch(BaseClient):
             client._headers = self._headers.copy()
 
         if request_timeout is not DEFAULT:
+            if not isinstance(request_timeout, (int, float, type(None))):
+                raise TypeError(
+                    "'request_timeout' must be of type 'int', 'float', or 'None'"
+                )
             client._request_timeout = request_timeout
         else:
             client._request_timeout = self._request_timeout

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -333,6 +333,12 @@ class Elasticsearch(BaseClient):
             super().__init__(_transport)
 
             # These are set per-request so are stored separately.
+            if request_timeout is not DEFAULT and not isinstance(
+                request_timeout, (int, float, type(None))
+            ):
+                raise TypeError(
+                    "'request_timeout' must be of type 'int', 'float', or 'None'"
+                )
             self._request_timeout = request_timeout
             self._max_retries = max_retries
             self._retry_on_timeout = retry_on_timeout
@@ -460,6 +466,10 @@ class Elasticsearch(BaseClient):
             client._headers = self._headers.copy()
 
         if request_timeout is not DEFAULT:
+            if not isinstance(request_timeout, (int, float, type(None))):
+                raise TypeError(
+                    "'request_timeout' must be of type 'int', 'float', or 'None'"
+                )
             client._request_timeout = request_timeout
         else:
             client._request_timeout = self._request_timeout

--- a/test_elasticsearch/test_client/test_options.py
+++ b/test_elasticsearch/test_client/test_options.py
@@ -496,6 +496,37 @@ class TestOptions(DummyTransportTestCase):
             "retry_on_timeout": True,
         }
 
+    def test_request_timeout_type_validation(self):
+        # Valid types should not raise
+        Elasticsearch(
+            "http://localhost:9200", transport_class=DummyTransport, request_timeout=1
+        )
+        Elasticsearch(
+            "http://localhost:9200", transport_class=DummyTransport, request_timeout=1.5
+        )
+        Elasticsearch(
+            "http://localhost:9200",
+            transport_class=DummyTransport,
+            request_timeout=None,
+        )
+
+        client = Elasticsearch("http://localhost:9200", transport_class=DummyTransport)
+        client.options(request_timeout=1)
+        client.options(request_timeout=1.5)
+        client.options(request_timeout=None)
+
+        # String type should raise TypeError on constructor
+        with pytest.raises(TypeError, match="'request_timeout' must be of type"):
+            Elasticsearch(
+                "http://localhost:9200",
+                transport_class=DummyTransport,
+                request_timeout="1",
+            )
+
+        # String type should raise TypeError on .options()
+        with pytest.raises(TypeError, match="'request_timeout' must be of type"):
+            client.options(request_timeout="1")
+
     def test_serializer_and_serializers(self):
         with pytest.raises(ValueError) as e:
             Elasticsearch(


### PR DESCRIPTION
Passing a string (or any non int/float/None value) as request_timeout previously surfaced as a confusing FullPoolError deep in the transport layer. Raise a clear TypeError at the client boundary instead, matching the existing validation pattern used for max_retries.

Closes #3423