### PR TITLE
Evaluate string annotations so Optional fields are not required

### DIFF
--- a/elasticsearch/dsl/document_base.py
+++ b/elasticsearch/dsl/document_base.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 import json
+import sys
 from datetime import date, datetime
 from fnmatch import fnmatch
 from typing import (
@@ -276,6 +277,20 @@ class InstrumentedField(InstrumentedExpression):
         return f"InstrumentedField[{self._expr}]"
 
 
+def _evaluate_annotation(type_: Any, globalns: Dict[str, Any], localns: Dict[str, Any]) -> Any:
+    """Resolve PEP 563 string annotations so Optional/UnionType checks can run.
+
+    ``from __future__ import annotations`` stores hints like ``'str | None'``.
+    Without evaluating them, every field is treated as required.
+    """
+    if not isinstance(type_, str):
+        return type_
+    try:
+        return eval(type_, globalns, localns)
+    except Exception:
+        return type_
+
+
 class DocumentMeta(type):
     _doc_type: "DocumentOptions"
     _index: "IndexBase"
@@ -355,6 +370,9 @@ class DocumentOptions:
         fields = {n for n in attrs if isinstance(attrs[n], Field)}
         fields.update(annotations.keys())
         field_defaults = {}
+        module = sys.modules.get(attrs.get("__module__", ""))
+        globalns = getattr(module, "__dict__", {}) if module is not None else {}
+        localns = dict(attrs)
         for name in fields:
             value: Any = None
             required = None
@@ -362,7 +380,7 @@ class DocumentOptions:
             if name in annotations:
                 # the field has a type annotation, so next we try to figure out
                 # what field type we can use
-                type_ = annotations[name]
+                type_ = _evaluate_annotation(annotations[name], globalns, localns)
                 type_metadata = []
                 if isinstance(type_, _AnnotatedAlias):
                     type_metadata = type_.__metadata__

--- a/test_elasticsearch/test_dsl/_sync/test_document.py
+++ b/test_elasticsearch/test_dsl/_sync/test_document.py
@@ -882,6 +882,24 @@ def test_doc_with_type_hints() -> None:
         assert d["sort"] == ["st", {"dt": {"order": "desc"}}, "ob.st"]
 
 
+def test_future_annotations_optional_is_not_required() -> None:
+    ns: Dict[str, Any] = {}
+    exec(
+        """
+from __future__ import annotations
+from elasticsearch.dsl import Document, Keyword, mapped_field
+
+class MyDoc(Document):
+    name: str = mapped_field(Keyword(required=True))
+    note: str | None = mapped_field(Keyword())
+""",
+        ns,
+    )
+    mapping = ns["MyDoc"]._doc_type.mapping
+    assert mapping["name"]._required is True
+    assert mapping["note"]._required is False
+
+
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10")
 def test_doc_with_pipe_type_hints() -> None:
     with pytest.raises(TypeError):


### PR DESCRIPTION
`from __future__ import annotations` stores hints like `str | None` as strings. The DSL only treats live `Union` / `UnionType` objects as optional, so on Python < 3.14 every field became required.

Evaluate those strings before the required-field check.

Fixes #3554