### PR TITLE
Skip failing sql yaml test to restore CI

### DIFF
--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -79,8 +79,7 @@ FAILING_TESTS = {
     "indices/resolve_cluster",
     "indices/settings",
     "machine_learning/jobs_crud",
-    # Async SQL query can complete before the status check, leaving no
-    # .async-search index and making sql.get_async_status return 404
+    # async query can complete before the status check, causing a 404
     "sql/10_basic[1]",
 }
 SKIPPED_TESTS = {

--- a/test_elasticsearch/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch/test_server/test_rest_api_spec.py
@@ -79,6 +79,9 @@ FAILING_TESTS = {
     "indices/resolve_cluster",
     "indices/settings",
     "machine_learning/jobs_crud",
+    # Async SQL query can complete before the status check, leaving no
+    # .async-search index and making sql.get_async_status return 404
+    "sql/10_basic[1]",
 }
 SKIPPED_TESTS = {
     # Timeouts


### PR DESCRIPTION
The `sql/10_basic[1]` yaml test fails against main when the async SQL query completes before `sql.get_async_status` runs (404, no such index `.async-search`). Skip it to restore CI.

similar to https://github.com/elastic/elasticsearch-py/pull/2808