### PR TITLE
Fix generated encryption module to restore lint

### DIFF
--- a/elasticsearch/_async/client/__init__.py
+++ b/elasticsearch/_async/client/__init__.py
@@ -47,6 +47,7 @@ from .ccr import CcrClient
 from .cluster import ClusterClient
 from .connector import ConnectorClient
 from .dangling_indices import DanglingIndicesClient
+from .encryption import EncryptionClient
 from .enrich import EnrichClient
 from .eql import EqlClient
 from .esql import EsqlClient
@@ -379,6 +380,7 @@ class AsyncElasticsearch(BaseClient):
         self.xpack = XPackClient(self)
         self.ccr = CcrClient(self)
         self.dangling_indices = DanglingIndicesClient(self)
+        self.encryption = EncryptionClient(self)
         self.enrich = EnrichClient(self)
         self.eql = EqlClient(self)
         self.esql = EsqlClient(self)

--- a/elasticsearch/_async/client/encryption.py
+++ b/elasticsearch/_async/client/encryption.py
@@ -15,7 +15,19 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import (
+    Stability,
+    _availability_warning,
+    _rewrite_parameters,
+)
+
+
+class EncryptionClient(NamespacedClient):
 
     @_rewrite_parameters()
     @_availability_warning(Stability.EXPERIMENTAL)

--- a/elasticsearch/_sync/client/__init__.py
+++ b/elasticsearch/_sync/client/__init__.py
@@ -47,6 +47,7 @@ from .ccr import CcrClient
 from .cluster import ClusterClient
 from .connector import ConnectorClient
 from .dangling_indices import DanglingIndicesClient
+from .encryption import EncryptionClient
 from .enrich import EnrichClient
 from .eql import EqlClient
 from .esql import EsqlClient
@@ -379,6 +380,7 @@ class Elasticsearch(BaseClient):
         self.xpack = XPackClient(self)
         self.ccr = CcrClient(self)
         self.dangling_indices = DanglingIndicesClient(self)
+        self.encryption = EncryptionClient(self)
         self.enrich = EnrichClient(self)
         self.eql = EqlClient(self)
         self.esql = EsqlClient(self)

--- a/elasticsearch/_sync/client/encryption.py
+++ b/elasticsearch/_sync/client/encryption.py
@@ -15,7 +15,19 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-class C:
+import typing as t
+
+from elastic_transport import ObjectApiResponse
+
+from ._base import NamespacedClient
+from .utils import (
+    Stability,
+    _availability_warning,
+    _rewrite_parameters,
+)
+
+
+class EncryptionClient(NamespacedClient):
 
     @_rewrite_parameters()
     @_availability_warning(Stability.EXPERIMENTAL)

--- a/elasticsearch/client.py
+++ b/elasticsearch/client.py
@@ -31,6 +31,7 @@ from ._sync.client.connector import ConnectorClient as ConnectorClient  # noqa: 
 from ._sync.client.dangling_indices import (  # noqa: F401
     DanglingIndicesClient as DanglingIndicesClient,
 )
+from ._sync.client.encryption import EncryptionClient as EncryptionClient  # noqa: F401
 from ._sync.client.enrich import EnrichClient as EnrichClient  # noqa: F401
 from ._sync.client.eql import EqlClient as EqlClient  # noqa: F401
 from ._sync.client.esql import EsqlClient as EsqlClient  # noqa: F401
@@ -93,6 +94,7 @@ __all__ = [
     "ConnectorClient",
     "DanglingIndicesClient",
     "Elasticsearch",
+    "EncryptionClient",
     "EnrichClient",
     "EqlClient",
     "FeaturesClient",


### PR DESCRIPTION
Lint fails on main: the new generated encryption modules were scaffolded as a bare `class C:` with no imports. Regenerated them with the generator fix from elastic/elastic-client-generator-python#72 and wired `EncryptionClient` into `__init__.py` and `client.py`, same as streams/project in #3074. Full `nox -rs lint` passes locally.