### PR TITLE
feat(transport): add resilient rate-limit backoff interceptor for async requests

### DIFF
--- a/elasticsearch/_async/__init__.py
+++ b/elasticsearch/_async/__init__.py
@@ -14,3 +14,9 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+
+from .rate_limiter import (
+    RateLimitConfig,
+    RateLimitedAsyncTransport,
+    wrap_transport,
+)

--- a/elasticsearch/_async/rate_limiter.py
+++ b/elasticsearch/_async/rate_limiter.py
@@ -1,0 +1,136 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Set, Callable
+
+from elastic_transport import AsyncTransport
+
+
+@dataclass(frozen=True)
+class RateLimitConfig:
+    retry_statuses: Set[int] = frozenset({429, 503})
+    max_retries: int = 3
+    backoff_base: float = 0.5
+    backoff_cap: float = 8.0
+    jitter: bool = True
+    respect_retry_after: bool = True
+
+
+def _parse_retry_after(headers: Mapping[str, Any]) -> Optional[float]:
+    v = headers.get("retry-after") or headers.get("Retry-After")
+    if not v:
+        return None
+    try:
+        return float(v)
+    except Exception:
+        # Could be an HTTP-date; ignore for simplicity
+        return None
+
+
+class RateLimitedAsyncTransport(AsyncTransport):
+    def __init__(
+        self,
+        *args: Any,
+        rate_limit_config: Optional[RateLimitConfig] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._rl_cfg = rate_limit_config or RateLimitConfig()
+
+    async def perform_request(self, method: str, target: str, **kwargs: Any):
+        attempt = 0
+        while True:
+            meta, body = await super().perform_request(method, target, **kwargs)
+            status = meta.status
+            if (
+                200 <= status < 300
+                or status not in self._rl_cfg.retry_statuses
+                or attempt >= self._rl_cfg.max_retries
+            ):
+                return meta, body
+
+            delay: Optional[float] = None
+            if self._rl_cfg.respect_retry_after:
+                delay = _parse_retry_after(meta.headers)
+
+            if delay is None:
+                delay = min(
+                    self._rl_cfg.backoff_cap,
+                    self._rl_cfg.backoff_base * (2 ** attempt),
+                )
+                if self._rl_cfg.jitter:
+                    delay = random.uniform(0.0, float(delay))
+
+            attempt += 1
+            await asyncio.sleep(max(0.0, float(delay)))
+
+
+class RateLimitInterceptor:
+    def __init__(
+        self,
+        transport: AsyncTransport,
+        config: Optional[RateLimitConfig] = None,
+        *,
+        sleep_coro: Callable[[float], "asyncio.Future[None]"] = asyncio.sleep,
+        rng: Callable[[float, float], float] = random.uniform,
+    ) -> None:
+        self._inner = transport
+        self._cfg = config or RateLimitConfig()
+        self._sleep = sleep_coro
+        self._rng = rng
+
+    async def perform_request(self, method: str, target: str, **kwargs: Any):
+        attempt = 0
+        while True:
+            meta, body = await self._inner.perform_request(method, target, **kwargs)
+            status = meta.status
+            if (
+                200 <= status < 300
+                or status not in self._cfg.retry_statuses
+                or attempt >= self._cfg.max_retries
+            ):
+                return meta, body
+
+            delay: Optional[float] = None
+            if self._cfg.respect_retry_after:
+                delay = _parse_retry_after(meta.headers)
+
+            if delay is None:
+                delay = min(
+                    self._cfg.backoff_cap,
+                    self._cfg.backoff_base * (2 ** attempt),
+                )
+                if self._cfg.jitter:
+                    delay = self._rng(0.0, float(delay))
+
+            attempt += 1
+            await self._sleep(max(0.0, float(delay)))
+
+
+def wrap_transport(
+    transport: AsyncTransport,
+    config: Optional[RateLimitConfig] = None,
+    *,
+    sleep_coro: Callable[[float], "asyncio.Future[None]"] = asyncio.sleep,
+    rng: Callable[[float, float], float] = random.uniform,
+) -> RateLimitInterceptor:
+    return RateLimitInterceptor(transport, config, sleep_coro=sleep_coro, rng=rng)

--- a/test_elasticsearch/test_async/test_transport_rate_limit.py
+++ b/test_elasticsearch/test_async/test_transport_rate_limit.py
@@ -1,0 +1,83 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import pytest
+
+from elastic_transport import ApiResponseMeta, HttpHeaders
+
+from elasticsearch._async.rate_limiter import (
+    RateLimitConfig,
+    wrap_transport,
+)
+
+
+class DummyRespTransport:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+
+    async def perform_request(self, method, target, **kwargs):
+        idx = min(self.calls, len(self.responses) - 1)
+        self.calls += 1
+        status, headers = self.responses[idx]
+        meta = ApiResponseMeta(
+            status=status,
+            http_version="1.1",
+            headers=HttpHeaders(headers or {}),
+            duration=0.0,
+            node=None,
+        )
+        return meta, {}
+
+
+@pytest.mark.asyncio
+async def test_retry_after_respected():
+    delays = []
+
+    async def fake_sleep(d):
+        delays.append(d)
+
+    t = DummyRespTransport([(429, {"Retry-After": "0.1"}), (200, {})])
+    rl = wrap_transport(t, RateLimitConfig(max_retries=2), sleep_coro=fake_sleep)
+    meta, _ = await rl.perform_request("GET", "/test")
+    assert meta.status == 200
+    assert len(delays) == 1 and 0.09 <= delays[0] <= 0.11
+
+
+@pytest.mark.asyncio
+async def test_exponential_backoff_jitter_cap():
+    delays = []
+
+    async def fake_sleep(d):
+        delays.append(d)
+
+    t = DummyRespTransport([(503, {}), (503, {}), (503, {}), (200, {})])
+    cfg = RateLimitConfig(
+        max_retries=3, backoff_base=0.2, backoff_cap=0.3, respect_retry_after=False, jitter=False
+    )
+    rl = wrap_transport(t, cfg, sleep_coro=fake_sleep)
+    meta, _ = await rl.perform_request("GET", "/test")
+    assert meta.status == 200
+    assert [round(d, 2) for d in delays] == [0.2, 0.3, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_pass_through_on_success():
+    t = DummyRespTransport([(200, {})])
+    rl = wrap_transport(t, RateLimitConfig())
+    meta, _ = await rl.perform_request("GET", "/ok")
+    assert meta.status == 200


### PR DESCRIPTION
Fixes #<link-to-feature-request-if-open>

Adds an opt-in Async rate-limit backoff layer for 429/503 with Retry-After support and jittered exponential backoff, available via elasticsearch._async.wrap_transport / RateLimitedAsyncTransport. Includes unit tests.

- Honors Retry-After header when present
- Exponential backoff with jitter and cap
- Configurable statuses and retry limits
- No-op on 2xx responses