### PR TITLE
Fix mypy unused-ignore flakiness on optional imports

### DIFF
--- a/elasticsearch/dsl/document_base.py
+++ b/elasticsearch/dsl/document_base.py
@@ -36,15 +36,21 @@ from typing import (
 
 from typing_extensions import _AnnotatedAlias
 
-try:
+if TYPE_CHECKING:
     import annotationlib
-except ImportError:
-    annotationlib = None  # type: ignore[assignment]
+else:
+    try:
+        import annotationlib
+    except ImportError:
+        annotationlib = None
 
-try:
+if TYPE_CHECKING:
     from types import UnionType
-except ImportError:
-    UnionType = None  # type: ignore[assignment, misc]
+else:
+    try:
+        from types import UnionType
+    except ImportError:
+        UnionType = None
 
 from typing_extensions import dataclass_transform
 

--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -18,7 +18,7 @@
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, ClassVar, Dict, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Tuple
 
 from elastic_transport import JsonSerializer as _JsonSerializer
 from elastic_transport import NdjsonSerializer as _NdjsonSerializer
@@ -49,12 +49,15 @@ except ImportError:
     _OrjsonSerializer = None  # type: ignore[assignment,misc]
 
 
-try:
+if TYPE_CHECKING:
     import pyarrow as pa
+else:
+    try:
+        import pyarrow as pa
 
-    __all__.append("PyArrowSerializer")
-except ImportError:
-    pa = None  # type: ignore[assignment]
+        __all__.append("PyArrowSerializer")
+    except ImportError:
+        pa = None
 
 
 class JsonSerializer(_JsonSerializer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,11 +143,3 @@ exclude_lines = [
 [tool.mypy]
 plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "elasticsearch.dsl.document_base"
-warn_unused_ignores = false
-
-[[tool.mypy.overrides]]
-module = "elasticsearch.serializer"
-warn_unused_ignores = false


### PR DESCRIPTION
## Summary

Fixes #3481. The `# type: ignore[assignment]` fallbacks on optional imports (`pyarrow` in `serializer.py`; `annotationlib` and `UnionType` in `document_base.py`) were flipping between needed/unused depending on which mypy/pyarrow-stubs version was installed, causing CI to break twice already (#3475, backported in #3482).

This splits each import into separate type-checking and runtime paths using `TYPE_CHECKING`:

```python
if TYPE_CHECKING:
    import pyarrow as pa
else:
    try:
        import pyarrow as pa
        __all__.append("PyArrowSerializer")
    except ImportError:
        pa = None
```

Mypy only ever evaluates the `if TYPE_CHECKING` branch, so it always sees a clean import and the `# type: ignore` is no longer needed. The `else` branch still runs at runtime exactly as before, so the fallback behavior is unchanged.

Also removes the two `warn_unused_ignores = false` overrides in `pyproject.toml` (added in #3482 as a stopgap) since they're no longer needed and were masking any other real unused-ignores in these two files.

## Test plan

- [x] `mypy --strict --implicit-reexport --explicit-package-bases
      --show-error-codes --enable-error-code=ignore-without-code
      elasticsearch/ test_elasticsearch/test_types/ examples/dsl/` passes
      (188 source files, no issues)
- [x] Verified with pyarrow installed
- [x] Verified with pyarrow uninstalled (fallback still returns `None` at
      runtime, no import error)
- [x] `flake8`, `black --check`, `isort --check` all pass