### PR TITLE
ci: allow pypi publish from any branch

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish (e.g. 9.5.1). Checks out the matching major.minor branch."
+        description: "Existing release tag to publish (e.g. 9.5.1 or v9.5.1). The tag must already exist."
         required: true
         type: string
 
@@ -34,8 +34,8 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
-      - name: Derive branch from version
-        id: branch
+      - name: Derive release tag
+        id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             version="${{ github.event.inputs.version }}"
@@ -43,13 +43,21 @@ jobs:
             version="${{ github.event.release.tag_name }}"
           fi
           version="${version#v}"
-          major=$(echo "$version" | cut -d '.' -f1)
-          minor=$(echo "$version" | cut -d '.' -f2)
-          echo "name=$major.$minor" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "name=v$version" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v5
         with:
-          ref: ${{ steps.branch.outputs.name }}
+          ref: ${{ steps.tag.outputs.name }}
+
+      - name: Verify package version matches tag
+        run: |
+          actual=$(sed -n 's/^__versionstr__ = "\(.*\)"/\1/p' elasticsearch/_version.py)
+          expected="${{ steps.tag.outputs.version }}"
+          if [ "$actual" != "$expected" ]; then
+            echo "elasticsearch/_version.py is $actual, tag is $expected"
+            exit 1
+          fi
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,12 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 9.5.1). Checks out the matching major.minor branch."
+        required: true
+        type: string
 
 permissions: {}
 
@@ -28,10 +34,14 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
-      - name: Derive branch from release tag
+      - name: Derive branch from version
         id: branch
         run: |
-          version="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${{ github.event.release.tag_name }}"
+          fi
           version="${version#v}"
           major=$(echo "$version" | cut -d '.' -f1)
           minor=$(echo "$version" | cut -d '.' -f2)


### PR DESCRIPTION
Adds workflow_dispatch so Publish to PyPI can be run from main against any major.minor branch (e.g. 9.5.1).