### PR TITLE
ci: allow pypi publish from any branch

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,12 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing release tag to publish (e.g. 9.5.1 or v9.5.1). The tag must already exist."
+        required: true
+        type: string
 
 permissions: {}
 
@@ -28,18 +34,30 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
-      - name: Derive branch from release tag
-        id: branch
+      - name: Derive release tag
+        id: tag
         run: |
-          version="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${{ github.event.release.tag_name }}"
+          fi
           version="${version#v}"
-          major=$(echo "$version" | cut -d '.' -f1)
-          minor=$(echo "$version" | cut -d '.' -f2)
-          echo "name=$major.$minor" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "name=v$version" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v5
         with:
-          ref: ${{ steps.branch.outputs.name }}
+          ref: ${{ steps.tag.outputs.name }}
+
+      - name: Verify package version matches tag
+        run: |
+          actual=$(sed -n 's/^__versionstr__ = "\(.*\)"/\1/p' elasticsearch/_version.py)
+          expected="${{ steps.tag.outputs.version }}"
+          if [ "$actual" != "$expected" ]; then
+            echo "elasticsearch/_version.py is $actual, tag is $expected"
+            exit 1
+          fi
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Adds workflow_dispatch so Publish to PyPI can run from main the same way the JS npm workflow does. Still listens for release tags. Builds the tag (`v9.5.1`), not the live `9.5` branch, and fails if `_version.py` does not match, so dispatch cannot publish an untagged HEAD. Relates to the 9.5.1 publish that never started because this file is only on main.