### PR TITLE
ci: add `x-access-token` user to `make.sh` script

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -182,7 +182,7 @@ if [[ "$CMD" == "codegen" ]]; then
      --rm -v $repo:/code/elasticsearch-py \
      $product \
      /bin/bash -c "cd /code && python -m pip install nox && \
-     git clone https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-python.git && \
+     git clone https://x-access-token:$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-python.git && \
      cd /code/elastic-client-generator-python && GIT_BRANCH=$VERSION python -m nox -s generate-es && \
      cd /code/elasticsearch-py && python -m nox -s format"
 


### PR DESCRIPTION
Codegen is failing since switching to ephemeral tokens with `fatal: could not read Password for 'https://***@github.com': No such device or address` 

This is working for [elasticsearch-js](https://github.com/elastic/elasticsearch-js/blob/4b336837419c49d3faee6ac34dbf7e3f10e7df80/.github/make.sh#L179) which uses `https://x-access-token:$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git`