### PR TITLE
fix: mypy strict unused-ignore on 8.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,11 @@ exclude_lines = [
 
 [tool.mypy]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "elasticsearch.dsl.document_base"
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = "elasticsearch.serializer"
+warn_unused_ignores = false


### PR DESCRIPTION
## Summary

Backport of #3475 to the `8.19` branch. Suppresses `warn_unused_ignores` for `elasticsearch.serializer` and `elasticsearch.dsl.document_base`, where the `# type: ignore[assignment]` on optional-import fallbacks flips between needed/unused depending on mypy/pyarrow-stubs version. Currently blocking #3469 and #3470.

Relates to #3481 for the root-cause fix.

## Test plan

- [ ] `lint` check passes