### PR TITLE
Bring 9.5.0 release to parent

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,28 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % *
 
 % ### Fixes [elasticsearch-python-client-next-fixes]
+## 9.5.0 (2026-08-04)
+
+API
+
+* Added `encryption.reset` API
+* Added `inference.delete_region_policy`, `inference.get_region_policy` and `inference.put_region_policy` APIs
+* Added `search_after` parameter to `synonyms.get_synonym` API
+* Added `append` parameter to `synonyms.put_synonym` API
+* Added `stats` parameter to `search` API
+* Added `project_routing` parameter to `terms_enum` API
+* Added `basic` parameter to `transform.get_transform_stats` API
+* Added `routing` and `route_slice` parameters to `indices.validate_query` API
+
+DSL
+
+* Added `DocValuesConfig` type; `doc_values` now accepts a `DocValuesConfig` object on all field types
+* Added `preserve_leaf_arrays` attribute to `Flattened` field
+
+Fixes
+
+* Forward `opaque_id` in `async_scan` ([#3445](https://github.com/elastic/elasticsearch-py/pull/3445))
+
 ## 9.4.1 (2026-05-26)
 
 Enhancements

--- a/elasticsearch/_version.py
+++ b/elasticsearch/_version.py
@@ -15,6 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__versionstr__ = "9.4.1"
+__versionstr__ = "9.5.0"
 __es_specification_commit__ = "e17c791d9c847b6063c7068e5aa6f4c5b27cc241"
 _SERVERLESS_API_VERSION = "2023-10-31"


### PR DESCRIPTION
## Summary

Brings the 9.5.0 version bump and release notes from `9.5` forward to `main`, matching the pattern from #3438.

`__es_specification_commit__` is left at `main`'s own value since `main` has since moved ahead on the 9.6 codegen track.

## Test plan

- [ ] Confirm 9.5.0 release notes render correctly