### PR TITLE
Quote query parameter keys

### DIFF
--- a/elasticsearch/_sync/client/utils.py
+++ b/elasticsearch/_sync/client/utils.py
@@ -260,7 +260,7 @@ def _quote(value: Any) -> str:
 
 
 def _quote_query(query: Mapping[str, Any]) -> str:
-    return "&".join([f"{k}={_quote(v)}" for k, v in query.items()])
+    return "&".join([f"{_quote(k)}={_quote(v)}" for k, v in query.items()])
 
 
 def _merge_kwargs_no_duplicates(kwargs: Dict[str, Any], values: Dict[str, Any]) -> None:

--- a/test_elasticsearch/test_client/test_utils.py
+++ b/test_elasticsearch/test_client/test_utils.py
@@ -25,6 +25,7 @@ from elasticsearch._sync.client.utils import (
     Visibility,
     _availability_warning,
     _quote,
+    _quote_query,
 )
 from elasticsearch.exceptions import GeneralAvailabilityWarning
 
@@ -46,6 +47,15 @@ def test_handles_unicode():
 def test_handles_unicode2():
     string = "中*文,"
     assert "%E4%B8%AD*%E6%96%87," == _quote(string)
+
+
+def test_quote_query_encodes_keys_and_values():
+    query = {"filter_path&pretty": "hits.hits", "routing=user": "a&b"}
+
+    assert (
+        "filter_path%26pretty=hits.hits&routing%3Duser=a%26b"
+        == _quote_query(query)
+    )
 
 
 class TestAvailabilityWarning:


### PR DESCRIPTION
## Summary
- URL-encode query parameter keys when building request query strings
- add a regression test covering special characters in both keys and values

## Why
`_quote_query()` already encoded parameter values, but left keys unchanged. When callers use the low-level `params` mapping, a key containing query delimiters such as `&` or `=` can change the shape of the final query string instead of being treated as one parameter name.

## Testing
- `python -m pytest test_elasticsearch/test_client/test_utils.py -q`
