### PR TITLE
backoff delays between retries (Fixes #197)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -449,6 +449,76 @@ async def example():
 
 ::::
 
+### Exponential backoff [_exponential_backoff]
+
+By default, retries are executed in quick succession, without any pause between them.
+If desired, the client can be configured to use an exponential backoff strategy that
+spaces out the retries to give the server more time to recover from a transient
+failure.
+
+The exponential backoff algorithm used by the client is called "Equal Jitter". It is
+described in detail in the [Exponential Backoff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) article, published in the AWS
+Architecture blog.
+
+Exponential backoff delays between retries are configured with the `retry_backoff_base`
+and `retry_backoff_cap` arguments. As with other configuration options, these can be
+given in the client's constructor to be used in all calls made with the client, or
+passed in the client's `.options()` method for use only with specific calls.
+
+::::{tab-set}
+:group: sync_or_async
+
+:::{tab-item} Standard Python
+:sync: sync
+```python
+client = Elasticsearch(
+    ...,
+    max_retries=5,
+    retry_backoff_base=1,
+    retry_backoff_cap=20,
+)
+:::
+
+:::{tab-item} Async Python
+:sync: async
+```python
+client = AsyncElasticsearch(
+    ...,
+    max_retries=5,
+    retry_backoff_base=1,
+    retry_backoff_cap=20,
+)
+```
+:::
+
+::::
+
+The `retry_backoff_base` and `retry_backoff_cap` arguments are of type float, and
+given in seconds. They control the starting delay configuration and the maximum
+allowed delay respectively.
+
+The default for these two arguments is 0, which effectively disables the backoff
+strategy. Both arguments must be greater than 0 for delays between retries to be
+used.
+
+The `retry_backoff_base` argument determines the maximum possible delay before the
+first retry attempt, with the actual delay reduced from that by a randomly generated
+amount (the "jitter"). In successive retry attempts, the base value is grown
+exponentially, so that with each retry attempt the pauses get longer.
+
+The `retry_backoff_cap` argument prevents the exponential growth of
+`retry_backoff_base` from making the pauses extremely large when too many retries
+need to be attempted.
+
+In the example above, the first retry attempt is going to be issued after a pause
+of no more than 1 second. For a second retry attempt the pause is going to be up
+to 2 seconds. The follow up retries will be capped at 4, 8 and 16 seconds. If more
+retries are needed after that, then they'll all be 20 seconds or less, and this will
+continue until the call succeeds or the maximum number of retries is reached.
+
+For more details about the "Equal Jitter" algorithm, please consult the blog article
+linked above.
+
 ### Ignoring status codes [_ignoring_status_codes]
 
 By default an `ApiError` exception will be raised for any non-2XX HTTP requests that exhaust retries, if any. If you’re expecting an HTTP error from the API but aren’t interested in raising an exception you can use the `ignore_status` parameter via the client `.options()` method.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -456,7 +456,7 @@ If desired, the client can be configured to use an exponential backoff strategy 
 spaces out the retries to give the server more time to recover from a transient
 failure.
 
-The exponential backoff algorithm used by the client is called "Equal Jitter". It is
+The exponential backoff algorithm used by the client is called "Equal Jitter." It is
 described in detail in the [Exponential Backoff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) article, published in the AWS
 Architecture blog.
 
@@ -497,7 +497,7 @@ The `retry_backoff_base` and `retry_backoff_cap` arguments are of type float, an
 given in seconds. They control the starting delay configuration and the maximum
 allowed delay respectively.
 
-The default for these two arguments is 0, which effectively disables the backoff
+The default for these two arguments is 0, which effectively turns off the backoff
 strategy. Both arguments must be greater than 0 for delays between retries to be
 used.
 
@@ -510,13 +510,13 @@ The `retry_backoff_cap` argument prevents the exponential growth of
 `retry_backoff_base` from making the pauses extremely large when too many retries
 need to be attempted.
 
-In the example above, the first retry attempt is going to be issued after a pause
+In the preceding example, the first retry attempt is going to be issued after a pause
 of no more than 1 second. For a second retry attempt the pause is going to be up
 to 2 seconds. The follow up retries will be capped at 4, 8 and 16 seconds. If more
 retries are needed after that, then they'll all be 20 seconds or less, and this will
 continue until the call succeeds or the maximum number of retries is reached.
 
-For more details about the "Equal Jitter" algorithm, please consult the blog article
+For more details about the "Equal Jitter" algorithm, consult the blog article
 linked above.
 
 ### Ignoring status codes [_ignoring_status_codes]

--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -174,6 +174,8 @@ class AsyncElasticsearch(BaseClient):
         max_retries: t.Union[DefaultType, int] = DEFAULT,
         retry_on_status: t.Union[DefaultType, int, t.Collection[int]] = DEFAULT,
         retry_on_timeout: t.Union[DefaultType, bool] = DEFAULT,
+        retry_backoff_base: t.Union[DefaultType, float] = DEFAULT,
+        retry_backoff_cap: t.Union[DefaultType, float] = DEFAULT,
         sniff_on_start: t.Union[DefaultType, bool] = DEFAULT,
         sniff_before_requests: t.Union[DefaultType, bool] = DEFAULT,
         sniff_on_node_failure: t.Union[DefaultType, bool] = DEFAULT,
@@ -339,6 +341,8 @@ class AsyncElasticsearch(BaseClient):
             if isinstance(retry_on_status, int):
                 retry_on_status = (retry_on_status,)
             self._retry_on_status = retry_on_status
+            self._retry_backoff_base = retry_backoff_base
+            self._retry_backoff_cap = retry_backoff_cap
 
         else:
             super().__init__(_transport)
@@ -438,6 +442,8 @@ class AsyncElasticsearch(BaseClient):
         max_retries: t.Union[DefaultType, int] = DEFAULT,
         retry_on_status: t.Union[DefaultType, int, t.Collection[int]] = DEFAULT,
         retry_on_timeout: t.Union[DefaultType, bool] = DEFAULT,
+        retry_backoff_base: t.Union[DefaultType, float] = DEFAULT,
+        retry_backoff_cap: t.Union[DefaultType, float] = DEFAULT,
     ) -> SelfType:
         client = type(self)(_transport=self.transport)
 
@@ -491,6 +497,16 @@ class AsyncElasticsearch(BaseClient):
             client._retry_on_timeout = retry_on_timeout
         else:
             client._retry_on_timeout = self._retry_on_timeout
+
+        if retry_backoff_base is not DEFAULT:
+            client._retry_backoff_base = retry_backoff_base
+        else:
+            client._retry_backoff_base = self._retry_backoff_base
+
+        if retry_backoff_cap is not DEFAULT:
+            client._retry_backoff_cap = retry_backoff_cap
+        else:
+            client._retry_backoff_cap = self._retry_backoff_cap
 
         client._is_serverless = self._is_serverless
 

--- a/elasticsearch/_async/client/_base.py
+++ b/elasticsearch/_async/client/_base.py
@@ -245,6 +245,8 @@ class BaseClient:
         self._max_retries: Union[DefaultType, int] = DEFAULT
         self._retry_on_timeout: Union[DefaultType, bool] = DEFAULT
         self._retry_on_status: Union[DefaultType, Collection[int]] = DEFAULT
+        self._retry_backoff_base: Union[DefaultType, float] = DEFAULT
+        self._retry_backoff_cap: Union[DefaultType, float] = DEFAULT
         self._is_serverless = False
         self._verified_elasticsearch = False
         self._otel = OpenTelemetry()
@@ -326,6 +328,8 @@ class BaseClient:
             max_retries=self._max_retries,
             retry_on_status=self._retry_on_status,
             retry_on_timeout=self._retry_on_timeout,
+            retry_backoff_base=self._retry_backoff_base,
+            retry_backoff_cap=self._retry_backoff_cap,
             client_meta=self._client_meta,
             otel_span=otel_span,
         )

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -174,6 +174,8 @@ class Elasticsearch(BaseClient):
         max_retries: t.Union[DefaultType, int] = DEFAULT,
         retry_on_status: t.Union[DefaultType, int, t.Collection[int]] = DEFAULT,
         retry_on_timeout: t.Union[DefaultType, bool] = DEFAULT,
+        retry_backoff_base: t.Union[DefaultType, int] = DEFAULT,
+        retry_backoff_cap: t.Union[DefaultType, int] = DEFAULT,
         sniff_on_start: t.Union[DefaultType, bool] = DEFAULT,
         sniff_before_requests: t.Union[DefaultType, bool] = DEFAULT,
         sniff_on_node_failure: t.Union[DefaultType, bool] = DEFAULT,
@@ -339,6 +341,8 @@ class Elasticsearch(BaseClient):
             if isinstance(retry_on_status, int):
                 retry_on_status = (retry_on_status,)
             self._retry_on_status = retry_on_status
+            self._retry_backoff_base = retry_backoff_base
+            self._retry_backoff_cap = retry_backoff_cap
 
         else:
             super().__init__(_transport)
@@ -438,6 +442,8 @@ class Elasticsearch(BaseClient):
         max_retries: t.Union[DefaultType, int] = DEFAULT,
         retry_on_status: t.Union[DefaultType, int, t.Collection[int]] = DEFAULT,
         retry_on_timeout: t.Union[DefaultType, bool] = DEFAULT,
+        retry_backoff_base: t.Union[DefaultType, int] = DEFAULT,
+        retry_backoff_cap: t.Union[DefaultType, int] = DEFAULT,
     ) -> SelfType:
         client = type(self)(_transport=self.transport)
 
@@ -491,6 +497,16 @@ class Elasticsearch(BaseClient):
             client._retry_on_timeout = retry_on_timeout
         else:
             client._retry_on_timeout = self._retry_on_timeout
+
+        if retry_backoff_base is not DEFAULT:
+            client._retry_backoff_base = retry_backoff_base
+        else:
+            client._retry_backoff_base = self._retry_backoff_base
+
+        if retry_backoff_cap is not DEFAULT:
+            client._retry_backoff_cap = retry_backoff_cap
+        else:
+            client._retry_backoff_cap = self._retry_backoff_cap
 
         client._is_serverless = self._is_serverless
 

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -174,8 +174,8 @@ class Elasticsearch(BaseClient):
         max_retries: t.Union[DefaultType, int] = DEFAULT,
         retry_on_status: t.Union[DefaultType, int, t.Collection[int]] = DEFAULT,
         retry_on_timeout: t.Union[DefaultType, bool] = DEFAULT,
-        retry_backoff_base: t.Union[DefaultType, int] = DEFAULT,
-        retry_backoff_cap: t.Union[DefaultType, int] = DEFAULT,
+        retry_backoff_base: t.Union[DefaultType, float] = DEFAULT,
+        retry_backoff_cap: t.Union[DefaultType, float] = DEFAULT,
         sniff_on_start: t.Union[DefaultType, bool] = DEFAULT,
         sniff_before_requests: t.Union[DefaultType, bool] = DEFAULT,
         sniff_on_node_failure: t.Union[DefaultType, bool] = DEFAULT,
@@ -442,8 +442,8 @@ class Elasticsearch(BaseClient):
         max_retries: t.Union[DefaultType, int] = DEFAULT,
         retry_on_status: t.Union[DefaultType, int, t.Collection[int]] = DEFAULT,
         retry_on_timeout: t.Union[DefaultType, bool] = DEFAULT,
-        retry_backoff_base: t.Union[DefaultType, int] = DEFAULT,
-        retry_backoff_cap: t.Union[DefaultType, int] = DEFAULT,
+        retry_backoff_base: t.Union[DefaultType, float] = DEFAULT,
+        retry_backoff_cap: t.Union[DefaultType, float] = DEFAULT,
     ) -> SelfType:
         client = type(self)(_transport=self.transport)
 

--- a/elasticsearch/_sync/client/_base.py
+++ b/elasticsearch/_sync/client/_base.py
@@ -245,8 +245,8 @@ class BaseClient:
         self._max_retries: Union[DefaultType, int] = DEFAULT
         self._retry_on_timeout: Union[DefaultType, bool] = DEFAULT
         self._retry_on_status: Union[DefaultType, Collection[int]] = DEFAULT
-        self._retry_backoff_base: Union[DefaultType, int] = DEFAULT
-        self._retry_backoff_cap: Union[DefaultType, int] = DEFAULT
+        self._retry_backoff_base: Union[DefaultType, float] = DEFAULT
+        self._retry_backoff_cap: Union[DefaultType, float] = DEFAULT
         self._is_serverless = False
         self._verified_elasticsearch = False
         self._otel = OpenTelemetry()

--- a/elasticsearch/_sync/client/_base.py
+++ b/elasticsearch/_sync/client/_base.py
@@ -245,6 +245,8 @@ class BaseClient:
         self._max_retries: Union[DefaultType, int] = DEFAULT
         self._retry_on_timeout: Union[DefaultType, bool] = DEFAULT
         self._retry_on_status: Union[DefaultType, Collection[int]] = DEFAULT
+        self._retry_backoff_base: Union[DefaultType, int] = DEFAULT
+        self._retry_backoff_cap: Union[DefaultType, int] = DEFAULT
         self._is_serverless = False
         self._verified_elasticsearch = False
         self._otel = OpenTelemetry()
@@ -326,6 +328,8 @@ class BaseClient:
             max_retries=self._max_retries,
             retry_on_status=self._retry_on_status,
             retry_on_timeout=self._retry_on_timeout,
+            retry_backoff_base=self._retry_backoff_base,
+            retry_backoff_cap=self._retry_backoff_cap,
             client_meta=self._client_meta,
             otel_span=otel_span,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "elastic-transport>=9.2.0,<10",
+    "elastic-transport>=9.4.1,<10",
     "python-dateutil",
     "typing-extensions",
     "sniffio",

--- a/test_elasticsearch/test_async/test_transport.py
+++ b/test_elasticsearch/test_async/test_transport.py
@@ -331,7 +331,9 @@ class TestTransport:
             retry_backoff_cap=2,
         )
 
-        with mock.patch("elastic_transport._async_transport.asyncio.sleep") as mock_sleep:
+        with mock.patch(
+            "elastic_transport._async_transport.asyncio.sleep"
+        ) as mock_sleep:
             with pytest.raises(ConnectionError) as e:
                 await client.info()
 

--- a/test_elasticsearch/test_async/test_transport.py
+++ b/test_elasticsearch/test_async/test_transport.py
@@ -20,6 +20,7 @@ import re
 import time
 import warnings
 from typing import Any, Dict, Optional
+from unittest import mock
 
 import anyio
 import pytest
@@ -314,6 +315,31 @@ class TestTransport:
             await client.options(max_retries=5).info()
         calls = client.transport.node_pool.get().calls
         assert 6 == len(calls)
+
+    async def test_request_with_backoff_retries(self):
+        client = AsyncElasticsearch(
+            [
+                NodeConfig(
+                    "http",
+                    "localhost",
+                    9200,
+                    _extras={"exception": ConnectionError("abandon ship!")},
+                )
+            ],
+            node_class=DummyNode,
+            retry_backoff_base=1,
+            retry_backoff_cap=2,
+        )
+
+        with mock.patch("elastic_transport._async_transport.asyncio.sleep") as mock_sleep:
+            with pytest.raises(ConnectionError) as e:
+                await client.info()
+
+        calls = client.transport.node_pool.get().calls
+        assert 4 == len(calls)
+        assert len(e.value.errors) == 3
+        assert mock_sleep.await_count == 3
+        assert all(0 < arg[0][0] for arg in mock_sleep.await_args_list)
 
     async def test_failed_connection_will_be_marked_as_dead(self):
         client = AsyncElasticsearch(

--- a/test_elasticsearch/test_client/test_options.py
+++ b/test_elasticsearch/test_client/test_options.py
@@ -152,6 +152,8 @@ class TestOptions(DummyTransportTestCase):
         assert call.pop("max_retries") is DEFAULT
         assert call.pop("retry_on_timeout") is DEFAULT
         assert call.pop("retry_on_status") is DEFAULT
+        assert call.pop("retry_backoff_base") is DEFAULT
+        assert call.pop("retry_backoff_cap") is DEFAULT
         assert call.pop("client_meta") is DEFAULT
         assert isinstance(call.pop("otel_span"), OpenTelemetrySpan)
         assert call == {
@@ -171,6 +173,8 @@ class TestOptions(DummyTransportTestCase):
 
         calls = client.transport.calls
         call = calls[("GET", "/test")][1]
+        assert call.pop("retry_backoff_base") is DEFAULT
+        assert call.pop("retry_backoff_cap") is DEFAULT
         assert call.pop("client_meta") is DEFAULT
         assert isinstance(call.pop("otel_span"), OpenTelemetrySpan)
         assert call == {
@@ -197,6 +201,8 @@ class TestOptions(DummyTransportTestCase):
 
         calls = client.transport.calls
         call = calls[("GET", "/test")][0]
+        assert call.pop("retry_backoff_base") is DEFAULT
+        assert call.pop("retry_backoff_cap") is DEFAULT
         assert call.pop("client_meta") is DEFAULT
         assert isinstance(call.pop("otel_span"), OpenTelemetrySpan)
         assert call == {
@@ -225,6 +231,8 @@ class TestOptions(DummyTransportTestCase):
         assert call.pop("max_retries") is DEFAULT
         assert call.pop("retry_on_timeout") is DEFAULT
         assert call.pop("retry_on_status") is DEFAULT
+        assert call.pop("retry_backoff_base") is DEFAULT
+        assert call.pop("retry_backoff_cap") is DEFAULT
         assert call.pop("client_meta") is DEFAULT
         assert isinstance(call.pop("otel_span"), OpenTelemetrySpan)
         assert call == {
@@ -244,6 +252,8 @@ class TestOptions(DummyTransportTestCase):
 
         calls = client.transport.calls
         call = calls[("GET", "/test")][1]
+        assert call.pop("retry_backoff_base") is DEFAULT
+        assert call.pop("retry_backoff_cap") is DEFAULT
         assert call.pop("client_meta") is DEFAULT
         assert isinstance(call.pop("otel_span"), OpenTelemetrySpan)
         assert call == {
@@ -270,6 +280,8 @@ class TestOptions(DummyTransportTestCase):
 
         calls = client.transport.calls
         call = calls[("GET", "/test")][0]
+        assert call.pop("retry_backoff_base") is DEFAULT
+        assert call.pop("retry_backoff_cap") is DEFAULT
         assert call.pop("client_meta") is DEFAULT
         assert isinstance(call.pop("otel_span"), OpenTelemetrySpan)
         assert call == {
@@ -399,6 +411,8 @@ class TestOptions(DummyTransportTestCase):
             max_retries=2,
             retry_on_status=(404,),
             retry_on_timeout=True,
+            retry_backoff_base=1,
+            retry_backoff_cap=2,
         )
 
         # timeout parameters are preserved with .options()
@@ -417,6 +431,8 @@ class TestOptions(DummyTransportTestCase):
             "max_retries": 2,
             "retry_on_status": (404,),
             "retry_on_timeout": True,
+            "retry_backoff_base": 1,
+            "retry_backoff_cap": 2,
         }
 
         client = Elasticsearch(
@@ -432,6 +448,8 @@ class TestOptions(DummyTransportTestCase):
             max_retries=3,
             retry_on_status=(400,),
             retry_on_timeout=False,
+            retry_backoff_base=1,
+            retry_backoff_cap=2,
         ).indices.get(index="test")
 
         calls = client.transport.calls
@@ -447,6 +465,8 @@ class TestOptions(DummyTransportTestCase):
             "max_retries": 3,
             "retry_on_status": (400,),
             "retry_on_timeout": False,
+            "retry_backoff_base": 1,
+            "retry_backoff_cap": 2,
         }
 
         client = Elasticsearch(
@@ -461,6 +481,8 @@ class TestOptions(DummyTransportTestCase):
         assert call.pop("max_retries") is DEFAULT
         assert call.pop("retry_on_timeout") is DEFAULT
         assert call.pop("retry_on_status") is DEFAULT
+        assert call.pop("retry_backoff_base") is DEFAULT
+        assert call.pop("retry_backoff_cap") is DEFAULT
         assert call.pop("client_meta") is DEFAULT
         assert isinstance(call.pop("otel_span"), OpenTelemetrySpan)
         assert call == {
@@ -479,6 +501,8 @@ class TestOptions(DummyTransportTestCase):
             max_retries=2,
             retry_on_status=(404,),
             retry_on_timeout=True,
+            retry_backoff_base=1,
+            retry_backoff_cap=2,
         ).indices.get(index="test")
 
         calls = client.transport.calls
@@ -494,6 +518,8 @@ class TestOptions(DummyTransportTestCase):
             "max_retries": 2,
             "retry_on_status": (404,),
             "retry_on_timeout": True,
+            "retry_backoff_base": 1,
+            "retry_backoff_cap": 2,
         }
 
     def test_serializer_and_serializers(self):

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -19,6 +19,7 @@ import re
 import time
 import warnings
 from typing import Any, Dict, Optional
+from unittest import mock
 
 import pytest
 from elastic_transport import (
@@ -330,6 +331,33 @@ class TestTransport:
             client.options(max_retries=5).info()
         calls = client.transport.node_pool.get().calls
         assert 6 == len(calls)
+
+    def test_request_with_backoff_retries(self):
+        client = Elasticsearch(
+            [
+                NodeConfig(
+                    "http",
+                    "localhost",
+                    9200,
+                    _extras={
+                        "exception_factory": lambda: ConnectionError("abandon ship!")
+                    },
+                )
+            ],
+            node_class=DummyNode,
+            retry_backoff_base=1,
+            retry_backoff_cap=2,
+        )
+
+        with mock.patch("elastic_transport._transport.time.sleep") as mock_sleep:
+            with pytest.raises(ConnectionError) as e:
+                client.info()
+
+        calls = client.transport.node_pool.get().calls
+        assert 4 == len(calls)
+        assert len(e.value.errors) == 3
+        assert mock_sleep.call_count == 3
+        assert all(0 < arg[0][0] for arg in mock_sleep.call_args_list)
 
     def test_failed_connection_will_be_marked_as_dead(self):
         client = Elasticsearch(


### PR DESCRIPTION
Counterpart to https://github.com/elastic/elastic-transport-python/pull/279 in the transport, to add optional delays between retries.