### PR TITLE
Handle non-dict Mapping query in scan helpers

### DIFF
--- a/elasticsearch/_async/helpers.py
+++ b/elasticsearch/_async/helpers.py
@@ -473,7 +473,7 @@ async def async_scan(
     scroll_kwargs = scroll_kwargs or {}
 
     if not preserve_order:
-        query = query.copy() if query else {}
+        query = dict(query) if query else {}
         query["sort"] = "_doc"
 
     def pop_transport_kwargs(kw: MutableMapping[str, Any]) -> MutableMapping[str, Any]:

--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -782,7 +782,7 @@ def scan(
     """
     scroll_kwargs = scroll_kwargs or {}
     if not preserve_order:
-        query = query.copy() if query else {}
+        query = dict(query) if query else {}
         query["sort"] = "_doc"
 
     def pop_transport_kwargs(kw: MutableMapping[str, Any]) -> Dict[str, Any]:

--- a/test_elasticsearch/test_helpers.py
+++ b/test_elasticsearch/test_helpers.py
@@ -237,3 +237,41 @@ def test_serialize_scan_error():
     assert pickled.__class__ == helpers.ScanError
     assert pickled.scroll_id == error.scroll_id
     assert pickled.args == error.args
+
+
+def test_scan_accepts_non_dict_mapping_query():
+    from collections.abc import Mapping
+
+    class ReadOnlyMapping(Mapping):
+        def __init__(self, data):
+            self._data = dict(data)
+
+        def __getitem__(self, key):
+            return self._data[key]
+
+        def __iter__(self):
+            return iter(self._data)
+
+        def __len__(self):
+            return len(self._data)
+
+    query = ReadOnlyMapping({"query": {"match_all": {}}})
+
+    client = mock.create_autospec(Elasticsearch, instance=True)
+    client.options.return_value = client
+    client.search.return_value = {
+        "_scroll_id": "scroll_id",
+        "_shards": {"successful": 1, "total": 1, "skipped": 0},
+        "hits": {"hits": [{"_id": "1"}]},
+    }
+    client.scroll.return_value = {
+        "_scroll_id": "scroll_id",
+        "_shards": {"successful": 1, "total": 1, "skipped": 0},
+        "hits": {"hits": []},
+    }
+
+    list(helpers.scan(client, query=query))
+
+    sort = client.search.call_args.kwargs["sort"]
+    assert sort == "_doc"
+    assert "sort" not in query


### PR DESCRIPTION
The scan and async_scan helpers call query.copy() when preserve_order is False, which raises AttributeError if the query is a collections.abc.Mapping that doesn't implement copy() (only dict and a few others do). Switching to dict(query) builds a fresh mutable dict from any mapping, so the helper no longer assumes the input is a dict. Closes #3448.