### PR TITLE
Release 9.5.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,28 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % *
 
 % ### Fixes [elasticsearch-python-client-next-fixes]
+## 9.5.0 (2026-08-04)
+
+API
+
+* Added `encryption.reset` API
+* Added `inference.delete_region_policy`, `inference.get_region_policy` and `inference.put_region_policy` APIs
+* Added `search_after` parameter to `synonyms.get_synonym` API
+* Added `append` parameter to `synonyms.put_synonym` API
+* Added `stats` parameter to `search` API
+* Added `project_routing` parameter to `terms_enum` API
+* Added `basic` parameter to `transform.get_transform_stats` API
+* Added `routing` and `route_slice` parameters to `indices.validate_query` API
+
+DSL
+
+* Added `DocValuesConfig` type; `doc_values` now accepts a `DocValuesConfig` object on all field types
+* Added `preserve_leaf_arrays` attribute to `Flattened` field
+
+Fixes
+
+* Forward `opaque_id` in `async_scan` ([#3445](https://github.com/elastic/elasticsearch-py/pull/3445))
+
 ## 9.4.1 (2026-05-26)
 
 Enhancements

--- a/elasticsearch/_version.py
+++ b/elasticsearch/_version.py
@@ -15,6 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__versionstr__ = "9.4.1"
+__versionstr__ = "9.5.0"
 __es_specification_commit__ = "7555fc9af2cc5f3cedab2f35548136eb4972f1fa"
 _SERVERLESS_API_VERSION = "2023-10-31"


### PR DESCRIPTION
## Summary

Bumps version to 9.5.0 and fills in release notes for unreleased work on the `9.5` branch (new `encryption`, `inference` region-policy, and ES|QL APIs; several parameter additions; an `async_scan` opaque_id fix; DSL `DocValuesConfig` support).

## Test plan

- [ ] Review release notes for accuracy/wording
- [ ] Merge, then trigger the `release-tag` workflow in `dev-experience-team` for `elasticsearch-py` `9.5.0`