### PR TITLE
Forward opaque_id in async_scan

### DIFF
--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -480,7 +480,14 @@ async def async_scan(
         # Grab options that should be propagated to every
         # API call within this helper instead of just 'search()'
         transport_kwargs = {}
-        for key in ("headers", "api_key", "http_auth", "basic_auth", "bearer_auth"):
+        for key in (
+            "headers",
+            "api_key",
+            "http_auth",
+            "basic_auth",
+            "bearer_auth",
+            "opaque_id",
+        ):
             try:
                 value = kw.pop(key)
                 if key == "http_auth":

--- a/test_elasticsearch/test_async/test_server/test_helpers.py
+++ b/test_elasticsearch/test_async/test_server/test_helpers.py
@@ -797,6 +797,8 @@ class TestScan:
     async def test_scan_auth_kwargs_forwarded(
         self, async_client, scan_teardown, kwargs
     ):
+        ((key, val),) = kwargs.items()
+
         with (
             patch.object(async_client, "options", return_value=async_client) as options,
             patch.object(
@@ -840,11 +842,10 @@ class TestScan:
 
                     assert data == [{"search_data": 1}]
 
-        if "http_auth" in kwargs:
-            kwargs = {"basic_auth": kwargs.pop("http_auth")}
-
         assert options.call_args_list == [
-            call(request_timeout=None, **kwargs),
+            call(
+                request_timeout=None, **{key if key != "http_auth" else "basic_auth": val}
+            ),
             call(ignore_status=404),
         ]
 

--- a/test_elasticsearch/test_async/test_server/test_helpers.py
+++ b/test_elasticsearch/test_async/test_server/test_helpers.py
@@ -788,7 +788,10 @@ class TestScan:
         [
             {"api_key": ("name", "value")},
             {"http_auth": ("username", "password")},
+            {"basic_auth": ("username", "password")},
+            {"bearer_auth": "token"},
             {"headers": {"custom", "header"}},
+            {"opaque_id": "request-id"},
         ],
     )
     async def test_scan_auth_kwargs_forwarded(
@@ -888,8 +891,10 @@ class TestScan:
                             async_client,
                             index="test_index",
                             headers={"not scroll": "kwargs"},
+                            opaque_id="not-scroll-opaque-id",
                             scroll_kwargs={
                                 "headers": {"scroll": "kwargs"},
+                                "opaque_id": "scroll-opaque-id",
                                 "sort": "asc",
                             },
                         )
@@ -899,8 +904,15 @@ class TestScan:
 
                     # Assert that we see 'scroll_kwargs' options used instead of 'kwargs'
                     assert options.call_args_list == [
-                        call(request_timeout=None, headers={"not scroll": "kwargs"}),
-                        call(headers={"scroll": "kwargs"}),
+                        call(
+                            request_timeout=None,
+                            headers={"not scroll": "kwargs"},
+                            opaque_id="not-scroll-opaque-id",
+                        ),
+                        call(
+                            headers={"scroll": "kwargs"},
+                            opaque_id="scroll-opaque-id",
+                        ),
                         call(ignore_status=404),
                     ]
                     assert async_client.search.call_args_list == [

--- a/test_elasticsearch/test_async/test_server/test_helpers.py
+++ b/test_elasticsearch/test_async/test_server/test_helpers.py
@@ -844,7 +844,8 @@ class TestScan:
 
         assert options.call_args_list == [
             call(
-                request_timeout=None, **{key if key != "http_auth" else "basic_auth": val}
+                request_timeout=None,
+                **{key if key != "http_auth" else "basic_auth": val},
             ),
             call(ignore_status=404),
         ]

--- a/test_elasticsearch/test_server/test_helpers.py
+++ b/test_elasticsearch/test_server/test_helpers.py
@@ -679,6 +679,7 @@ def test_no_scroll_id_fast_route(sync_client):
         {"basic_auth": ("username", "password")},
         {"bearer_auth": "token"},
         {"headers": {"custom", "header"}},
+        {"opaque_id": "request-id"},
     ],
 )
 @pytest.mark.usefixtures("scan_teardown")
@@ -766,8 +767,13 @@ def test_scan_auth_kwargs_favor_scroll_kwargs_option(sync_client):
             helpers.scan(
                 sync_client,
                 index="test_index",
-                scroll_kwargs={"headers": {"scroll": "kwargs"}, "sort": "asc"},
                 headers={"not scroll": "kwargs"},
+                opaque_id="not-scroll-opaque-id",
+                scroll_kwargs={
+                    "headers": {"scroll": "kwargs"},
+                    "opaque_id": "scroll-opaque-id",
+                    "sort": "asc"
+                },
             )
         )
 
@@ -775,8 +781,15 @@ def test_scan_auth_kwargs_favor_scroll_kwargs_option(sync_client):
 
         # Assert that we see 'scroll_kwargs' options used instead of 'kwargs'
         assert options_mock.call_args_list == [
-            call(request_timeout=None, headers={"not scroll": "kwargs"}),
-            call(headers={"scroll": "kwargs"}),
+            call(
+                request_timeout=None,
+                headers={"not scroll": "kwargs"},
+                opaque_id="not-scroll-opaque-id",
+            ),
+            call(
+                headers={"scroll": "kwargs"},
+                opaque_id="scroll-opaque-id",
+            ),
             call(ignore_status=404),
         ]
         search_mock.assert_called_once_with(

--- a/test_elasticsearch/test_server/test_helpers.py
+++ b/test_elasticsearch/test_server/test_helpers.py
@@ -772,7 +772,7 @@ def test_scan_auth_kwargs_favor_scroll_kwargs_option(sync_client):
                 scroll_kwargs={
                     "headers": {"scroll": "kwargs"},
                     "opaque_id": "scroll-opaque-id",
-                    "sort": "asc"
+                    "sort": "asc",
                 },
             )
         )


### PR DESCRIPTION
## What

Adds `opaque_id` to the transport options extracted by `async_scan()` so the initial search client options and subsequent scroll client options can carry the same `x-opaque-id` behavior as the sync `scan()` helper.

## Why

The sync helper already treats `opaque_id` as a helper-level transport option, but the async helper only forwarded headers/auth options. That meant `opaque_id` was left in request kwargs instead of being applied through `client.options()`, and `scroll_kwargs` could not override it for scroll requests.

## Tests

- `python -m py_compile elasticsearch\_async\helpers.py test_elasticsearch\test_async\test_server\test_helpers.py`
- `git diff --check`
- `python -m pytest test_elasticsearch\test_async\test_server\test_helpers.py -k scan_auth_kwargs -rs` (selected tests skipped locally because no Elasticsearch service is listening on localhost:9200)