### PR TITLE
ci: add PyPI trusted publisher publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,93 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or tag to publish from (e.g. '9.3')"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        run: python -m pip install build
+
+      - name: Build dists
+        run: python utils/build-dists.py
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    name: Create GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Get version
+        id: version
+        run: |
+          python -c "exec(open('elasticsearch/_version.py').read()); print(__versionstr__)" > VERSION
+          echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          gh release create "v$VERSION" --title "$VERSION" --generate-notes

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -83,11 +83,9 @@ jobs:
           python -c "exec(open('elasticsearch/_version.py').read()); print(__versionstr__)" > VERSION
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
 
-      - name: Create tag and GitHub release
+      - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
-          gh release create "v$VERSION" --title "$VERSION" --generate-notes
+          gh release create "v$VERSION" --title "$VERSION" --target "${{ inputs.ref }}" --generate-notes

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,12 +18,8 @@
 name: Publish to PyPI
 
 on:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch or tag to publish from (e.g. '9.3')"
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions: {}
 
@@ -32,9 +28,18 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
+      - name: Derive branch from release tag
+        id: branch
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          version="${version#v}"
+          major=$(echo "$version" | cut -d '.' -f1)
+          minor=$(echo "$version" | cut -d '.' -f2)
+          echo "name=$major.$minor" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ steps.branch.outputs.name }}
 
       - uses: actions/setup-python@v5
         with:
@@ -65,34 +70,3 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-
-  release:
-    name: Create GitHub release
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Fetch ephemeral GitHub token
-        id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
-        with:
-          vault-instance: "ci-prod"
-
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.ref }}
-          token: ${{ steps.fetch-token.outputs.token }}
-
-      - name: Get version
-        id: version
-        run: |
-          python -c "exec(open('elasticsearch/_version.py').read()); print(__versionstr__)" > VERSION
-          echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ steps.fetch-token.outputs.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          gh release create "v$VERSION" --title "$VERSION" --target "${{ inputs.ref }}" --generate-notes

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -71,11 +71,18 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write
     steps:
+      - name: Fetch ephemeral GitHub token
+        id: fetch-token
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
+        with:
+          vault-instance: "ci-prod"
+
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
+          token: ${{ steps.fetch-token.outputs.token }}
 
       - name: Get version
         id: version
@@ -85,7 +92,7 @@ jobs:
 
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.fetch-token.outputs.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           gh release create "v$VERSION" --title "$VERSION" --target "${{ inputs.ref }}" --generate-notes


### PR DESCRIPTION
Adds `pypi-publish.yml`: publishes `elasticsearch` and `elasticsearch9` to PyPI when a GitHub release is published. Authenticates via GitHub OIDC ([Trusted Publishers](https://docs.pypi.org/trusted-publishers/)) so there's no token to manage.

The tag/release itself is created upstream by the `release-tag` workflow in elastic/dev-experience-team#1157, which fires the `release: published` event this workflow reacts to.

Relates to: elastic/catalog-info#4229 (merge that first)
Relates to: elastic/dev-experience-team#1168

## One-time PyPI setup

Add a Trusted Publisher on both projects pointing to this workflow:

| Field | Value |
|---|---|
| Owner | `elastic` |
| Repository | `elasticsearch-py` |
| Workflow filename | `pypi-publish.yml` |
| Environment | `pypi` |

- https://pypi.org/manage/project/elasticsearch/settings/publishing/
- https://pypi.org/manage/project/elasticsearch9/settings/publishing/

Also create a `pypi` environment in [repo Settings -> Environments](https://github.com/elastic/elasticsearch-py/settings/environments) with a required reviewer.