### PR TITLE
fix: wire up EncryptionClient and fix its generated module header

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -47,6 +47,7 @@ from .ccr import CcrClient
 from .cluster import ClusterClient
 from .connector import ConnectorClient
 from .dangling_indices import DanglingIndicesClient
+from .encryption import EncryptionClient
 from .enrich import EnrichClient
 from .eql import EqlClient
 from .esql import EsqlClient
@@ -379,6 +380,7 @@ class AsyncElasticsearch(BaseClient):
         self.xpack = XPackClient(self)
         self.ccr = CcrClient(self)
         self.dangling_indices = DanglingIndicesClient(self)
+        self.encryption = EncryptionClient(self)
         self.enrich = EnrichClient(self)
         self.eql = EqlClient(self)
         self.esql = EsqlClient(self)

--- a/elasticsearch/_async/client/encryption.py
+++ b/elasticsearch/_async/client/encryption.py
@@ -15,7 +15,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import Stability, _availability_warning, _rewrite_parameters
+
+
+class EncryptionClient(NamespacedClient):
 
     @_rewrite_parameters()
     @_availability_warning(Stability.EXPERIMENTAL)

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -47,6 +47,7 @@ from .ccr import CcrClient
 from .cluster import ClusterClient
 from .connector import ConnectorClient
 from .dangling_indices import DanglingIndicesClient
+from .encryption import EncryptionClient
 from .enrich import EnrichClient
 from .eql import EqlClient
 from .esql import EsqlClient
@@ -379,6 +380,7 @@ class Elasticsearch(BaseClient):
         self.xpack = XPackClient(self)
         self.ccr = CcrClient(self)
         self.dangling_indices = DanglingIndicesClient(self)
+        self.encryption = EncryptionClient(self)
         self.enrich = EnrichClient(self)
         self.eql = EqlClient(self)
         self.esql = EsqlClient(self)

--- a/elasticsearch/_sync/client/encryption.py
+++ b/elasticsearch/_sync/client/encryption.py
@@ -15,7 +15,15 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import Stability, _availability_warning, _rewrite_parameters
+
+
+class EncryptionClient(NamespacedClient):
 
     @_rewrite_parameters()
     @_availability_warning(Stability.EXPERIMENTAL)


### PR DESCRIPTION
## Summary

CI lint is failing on `main` (`black --check`) on `elasticsearch/_async/client/encryption.py` and `elasticsearch/_sync/client/encryption.py`. Both were newly generated files missing their standard module header: no `typing`/`ObjectApiResponse`/`NamespacedClient`/`utils` imports, and a placeholder `class C` instead of `EncryptionClient(NamespacedClient)`. Neither file was imported in `__init__.py`, so `es.encryption` was unreachable, and flake8 also fails on it with a pile of `F821 undefined name` errors (`t`, `ObjectApiResponse`, `_rewrite_parameters`, etc). Black just happened to be the first check to fail in the lint session.

## Fix

- Add the missing imports and rename `class C` to `EncryptionClient(NamespacedClient)` in both files, matching every other API group module.
- Wire `EncryptionClient` into `_async/client/__init__.py` and `_sync/client/__init__.py`.

## Verified

Ran the full `lint` nox session locally (isort, black, `run-unasync.py --check`, flake8, license headers, mypy `--strict`) - all pass. Also confirmed `Elasticsearch(...).encryption` and `AsyncElasticsearch(...).encryption` resolve to `EncryptionClient`.

## Test plan

- [ ] CI passes here