### PR TITLE
Preserve integral Decimal serialization precision

### DIFF
--- a/elasticsearch/serializer.py
+++ b/elasticsearch/serializer.py
@@ -72,6 +72,12 @@ class JsonSerializer(_JsonSerializer):
         if isinstance(data, uuid.UUID):
             return str(data)
         elif isinstance(data, FLOAT_TYPES):
+            if (
+                isinstance(data, Decimal)
+                and data.is_finite()
+                and data == data.to_integral_value()
+            ):
+                return int(data)
             return float(data)
 
         # This is kept for backwards compatibility even

--- a/test_elasticsearch/test_serializer.py
+++ b/test_elasticsearch/test_serializer.py
@@ -56,9 +56,11 @@ def test_datetime_serialization(json_serializer):
     )
 
 
-@requires_numpy_and_pandas
 def test_decimal_serialization(json_serializer):
     assert b'{"d":3.8}' == json_serializer.dumps({"d": Decimal("3.8")})
+    assert b'{"d":31124873853495702}' == json_serializer.dumps(
+        {"d": Decimal("31124873853495702")}
+    )
 
 
 def test_uuid_serialization(json_serializer):


### PR DESCRIPTION
## Summary

Serialize finite integral `Decimal` values as integers so large exact values
aren't changed by conversion through `float`.

This is intentionally limited to integral values. Fractional `Decimal` values
retain the existing float serialization behavior, avoiding a broader
serialization change.

Adds regression coverage for the large integral value reported in the tracking
issue.

Refs #895
