### PR TITLE
docs: add claude build skills

### DIFF
--- a/.claude/skills/build-failure.md
+++ b/.claude/skills/build-failure.md
@@ -1,0 +1,22 @@
+---
+name: build-failure
+description: Diagnose elasticsearch-py CI and local build failures.
+---
+
+# Build failure
+
+Read the failing job log before changing code.
+
+Edited generated client APIs: revert `elasticsearch/_sync/client/` and `elasticsearch/_async/client/`. Submit the change to `elastic/elasticsearch-specification`.
+
+Async out of date with sync: `nox -rs format` (runs unasync and the DSL generator). `nox -rs lint` fails on `--check` if this was skipped.
+
+black / isort / flake8: `nox -rs format`, then `nox -rs lint`. Do not reformat by hand or weaken lint.
+
+Missing license headers: `nox -rs format` runs `utils/license-headers.py fix`.
+
+Import fails without extras: the client must import with no optional deps. `nox -rs lint` checks `from elasticsearch import Elasticsearch` on a bare install.
+
+Integration tests failed: they need Elasticsearch. Locally they skip if none is running. CI uses `.buildkite/run-elasticsearch.sh`.
+
+Python version: 3.10 through 3.14. Do not use 3.9 APIs.

--- a/.claude/skills/build.md
+++ b/.claude/skills/build.md
@@ -1,0 +1,20 @@
+---
+name: build
+description: Install, test, and format a clean elasticsearch-py checkout.
+---
+
+# Build
+
+Python 3.10+. Task runner is nox.
+
+```bash
+python -m pip install nox
+nox -rs format
+nox -rs test
+```
+
+`nox -rs format` also regenerates async code via unasync. `nox -rs lint` is check-only (black, isort, flake8, unasync, license headers).
+
+Integration tests need a running Elasticsearch and skip automatically without one. Unit tests still run.
+
+Do not edit `elasticsearch/_sync/client/` or `elasticsearch/_async/client/`. Those are generated from `elastic/elasticsearch-specification`. DSL async files are generated from sync by `nox -rs format`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,5 @@ All API methods on the client are auto-generated from the Elasticsearch specific
 ## Adding new agent instructions
 
 If something you learned will be useful to any contributor, update `AGENTS.md`. Keep instructions concise.
+
+Task-specific agent skills belong in `.claude/skills/`.


### PR DESCRIPTION
moves the Build stage from documented commands (level 1) to agent-invokable skills (level 2): `.claude/skills/build.md` and `.claude/skills/build-failure.md`.