### PR TITLE
Avoid logging VectorStore custom query bodies

### DIFF
--- a/elasticsearch/helpers/vectorstore/_async/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_async/vectorstore.py
@@ -279,7 +279,7 @@ class AsyncVectorStore:
 
         if custom_query is not None:
             query_body = custom_query(query_body, query)
-            logger.debug(f"Calling custom_query, Query body now: {query_body}")
+            logger.debug("Applied custom_query to vectorstore search body")
 
         response = await self.client.search(
             index=self.index,

--- a/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
+++ b/elasticsearch/helpers/vectorstore/_sync/vectorstore.py
@@ -279,7 +279,7 @@ class VectorStore:
 
         if custom_query is not None:
             query_body = custom_query(query_body, query)
-            logger.debug(f"Calling custom_query, Query body now: {query_body}")
+            logger.debug("Applied custom_query to vectorstore search body")
 
         response = self.client.search(
             index=self.index,

--- a/test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py
@@ -605,6 +605,40 @@ class TestAsyncVectorStore:
         output = await store.search(query="foo", k=1, custom_query=my_custom_query)
         assert [doc["_source"]["text_field"] for doc in output] == ["bar"]
 
+    async def test_custom_query_debug_log_omits_query_body(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class FakeClient:
+            def options(self, **kwargs: Any) -> "FakeClient":
+                return self
+
+            async def search(self, **kwargs: Any) -> dict:
+                return {"hits": {"hits": []}}
+
+        class FakeStrategy:
+            def es_query(self, **kwargs: Any) -> dict:
+                return {"query": {"match": {"text_field": kwargs["query"]}}}
+
+        def custom_query(query_body: dict, query: Optional[str]) -> dict:
+            return {
+                "query": {"match": {"text_field": "secret customer token"}},
+                "post_filter": {"term": {"api_key": "secret-api-key"}},
+            }
+
+        store = AsyncVectorStore(
+            index="test-index",
+            retrieval_strategy=FakeStrategy(),  # type: ignore[arg-type]
+            client=FakeClient(),  # type: ignore[arg-type]
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            await store.search(query="secret customer token", custom_query=custom_query)
+
+        assert "Applied custom_query to vectorstore search body" in caplog.text
+        assert "secret customer token" not in caplog.text
+        assert "secret-api-key" not in caplog.text
+
     async def test_search_with_knn_infer_instack(
         self, async_client: AsyncElasticsearch, index: str
     ) -> None:

--- a/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
+++ b/test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py
@@ -591,6 +591,40 @@ class TestVectorStore:
         output = store.search(query="foo", k=1, custom_query=my_custom_query)
         assert [doc["_source"]["text_field"] for doc in output] == ["bar"]
 
+    def test_custom_query_debug_log_omits_query_body(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class FakeClient:
+            def options(self, **kwargs: Any) -> "FakeClient":
+                return self
+
+            def search(self, **kwargs: Any) -> dict:
+                return {"hits": {"hits": []}}
+
+        class FakeStrategy:
+            def es_query(self, **kwargs: Any) -> dict:
+                return {"query": {"match": {"text_field": kwargs["query"]}}}
+
+        def custom_query(query_body: dict, query: Optional[str]) -> dict:
+            return {
+                "query": {"match": {"text_field": "secret customer token"}},
+                "post_filter": {"term": {"api_key": "secret-api-key"}},
+            }
+
+        store = VectorStore(
+            index="test-index",
+            retrieval_strategy=FakeStrategy(),  # type: ignore[arg-type]
+            client=FakeClient(),  # type: ignore[arg-type]
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            store.search(query="secret customer token", custom_query=custom_query)
+
+        assert "Applied custom_query to vectorstore search body" in caplog.text
+        assert "secret customer token" not in caplog.text
+        assert "secret-api-key" not in caplog.text
+
     def test_search_with_knn_infer_instack(
         self, sync_client: Elasticsearch, index: str
     ) -> None:


### PR DESCRIPTION
VectorStore and AsyncVectorStore previously logged the full query body after a `custom_query` callback was applied. Since `custom_query` can add application-specific filters, identifiers, or other sensitive literals, emitting the full body at DEBUG level can expose that data in application logs.

This changes the debug log to a static message while preserving an indication that `custom_query` was applied, and adds sync/async tests to ensure sensitive query-body values are not logged.

Verification:

```text
python -m pytest test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py::TestVectorStore::test_custom_query_debug_log_omits_query_body -q
python -m pytest test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py::TestAsyncVectorStore::test_custom_query_debug_log_omits_query_body -q
python -m pytest test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py::TestVectorStore::test_search_knn_with_custom_query_fn test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py::TestVectorStore::test_custom_query_debug_log_omits_query_body test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py::TestAsyncVectorStore::test_search_knn_with_custom_query_fn test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py::TestAsyncVectorStore::test_custom_query_debug_log_omits_query_body -q
python -m ruff check elasticsearch/helpers/vectorstore/_sync/vectorstore.py elasticsearch/helpers/vectorstore/_async/vectorstore.py test_elasticsearch/test_server/test_vectorstore/test_vectorstore.py test_elasticsearch/test_async/test_server/test_vectorstore/test_vectorstore.py
git diff --check
```
