### PR TITLE
fix: mypy strict unused-ignore on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,6 @@ exclude_lines = [
 plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
 
-# annotationlib (3.14+) and pyarrow's optional-import fallbacks need
-# `type: ignore[assignment]` on some Python/mypy versions but not others.
 [[tool.mypy.overrides]]
 module = "elasticsearch.dsl.document_base"
 warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,3 +143,13 @@ exclude_lines = [
 [tool.mypy]
 plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
+
+# annotationlib (3.14+) and pyarrow's optional-import fallbacks need
+# `type: ignore[assignment]` on some Python/mypy versions but not others.
+[[tool.mypy.overrides]]
+module = "elasticsearch.dsl.document_base"
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = "elasticsearch.serializer"
+warn_unused_ignores = false


### PR DESCRIPTION
`nox -s lint` fails on main with mypy strict errors in `serializer.py` and `dsl/document_base.py`: the `type: ignore[assignment]` on the optional-import fallbacks (`pyarrow`, `annotationlib`) is needed on some Python/mypy versions but flagged as unused on others.

Adds per-module `warn_unused_ignores = false` overrides, same fix already applied on the `9.5` backport branch.