### PR TITLE
do not warn about unused type ignores during build

### DIFF
--- a/utils/build-dists.py
+++ b/utils/build-dists.py
@@ -122,6 +122,7 @@ def test_dist(dist):
                 "--non-interactive",
                 "--ignore-missing-imports",
                 "--implicit-reexport",
+                "--no-warn-unused-ignores",
                 os.path.join(base_dir, "test_elasticsearch/test_types/async_types.py"),
             )
 
@@ -147,6 +148,7 @@ def test_dist(dist):
                 "--non-interactive",
                 "--ignore-missing-imports",
                 "--implicit-reexport",
+                "--no-warn-unused-ignores",
                 os.path.join(base_dir, "test_elasticsearch/test_types/sync_types.py"),
             )
         else:
@@ -159,6 +161,7 @@ def test_dist(dist):
                 "--non-interactive",
                 "--ignore-missing-imports",
                 "--implicit-reexport",
+                "--no-warn-unused-ignores",
                 os.path.join(
                     base_dir, "test_elasticsearch/test_types/aliased_types.py"
                 ),


### PR DESCRIPTION
The build script (utils/build-dists.py) runs mypy on a few isolated files. These for some reason trigger spurious warnings about unused type ignores that the regular mypy build needs, so just for the build script, I'm disabling the warnings about unused ignores.