### PR TITLE
Allow TypedDict actions in bulk helpers

### DIFF
--- a/elasticsearch/helpers/actions.py
+++ b/elasticsearch/helpers/actions.py
@@ -59,14 +59,14 @@ class BulkMeta(Enum):
 
 BULK_FLUSH = BulkMeta.flush
 
-_TYPE_BULK_ACTION = Union[bytes, str, Dict[str, Any]]
+_TYPE_BULK_ACTION = Union[bytes, str, Mapping[str, Any]]
 _TYPE_BULK_ACTION_HEADER = Dict[str, Any]
 _TYPE_BULK_ACTION_BODY = Union[None, bytes, Dict[str, Any]]
 _TYPE_BULK_ACTION_HEADER_AND_BODY = Tuple[
     _TYPE_BULK_ACTION_HEADER, _TYPE_BULK_ACTION_BODY
 ]
 
-_TYPE_BULK_ACTION_WITH_META = Union[bytes, str, Dict[str, Any], BulkMeta]
+_TYPE_BULK_ACTION_WITH_META = Union[bytes, str, Mapping[str, Any], BulkMeta]
 _TYPE_BULK_ACTION_HEADER_WITH_META = Union[Dict[str, Any], BulkMeta]
 _TYPE_BULK_ACTION_HEADER_WITH_META_AND_BODY = Union[
     Tuple[_TYPE_BULK_ACTION_HEADER, _TYPE_BULK_ACTION_BODY],
@@ -85,7 +85,7 @@ def expand_action(data: _TYPE_BULK_ACTION) -> _TYPE_BULK_ACTION_HEADER_AND_BODY:
         return {"index": {}}, to_bytes(data, "utf-8")
 
     # make sure we don't alter the action
-    data = data.copy()
+    data = dict(data)
     op_type: str = data.pop("_op_type", "index")
     action: Dict[str, Any] = {op_type: {}}
 

--- a/test_elasticsearch/test_helpers.py
+++ b/test_elasticsearch/test_helpers.py
@@ -18,6 +18,7 @@
 import pickle
 import threading
 import time
+from types import MappingProxyType
 from typing import Optional
 from unittest import mock
 
@@ -86,6 +87,14 @@ class TestChunkActions:
     def test_expand_action(self):
         assert helpers.expand_action({}) == ({"index": {}}, {})
         assert helpers.expand_action({"key": "val"}) == ({"index": {}}, {"key": "val"})
+
+    def test_expand_action_accepts_mapping(self):
+        action = MappingProxyType({"_index": "index", "key": "val"})
+
+        assert helpers.expand_action(action) == (
+            {"index": {"_index": "index"}},
+            {"key": "val"},
+        )
 
     def test_expand_action_actions(self):
         assert helpers.expand_action(

--- a/test_elasticsearch/test_types/async_types.py
+++ b/test_elasticsearch/test_types/async_types.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import Any, AsyncGenerator, Dict
+from typing import Any, AsyncGenerator, Dict, TypedDict
 
 from elasticsearch import AsyncElasticsearch
 from elasticsearch.helpers import (
@@ -33,6 +33,12 @@ es = AsyncElasticsearch(
     retry_on_status={100, 400, 503},
     retry_on_timeout=True,
 )
+
+
+class BulkAction(TypedDict, total=False):
+    _index: str
+    _op_type: str
+    _source: Dict[str, Any]
 
 
 async def main() -> None:
@@ -83,6 +89,16 @@ async def async_bulk_types() -> None:
     _, _ = await async_bulk(es, async_gen().__aiter__())
     _, _ = await async_bulk(es, [{}])
     _, _ = await async_bulk(es, ({"key": "value"},))
+
+
+async def async_bulk_typed_dict_types() -> None:
+    action: BulkAction = {
+        "_index": "test-index",
+        "_source": {"key": "value"},
+    }
+    _, _ = await async_bulk(es, [action])
+    async for _ in async_streaming_bulk(es, [action]):
+        pass
 
 
 async def async_reindex_types() -> None:

--- a/test_elasticsearch/test_types/sync_types.py
+++ b/test_elasticsearch/test_types/sync_types.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import Any, Dict, Generator
+from typing import Any, Dict, Generator, TypedDict
 
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk, reindex, scan, streaming_bulk
@@ -36,6 +36,12 @@ es.options(request_timeout=1.0, max_retries=0, api_key="api-key-example").search
 es.options(
     request_timeout=1.0, max_retries=0, api_key="api-key-example"
 ).indices.exists(index="test-index")
+
+
+class BulkAction(TypedDict, total=False):
+    _index: str
+    _op_type: str
+    _source: Dict[str, Any]
 
 
 def sync_gen() -> Generator[Dict[Any, Any], None, None]:
@@ -76,6 +82,16 @@ def bulk_types() -> None:
     _, _ = bulk(es, sync_gen().__iter__())
     _, _ = bulk(es, [{}])
     _, _ = bulk(es, ({"key": "value"},))
+
+
+def bulk_typed_dict_types() -> None:
+    action: BulkAction = {
+        "_index": "test-index",
+        "_source": {"key": "value"},
+    }
+    _, _ = bulk(es, [action])
+    for _ in streaming_bulk(es, [action]):
+        pass
 
 
 def reindex_types() -> None:


### PR DESCRIPTION
## What

Allows `TypedDict` and other read-only mapping types to be passed to the bulk helpers.

Closes #2523

## Why

The bulk helper input annotations accepted only `Dict[str, Any]`, which caused strict type checkers to reject valid `TypedDict` actions even though the helper only needs mapping access from callers.

## Design

- Broaden public bulk action input aliases from `Dict` to `Mapping`.
- Materialize a plain dictionary inside `expand_action()` before the existing metadata extraction mutates the action copy.
- Preserve the existing output and serialization types.
- Cover both sync and asyncio bulk helper type fixtures.
- Add a runtime regression test using `MappingProxyType`, proving non-dict mappings are accepted without mutation.

## Verification

- `mypy --strict --implicit-reexport --explicit-package-bases --show-error-codes --enable-error-code=ignore-without-code elasticsearch/ test_elasticsearch/test_types/sync_types.py test_elasticsearch/test_types/async_types.py`
  - Success: no issues found in 167 source files.
- `19 passed` for `test_elasticsearch/test_helpers.py`
- `isort --check --profile=black`, `black --check`, `flake8`
- `utils/run-unasync.py --check`
- `git diff --check`

Draft while CI and maintainer feedback run.
