### PR TITLE
docs: Fix hyphenation 'time based' -> 'time-based' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 * Configurable automatic discovery of cluster nodes
 * Persistent connections
 * Load balancing (with pluggable selection strategy) across available nodes
-* Failed connection penalization (time based - failed connections won't be
+* Failed connection penalization (time-based - failed connections won't be
   retried until a timeout is reached)
 * Support for TLS and HTTP authentication
 * Thread safety across requests


### PR DESCRIPTION
 Fixes compound adjective hyphenation ("time based" -> "time-based") in the features list of the README.