### PR TITLE
Fix parameter name in EmbeddingService.embed_query docstring

### DIFF
--- a/elasticsearch/helpers/vectorstore/_async/embedding_service.py
+++ b/elasticsearch/helpers/vectorstore/_async/embedding_service.py
@@ -36,7 +36,7 @@ class AsyncEmbeddingService(ABC):
     async def embed_query(self, query: str) -> List[float]:
         """Generate an embedding for a single query text.
 
-        :param text: The query text to generate an embedding for.
+        :param query: The query text to generate an embedding for.
 
         :return: The embedding for the input query text.
         """

--- a/elasticsearch/helpers/vectorstore/_sync/embedding_service.py
+++ b/elasticsearch/helpers/vectorstore/_sync/embedding_service.py
@@ -36,7 +36,7 @@ class EmbeddingService(ABC):
     def embed_query(self, query: str) -> List[float]:
         """Generate an embedding for a single query text.
 
-        :param text: The query text to generate an embedding for.
+        :param query: The query text to generate an embedding for.
 
         :return: The embedding for the input query text.
         """


### PR DESCRIPTION
## What

`EmbeddingService.embed_query` (and its async counterpart) documented `:param text:`, but the parameter is named `query`:

```python
def embed_query(self, query: str) -> List[float]:
    """Generate an embedding for a single query text.

    :param text: The query text to generate an embedding for.
    """
```

Sphinx therefore rendered a parameter that does not exist on the method, and the one that does was undocumented. One word in each of two files.

## How

The change was made in `elasticsearch/helpers/vectorstore/_async/embedding_service.py`, which is the source directory for this path (`utils/run-unasync.py` maps `helpers/vectorstore/_async/` → `helpers/vectorstore/_sync/`). The `_sync` counterpart was **regenerated with `python utils/run-unasync.py`** rather than hand-edited.

`nox -rs format` could not be run in full locally: `utils/dsl-generator.py` calls `git branch --show-current`, which requires git >= 2.22, and this machine has git 2.15. That step is unrelated to this change. `black --check` and `isort --profile=black --check-only` both pass on the two modified files.

Unrelated import-ordering churn that `run-unasync.py` produced in three other files (because `isort` normally runs after it in the `format` session) was reverted, so the diff is only the intended change.

## Testing

- `pytest test_elasticsearch/ --ignore=test_elasticsearch/test_server` → **890 passed, 462 skipped, 0 failed**
- `pytest test_elasticsearch/test_server/test_vectorstore/` → 29 skipped (integration tests, no local Elasticsearch)
- Verified via `inspect` that the documented parameter now matches the signature on both `EmbeddingService` and `AsyncEmbeddingService`

Documentation only — no behaviour change.
