### PR TITLE
fix: stabilize optional imports with TYPE_CHECKING branches

### DIFF
--- a/elasticsearch/dsl/document_base.py
+++ b/elasticsearch/dsl/document_base.py
@@ -36,15 +36,21 @@ from typing import (
 
 from typing_extensions import _AnnotatedAlias
 
-try:
+if TYPE_CHECKING:
     import annotationlib
-except ImportError:
-    annotationlib = None  # type: ignore[assignment]
+else:
+    try:
+        import annotationlib
+    except ImportError:
+        annotationlib = None
 
-try:
+if TYPE_CHECKING:
     from types import UnionType
-except ImportError:
-    UnionType = None  # type: ignore[assignment, misc]
+else:
+    try:
+        from types import UnionType
+    except ImportError:
+        UnionType = None
 
 from typing_extensions import dataclass_transform
 

--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -18,7 +18,7 @@
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, ClassVar, Dict, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Tuple
 
 from elastic_transport import JsonSerializer as _JsonSerializer
 from elastic_transport import NdjsonSerializer as _NdjsonSerializer
@@ -49,12 +49,15 @@ except ImportError:
     _OrjsonSerializer = None  # type: ignore[assignment,misc]
 
 
-try:
+if TYPE_CHECKING:
     import pyarrow as pa
+else:
+    try:
+        import pyarrow as pa
 
-    __all__.append("PyArrowSerializer")
-except ImportError:
-    pa = None  # type: ignore[assignment]
+        __all__.append("PyArrowSerializer")
+    except ImportError:
+        pa = None
 
 
 class JsonSerializer(_JsonSerializer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,10 +144,3 @@ exclude_lines = [
 plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "elasticsearch.dsl.document_base"
-warn_unused_ignores = false
-
-[[tool.mypy.overrides]]
-module = "elasticsearch.serializer"
-warn_unused_ignores = false


### PR DESCRIPTION
## Summary

Fixes #3481.

`# type: ignore[assignment]` on optional `ImportError` fallbacks for `pyarrow` (`serializer.py`), `annotationlib`, and `UnionType` (`document_base.py`) flips between needed and unused depending on mypy / stub / Python version. That forced module-wide `warn_unused_ignores = false` overrides in `pyproject.toml`, which also hide real unused ignores later.

## Change

Split each optional import into `TYPE_CHECKING` vs runtime paths:

```python
if TYPE_CHECKING:
    import pyarrow as pa
else:
    try:
        import pyarrow as pa
        __all__.append("PyArrowSerializer")
    except ImportError:
        pa = None
```

Same shape for `annotationlib` and `UnionType`. Remove the two mypy overrides from `pyproject.toml`.

This matches the approach described on the issue (and the earlier closed attempt #3483).

## Test plan

- [x] AST parse of both modules
- [ ] CI mypy matrix on PR (authoritative)
- [x] Diff limited to the three files called out in #3481

## Notes

Elastic CLA may be required for first-time contributors: https://www.elastic.co/contributor-agreement
