### PR TITLE
Fix logic error in bulk helper _process_bulk_chunk_success

### DIFF
--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -326,7 +326,7 @@ def _process_bulk_chunk_success(
                 item["data"] = data[1]
             errors.append({op_type: item})
 
-        if ok or not errors:
+        if ok or not raise_on_error or status_code in ignore_status:
             # if we are not just recording all errors to be able to raise
             # them all at once, yield items individually
             yield ok, {op_type: item}

--- a/test_elasticsearch/test_server/test_helpers.py
+++ b/test_elasticsearch/test_server/test_helpers.py
@@ -1116,3 +1116,40 @@ def test_reindex_index_datastream_op_type_index(sync_client):
             query={"query": {"bool": {"filter": {"term": {"type": "answers"}}}}},
             op_type="_index",
         )
+
+
+def test_process_bulk_chunk_success_yield_logic():
+    resp = {
+        "items": [
+            {"index": {"status": 200}},
+            {"index": {"status": 400}},  # Real failure
+            {"index": {"status": 409}},  # Ignored failure
+        ]
+    }
+    bulk_data = [
+        ({"index": {}},),
+        ({"index": {}},),
+        ({"index": {}},),
+    ]
+
+    # We expect a BulkIndexError at the end because of the 400 error.
+    # But the 409 error is in ignore_status, so it should be yielded (with ok=False),
+    # while the 200 success is yielded (with ok=True).
+    iterator = helpers.actions._process_bulk_chunk_success(
+        resp=resp,
+        bulk_data=bulk_data,
+        ignore_status=(409,),
+        raise_on_error=True,
+    )
+
+    yielded = []
+    try:
+        for ok, item in iterator:
+            yielded.append((ok, item))
+    except helpers.BulkIndexError as e:
+        assert len(e.errors) == 1
+        assert e.errors[0]["index"]["status"] == 400
+
+    assert len(yielded) == 2
+    assert yielded[0][0] is True  # 200 OK
+    assert yielded[1][0] is False  # 409 Ignored Error


### PR DESCRIPTION
This PR fixes a logic error in _process_bulk_chunk_success where ignored failures (e.g. document conflicts/409) were lost and never yielded if a real failure occurred before them in the same chunk.