### PR TITLE
chore: release 9.5.1

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -18,6 +18,21 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % *
 
 % ### Fixes [elasticsearch-python-client-next-fixes]
+## 9.5.1 (2026-08-31)
+
+API
+
+* Added `esql.delete_data_source`, `esql.get_data_source`, and `esql.put_data_source` APIs
+
+DSL
+
+* Updated `SemanticText.inference_id` default from `.elser-2-elasticsearch` to `.jina-embeddings-v5-text-small` when the Elastic Inference Service is available
+
+Fixes
+
+* Fixed `DenseVectorIndexOptions` to include missing `bbq_disk` properties: `cluster_size`, `default_visit_percentage`, `bits`, `precondition`, and `auto_calibrate`
+* `confidence_interval` on `DenseVectorIndexOptions` is now deprecated (Lucene 10.4 computes it automatically)
+
 ## 9.5.0 (2026-08-04)
 
 API

--- a/elasticsearch/_version.py
+++ b/elasticsearch/_version.py
@@ -15,6 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__versionstr__ = "9.5.0"
+__versionstr__ = "9.5.1"
 __es_specification_commit__ = "d669cedaf2a20400a96d6c786ff6296d0630e7b2"
 _SERVERLESS_API_VERSION = "2023-10-31"


### PR DESCRIPTION
Patch release with updated codegen from the latest specification. Adds missing ES|QL data source APIs, missing `bbq_disk` index options (`cluster_size`, `default_visit_percentage`, `bits`, `precondition`, `auto_calibrate`), and marks `confidence_interval` as deprecated.